### PR TITLE
ci: add JVM Gradle test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,36 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features
+
+  jvm-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build server
+        run: cargo build
+
+      - name: Start dev server
+        run: |
+          cargo run -- config/triplox-dev.toml &
+          for i in $(seq 1 30); do nc -z localhost 5490 && break || sleep 1; done
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Run unit tests
+        run: cd triplox-jvm && ./gradlew test
+
+      - name: Run integration tests
+        run: cd triplox-jvm && ./gradlew integrationTest


### PR DESCRIPTION
Add jvm-test job that builds the Triplox server, starts it in the background, and runs both unit and integration tests for the JVM client.