### PR TITLE
feat: add predicate/function parsing and end-to-end tests

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -195,7 +195,8 @@ mod tests {
     use slatedb::config::ScanOptions;
 
     use crate::codec;
-    use crate::datalog::{FindElement, FindSpec, OrBranch, PatternElement, Query, TriplePattern, WhereClause};
+    use crate::datalog::{FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern, WhereClause};
+    use crate::expr::{BinaryExpr, BinaryOp, Expr};
     use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
     use crate::ops::{Attribute, DataType, Document, EntityId, Triple, TxOp, Value};
     use crate::schema::test_schema_tx;
@@ -919,5 +920,264 @@ mod tests {
         assert_eq!(basis.seq_num, 0);
 
         node.close().await;
+    }
+
+    /// Insert 3 people: Ivan (100, age=30), Bob (101, age=40), Dominic (102, age=50).
+    async fn insert_three_people(node: &impl SubmitNode) {
+        let people = vec![
+            (100, "Ivan", 30),
+            (101, "Bob", 40),
+            (102, "Dominic", 50),
+        ];
+        for (id, name, age) in people {
+            let mut doc = BTreeMap::new();
+            doc.insert("db/id".to_string(), DataType::Long(id));
+            doc.insert("name".to_string(), DataType::String(name.to_string()));
+            doc.insert("age".to_string(), DataType::Long(age));
+            node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        }
+    }
+
+    fn predicate(left: Expr, op: BinaryOp, right: Expr) -> WhereClause {
+        WhereClause::Predicate(Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        }))
+    }
+
+    fn fn_expr(left: Expr, op: BinaryOp, right: Expr, output: &str) -> WhereClause {
+        WhereClause::FnExpr(FnExpr {
+            expr: Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            }),
+            output: output.to_string(),
+        })
+    }
+
+    fn var(name: &str) -> Expr {
+        Expr::Variable(name.to_string())
+    }
+
+    fn lit_long(n: i64) -> Expr {
+        Expr::Literal(DataType::Long(n))
+    }
+
+    fn lit_string(s: &str) -> Expr {
+        Expr::Literal(DataType::String(s.to_string()))
+    }
+
+    fn find_vars(names: &[&str]) -> FindSpec {
+        FindSpec::FindRel(names.iter().map(|n| FindElement::Variable(n.to_string())).collect())
+    }
+
+    fn triple(entity: &str, attr: &str, value: &str) -> WhereClause {
+        WhereClause::Triple(TriplePattern {
+            entity: PatternElement::Variable(entity.to_string()),
+            attribute: PatternElement::Constant(kw(attr)),
+            value: PatternElement::Variable(value.to_string()),
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_predicate_lt() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                triple("?e", "age", "?age"),
+                predicate(var("?age"), BinaryOp::Lt, lit_long(50)),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string())]));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_predicate_gte() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                triple("?e", "age", "?age"),
+                predicate(var("?age"), BinaryOp::GtEq, lit_long(50)),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], vec![DataType::String("Dominic".to_string())]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_predicate_eq_entity() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                predicate(lit_long(100), BinaryOp::Eq, var("?e")),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], vec![DataType::String("Ivan".to_string())]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_predicate_eq_value() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?e"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                predicate(lit_string("Ivan"), BinaryOp::Eq, var("?name")),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], vec![DataType::Long(100)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_predicate_lte_two_vars() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name1", "?name2"]),
+            where_clauses: vec![
+                triple("?e1", "name", "?name1"),
+                triple("?e1", "age", "?age1"),
+                triple("?e2", "name", "?name2"),
+                triple("?e2", "age", "?age2"),
+                predicate(var("?age1"), BinaryOp::LtEq, var("?age2")),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        // 3 people → 6 pairs where age1 <= age2:
+        // (Ivan,Ivan), (Ivan,Bob), (Ivan,Dominic), (Bob,Bob), (Bob,Dominic), (Dominic,Dominic)
+        assert_eq!(result.len(), 6);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_fn_div() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name", "?half"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                triple("?e", "age", "?age"),
+                fn_expr(var("?age"), BinaryOp::Div, lit_long(2), "?half"),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(20)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(25)]));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_fn_with_predicate() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name", "?half"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                triple("?e", "age", "?age"),
+                fn_expr(var("?age"), BinaryOp::Div, lit_long(2), "?half"),
+                predicate(var("?half"), BinaryOp::Gt, lit_long(20)),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], vec![DataType::String("Dominic".to_string()), DataType::Long(25)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_fn_sub() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name", "?result"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                triple("?e", "age", "?age"),
+                fn_expr(var("?age"), BinaryOp::Sub, lit_long(15), "?result"),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(25)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(35)]));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_not_clause() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        insert_three_people(&node).await;
+
+        let query = Query {
+            find: find_vars(&["?name"]),
+            where_clauses: vec![
+                triple("?e", "name", "?name"),
+                WhereClause::Not(vec![WhereClause::Triple(TriplePattern {
+                    entity: PatternElement::Variable("?e".to_string()),
+                    attribute: PatternElement::Constant(kw("age")),
+                    value: PatternElement::Constant(DataType::Long(50)),
+                })]),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string())]));
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,8 +5,10 @@ use edn::query as eq;
 use edn::Keyword;
 
 use crate::datalog::{
-    FindElement, FindSpec, OrBranch, PatternElement, Query, TriplePattern, Variable, WhereClause,
+    FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern, Variable,
+    WhereClause,
 };
+use crate::expr::{BinaryExpr, BinaryOp, Expr};
 use crate::ops::DataType;
 
 pub fn parse_query(input: &str) -> Result<Query> {
@@ -114,8 +116,14 @@ fn convert_where_clause(clause: eq::WhereClause) -> Result<WhereClause> {
                 }
             }
         }
-        eq::WhereClause::Pred(_) => Err(anyhow!("predicate clauses are not yet supported")),
-        eq::WhereClause::WhereFn(_) => Err(anyhow!("where-fn clauses are not yet supported")),
+        eq::WhereClause::Pred(pred) => {
+            let expr = convert_predicate(&pred)?;
+            Ok(WhereClause::Predicate(expr))
+        }
+        eq::WhereClause::WhereFn(wf) => {
+            let fn_expr = convert_where_fn(&wf)?;
+            Ok(WhereClause::FnExpr(fn_expr))
+        }
         eq::WhereClause::RuleExpr => Err(anyhow!("rule expressions are not yet supported")),
         eq::WhereClause::TypeAnnotation(_) => {
             Err(anyhow!("type annotations are not yet supported"))
@@ -134,6 +142,86 @@ fn convert_or_where_clause(clause: eq::OrWhereClause) -> Result<OrBranch> {
             Ok(OrBranch::And(converted))
         }
     }
+}
+
+fn convert_fn_arg(arg: &eq::FnArg) -> Result<Expr> {
+    match arg {
+        eq::FnArg::Variable(v) => Ok(Expr::Variable(var_to_string(v))),
+        eq::FnArg::EntidOrInteger(i) => Ok(Expr::Literal(DataType::Long(*i))),
+        eq::FnArg::Constant(c) => match c {
+            eq::NonIntegerConstant::Text(t) => Ok(Expr::Literal(DataType::String((**t).clone()))),
+            eq::NonIntegerConstant::Float(f) => {
+                Ok(Expr::Literal(DataType::Double(f.into_inner())))
+            }
+            eq::NonIntegerConstant::Boolean(b) => Ok(Expr::Literal(DataType::Boolean(*b))),
+            other => Err(anyhow!("unsupported constant type in predicate/fn: {:?}", other)),
+        },
+        eq::FnArg::IdentOrKeyword(kw) => {
+            Ok(Expr::Literal(DataType::Keyword((*kw).clone())))
+        }
+        other => Err(anyhow!("unsupported fn arg type: {:?}", other)),
+    }
+}
+
+fn convert_binary_op(name: &str) -> Result<BinaryOp> {
+    match name {
+        "<" => Ok(BinaryOp::Lt),
+        "<=" => Ok(BinaryOp::LtEq),
+        ">" => Ok(BinaryOp::Gt),
+        ">=" => Ok(BinaryOp::GtEq),
+        "=" => Ok(BinaryOp::Eq),
+        "not=" | "!=" => Ok(BinaryOp::NotEq),
+        "+" => Ok(BinaryOp::Add),
+        "-" => Ok(BinaryOp::Sub),
+        "*" => Ok(BinaryOp::Mul),
+        "/" | "quot" => Ok(BinaryOp::Div),
+        "mod" => Ok(BinaryOp::Mod),
+        "concat" => Ok(BinaryOp::Concat),
+        _ => Err(anyhow!("unknown operator: {}", name)),
+    }
+}
+
+fn convert_predicate(pred: &eq::Predicate) -> Result<Expr> {
+    let op_name = &pred.operator.0;
+    let op = convert_binary_op(op_name)?;
+    if pred.args.len() != 2 {
+        return Err(anyhow!(
+            "predicate '{}' requires exactly 2 arguments, got {}",
+            op_name,
+            pred.args.len()
+        ));
+    }
+    let left = convert_fn_arg(&pred.args[0])?;
+    let right = convert_fn_arg(&pred.args[1])?;
+    Ok(Expr::BinaryExpr(BinaryExpr {
+        left: Box::new(left),
+        op,
+        right: Box::new(right),
+    }))
+}
+
+fn convert_where_fn(wf: &eq::WhereFn) -> Result<FnExpr> {
+    let op_name = &wf.operator.0;
+    let op = convert_binary_op(op_name)?;
+    if wf.args.len() != 2 {
+        return Err(anyhow!(
+            "function '{}' requires exactly 2 arguments, got {}",
+            op_name,
+            wf.args.len()
+        ));
+    }
+    let left = convert_fn_arg(&wf.args[0])?;
+    let right = convert_fn_arg(&wf.args[1])?;
+    let expr = Expr::BinaryExpr(BinaryExpr {
+        left: Box::new(left),
+        op,
+        right: Box::new(right),
+    });
+    let output = match &wf.binding {
+        eq::Binding::BindScalar(v) => var_to_string(v),
+        other => return Err(anyhow!("only scalar binding is supported for where-fn, got {:?}", other)),
+    };
+    Ok(FnExpr { expr, output })
 }
 
 fn convert_non_value_place(place: eq::PatternNonValuePlace) -> Result<PatternElement> {
@@ -369,13 +457,40 @@ mod tests {
     }
 
     #[test]
-    fn parse_predicate_unsupported() {
-        let (e1, e2) = assert_both_err(
+    fn parse_predicate() {
+        let q = parse_both(
             "[:find ?x :where [?x _ ?y] [(< ?y 10)]]",
             "{:find [?x] :where [[?x _ ?y] [(< ?y 10)]]}",
         );
-        assert!(e1.to_string().contains("predicate"));
-        assert!(e2.to_string().contains("predicate"));
+        assert_eq!(q.where_clauses.len(), 2);
+        assert_eq!(
+            q.where_clauses[1],
+            WhereClause::Predicate(Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(Expr::Variable("?y".into())),
+                op: BinaryOp::Lt,
+                right: Box::new(Expr::Literal(DataType::Long(10))),
+            }))
+        );
+    }
+
+    #[test]
+    fn parse_fn() {
+        let q = parse_both(
+            "[:find ?x ?result :where [?x _ ?y] [(quot ?y 2) ?result]]",
+            "{:find [?x ?result] :where [[?x _ ?y] [(quot ?y 2) ?result]]}",
+        );
+        assert_eq!(q.where_clauses.len(), 2);
+        assert_eq!(
+            q.where_clauses[1],
+            WhereClause::FnExpr(FnExpr {
+                expr: Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(Expr::Variable("?y".into())),
+                    op: BinaryOp::Div,
+                    right: Box::new(Expr::Literal(DataType::Long(2))),
+                }),
+                output: "?result".into(),
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds parsing support for Datalog predicate clauses (e.g. `[(< ?age 50)]`) and function clauses (e.g. `[(quot ?age 2) ?half-age]`) in the query engine
- Adds 9 new end-to-end Rust tests in `node.rs` covering predicate filters (`<`, `>=`, `<=`, `=` with entities/values/two vars), function expressions (`div`, `sub`), fn+predicate combos, and `not` clauses

Cherry-picked from #12 (commits `adb3674` and `4e267a8`).

## Test plan

- [x] `cargo test` — 277 tests pass, 0 failures