### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.idea/
+.claude/
+.beads/
+*.md
+!docker/README.md

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,24 @@
+name: Docker Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # Weekly, Sunday 3am UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old SHA-tagged images
+        uses: snok/container-retention-policy@v3
+        with:
+          account: FiV0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: triplox
+          cut-off: 1 week ago UTC
+          tag-selection: "both"
+          filter-tags: "main,v*"
+          filter-include-untagged: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,55 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+# --- Stage 1: Chef base ---
+FROM rust:1-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+# --- Stage 2: Planner ---
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# --- Stage 3: Builder ---
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Copy the full edn crate — it's a local path dependency with a build script
+# (PEG parser generator), so it needs to be present for cargo chef to work.
+# It's small, so the cache benefit of stubbing it isn't worth the brittleness.
+COPY edn/ edn/
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release
+
+# --- Stage 4: Runtime ---
+FROM debian:bookworm-slim AS runtime
+
+ARG GIT_SHA="unknown"
+
+LABEL org.opencontainers.image.source="https://github.com/FiV0/triplox"
+LABEL org.opencontainers.image.description="Triplox database server"
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 20000 triplox && \
+    useradd -u 20000 -g triplox -m triplox
+
+COPY --from=builder /app/target/release/triplox /usr/local/bin/triplox
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/config/ /etc/triplox/
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    mkdir -p /var/lib/triplox && \
+    chown -R triplox:triplox /var/lib/triplox
+
+USER triplox
+
+VOLUME /var/lib/triplox
+EXPOSE 5490
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+# Triplox Docker
+
+Docker support for running Triplox with in-memory or local persisted storage.
+
+## Building
+
+```bash
+./docker/scripts/build-image.sh
+```
+
+This builds and tags the image as `triplox:latest` and `triplox:<short-sha>`.
+
+## Running
+
+### In-memory mode (default)
+
+```bash
+docker run -p 5490:5490 triplox:latest
+```
+
+### Local persisted mode
+
+```bash
+docker run -p 5490:5490 \
+  -e TRIPLOX_STORAGE=local \
+  -v triplox-data:/var/lib/triplox \
+  triplox:latest
+```
+
+### Custom config
+
+Mount your own config file and pass its path as an argument:
+
+```bash
+docker run -p 5490:5490 \
+  -v ./my-config.toml:/etc/triplox/custom.toml \
+  triplox:latest /etc/triplox/custom.toml
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TRIPLOX_STORAGE` | `memory` | Storage mode: `memory` or `local` |
+
+## Ports
+
+| Port | Protocol | Description |
+|---|---|---|
+| 5490 | TCP | Triplox wire protocol |
+
+## Volumes
+
+| Path | Description |
+|---|---|
+| `/var/lib/triplox` | Persistent data directory (used in `local` mode) |

--- a/docker/config/triplox-local.toml
+++ b/docker/config/triplox-local.toml
@@ -1,0 +1,7 @@
+[storage]
+type = "local"
+path = "/var/lib/triplox/data"
+
+[server]
+host = "0.0.0.0"
+port = 5490

--- a/docker/config/triplox-memory.toml
+++ b/docker/config/triplox-memory.toml
@@ -1,0 +1,6 @@
+[storage]
+type = "memory"
+
+[server]
+host = "0.0.0.0"
+port = 5490

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# If arguments are passed, use them as the config path
+if [ $# -gt 0 ]; then
+    exec triplox "$@"
+fi
+
+# Select config based on TRIPLOX_STORAGE env var
+TRIPLOX_STORAGE="${TRIPLOX_STORAGE:-memory}"
+
+case "$TRIPLOX_STORAGE" in
+    memory)
+        CONFIG_FILE="/etc/triplox/triplox-memory.toml"
+        ;;
+    local)
+        CONFIG_FILE="/etc/triplox/triplox-local.toml"
+        ;;
+    *)
+        echo "Error: unknown TRIPLOX_STORAGE value: $TRIPLOX_STORAGE"
+        echo "Supported values: memory, local"
+        exit 1
+        ;;
+esac
+
+exec triplox "$CONFIG_FILE"

--- a/docker/scripts/build-image.sh
+++ b/docker/scripts/build-image.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Build from the repository root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+docker build \
+    -f "$REPO_ROOT/docker/Dockerfile" \
+    --build-arg GIT_SHA="$GIT_SHA" \
+    -t "triplox:latest" \
+    -t "triplox:$GIT_SHA" \
+    "$REPO_ROOT"
+
+echo "Built triplox:latest and triplox:$GIT_SHA"

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,23 @@ cargo run
 
 This uses the default `config/triplox.toml` config (in-memory storage, listening on `127.0.0.1:5490`).
 
+## Running against Docker
+
+Alternatively, start the server via Docker using the pre-built image:
+
+```bash
+docker run -p 5490:5490 ghcr.io/fiv0/triplox:main
+```
+
+Or build locally (from the project root):
+
+```bash
+./docker/scripts/build-image.sh
+docker run -p 5490:5490 triplox:latest
+```
+
+Then run the examples as shown below. The Docker image binds to `0.0.0.0:5490`, so examples connecting to `127.0.0.1:5490` work out of the box.
+
 ## Running
 
 In a separate terminal, from the `examples/` directory:


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile using cargo-chef for cached dependency builds
- Add entrypoint script that selects in-memory or local storage via `TRIPLOX_STORAGE` env var
- Add convenience build script that tags images as `triplox:latest` and `triplox:<git-sha>`

## Usage

```bash
# Build
./docker/scripts/build-image.sh

# In-memory (default)
docker run -p 5490:5490 triplox:latest

# Local persisted
docker run -p 5490:5490 -e TRIPLOX_STORAGE=local -v triplox-data:/var/lib/triplox triplox:latest
```

## Test plan

- [ ] Build image with `./docker/scripts/build-image.sh`
- [ ] Run in-memory mode and verify server accepts connections on port 5490
- [ ] Run local mode with volume and verify data persists across restarts
- [ ] Run simple example against the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)