### PR TITLE
feat: main entrypoint with TOML config and examples

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+dev = "watch -x 'run -- config/triplox.toml'"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
  "triplox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 slatedb = { git = "https://github.com/FiV0/slatedb.git", branch = "range-apis" }
 thiserror = "2.0.1"
 time = { version = "0.3.36", features = ["serde"] }
+toml = "0.8"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"

--- a/config/triplox-local.toml
+++ b/config/triplox-local.toml
@@ -1,0 +1,7 @@
+[storage]
+type = "local"
+path = "./data"
+
+[server]
+host = "127.0.0.1"
+port = 5490

--- a/config/triplox.toml
+++ b/config/triplox.toml
@@ -1,0 +1,6 @@
+[storage]
+type = "memory"
+
+[server]
+host = "127.0.0.1"
+port = 5490

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "examples"
+version = "0.1.0"
+edition = "2021"
+publish = false
+readme = "README.md"
+
+[[bin]]
+name = "simple-example"
+path = "src/simple_example.rs"
+test = false
+bench = false
+
+[dependencies]
+triplox = { path = ".." }
+edn = { path = "../edn" }
+anyhow = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Triplox Examples
+
+## Prerequisites
+
+Start the Triplox server first (from the project root):
+
+```bash
+cargo run
+```
+
+This uses the default `config/triplox.toml` config (in-memory storage, listening on `127.0.0.1:5490`).
+
+## Running
+
+In a separate terminal, from the `examples/` directory:
+
+```bash
+cargo run --bin simple-example
+```
+
+### simple-example
+
+Connects to the running server, defines `:name` and `:age` schema attributes, inserts two documents (alice and bob), queries them back, and prints the results.

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -1,0 +1,96 @@
+//! Simple example: connect to a running Triplox server, define a schema
+//! attribute, insert data, and query it back.
+//!
+//! Start the server first:
+//!   cargo run                     (from project root, uses config/triplox.toml)
+//!
+//! Then run this example:
+//!   cargo run --bin simple-example  (from examples/)
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use edn::Keyword;
+use triplox::client::ClientNode;
+use triplox::node::{QueryNode, SubmitNode, TransactionResult};
+use triplox::ops::{DataType, Document, TxOp};
+
+/// Build a schema attribute definition as a Put document.
+/// This mirrors the internal `plain_schema_attribute` helper.
+fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
+    let mut doc = BTreeMap::new();
+    doc.insert("db/id".to_string(), DataType::Long(id));
+    doc.insert(
+        "db/ident".to_string(),
+        DataType::Keyword(Keyword::plain(name)),
+    );
+    doc.insert(
+        "db/valueType".to_string(),
+        DataType::Keyword(Keyword::namespaced("db.type", value_type)),
+    );
+    TxOp::Put(Document(doc))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let addr = "127.0.0.1:5490";
+    println!("Connecting to {addr}...");
+    let node = ClientNode::connect(addr).await?;
+    println!("Connected.");
+
+    // 1. Define schema attributes (entity IDs 50-51, above bootstrap range 1-31)
+    let schema_ops = vec![
+        schema_attribute(50, "name", "string"),
+        schema_attribute(51, "age", "long"),
+    ];
+    let result = node.execute_tx(schema_ops).await?;
+    match &result {
+        TransactionResult::TxCommited(basis) => {
+            println!("Schema defined (tx_id={}).", basis.tx_key.tx_id);
+        }
+        TransactionResult::TxAborted(_, err) => {
+            anyhow::bail!("Schema transaction aborted: {err}");
+        }
+    }
+
+    // 2. Insert some data
+    let mut alice = BTreeMap::new();
+    alice.insert("db/id".to_string(), DataType::Long(100));
+    alice.insert("name".to_string(), DataType::String("alice".to_string()));
+    alice.insert("age".to_string(), DataType::Long(30));
+
+    let mut bob = BTreeMap::new();
+    bob.insert("db/id".to_string(), DataType::Long(101));
+    bob.insert("name".to_string(), DataType::String("bob".to_string()));
+    bob.insert("age".to_string(), DataType::Long(25));
+
+    let data_ops = vec![TxOp::Put(Document(alice)), TxOp::Put(Document(bob))];
+    let result = node.execute_tx(data_ops).await?;
+    match &result {
+        TransactionResult::TxCommited(basis) => {
+            println!("Data inserted (tx_id={}).", basis.tx_key.tx_id);
+        }
+        TransactionResult::TxAborted(_, err) => {
+            anyhow::bail!("Data transaction aborted: {err}");
+        }
+    }
+
+    // 3. Open a DB snapshot and query
+    let db = node.db().await?;
+    println!("Opened DB snapshot (tx_id={}).", db.tx_id());
+
+    let edn_query = r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#;
+    let rows = db.query_edn(edn_query).await?;
+
+    println!("Query returned {} row(s):", rows.len());
+    for row in &rows {
+        println!("  {:?}", row);
+    }
+
+    // 4. Clean up
+    db.close().await?;
+    node.close().await?;
+    println!("Done.");
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub storage: StorageConfig,
+    #[serde(default)]
+    pub server: ServerConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum StorageConfig {
+    Memory,
+    Local { path: PathBuf },
+    Remote {
+        #[serde(flatten)]
+        _extra: toml::Table,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default = "default_max_open_dbs")]
+    pub max_open_dbs: usize,
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_port() -> u16 {
+    5490
+}
+
+fn default_max_open_dbs() -> usize {
+    1024
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+            host: default_host(),
+            port: default_port(),
+            max_open_dbs: default_max_open_dbs(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod index;
 mod indexer;
 mod iterator;
 mod log;
-mod logging;
+pub mod logging;
 mod memory_log;
 pub mod ops;
 mod parse;
@@ -23,6 +23,7 @@ mod slate;
 mod transaction;
 mod util;
 
+pub mod config;
 pub mod node;
 pub mod protocol;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,78 @@
-fn main() {
-    println!("Hello, world!");
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use triplox::config::{Config, StorageConfig};
+use triplox::node::Node;
+use triplox::server::Server;
+
+fn load_config() -> Result<Config> {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "config/triplox.toml".to_string());
+    let contents = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read config file: {}", path))?;
+    let config: Config =
+        toml::from_str(&contents).with_context(|| format!("Failed to parse config file: {}", path))?;
+    Ok(config)
+}
+
+async fn run_server(config: Config) -> Result<()> {
+    let bind_addr = format!("{}:{}", config.server.host, config.server.port);
+    let max_open_dbs = config.server.max_open_dbs;
+
+    let token = CancellationToken::new();
+    let shutdown_token = token.clone();
+
+    tokio::spawn(async move {
+        let ctrl_c = tokio::signal::ctrl_c();
+
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut sigterm =
+                signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+            tokio::select! {
+                _ = ctrl_c => info!("SIGINT received, shutting down..."),
+                _ = sigterm.recv() => info!("SIGTERM received, shutting down..."),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            ctrl_c.await.ok();
+            info!("Ctrl+C received, shutting down...");
+        }
+
+        shutdown_token.cancel();
+    });
+
+    match config.storage {
+        StorageConfig::Memory => {
+            let node = Arc::new(Node::memory_node().await);
+            let server = Server::new(node, max_open_dbs);
+            server.listen(&bind_addr, token).await
+        }
+        StorageConfig::Local { path } => {
+            let node = Arc::new(Node::local_node(&path).await);
+            let server = Server::new(node, max_open_dbs);
+            server.listen(&bind_addr, token).await
+        }
+        StorageConfig::Remote { .. } => {
+            bail!("Remote storage is not yet supported")
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    triplox::logging::init();
+
+    let config = load_config()?;
+    info!("Starting triplox with {:?} storage", config.storage);
+
+    run_server(config).await
 }


### PR DESCRIPTION
## Summary

- Replace the stub `main.rs` with a real server entrypoint that reads a TOML config file, creates the appropriate Node (memory/local), and starts the TCP server with graceful Ctrl+C shutdown
- Add `src/config.rs` with serde-backed config structs (`Config`, `StorageConfig`, `ServerConfig`) supporting memory, local, and remote (stub) storage types
- Add default `config/triplox.toml` (memory) and `config/triplox-local.toml` (local disk) config files
- Add `cargo dev` alias via `.cargo/config.toml` for file-watching dev workflow
- Add `examples/` directory with a `simple-example` binary that connects to a running server, defines schema attributes, inserts data, and queries it back

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] `cargo run` reads `config/triplox.toml` and starts memory server on 127.0.0.1:5490
- [ ] `cargo run -- config/triplox-local.toml` starts with local disk storage
- [ ] Ctrl+C triggers graceful shutdown
- [ ] `cargo run --bin simple-example` (from `examples/`) connects and runs end-to-end
- [ ] `cargo test` — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)