### PR TITLE
feat: align indices with COVERING_INDICES.md design

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use slatedb::Db;
+use crate::clock;
 use crate::codec;
 use crate::indexer::build_index_write_batch;
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
@@ -27,7 +28,7 @@ pub async fn init_db(slatedb: Arc<Db>) -> SchemaCache {
             let mut cache = SchemaCache::new();
             cache.process_tx(&tx_ops).unwrap();
 
-            let write_batch = build_index_write_batch(&tx_ops, &cache).unwrap();
+            let write_batch = build_index_write_batch(&tx_ops, &cache, clock::st_from_unix_epoch(0)).unwrap();
             slatedb.write_with_options(write_batch, &DEFAULT_WRITE_OPTIONS).await.unwrap();
 
             // Write version

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -54,8 +54,13 @@ pub fn encode_timestamp(t: Instant) -> [u8; 8] {
 }
 
 /// Decode an inverted big-endian timestamp back to an Instant.
-pub fn decode_timestamp(bytes: &[u8]) -> Instant {
-    let inverted = i64::from_be_bytes(bytes.try_into().expect("timestamp must be 8 bytes"));
+pub fn decode_timestamp(bytes: &[u8]) -> Result<Instant, Error> {
+    let arr: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("timestamp must be exactly 8 bytes, got {}", bytes.len()))?;
+    let inverted = i64::from_be_bytes(arr);
     let micros = !inverted;
-    chrono::TimeZone::timestamp_micros(&chrono::Utc, micros).unwrap()
+    chrono::TimeZone::timestamp_micros(&chrono::Utc, micros)
+        .single()
+        .ok_or_else(|| anyhow::anyhow!("ambiguous or invalid timestamp: {} micros", micros))
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use anyhow::Error;
 
+use crate::clock::Instant;
 use crate::index::IndexType;
 
 // TODO should this become 2 bytes?
@@ -31,6 +32,9 @@ pub const DELETE: u8 = 1;
 pub const RETRACT: u8 = 2;
 
 
+/// Suffix length: timestamp (8 bytes) + op (1 byte), used for end-of-key extraction.
+pub const TIMESTAMP_OP_SUFFIX: usize = TIMESTAMP_LENGTH + OP_LENGTH;
+
 // TODO move this to lazy_static
 pub fn index_type_to_prefix(index_type: IndexType) -> Result<u8, Error> {
     match index_type {
@@ -40,4 +44,18 @@ pub fn index_type_to_prefix(index_type: IndexType) -> Result<u8, Error> {
         IndexType::AE => Ok(AE),
         IndexType::AV => Ok(AV),
     }
+}
+
+/// Encode a timestamp as inverted big-endian i64 microseconds.
+/// Inverted so that newer timestamps sort first in ascending byte order.
+pub fn encode_timestamp(t: Instant) -> [u8; 8] {
+    let micros = t.timestamp_micros();
+    (!micros).to_be_bytes()
+}
+
+/// Decode an inverted big-endian timestamp back to an Instant.
+pub fn decode_timestamp(bytes: &[u8]) -> Instant {
+    let inverted = i64::from_be_bytes(bytes.try_into().expect("timestamp must be 8 bytes"));
+    let micros = !inverted;
+    chrono::TimeZone::timestamp_micros(&chrono::Utc, micros).unwrap()
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -48,7 +48,7 @@ fn resolve_attribute_id(schema_cache: &SchemaCache, attr: &str) -> Result<i64, E
         .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", attr))
 }
 
-fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache) -> Result<TxIndexKeys, Error> {
+fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache, timestamp: &[u8; 8]) -> Result<TxIndexKeys, Error> {
     match tx_op {
         TxOp::Put(Document(doc)) => {
             let entity_id = match doc.get("db/id") {
@@ -72,11 +72,11 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache) -> Result<TxIndexK
             let mut av: Vec<Vec<u8>> = Vec::new();
 
             for (attribute, value) in attribute_and_values {
-                eav.push(concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &[codec::ADD]]));
-                ave.push(concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &[codec::ADD]]));
-                aev.push(concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &[codec::ADD]]));
-                ae.push(concat_bytes(&[&[codec::AE], &attribute, &entity_id, &[codec::ADD]]));
-                av.push(concat_bytes(&[&[codec::AV], &attribute, &value, &[codec::ADD]]));
+                eav.push(concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::ADD]]));
+                ave.push(concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::ADD]]));
+                aev.push(concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::ADD]]));
+                ae.push(concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::ADD]]));
+                av.push(concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::ADD]]));
             }
 
             Ok(TxIndexKeys { eav, ave, aev, ae, av })
@@ -89,11 +89,11 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache) -> Result<TxIndexK
             let attribute = bincode::serialize(&attribute_id)?;
             let value = bincode::serialize(&value)?;
 
-            let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &[codec::ADD]]);
-            let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &[codec::ADD]]);
-            let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &[codec::ADD]]);
-            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, &[codec::ADD]]);
-            let av = concat_bytes(&[&[codec::AV], &attribute, &value, &[codec::ADD]]);
+            let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::ADD]]);
+            let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::ADD]]);
+            let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::ADD]]);
+            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::ADD]]);
+            let av = concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::ADD]]);
 
             Ok(TxIndexKeys { eav: vec![eav], ave: vec![ave], aev: vec![aev], ae: vec![ae], av: vec![av] })
         },
@@ -105,11 +105,11 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache) -> Result<TxIndexK
             let attribute = bincode::serialize(&attribute_id)?;
             let value = bincode::serialize(&value)?;
 
-            let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &[codec::RETRACT]]);
-            let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &[codec::RETRACT]]);
-            let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &[codec::RETRACT]]);
-            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, &[codec::RETRACT]]);
-            let av = concat_bytes(&[&[codec::AV], &attribute, &value, &[codec::RETRACT]]);
+            let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::RETRACT]]);
+            let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::RETRACT]]);
+            let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::RETRACT]]);
+            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::RETRACT]]);
+            let av = concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::RETRACT]]);
 
             Ok(TxIndexKeys { eav: vec![eav], ave: vec![ave], aev: vec![aev], ae: vec![ae], av: vec![av] })
         },
@@ -121,9 +121,11 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache) -> Result<TxIndexK
 pub(crate) fn build_index_write_batch(
     tx_ops: &[TxOp],
     schema_cache: &SchemaCache,
+    system_time: Instant,
 ) -> Result<WriteBatch, Error> {
+    let timestamp = codec::encode_timestamp(system_time);
     let index_keys: Vec<TxIndexKeys> = tx_ops.iter()
-        .map(|op| op_to_index_keys(op, schema_cache))
+        .map(|op| op_to_index_keys(op, schema_cache, &timestamp))
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut write_batch = WriteBatch::new();
@@ -211,7 +213,7 @@ impl Indexer {
     pub async fn transact_tx(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
         self.schema_cache.validate_tx(&tx_ops)?;
 
-        let write_batch = build_index_write_batch(&tx_ops, &self.schema_cache)?;
+        let write_batch = build_index_write_batch(&tx_ops, &self.schema_cache, tx_key.system_time)?;
 
         self.slatedb.write_with_options(write_batch, &DEFAULT_WRITE_OPTIONS).await?;
 
@@ -324,7 +326,7 @@ impl Subscriber for Indexer {
 
 // TODO: something to refactor
 
-pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, u8), Error> {
+pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, Instant, u8), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::EAV {
@@ -334,18 +336,19 @@ pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, u8), Err
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix = &key[1..key.len()-1];
+    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
     let suffix = key[key.len()-1];
 
-    let mut cursor = Cursor::new(without_prefix);
+    let mut cursor = Cursor::new(without_prefix_and_suffix);
     let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let value: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((entity_id, attribute, value, suffix))
+    Ok((entity_id, attribute, value, timestamp, suffix))
 }
 
-pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, u8), Error> {
+pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AVE {
@@ -355,18 +358,19 @@ pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, u8), Err
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix = &key[1..key.len()-1];
+    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
     let suffix = key[key.len()-1];
 
-    let mut cursor = Cursor::new(without_prefix);
+    let mut cursor = Cursor::new(without_prefix_and_suffix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let value: DataType = bincode::deserialize_from(&mut cursor)?;
     let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, value, entity_id, suffix))
+    Ok((attribute, value, entity_id, timestamp, suffix))
 }
 
-pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, u8), Error> {
+pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AEV {
@@ -376,18 +380,19 @@ pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, u8), Err
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix = &key[1..key.len()-1];
+    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
     let suffix = key[key.len()-1];
 
-    let mut cursor = std::io::Cursor::new(without_prefix);
+    let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
     let value: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, entity_id, value, suffix))
+    Ok((attribute, entity_id, value, timestamp, suffix))
 }
 
-pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType, u8), Error> {
+pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AE {
@@ -397,17 +402,18 @@ pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType, u8), Error> {
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix = &key[1..key.len()-1];
+    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
     let suffix = key[key.len()-1];
 
-    let mut cursor = std::io::Cursor::new(without_prefix);
+    let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, entity_id, suffix))
+    Ok((attribute, entity_id, timestamp, suffix))
 }
 
-pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType, u8), Error> {
+pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AV {
@@ -417,14 +423,15 @@ pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType, u8), Error> {
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix = &key[1..key.len()-1];
+    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
     let suffix = key[key.len()-1];
 
-    let mut cursor = std::io::Cursor::new(without_prefix);
+    let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let value: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, value, suffix))
+    Ok((attribute, value, timestamp, suffix))
 }
 
 #[cfg(test)]
@@ -467,7 +474,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, attribute, value, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(value, DataType::String("alan".to_string()));
@@ -498,7 +505,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, _, _, _) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 found = true;
                 break;
@@ -527,7 +534,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut eav_count = 0;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, _, _, _) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 eav_count += 1;
             }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -75,8 +75,8 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache, timestamp: &[u8; 8
                 eav.push(concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::ADD]]));
                 ave.push(concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::ADD]]));
                 aev.push(concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::ADD]]));
-                ae.push(concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::ADD]]));
-                av.push(concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::ADD]]));
+                ae.push(concat_bytes(&[&[codec::AE], &attribute, &entity_id]));
+                av.push(concat_bytes(&[&[codec::AV], &attribute, &value]));
             }
 
             Ok(TxIndexKeys { eav, ave, aev, ae, av })
@@ -92,8 +92,8 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache, timestamp: &[u8; 8
             let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::ADD]]);
             let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::ADD]]);
             let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::ADD]]);
-            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::ADD]]);
-            let av = concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::ADD]]);
+            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id]);
+            let av = concat_bytes(&[&[codec::AV], &attribute, &value]);
 
             Ok(TxIndexKeys { eav: vec![eav], ave: vec![ave], aev: vec![aev], ae: vec![ae], av: vec![av] })
         },
@@ -108,10 +108,11 @@ fn op_to_index_keys(tx_op: &TxOp, schema_cache: &SchemaCache, timestamp: &[u8; 8
             let eav = concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, timestamp, &[codec::RETRACT]]);
             let ave = concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, timestamp, &[codec::RETRACT]]);
             let aev = concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, timestamp, &[codec::RETRACT]]);
-            let ae = concat_bytes(&[&[codec::AE], &attribute, &entity_id, timestamp, &[codec::RETRACT]]);
-            let av = concat_bytes(&[&[codec::AV], &attribute, &value, timestamp, &[codec::RETRACT]]);
+            // AE/AV are purely additive — retractions are not written to partial indices
+            let ae = vec![];
+            let av = vec![];
 
-            Ok(TxIndexKeys { eav: vec![eav], ave: vec![ave], aev: vec![aev], ae: vec![ae], av: vec![av] })
+            Ok(TxIndexKeys { eav: vec![eav], ave: vec![ave], aev: vec![aev], ae, av })
         },
         TxOp::Delete(_entity) => todo!(),
         TxOp::Erase(_entity) => todo!(),
@@ -392,7 +393,7 @@ pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant,
     Ok((attribute, entity_id, value, timestamp, suffix))
 }
 
-pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error> {
+pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AE {
@@ -402,18 +403,16 @@ pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
-    let suffix = key[key.len()-1];
+    let without_prefix = &key[1..];
 
-    let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);
+    let mut cursor = std::io::Cursor::new(without_prefix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, entity_id, timestamp, suffix))
+    Ok((attribute, entity_id))
 }
 
-pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error> {
+pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
     let key = key.as_ref();
 
     if key.is_empty() || key[0] != codec::AV {
@@ -423,15 +422,13 @@ pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType, Instant, u8), Error
     if key.len() < 2 {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
-    let suffix = key[key.len()-1];
+    let without_prefix = &key[1..];
 
-    let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);
+    let mut cursor = std::io::Cursor::new(without_prefix);
     let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
     let value: DataType = bincode::deserialize_from(&mut cursor)?;
 
-    Ok((attribute, value, timestamp, suffix))
+    Ok((attribute, value))
 }
 
 #[cfg(test)]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -338,7 +338,7 @@ pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, Instant,
         return Err(anyhow::anyhow!("Key too short"));
     }
     let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH])?;
     let suffix = key[key.len()-1];
 
     let mut cursor = Cursor::new(without_prefix_and_suffix);
@@ -360,7 +360,7 @@ pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant,
         return Err(anyhow::anyhow!("Key too short"));
     }
     let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH])?;
     let suffix = key[key.len()-1];
 
     let mut cursor = Cursor::new(without_prefix_and_suffix);
@@ -382,7 +382,7 @@ pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant,
         return Err(anyhow::anyhow!("Key too short"));
     }
     let without_prefix_and_suffix = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]);
+    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH])?;
     let suffix = key[key.len()-1];
 
     let mut cursor = std::io::Cursor::new(without_prefix_and_suffix);

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -203,10 +203,6 @@ mod tests {
         Bytes::from(s.as_bytes().to_vec())
     }
 
-    fn default_timestamp() -> [u8; 8] {
-        crate::codec::encode_timestamp(crate::clock::st_from_unix_epoch(1_000_000))
-    }
-
     async fn insert_ave(
         slate: &slatedb::Db,
         attribute: i64,
@@ -217,7 +213,7 @@ mod tests {
         key.extend_from_slice(&bincode::serialize(&attribute)?);
         key.extend_from_slice(&value);
         key.extend_from_slice(&bincode::serialize(&DataType::Long(entity))?);
-        key.extend_from_slice(&default_timestamp());
+        key.extend_from_slice(&crate::codec::encode_timestamp(crate::clock::st_from_unix_epoch(1_000_000)));
         key.push(crate::codec::ADD);
 
         slate.put(&key, b"dummy_value").await?;

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -97,7 +97,7 @@ impl GenericPrefixExtender {
                         .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e)),
                 )
             }
-            _ => {
+            IndexType::EAV | IndexType::AVE | IndexType::AEV => {
                 Box::new(
                     TemporalFilterIterator::new(
                         slate_prefix,

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -5,11 +5,13 @@ use bytes::Bytes;
 use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
+use crate::clock::Instant;
 use crate::codec::index_type_to_prefix;
 use crate::index::IndexType;
 use crate::util::make_extractor;
 
-use super::slate_iterator::{Extractor, Index, SlateIterator};
+use super::slate_iterator::{Extractor, Index};
+use super::temporal_filter_iterator::TemporalFilterIterator;
 
 /// GenericPrefixExtender implements PrefixExtender using SlateDB with byte prefixes.
 ///
@@ -20,6 +22,7 @@ pub struct GenericPrefixExtender {
     index_types: Vec<IndexType>,      // e.g., [AV, AVE]
     constant_prefix: Vec<u8>,         // attr_bytes + serialized constant values from the pattern
     participating_levels: Vec<usize>, // Which join levels this participates in
+    as_of: Instant,                   // temporal filter: only see facts at or before this time
 }
 
 impl GenericPrefixExtender {
@@ -30,6 +33,7 @@ impl GenericPrefixExtender {
         attribute_id: i64,
         constant_prefix: Vec<u8>,
         participating_levels: Vec<usize>,
+        as_of: Instant,
     ) -> Self {
         let mut full_prefix = bincode::serialize(&attribute_id)
             .expect("Failed to serialize attribute_id");
@@ -41,6 +45,7 @@ impl GenericPrefixExtender {
             index_types,
             constant_prefix: full_prefix,
             participating_levels,
+            as_of,
         }
     }
 
@@ -99,11 +104,12 @@ impl PrefixExtender for GenericPrefixExtender {
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let iter = SlateIterator::new(
+        let iter = TemporalFilterIterator::new(
             &slate_prefix,
             self.slate.as_ref(),
             self.handle.clone(),
             extractor,
+            self.as_of,
         )
         .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
 
@@ -117,11 +123,12 @@ impl PrefixExtender for GenericPrefixExtender {
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let mut iter = SlateIterator::new(
+        let mut iter = TemporalFilterIterator::new(
             &slate_prefix,
             self.slate.as_ref(),
             self.handle.clone(),
             extractor,
+            self.as_of,
         )
         .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
 
@@ -142,11 +149,12 @@ impl PrefixExtender for GenericPrefixExtender {
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let mut iter = SlateIterator::new(
+        let mut iter = TemporalFilterIterator::new(
             &slate_prefix,
             self.slate.as_ref(),
             self.handle.clone(),
             extractor,
+            self.as_of,
         )
         .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
 
@@ -184,6 +192,10 @@ mod tests {
         Bytes::from(s.as_bytes().to_vec())
     }
 
+    fn default_timestamp() -> [u8; 8] {
+        crate::codec::encode_timestamp(crate::clock::st_from_unix_epoch(1_000_000))
+    }
+
     async fn insert_ave(
         slate: &slatedb::Db,
         attribute: i64,
@@ -194,6 +206,7 @@ mod tests {
         key.extend_from_slice(&bincode::serialize(&attribute)?);
         key.extend_from_slice(&value);
         key.extend_from_slice(&bincode::serialize(&DataType::Long(entity))?);
+        key.extend_from_slice(&default_timestamp());
         key.push(crate::codec::ADD);
 
         slate.put(&key, b"dummy_value").await?;
@@ -204,6 +217,7 @@ mod tests {
         let mut key = vec![crate::codec::AV];
         key.extend_from_slice(&bincode::serialize(&attribute)?);
         key.extend_from_slice(&value);
+        key.extend_from_slice(&default_timestamp());
         key.push(crate::codec::ADD);
 
         slate.put(&key, b"dummy_value").await?;
@@ -223,6 +237,7 @@ mod tests {
             42,
             vec![],
             vec![0, 1],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         assert!(extender.participates_in_level(0));
@@ -249,6 +264,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         let count = extender.count(&vec![]);
@@ -276,6 +292,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         let values = extender.propose(&vec![]);
@@ -306,6 +323,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0, 1],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         let values = extender.propose(&vec![]);
@@ -336,6 +354,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         let candidates = vec![
@@ -380,6 +399,7 @@ mod tests {
             attr_name,
             value_bytes.to_vec(),
             vec![0],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         let proposed = extender.propose(&vec![]);
@@ -405,6 +425,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
+            crate::clock::st_from_unix_epoch(2_000_000),
         );
 
         // Note: estimate_key_count may return non-zero even for empty ranges

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -10,7 +10,7 @@ use crate::codec::index_type_to_prefix;
 use crate::index::IndexType;
 use crate::util::make_extractor;
 
-use super::slate_iterator::{Extractor, Index};
+use super::slate_iterator::{Extractor, Index, SlateIterator};
 use super::temporal_filter_iterator::TemporalFilterIterator;
 
 /// GenericPrefixExtender implements PrefixExtender using SlateDB with byte prefixes.
@@ -60,7 +60,8 @@ impl GenericPrefixExtender {
     /// Build SlateDB key prefix from join prefix
     ///
     /// Selects index type based on join depth and constructs the appropriate byte prefix.
-    fn build_slate_prefix(&self, join_prefix: &Prefix) -> Result<Bytes, Error> {
+    /// Returns both the prefix bytes and the resolved index type.
+    fn build_slate_prefix(&self, join_prefix: &Prefix) -> Result<(Bytes, IndexType), Error> {
         let pattern_level = self.pattern_level(join_prefix);
         let index_type = self.index_types[pattern_level];
         let codec = index_type_to_prefix(index_type)?;
@@ -76,7 +77,39 @@ impl GenericPrefixExtender {
             key.extend_from_slice(&join_prefix[level]);
         }
 
-        Ok(Bytes::from(key))
+        Ok((Bytes::from(key), index_type))
+    }
+
+    /// Create the appropriate iterator for the given prefix and index type.
+    ///
+    /// AE/AV are atemporal indices — use SlateIterator (no temporal filtering).
+    /// Full indices (EAV, AVE, AEV) — use TemporalFilterIterator.
+    fn create_iterator(
+        &self,
+        slate_prefix: &Bytes,
+        index_type: IndexType,
+        extractor: Extractor,
+    ) -> Box<dyn Index> {
+        match index_type {
+            IndexType::AE | IndexType::AV => {
+                Box::new(
+                    SlateIterator::new(slate_prefix, self.slate.as_ref(), self.handle.clone(), extractor)
+                        .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e)),
+                )
+            }
+            _ => {
+                Box::new(
+                    TemporalFilterIterator::new(
+                        slate_prefix,
+                        self.slate.as_ref(),
+                        self.handle.clone(),
+                        extractor,
+                        self.as_of,
+                    )
+                    .unwrap_or_else(|e| panic!("Failed to create TemporalFilterIterator: {}", e)),
+                )
+            }
+        }
     }
 
     /// Create an extractor function for the current index type and position.
@@ -99,38 +132,23 @@ impl GenericPrefixExtender {
 impl PrefixExtender for GenericPrefixExtender {
     fn count(&self, join_prefix: &Prefix) -> usize {
         // TODO: proper error handling
-        let slate_prefix = self
+        let (slate_prefix, index_type) = self
             .build_slate_prefix(join_prefix)
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let iter = TemporalFilterIterator::new(
-            &slate_prefix,
-            self.slate.as_ref(),
-            self.handle.clone(),
-            extractor,
-            self.as_of,
-        )
-        .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
-
+        let iter = self.create_iterator(&slate_prefix, index_type, extractor);
         iter.count().unwrap_or(0) as usize
     }
 
     fn propose(&self, join_prefix: &Prefix) -> Vec<Extension> {
         // TODO: proper error handling
-        let slate_prefix = self
+        let (slate_prefix, index_type) = self
             .build_slate_prefix(join_prefix)
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let mut iter = TemporalFilterIterator::new(
-            &slate_prefix,
-            self.slate.as_ref(),
-            self.handle.clone(),
-            extractor,
-            self.as_of,
-        )
-        .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
+        let mut iter = self.create_iterator(&slate_prefix, index_type, extractor);
 
         let mut extensions = Vec::new();
         while let Ok(Some(extension)) = iter.get_value() {
@@ -144,19 +162,12 @@ impl PrefixExtender for GenericPrefixExtender {
 
     fn intersect(&self, join_prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
         // TODO: proper error handling
-        let slate_prefix = self
+        let (slate_prefix, index_type) = self
             .build_slate_prefix(join_prefix)
             .unwrap_or_else(|e| panic!("Failed to build slate prefix: {}", e));
         let extractor = self.make_extractor_fn(join_prefix);
 
-        let mut iter = TemporalFilterIterator::new(
-            &slate_prefix,
-            self.slate.as_ref(),
-            self.handle.clone(),
-            extractor,
-            self.as_of,
-        )
-        .unwrap_or_else(|e| panic!("Failed to create SlateIterator: {}", e));
+        let mut iter = self.create_iterator(&slate_prefix, index_type, extractor);
 
         let mut result = Vec::new();
         for ext in extensions {
@@ -214,11 +225,10 @@ mod tests {
     }
 
     async fn insert_av(slate: &slatedb::Db, attribute: i64, value: Bytes) -> anyhow::Result<()> {
+        // AV is atemporal — no timestamp or op suffix
         let mut key = vec![crate::codec::AV];
         key.extend_from_slice(&bincode::serialize(&attribute)?);
         key.extend_from_slice(&value);
-        key.extend_from_slice(&default_timestamp());
-        key.push(crate::codec::ADD);
 
         slate.put(&key, b"dummy_value").await?;
         Ok(())

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod generic_predicate_prefix_extender;
 pub(crate) mod generic_prefix_extender;
 mod prefix_extender;
 pub(crate) mod slate_iterator;
+pub(crate) mod temporal_filter_iterator;
 
 pub use generic_and_prefix_extender::GenericAndPrefixExtender;
 pub use generic_fn_prefix_extender::GenericFnPrefixExtender;

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -66,6 +66,20 @@ impl TemporalFilterIterator {
         Ok(iter)
     }
 
+    /// Seek the underlying iterator past a logical key group.
+    /// Returns true if the seek succeeded, false if no successor exists (all 0xFF).
+    fn seek_past_logical_key(&mut self, key: &[u8]) -> Result<bool, Error> {
+        // Assumes prefix-free value encodings
+        match next_prefix(logical_key(key)) {
+            Some(target) => {
+                self.handle
+                    .block_on(self.inner.seek(Bytes::from(target)))?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
     /// Advance the underlying iterator to the next key whose timestamp <= as_of,
     /// skipping entries newer than as_of and groups whose newest valid entry is a retraction.
     fn advance_to_next_valid(&mut self) -> Result<(), Error> {
@@ -92,10 +106,11 @@ impl TemporalFilterIterator {
                         // Check the op byte: if retracted, skip the entire group.
                         let op = key[key.len() - 1];
                         if op == codec::RETRACT {
-                            // Seek past this logical key group and find the next valid entry.
-                            // advance_past_current_group calls advance_to_next_valid internally.
-                            self.current_key = Some(key);
-                            return self.advance_past_current_group();
+                            if !self.seek_past_logical_key(&key)? {
+                                self.current_key = None;
+                                return Ok(());
+                            }
+                            continue;
                         }
                         self.current_key = Some(key);
                         return Ok(());
@@ -107,26 +122,18 @@ impl TemporalFilterIterator {
         }
     }
 
-    /// Seek the underlying iterator past all entries in the current logical key group.
+    /// Seek the underlying iterator past all entries in the current logical key group,
+    /// then advance to the next valid entry.
     fn advance_past_current_group(&mut self) -> Result<(), Error> {
         let current = match &self.current_key {
             Some(k) => k.clone(),
             None => return Ok(()),
         };
-
-        // Assumes prefix-free value encodings
-        match next_prefix(logical_key(&current)) {
-            Some(target) => {
-                self.handle
-                    .block_on(self.inner.seek(Bytes::from(target)))?;
-                self.advance_to_next_valid()
-            }
-            None => {
-                // Logical key is all 0xFF — no successor, we're done
-                self.current_key = None;
-                Ok(())
-            }
+        if !self.seek_past_logical_key(&current)? {
+            self.current_key = None;
+            return Ok(());
         }
+        self.advance_to_next_valid()
     }
 }
 

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -6,6 +6,7 @@ use tokio::runtime::Handle;
 use crate::clock::Instant;
 use crate::codec;
 use crate::slate::DEFAULT_SCAN_OPTIONS;
+use crate::util::next_prefix;
 
 use super::slate_iterator::{Extractor, Index};
 
@@ -77,9 +78,11 @@ impl TemporalFilterIterator {
                 }
                 Some(kv) => {
                     let key = kv.key;
-                    if key.len() < codec::TIMESTAMP_OP_SUFFIX {
-                        continue; // malformed key, skip
-                    }
+                    assert!(
+                        key.len() >= codec::TIMESTAMP_OP_SUFFIX,
+                        "Key too short ({} bytes) to contain timestamp + op suffix",
+                        key.len()
+                    );
 
                     let ts = timestamp_bytes(&key);
                     // Inverted encoding: smaller encoded bytes = newer real time.
@@ -97,75 +100,23 @@ impl TemporalFilterIterator {
         }
     }
 
-    /// Skip past all remaining entries in the current logical key group.
-    fn skip_current_group(&mut self) -> Result<(), Error> {
+    /// Seek the underlying iterator past all entries in the current logical key group.
+    fn advance_past_current_group(&mut self) -> Result<(), Error> {
         let current = match &self.current_key {
             Some(k) => k.clone(),
             None => return Ok(()),
         };
-        let current_logical = logical_key(&current).to_vec();
 
-        loop {
-            let entry = self.handle.block_on(self.inner.next())?;
-            match entry {
-                None => {
-                    self.current_key = None;
-                    return Ok(());
-                }
-                Some(kv) => {
-                    if kv.key.len() < codec::TIMESTAMP_OP_SUFFIX {
-                        continue; // malformed, skip
-                    }
-                    if logical_key(&kv.key) != current_logical.as_slice() {
-                        // New group — check if this entry is valid
-                        let ts = timestamp_bytes(&kv.key);
-                        if ts >= &self.as_of_encoded[..] {
-                            self.current_key = Some(kv.key);
-                            return Ok(());
-                        }
-                        // New group but this entry is too new — continue scanning
-                        // We need to find a valid entry in this or subsequent groups
-                        return self.advance_to_next_valid_from(kv.key);
-                    }
-                    // Same group — skip
-                }
+        match next_prefix(logical_key(&current)) {
+            Some(target) => {
+                self.handle
+                    .block_on(self.inner.seek(Bytes::from(target)))?;
+                self.advance_to_next_valid()
             }
-        }
-    }
-
-    /// Continue scanning from a key that started a new group but wasn't valid itself.
-    fn advance_to_next_valid_from(&mut self, start_key: Bytes) -> Result<(), Error> {
-        let start_logical = logical_key(&start_key).to_vec();
-
-        loop {
-            let entry = self.handle.block_on(self.inner.next())?;
-            match entry {
-                None => {
-                    self.current_key = None;
-                    return Ok(());
-                }
-                Some(kv) => {
-                    if kv.key.len() < codec::TIMESTAMP_OP_SUFFIX {
-                        continue;
-                    }
-                    let ts = timestamp_bytes(&kv.key);
-                    let is_same_group = logical_key(&kv.key) == start_logical.as_slice();
-
-                    if is_same_group && ts >= &self.as_of_encoded[..] {
-                        // Found a valid entry in this group
-                        self.current_key = Some(kv.key);
-                        return Ok(());
-                    } else if !is_same_group {
-                        // Moved to a new group
-                        if ts >= &self.as_of_encoded[..] {
-                            self.current_key = Some(kv.key);
-                            return Ok(());
-                        }
-                        // New group, entry too new — recurse with new group
-                        return self.advance_to_next_valid_from(kv.key);
-                    }
-                    // Same group, entry too new — keep scanning
-                }
+            None => {
+                // Logical key is all 0xFF — no successor, we're done
+                self.current_key = None;
+                Ok(())
             }
         }
     }
@@ -198,8 +149,8 @@ impl Index for TemporalFilterIterator {
     }
 
     fn next(&mut self) -> Result<Option<Bytes>, Error> {
-        // Skip rest of current group, then find next valid entry
-        self.skip_current_group()?;
+        // Seek past current group, then find next valid entry
+        self.advance_past_current_group()?;
         match &self.current_key {
             Some(key) => Ok(Some((self.extractor)(key.clone()))),
             None => Ok(None),

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -49,7 +49,7 @@ impl TemporalFilterIterator {
     ) -> Result<Self, Error> {
         let prefix_bytes = Bytes::from(prefix.to_vec());
         let as_of_encoded = codec::encode_timestamp(as_of);
-        let mut iterator =
+        let iterator =
             handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
 
         let mut iter = Self {

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -1,0 +1,390 @@
+use bytes::Bytes;
+
+use anyhow::Error;
+use tokio::runtime::Handle;
+
+use crate::clock::Instant;
+use crate::codec;
+use crate::slate::DEFAULT_SCAN_OPTIONS;
+
+use super::slate_iterator::{Extractor, Index};
+
+/// An iterator that wraps a SlateDB prefix scan and resolves temporal versions.
+///
+/// Keys are expected to have the layout: `[prefix...][data...][T:8][op:1]`
+/// where T is an inverted big-endian timestamp (newest first in sort order).
+///
+/// For each distinct logical key (everything except T and op), emits only the
+/// most recent version whose real timestamp <= `as_of`.
+///
+/// TODO(triplox-28q): Add a history mode option that iterates over all history
+/// <= `as_of` including retractions, rather than resolving to current state.
+pub(crate) struct TemporalFilterIterator {
+    inner: slatedb::DbIterator,
+    current_key: Option<Bytes>,
+    prefix: Bytes,
+    handle: Handle,
+    extractor: Extractor,
+    as_of_encoded: [u8; 8],
+}
+
+/// Extract the logical key from a full key (everything except timestamp + op suffix).
+fn logical_key(key: &[u8]) -> &[u8] {
+    &key[..key.len() - codec::TIMESTAMP_OP_SUFFIX]
+}
+
+/// Extract the encoded timestamp bytes from a full key.
+fn timestamp_bytes(key: &[u8]) -> &[u8] {
+    &key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]
+}
+
+impl TemporalFilterIterator {
+    pub fn new(
+        prefix: &[u8],
+        slate: &slatedb::DbSnapshot,
+        handle: Handle,
+        extractor: Extractor,
+        as_of: Instant,
+    ) -> Result<Self, Error> {
+        let prefix_bytes = Bytes::from(prefix.to_vec());
+        let as_of_encoded = codec::encode_timestamp(as_of);
+        let mut iterator =
+            handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
+
+        let mut iter = Self {
+            inner: iterator,
+            current_key: None,
+            prefix: prefix_bytes,
+            handle,
+            extractor,
+            as_of_encoded,
+        };
+
+        // Advance to the first valid entry
+        iter.advance_to_next_valid()?;
+        Ok(iter)
+    }
+
+    /// Advance the underlying iterator to the next key whose timestamp <= as_of,
+    /// resolving temporal groups (skip newer entries and duplicates).
+    fn advance_to_next_valid(&mut self) -> Result<(), Error> {
+        loop {
+            let entry = self.handle.block_on(self.inner.next())?;
+            match entry {
+                None => {
+                    self.current_key = None;
+                    return Ok(());
+                }
+                Some(kv) => {
+                    let key = kv.key;
+                    if key.len() < codec::TIMESTAMP_OP_SUFFIX {
+                        continue; // malformed key, skip
+                    }
+
+                    let ts = timestamp_bytes(&key);
+                    // Inverted encoding: smaller encoded bytes = newer real time.
+                    // We want real_T <= as_of, i.e. encoded_T >= as_of_encoded.
+                    if ts >= &self.as_of_encoded[..] {
+                        // This is the newest valid entry for this logical key group.
+                        // Set it as current and skip remaining entries in this group.
+                        self.current_key = Some(key);
+                        return Ok(());
+                    }
+                    // ts < as_of_encoded means this entry is newer than as_of — skip it,
+                    // but we're still in the same or a new group, keep scanning.
+                }
+            }
+        }
+    }
+
+    /// Skip past all remaining entries in the current logical key group.
+    fn skip_current_group(&mut self) -> Result<(), Error> {
+        let current = match &self.current_key {
+            Some(k) => k.clone(),
+            None => return Ok(()),
+        };
+        let current_logical = logical_key(&current).to_vec();
+
+        loop {
+            let entry = self.handle.block_on(self.inner.next())?;
+            match entry {
+                None => {
+                    self.current_key = None;
+                    return Ok(());
+                }
+                Some(kv) => {
+                    if kv.key.len() < codec::TIMESTAMP_OP_SUFFIX {
+                        continue; // malformed, skip
+                    }
+                    if logical_key(&kv.key) != current_logical.as_slice() {
+                        // New group — check if this entry is valid
+                        let ts = timestamp_bytes(&kv.key);
+                        if ts >= &self.as_of_encoded[..] {
+                            self.current_key = Some(kv.key);
+                            return Ok(());
+                        }
+                        // New group but this entry is too new — continue scanning
+                        // We need to find a valid entry in this or subsequent groups
+                        return self.advance_to_next_valid_from(kv.key);
+                    }
+                    // Same group — skip
+                }
+            }
+        }
+    }
+
+    /// Continue scanning from a key that started a new group but wasn't valid itself.
+    fn advance_to_next_valid_from(&mut self, start_key: Bytes) -> Result<(), Error> {
+        let start_logical = logical_key(&start_key).to_vec();
+
+        loop {
+            let entry = self.handle.block_on(self.inner.next())?;
+            match entry {
+                None => {
+                    self.current_key = None;
+                    return Ok(());
+                }
+                Some(kv) => {
+                    if kv.key.len() < codec::TIMESTAMP_OP_SUFFIX {
+                        continue;
+                    }
+                    let ts = timestamp_bytes(&kv.key);
+                    let is_same_group = logical_key(&kv.key) == start_logical.as_slice();
+
+                    if is_same_group && ts >= &self.as_of_encoded[..] {
+                        // Found a valid entry in this group
+                        self.current_key = Some(kv.key);
+                        return Ok(());
+                    } else if !is_same_group {
+                        // Moved to a new group
+                        if ts >= &self.as_of_encoded[..] {
+                            self.current_key = Some(kv.key);
+                            return Ok(());
+                        }
+                        // New group, entry too new — recurse with new group
+                        return self.advance_to_next_valid_from(kv.key);
+                    }
+                    // Same group, entry too new — keep scanning
+                }
+            }
+        }
+    }
+}
+
+impl Index for TemporalFilterIterator {
+    fn count(&self) -> Result<u64, Error> {
+        // TODO: proper count estimation
+        Ok(100)
+    }
+
+    fn seek(&mut self, extension: Bytes) -> Result<(), Error> {
+        let mut full_key = self.prefix.to_vec();
+        full_key.extend_from_slice(&extension);
+        let full_key = Bytes::from(full_key);
+
+        // Skip forward if already past the target
+        match &self.current_key {
+            Some(current) => {
+                let current_logical = logical_key(current);
+                if current_logical >= full_key.as_ref() {
+                    return Ok(());
+                }
+            }
+            _ => {}
+        }
+
+        self.handle.block_on(self.inner.seek(full_key))?;
+        self.advance_to_next_valid()
+    }
+
+    fn next(&mut self) -> Result<Option<Bytes>, Error> {
+        // Skip rest of current group, then find next valid entry
+        self.skip_current_group()?;
+        match &self.current_key {
+            Some(key) => Ok(Some((self.extractor)(key.clone()))),
+            None => Ok(None),
+        }
+    }
+
+    fn get_value(&self) -> Result<Option<Bytes>, Error> {
+        match &self.current_key {
+            Some(key) => Ok(Some((self.extractor)(key.clone()))),
+            None => Ok(None),
+        }
+    }
+
+    fn has_next(&self) -> bool {
+        self.current_key.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::st_from_unix_epoch;
+    use crate::slate::in_memory_slate;
+
+    const PFX: &[u8] = b"\x04"; // AV prefix
+
+    fn make_key(prefix: &[u8], data: &[u8], time: Instant, op: u8) -> Vec<u8> {
+        let mut key = prefix.to_vec();
+        key.extend_from_slice(data);
+        key.extend_from_slice(&codec::encode_timestamp(time));
+        key.push(op);
+        key
+    }
+
+    fn make_test_extractor(prefix_len: usize) -> Extractor {
+        Box::new(move |key: Bytes| {
+            key.slice(prefix_len..key.len() - codec::TIMESTAMP_OP_SUFFIX)
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_single_version() {
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+            ).unwrap();
+
+            assert!(iter.has_next());
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_skips_future() {
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+        let t2 = st_from_unix_epoch(2_000_000);
+
+        // Two versions of "alice" at t1 and t2
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            // Query as-of t1 — should see alice (t2 is in the future)
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snapshot, handle, extractor, t1,
+            ).unwrap();
+
+            assert!(iter.has_next());
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_before_all() {
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(2_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            // Query as-of before t1 — should see nothing
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
+            ).unwrap();
+
+            assert!(!iter.has_next());
+            assert_eq!(iter.get_value().unwrap(), None);
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_multiple_logical_keys() {
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+        let t2 = st_from_unix_epoch(2_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"bob", t2, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
+            ).unwrap();
+
+            // Should see alice and bob (deduplicated)
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+            iter.next().unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_add_add_cycle() {
+        // Same (E, A, V) added at T1 and T2.
+        // Query as-of T1 sees it once, as-of T2 sees it once, as-of T0 sees nothing.
+        let slate = in_memory_slate().await;
+        let t0 = st_from_unix_epoch(500_000);
+        let t1 = st_from_unix_epoch(1_000_000);
+        let t2 = st_from_unix_epoch(2_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+
+        // as-of T0: nothing
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t0,
+            ).unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+
+        // as-of T1: alice once
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t1,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+
+        // as-of T2: alice once (deduplicated)
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t2,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+    }
+}

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -114,6 +114,7 @@ impl TemporalFilterIterator {
             None => return Ok(()),
         };
 
+        // Assumes prefix-free value encodings
         match next_prefix(logical_key(&current)) {
             Some(target) => {
                 self.handle

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -67,7 +67,7 @@ impl TemporalFilterIterator {
     }
 
     /// Advance the underlying iterator to the next key whose timestamp <= as_of,
-    /// resolving temporal groups (skip newer entries and duplicates).
+    /// skipping entries newer than as_of.
     fn advance_to_next_valid(&mut self) -> Result<(), Error> {
         loop {
             let entry = self.handle.block_on(self.inner.next())?;

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -149,14 +149,11 @@ impl Index for TemporalFilterIterator {
         let full_key = Bytes::from(full_key);
 
         // Skip forward if already past the target
-        match &self.current_key {
-            Some(current) => {
-                let current_logical = logical_key(current);
-                if current_logical >= full_key.as_ref() {
-                    return Ok(());
-                }
+        if let Some(current) = &self.current_key {
+            let current_logical = logical_key(current);
+            if current_logical >= full_key.as_ref() {
+                return Ok(());
             }
-            _ => {}
         }
 
         self.handle.block_on(self.inner.seek(full_key))?;

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -67,7 +67,7 @@ impl TemporalFilterIterator {
     }
 
     /// Advance the underlying iterator to the next key whose timestamp <= as_of,
-    /// skipping entries newer than as_of.
+    /// skipping entries newer than as_of and groups whose newest valid entry is a retraction.
     fn advance_to_next_valid(&mut self) -> Result<(), Error> {
         loop {
             let entry = self.handle.block_on(self.inner.next())?;
@@ -89,7 +89,14 @@ impl TemporalFilterIterator {
                     // We want real_T <= as_of, i.e. encoded_T >= as_of_encoded.
                     if ts >= &self.as_of_encoded[..] {
                         // This is the newest valid entry for this logical key group.
-                        // Set it as current and skip remaining entries in this group.
+                        // Check the op byte: if retracted, skip the entire group.
+                        let op = key[key.len() - 1];
+                        if op == codec::RETRACT {
+                            // Seek past this logical key group and find the next valid entry.
+                            // advance_past_current_group calls advance_to_next_valid internally.
+                            self.current_key = Some(key);
+                            return self.advance_past_current_group();
+                        }
                         self.current_key = Some(key);
                         return Ok(());
                     }
@@ -336,6 +343,99 @@ mod tests {
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
             assert!(!iter.has_next());
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_retraction_skips_group() {
+        // "alice" added at T1, retracted at T2. "bob" added at T1.
+        // As-of T1: see alice and bob.
+        // As-of T2: only bob (alice retracted).
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+        let t2 = st_from_unix_epoch(2_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
+        slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+
+        // as-of T1: alice and bob
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t1,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+            iter.next().unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+
+        // as-of T2: only bob (alice retracted)
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t2,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_retraction_then_re_add() {
+        // "alice" added at T1, retracted at T2, re-added at T3.
+        // As-of T2: not visible. As-of T3: visible again.
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+        let t2 = st_from_unix_epoch(2_000_000);
+        let t3 = st_from_unix_epoch(3_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
+        slate.put(&make_key(PFX, b"alice", t3, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+
+        // as-of T1: alice visible
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t1,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+        }).await.unwrap();
+
+        // as-of T2: alice retracted
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t2,
+            ).unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+
+        // as-of T3: alice visible again
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t3,
+            ).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         }).await.unwrap();
     }
 }

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -301,6 +301,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_add_add_cycle() {
+        // TODO: update to add_retract_add cycle
         // Same (E, A, V) added at T1 and T2.
         // Query as-of T1 sees it once, as-of T2 sees it once, as-of T0 sees nothing.
         let slate = in_memory_slate().await;
@@ -346,6 +347,43 @@ mod tests {
                 PFX, &snap, handle, extractor, t2,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+            iter.next().unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_temporal_filter_seek() {
+        // Three logical keys: alice, bob, charlie at T1.
+        // Seek to "bob" should land on bob, then next gives charlie.
+        let slate = in_memory_slate().await;
+        let t1 = st_from_unix_epoch(1_000_000);
+
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"charlie", t1, codec::ADD), b"").await;
+
+        let snapshot = slate.snapshot().await.unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let mut iter = TemporalFilterIterator::new(
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+            ).unwrap();
+
+            // Initially at alice
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
+
+            // Seek to bob
+            iter.seek(Bytes::from("bob")).unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
+
+            // Next gives charlie
+            iter.next().unwrap();
+            assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("charlie")));
+
+            // No more
             iter.next().unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -77,9 +77,10 @@ impl Database for DB {
         let handle = self.handle.clone();
         let attribute_map = self.attribute_map.clone();
         let query = query.clone();
+        let as_of = self.basis.tx_key.system_time;
 
         tokio::task::spawn_blocking(move || {
-            execute_query(&query, snapshot, handle, &attribute_map)
+            execute_query(&query, snapshot, handle, &attribute_map, as_of)
         })
         .await
         .map_err(|e| anyhow::anyhow!("Query task failed: {}", e))?
@@ -237,7 +238,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(value, DataType::String("alice".to_string()));
@@ -253,7 +254,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AVE], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, value, entity_id, suffix) = ave_key_to_parts(kv.key).unwrap();
+            let (attribute, value, entity_id, _timestamp, suffix) = ave_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(value, DataType::String("alice".to_string()));
@@ -268,7 +269,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AEV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, entity_id, value, suffix) = aev_key_to_parts(kv.key).unwrap();
+            let (attribute, entity_id, value, _timestamp, suffix) = aev_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(value, DataType::String("alice".to_string()));
@@ -283,7 +284,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AE], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, entity_id, suffix) = ae_key_to_parts(kv.key).unwrap();
+            let (attribute, entity_id, _timestamp, suffix) = ae_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(suffix, codec::ADD);
@@ -297,7 +298,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, value, suffix) = av_key_to_parts(kv.key).unwrap();
+            let (attribute, value, _timestamp, suffix) = av_key_to_parts(kv.key).unwrap();
             if attribute == name_id && value == DataType::String("alice".to_string()) {
                 assert_eq!(suffix, codec::ADD);
                 found = true;
@@ -335,7 +336,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
                 assert_eq!(value, DataType::String("bob".to_string()));
@@ -371,7 +372,7 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, email_id);
                 assert_eq!(value, DataType::String("test@example.com".to_string()));

--- a/src/node.rs
+++ b/src/node.rs
@@ -284,10 +284,9 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AE], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, entity_id, _timestamp, suffix) = ae_key_to_parts(kv.key).unwrap();
+            let (attribute, entity_id) = ae_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(100) {
                 assert_eq!(attribute, name_id);
-                assert_eq!(suffix, codec::ADD);
                 found = true;
                 break;
             }
@@ -298,9 +297,8 @@ mod tests {
         let mut iter = slate.scan_prefix_with_options(&[codec::AV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (attribute, value, _timestamp, suffix) = av_key_to_parts(kv.key).unwrap();
+            let (attribute, value) = av_key_to_parts(kv.key).unwrap();
             if attribute == name_id && value == DataType::String("alice".to_string()) {
-                assert_eq!(suffix, codec::ADD);
                 found = true;
                 break;
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,6 +7,7 @@ use anyhow::Error;
 use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple};
+use crate::clock::Instant;
 use crate::datalog::{
     FindElement, FindSpec, FnExpr, OrBranch, PatternClause, PatternElement, Query, TriplePattern,
     Variable, WhereClause,
@@ -343,6 +344,7 @@ pub fn compile_pattern(
     attribute_id: i64,
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
+    as_of: Instant,
 ) -> Result<GenericPrefixExtender, Error> {
     let pattern_clause = PatternClause::from(pattern.clone());
     let pattern_vars = pattern_clause.variables();
@@ -371,6 +373,7 @@ pub fn compile_pattern(
         attribute_id,
         constant_prefix,
         participating_levels,
+        as_of,
     ))
 }
 
@@ -475,15 +478,16 @@ fn compile_or_branch(
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
     attribute_map: &HashMap<String, i64>,
+    as_of: Instant,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match branch {
         OrBranch::Clause(clause) => {
-            compile_where_clause(clause, join_order, var_index, slate, handle, attribute_map)
+            compile_where_clause(clause, join_order, var_index, slate, handle, attribute_map, as_of)
         }
         OrBranch::And(children) => {
             let extenders: Vec<Box<dyn PrefixExtender>> = children
                 .iter()
-                .map(|c| compile_where_clause(c, join_order, var_index, slate, handle, attribute_map))
+                .map(|c| compile_where_clause(c, join_order, var_index, slate, handle, attribute_map, as_of))
                 .collect::<Result<_, _>>()?;
             Ok(Box::new(GenericAndPrefixExtender::new(extenders)))
         }
@@ -498,6 +502,7 @@ fn compile_where_clause(
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
     attribute_map: &HashMap<String, i64>,
+    as_of: Instant,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match clause {
         WhereClause::Triple(pattern) => {
@@ -509,13 +514,14 @@ fn compile_where_clause(
                 attr_id,
                 slate.clone(),
                 handle.clone(),
+                as_of,
             )?;
             Ok(Box::new(extender))
         }
         WhereClause::Or(branches) => {
             let children: Vec<Box<dyn PrefixExtender>> = branches
                 .iter()
-                .map(|b| compile_or_branch(b, join_order, var_index, slate, handle, attribute_map))
+                .map(|b| compile_or_branch(b, join_order, var_index, slate, handle, attribute_map, as_of))
                 .collect::<Result<_, _>>()?;
             Ok(Box::new(GenericOrPrefixExtender::new(children)))
         }
@@ -523,7 +529,7 @@ fn compile_where_clause(
             let children: Vec<Box<dyn PrefixExtender>> = inner_clauses
                 .iter()
                 .map(|c| {
-                    compile_where_clause(c, join_order, var_index, slate, handle, attribute_map)
+                    compile_where_clause(c, join_order, var_index, slate, handle, attribute_map, as_of)
                 })
                 .collect::<Result<_, _>>()?;
             let not_level = var_index.len() - 1;
@@ -544,6 +550,7 @@ pub fn execute_query(
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
     attribute_map: &HashMap<String, i64>,
+    as_of: Instant,
 ) -> Result<QueryResult, Error> {
     // 1. Extract variable order
     let join_order = query_variable_order(&query.where_clauses);
@@ -561,6 +568,7 @@ pub fn execute_query(
             &slate,
             &handle,
             attribute_map,
+            as_of,
         )?);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -393,6 +393,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
     validate_query(&query).expect("Schema query validation failed");
 
     let results = tokio::task::spawn_blocking(move || {
+        // TODO: use the latest submitted system_time instead of Utc::now() for consistency
         execute_query(&query, snapshot, handle, &attribute_map, chrono::Utc::now())
     })
     .await

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -393,7 +393,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
     validate_query(&query).expect("Schema query validation failed");
 
     let results = tokio::task::spawn_blocking(move || {
-        execute_query(&query, snapshot, handle, &attribute_map)
+        execute_query(&query, snapshot, handle, &attribute_map, chrono::Utc::now())
     })
     .await
     .expect("Schema query task failed")

--- a/src/util.rs
+++ b/src/util.rs
@@ -140,6 +140,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                     total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
+            // AE/AV are atemporal — no T+op suffix
             IndexType::AE => match position {
                 0 => (
                     codec::CODEC_LENGTH,
@@ -147,7 +148,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length,
                 ),
             },
             IndexType::AV => match position {
@@ -157,7 +158,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length,
                 ),
             },
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -211,3 +211,19 @@ pub fn extract_prefix<T: GetSlice + AsRef<[u8]>>(bytes: T, position: usize, inde
     prefix_extractor(position, index)(bytes)
 }
 
+/// Compute the lexicographic successor of a byte string.
+/// Returns None if all bytes are 0xFF (no successor exists).
+///
+/// Note: this duplicates `BytesRange::increment_prefix` in SlateDB
+/// (`slatedb/src/bytes_range.rs`), which is not publicly exposed.
+pub fn next_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut next = prefix.to_vec();
+    for i in (0..next.len()).rev() {
+        if next[i] < 0xFF {
+            next[i] += 1;
+            next.truncate(i + 1);
+            return Some(next);
+        }
+    }
+    None
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,7 +109,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 2.. => (
                     codec::CODEC_LENGTH + codec::ENTITY_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::OP_LENGTH,
+                    total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
             IndexType::AVE => match position {
@@ -119,11 +119,11 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1 => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::ENTITY_LENGTH - codec::OP_LENGTH,
+                    total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
                 ),
                 2.. => (
-                    total_length - codec::ENTITY_LENGTH - codec::OP_LENGTH,
-                    total_length - codec::OP_LENGTH,
+                    total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
             IndexType::AEV => match position {
@@ -137,7 +137,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 2.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH + codec::ENTITY_LENGTH,
-                    total_length - codec::OP_LENGTH,
+                    total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
             IndexType::AE => match position {
@@ -147,7 +147,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::OP_LENGTH,
+                    total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
             IndexType::AV => match position {
@@ -157,7 +157,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::OP_LENGTH,
+                    total_length - codec::TIMESTAMP_OP_SUFFIX,
                 ),
             },
         };
@@ -187,7 +187,7 @@ pub fn prefix_extractor<T: GetSlice + AsRef<[u8]>>(
             IndexType::AVE => match position {
                 0 => codec::CODEC_LENGTH,
                 1 => codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                2.. => total_length - codec::ENTITY_LENGTH - codec::OP_LENGTH,
+                2.. => total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
             },
             IndexType::AEV => match position {
                 0 => codec::CODEC_LENGTH,
@@ -210,3 +210,4 @@ pub fn prefix_extractor<T: GetSlice + AsRef<[u8]>>(
 pub fn extract_prefix<T: GetSlice + AsRef<[u8]>>(bytes: T, position: usize, index: IndexType) -> T {
     prefix_extractor(position, index)(bytes)
 }
+


### PR DESCRIPTION
## Summary
- Embed inverted big-endian `system_time` timestamps into EAV, AVE, AEV index keys for MVCC-style history
- Make AE/AV indices atemporal — no timestamp or op suffix, no retraction entries
- Add `TemporalFilterIterator` that resolves newest version <= `as_of` per logical key group, with retraction resolution (skips retracted groups)
- Thread `as_of: Instant` through the full query pipeline (`execute_query` → `compile_pattern` → `GenericPrefixExtender`)
- `GenericPrefixExtender` dispatches to `SlateIterator` for AE/AV, `TemporalFilterIterator` for full indices

## Key design choices
- **Inverted timestamps** (`(!micros).to_be_bytes()`) — newest versions sort first in ascending byte order, enabling short-circuit on first valid match
- **Variable-length V handling** — T+op are fixed-width suffix (9 bytes), extracted from key end regardless of V length
- **Retraction resolution** — newest valid entry's op byte is checked; if RETRACT, the entire logical key group is skipped via seek
- **Atemporal partial indices** — AE/AV are purely additive, iterated with plain `SlateIterator`
- **TODO(triplox-28q)** — future history mode for iterating all changes <= `as_of` including retractions

## Test plan
- [x] All 279 lib tests pass (including updated key format tests)
- [x] All 11 integration tests pass
- [x] 8 new `TemporalFilterIterator` tests: single version, skip future, before-all, multiple logical keys, add+add cycle, seek, retraction skips group, retraction then re-add

🤖 Generated with [Claude Code](https://claude.com/claude-code)