### PR TITLE
feat: add dev server mode with per-connection in-memory nodes

### DIFF
--- a/config/triplox-dev.toml
+++ b/config/triplox-dev.toml
@@ -1,0 +1,6 @@
+[storage]
+type = "dev"
+
+[server]
+host = "127.0.0.1"
+port = 5490

--- a/docker/config/triplox-dev.toml
+++ b/docker/config/triplox-dev.toml
@@ -1,0 +1,6 @@
+[storage]
+type = "dev"
+
+[server]
+host = "0.0.0.0"
+port = 5490

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,6 +10,9 @@ fi
 TRIPLOX_STORAGE="${TRIPLOX_STORAGE:-memory}"
 
 case "$TRIPLOX_STORAGE" in
+    dev)
+        CONFIG_FILE="/etc/triplox/triplox-dev.toml"
+        ;;
     memory)
         CONFIG_FILE="/etc/triplox/triplox-memory.toml"
         ;;
@@ -18,7 +21,7 @@ case "$TRIPLOX_STORAGE" in
         ;;
     *)
         echo "Error: unknown TRIPLOX_STORAGE value: $TRIPLOX_STORAGE"
-        echo "Supported values: memory, local"
+        echo "Supported values: dev, memory, local"
         exit 1
         ;;
 esac

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum StorageConfig {
+    Dev,
     Memory,
     Local { path: PathBuf },
     Remote {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use triplox::config::{Config, StorageConfig};
 use triplox::node::Node;
-use triplox::server::Server;
+use triplox::server::{DevServer, Server};
 
 fn load_config() -> Result<Config> {
     let path = std::env::args()
@@ -51,6 +51,10 @@ async fn run_server(config: Config) -> Result<()> {
     });
 
     match config.storage {
+        StorageConfig::Dev => {
+            let server = DevServer::new(max_open_dbs);
+            server.listen(&bind_addr, token).await
+        }
         StorageConfig::Memory => {
             let node = Arc::new(Node::memory_node().await);
             let server = Server::new(node, max_open_dbs);

--- a/src/server.rs
+++ b/src/server.rs
@@ -237,9 +237,11 @@ impl DevServer {
                 } else {
                     info!("Connection from {} closed cleanly", peer_addr);
                 }
-                if let Ok(node) = Arc::try_unwrap(node) {
-                    node.close().await;
-                }
+                // This should never fail: handle_connection only borrows the Arc,
+                // so refcount is 1 after it returns.
+                let node = Arc::try_unwrap(node)
+                    .unwrap_or_else(|_| panic!("dev node Arc should have refcount 1 after connection close"));
+                node.close().await;
             });
         }).await
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,12 +5,14 @@
 //! to the underlying Node.
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use tokio::io::{AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -186,65 +188,126 @@ impl<L: TxLog + 'static> Server<L> {
         listener: TcpListener,
         token: CancellationToken,
     ) -> Result<()> {
-        info!(
-            "Triplox server listening on {}",
-            listener.local_addr()?
-        );
-
-        let mut connections = tokio::task::JoinSet::new();
-
-        loop {
-            tokio::select! {
-                _ = token.cancelled() => {
-                    info!("Shutdown signal received, stopping listener");
-                    break;
+        let node = self.node.clone();
+        let db_cache = self.db_cache.clone();
+        accept_loop(listener, token, |stream, peer_addr, conn_token, connections| {
+            let node = node.clone();
+            let db_cache = db_cache.clone();
+            connections.spawn(async move {
+                if let Err(e) = handle_connection(stream, node, db_cache, conn_token).await {
+                    warn!("Connection from {} closed with error: {}", peer_addr, e);
+                } else {
+                    info!("Connection from {} closed cleanly", peer_addr);
                 }
-                result = listener.accept() => {
-                    let (stream, peer_addr) = result?;
-                    stream.set_nodelay(true)?;
-                    info!("New connection from {}", peer_addr);
+            });
+        }).await
+    }
+}
 
-                    let node = self.node.clone();
-                    let db_cache = self.db_cache.clone();
-                    let conn_token = token.child_token();
+// ---------------------------------------------------------------------------
+// Dev Server (per-connection in-memory nodes)
+// ---------------------------------------------------------------------------
 
-                    connections.spawn(async move {
-                        if let Err(e) = handle_connection(stream, node, db_cache, conn_token).await {
-                            warn!("Connection from {} closed with error: {}", peer_addr, e);
-                        } else {
-                            info!("Connection from {} closed cleanly", peer_addr);
-                        }
-                    });
+pub struct DevServer {
+    max_open_dbs: usize,
+}
+
+impl DevServer {
+    pub fn new(max_open_dbs: usize) -> Self {
+        DevServer { max_open_dbs }
+    }
+
+    pub async fn listen(&self, addr: &str, token: CancellationToken) -> Result<()> {
+        let listener = TcpListener::bind(addr).await?;
+        self.listen_on(listener, token).await
+    }
+
+    pub async fn listen_on(
+        &self,
+        listener: TcpListener,
+        token: CancellationToken,
+    ) -> Result<()> {
+        let max_open_dbs = self.max_open_dbs;
+        accept_loop(listener, token, move |stream, peer_addr, conn_token, connections| {
+            connections.spawn(async move {
+                let node = Arc::new(Node::memory_node().await);
+                let db_cache = Arc::new(DbCache::new(max_open_dbs));
+                if let Err(e) = handle_connection(stream, node.clone(), db_cache, conn_token).await {
+                    warn!("Connection from {} closed with error: {}", peer_addr, e);
+                } else {
+                    info!("Connection from {} closed cleanly", peer_addr);
                 }
+                if let Ok(node) = Arc::try_unwrap(node) {
+                    node.close().await;
+                }
+            });
+        }).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Accept loop (shared between Server and DevServer)
+// ---------------------------------------------------------------------------
+
+async fn accept_loop<F>(
+    listener: TcpListener,
+    token: CancellationToken,
+    mut spawn_handler: F,
+) -> Result<()>
+where
+    F: FnMut(TcpStream, SocketAddr, CancellationToken, &mut JoinSet<()>),
+{
+    info!(
+        "Triplox server listening on {}",
+        listener.local_addr()?
+    );
+
+    let mut connections = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => {
+                info!("Shutdown signal received, stopping listener");
+                break;
+            }
+            result = listener.accept() => {
+                let (stream, peer_addr) = result?;
+                stream.set_nodelay(true)?;
+                info!("New connection from {}", peer_addr);
+                spawn_handler(stream, peer_addr, token.child_token(), &mut connections);
             }
         }
+    }
 
-        // Drain: wait for in-flight connections to finish
-        let remaining = connections.len();
-        if remaining > 0 {
-            info!("Waiting for {} connection(s) to drain...", remaining);
-            match tokio::time::timeout(std::time::Duration::from_secs(30), async {
-                let mut panicked = 0usize;
-                while let Some(result) = connections.join_next().await {
-                    if result.is_err() {
-                        panicked += 1;
-                    }
-                }
-                panicked
-            }).await {
-                Ok(panicked) => {
-                    if panicked > 0 {
-                        warn!("{} connection task(s) panicked during drain", panicked);
-                    }
-                    info!("All connections drained");
-                }
-                Err(_) => {
-                    warn!("Drain timeout (30s) exceeded, dropping remaining connections");
+    drain_connections(&mut connections).await;
+    Ok(())
+}
+
+async fn drain_connections(connections: &mut JoinSet<()>) {
+    let remaining = connections.len();
+    if remaining > 0 {
+        info!("Waiting for {} connection(s) to drain...", remaining);
+        match tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            let mut panicked = 0usize;
+            while let Some(result) = connections.join_next().await {
+                if result.is_err() {
+                    panicked += 1;
                 }
             }
+            panicked
+        })
+        .await
+        {
+            Ok(panicked) => {
+                if panicked > 0 {
+                    warn!("{} connection task(s) panicked during drain", panicked);
+                }
+                info!("All connections drained");
+            }
+            Err(_) => {
+                warn!("Drain timeout (30s) exceeded, dropping remaining connections");
+            }
         }
-
-        Ok(())
     }
 }
 

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -8,7 +8,7 @@ use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, Document, TxOp};
 use triplox::schema::test_schema_tx;
-use triplox::server::Server;
+use triplox::server::{DevServer, Server};
 use triplox::{Basis, TransactionResult};
 
 async fn define_test_schema(client: &ClientNode) {
@@ -259,5 +259,62 @@ async fn test_basis_for_tx_after_submit() {
 
     db.close().await.unwrap();
     client.close().await.unwrap();
+    token.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// DevServer tests
+// ---------------------------------------------------------------------------
+
+async fn start_dev_server() -> (String, CancellationToken) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+
+    let server = DevServer::new(1024);
+
+    let token = CancellationToken::new();
+    let server_token = token.clone();
+    tokio::spawn(async move {
+        let _ = server.listen_on(listener, server_token).await;
+    });
+
+    (addr, token)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dev_server_connections_are_isolated() {
+    let (addr, token) = start_dev_server().await;
+
+    // Connection 1: define schema and insert data
+    let client1 = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client1).await;
+
+    let mut doc = BTreeMap::new();
+    doc.insert("db/id".to_string(), DataType::Long(1));
+    doc.insert("name".to_string(), DataType::String("alice".to_string()));
+    client1.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+
+    let db1 = client1.db().await.unwrap();
+    let result1 = db1
+        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .await
+        .unwrap();
+    assert_eq!(result1.len(), 1, "client1 should see its own data");
+
+    // Connection 2: gets a fresh node, should see nothing
+    let client2 = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client2).await;
+
+    let db2 = client2.db().await.unwrap();
+    let result2 = db2
+        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .await
+        .unwrap();
+    assert_eq!(result2.len(), 0, "client2 should not see client1's data");
+
+    db1.close().await.unwrap();
+    db2.close().await.unwrap();
+    client1.close().await.unwrap();
+    client2.close().await.unwrap();
     token.cancel();
 }


### PR DESCRIPTION
## Summary

- Adds a `dev` storage mode (`type = "dev"` in config) where each TCP connection gets its own fresh in-memory triplox node, providing full isolation between connections
- Extracts `accept_loop`/`drain_connections` from `Server::listen_on` to share logic between `Server` and the new `DevServer` via a `FnMut` closure pattern
- Adds config files and Docker entrypoint support (`TRIPLOX_STORAGE=dev`)

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` — all existing tests pass
- [ ] Manual test: start server with `config/triplox-dev.toml`, connect two clients, verify data written by one is invisible to the other
- [ ] Docker: build image, run with `TRIPLOX_STORAGE=dev`, verify per-connection isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)