### PR TITLE
fix: resolve infinite loop in transaction log subscriber

### DIFF
--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -166,4 +166,47 @@ mod tests {
         assert_eq!(subscriber2.records[1].record, vec![10, 11, 12]); // First tx after restart
         assert_eq!(subscriber2.records[2].record, vec![13, 14, 15]); // Second tx after restart
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_file_log_infinite_loop_bug() {
+        init();
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_infinite_loop.log");
+
+        let clock = MockClock::new(vec![
+            st_from_unix_epoch(0),
+            st_from_unix_epoch(100),
+        ]);
+
+        let log = Arc::new(std::sync::RwLock::new(FileLog::new(&file_path, Box::new(clock)).unwrap()));
+
+        // Write one transaction
+        {
+            let mut writer = log.write().unwrap();
+            writer.append_tx(vec![1, 2, 3]).await;
+        }
+
+        let tx_id_0 = {
+            let reader = log.read().unwrap();
+            reader.read_txs(0, 1).unwrap()[0].tx_key.tx_id
+        };
+
+        // Subscribe starting at the transaction we just wrote
+        // This creates the scenario where after_tx_id == latest_tx_id
+        let subscriber = Arc::new(RwLock::new(MockSubscriber::new()));
+        let token = subscribe(log.clone(), Some(tx_id_0), subscriber.clone());
+
+        // Give it some time to process
+        std::thread::sleep(std::time::Duration::from_millis(150));
+
+        token.cancel();
+
+        let subscriber = subscriber.read().await;
+
+        // Without the fix, the subscriber would process the same transaction
+        // multiple times in an infinite loop until cancellation
+        // With the fix, it should process it exactly once
+        assert_eq!(subscriber.records.len(), 1, "Should process transaction exactly once, not in an infinite loop");
+        assert_eq!(subscriber.records[0].record, vec![1, 2, 3]);
+    }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -44,12 +44,21 @@ pub(crate) fn subscribe<S: Subscriber + 'static>(log: Arc<RwLock<dyn TxLogReader
             };
             match txs {
                 Ok(txs_to_process) => {
-                    after_tx_id = txs_to_process.last().unwrap().tx_key.tx_id;
+                    if txs_to_process.is_empty() {
+                        break;
+                    }
+                    let last_id = txs_to_process.last().unwrap().tx_key.tx_id;
                     trace!("Processing {} txs catching up", txs_to_process.len());
                     let mut subscriber = subscriber.write().await;
                     for tx in txs_to_process {
                         subscriber.accept(tx).await;
                     }
+                    // Break if we've caught up to avoid infinite loop
+                    if last_id >= latest_tx_id {
+                        after_tx_id = last_id;
+                        break;
+                    }
+                    after_tx_id = last_id;
                 },
                 Err(e) => {
                     error!("Error reading txs: {}", e);
@@ -73,15 +82,18 @@ pub(crate) fn subscribe<S: Subscriber + 'static>(log: Arc<RwLock<dyn TxLogReader
                         Err(broadcast::error::RecvError::Lagged(missed)) => {
                             let txs = {
                                 let log = log.read().unwrap();
-                                log.read_txs(after_tx_id, missed.try_into().unwrap())
+                                // Read from after_tx_id + 1 to skip already-processed transaction
+                                log.read_txs(after_tx_id + 1, missed.try_into().unwrap())
                             };
                             match txs {
                                 Ok(txs_to_process) => {
-                                    after_tx_id = txs_to_process.last().unwrap().tx_key.tx_id;
-                                    info!("Processing {} txs catching up", txs_to_process.len());
-                                    let mut subscriber = subscriber.write().await;
-                                    for tx in txs_to_process {
-                                        subscriber.accept(tx).await;
+                                    if !txs_to_process.is_empty() {
+                                        after_tx_id = txs_to_process.last().unwrap().tx_key.tx_id;
+                                        info!("Processing {} txs catching up", txs_to_process.len());
+                                        let mut subscriber = subscriber.write().await;
+                                        for tx in txs_to_process {
+                                            subscriber.accept(tx).await;
+                                        }
                                     }
                                 },
                                 Err(e) => {

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -116,4 +116,38 @@ mod tests {
         assert_eq!(subscriber2.records[1].record, vec![10, 11, 12]); // First tx after restart
         assert_eq!(subscriber2.records[2].record, vec![13, 14, 15]); // Second tx after restart
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_memory_log_infinite_loop_bug() {
+        init();
+        let clock = MockClock::new(vec![
+            st_from_unix_epoch(0),
+            st_from_unix_epoch(100),
+        ]);
+        let log = Arc::new(std::sync::RwLock::new(MemoryLog::new(Box::new(clock))));
+
+        // Write one transaction
+        {
+            let mut writer = log.write().unwrap();
+            writer.append_tx(vec![1, 2, 3]).await;
+        }
+
+        // Subscribe starting at tx_id=0 (the transaction we just wrote)
+        // This creates the scenario where after_tx_id == latest_tx_id
+        let subscriber = Arc::new(RwLock::new(MockSubscriber::new()));
+        let token = subscribe(log.clone(), Some(0), subscriber.clone());
+
+        // Give it some time to process
+        thread::sleep(Duration::from_millis(150));
+
+        token.cancel();
+
+        let subscriber = subscriber.read().await;
+
+        // Without the fix, the subscriber would process the same transaction
+        // multiple times in an infinite loop until cancellation
+        // With the fix, it should process it exactly once
+        assert_eq!(subscriber.records.len(), 1, "Should process transaction exactly once, not in an infinite loop");
+        assert_eq!(subscriber.records[0].record, vec![1, 2, 3]);
+    }
 }


### PR DESCRIPTION
### Summary

Fixed infinite loop bug in transaction log subscriber that caused `test_file_log` and `test_memory_log` to be flaky.

### Problem

The catch-up loop in `subscribe()` was infinitely re-reading the same transaction when `after_tx_id == latest_tx_id`. Since the subscriber runs in a background async task, tests didn't hang - instead, the same transaction was processed repeatedly until cancellation, causing flaky assertions.

### Solution

1. **Added deterministic tests** that consistently reproduce the bug:
   - `test_memory_log_infinite_loop_bug` in `src/memory_log.rs`
   - `test_file_log_infinite_loop_bug` in `src/file_log.rs`

2. **Fixed catch-up phase** in `src/log.rs`:
   - Break when `last_id >= latest_tx_id` to prevent infinite loop
   - Added empty check for edge cases

3. **Fixed lagged recovery**:
   - Read from `after_tx_id + 1` to skip already-processed transactions
   - Added empty check before processing

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)