### PR TITLE
feat: order-preserving storage encoding for index keys

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,8 +1,24 @@
 #![allow(dead_code)]
+use std::collections::BTreeMap;
+use std::fmt;
+
 use anyhow::Error;
+use chrono::{DateTime, Utc};
+use edn::symbols::Keyword;
+use uuid::Uuid;
 
 use crate::clock::Instant;
 use crate::index::IndexType;
+use crate::ops::DataType;
+use crate::protocol::{
+    data_type_tag, micros_to_datetime, TAG_BIG_INT, TAG_BOOLEAN, TAG_BYTES, TAG_DOUBLE,
+    TAG_FLOAT, TAG_INSTANT, TAG_KEYWORD, TAG_LONG, TAG_MAP, TAG_STRING, TAG_TUPLE, TAG_UUID,
+    TAG_VECTOR,
+};
+
+// ---------------------------------------------------------------------------
+// Existing constants
+// ---------------------------------------------------------------------------
 
 // TODO should this become 2 bytes?
 pub const INDEX_VERSION: u8 = 1;
@@ -33,6 +49,7 @@ pub const DELETE: u8 = 1;
 pub const RETRACT: u8 = 2;
 
 
+
 /// Suffix length: timestamp (8 bytes) + op (1 byte), used for end-of-key extraction.
 pub const TIMESTAMP_OP_SUFFIX: usize = TIMESTAMP_LENGTH + OP_LENGTH;
 
@@ -44,6 +61,997 @@ pub fn index_type_to_prefix(index_type: IndexType) -> Result<u8, Error> {
         IndexType::AEV => Ok(AEV),
         IndexType::AE => Ok(AE),
         IndexType::AV => Ok(AV),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodeError {
+    pub message: String,
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DecodeError: {}", self.message)
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+impl From<String> for DecodeError {
+    fn from(message: String) -> Self {
+        DecodeError { message }
+    }
+}
+
+impl From<&str> for DecodeError {
+    fn from(message: &str) -> Self {
+        DecodeError {
+            message: message.to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Traits
+// ---------------------------------------------------------------------------
+
+pub trait Encode {
+    fn encode(&self) -> Vec<u8>;
+}
+
+pub trait Decode: Sized {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError>;
+}
+
+// ---------------------------------------------------------------------------
+// Signed integers — XOR sign bit + big-endian
+// ---------------------------------------------------------------------------
+
+pub fn encode_i64(value: i64, buf: &mut Vec<u8>) {
+    let encoded = (value ^ i64::MIN).to_be_bytes();
+    buf.extend_from_slice(&encoded);
+}
+
+pub fn decode_i64(cursor: &mut &[u8]) -> Result<i64, DecodeError> {
+    if cursor.len() < 8 {
+        return Err("not enough bytes for i64".into());
+    }
+    let bytes: [u8; 8] = cursor[..8].try_into().unwrap();
+    *cursor = &cursor[8..];
+    Ok(i64::from_be_bytes(bytes) ^ i64::MIN)
+}
+
+pub fn encode_i128(value: i128, buf: &mut Vec<u8>) {
+    let encoded = (value ^ (1_i128 << 127)).to_be_bytes();
+    buf.extend_from_slice(&encoded);
+}
+
+pub fn decode_i128(cursor: &mut &[u8]) -> Result<i128, DecodeError> {
+    if cursor.len() < 16 {
+        return Err("not enough bytes for i128".into());
+    }
+    let bytes: [u8; 16] = cursor[..16].try_into().unwrap();
+    *cursor = &cursor[16..];
+    Ok(i128::from_be_bytes(bytes) ^ (1_i128 << 127))
+}
+
+// ---------------------------------------------------------------------------
+// Unsigned integers — big-endian
+// ---------------------------------------------------------------------------
+
+pub fn encode_u64(value: u64, buf: &mut Vec<u8>) {
+    buf.extend_from_slice(&value.to_be_bytes());
+}
+
+pub fn decode_u64(cursor: &mut &[u8]) -> Result<u64, DecodeError> {
+    if cursor.len() < 8 {
+        return Err("not enough bytes for u64".into());
+    }
+    let bytes: [u8; 8] = cursor[..8].try_into().unwrap();
+    *cursor = &cursor[8..];
+    Ok(u64::from_be_bytes(bytes))
+}
+
+// ---------------------------------------------------------------------------
+// Floating point — IEEE 754 sortable encoding
+// ---------------------------------------------------------------------------
+
+pub fn encode_f64(value: f64, buf: &mut Vec<u8>) {
+    let bits = value.to_bits();
+    let sign_mask: u64 = 0x8000_0000_0000_0000;
+    let sortable = if bits & sign_mask != 0 {
+        !bits
+    } else {
+        bits ^ sign_mask
+    };
+    buf.extend_from_slice(&sortable.to_be_bytes());
+}
+
+pub fn decode_f64(cursor: &mut &[u8]) -> Result<f64, DecodeError> {
+    if cursor.len() < 8 {
+        return Err("not enough bytes for f64".into());
+    }
+    let bytes: [u8; 8] = cursor[..8].try_into().unwrap();
+    *cursor = &cursor[8..];
+    let sortable = u64::from_be_bytes(bytes);
+    let sign_mask: u64 = 0x8000_0000_0000_0000;
+    let bits = if sortable & sign_mask != 0 {
+        sortable ^ sign_mask
+    } else {
+        !sortable
+    };
+    Ok(f64::from_bits(bits))
+}
+
+pub fn encode_f32(value: f32, buf: &mut Vec<u8>) {
+    let bits = value.to_bits();
+    let sign_mask: u32 = 0x8000_0000;
+    let sortable = if bits & sign_mask != 0 {
+        !bits
+    } else {
+        bits ^ sign_mask
+    };
+    buf.extend_from_slice(&sortable.to_be_bytes());
+}
+
+pub fn decode_f32(cursor: &mut &[u8]) -> Result<f32, DecodeError> {
+    if cursor.len() < 4 {
+        return Err("not enough bytes for f32".into());
+    }
+    let bytes: [u8; 4] = cursor[..4].try_into().unwrap();
+    *cursor = &cursor[4..];
+    let sortable = u32::from_be_bytes(bytes);
+    let sign_mask: u32 = 0x8000_0000;
+    let bits = if sortable & sign_mask != 0 {
+        sortable ^ sign_mask
+    } else {
+        !sortable
+    };
+    Ok(f32::from_bits(bits))
+}
+
+// ---------------------------------------------------------------------------
+// Booleans
+// ---------------------------------------------------------------------------
+
+pub fn encode_bool(value: bool, buf: &mut Vec<u8>) {
+    buf.push(if value { 0x01 } else { 0x00 });
+}
+
+pub fn decode_bool(cursor: &mut &[u8]) -> Result<bool, DecodeError> {
+    if cursor.is_empty() {
+        return Err("not enough bytes for bool".into());
+    }
+    let byte = cursor[0];
+    *cursor = &cursor[1..];
+    match byte {
+        0x00 => Ok(false),
+        0x01 => Ok(true),
+        _ => Err(format!("invalid bool byte: 0x{:02x}", byte).into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variable-length — escaped terminated encoding
+// ---------------------------------------------------------------------------
+
+pub fn encode_bytes(value: &[u8], buf: &mut Vec<u8>) {
+    for &b in value {
+        match b {
+            0x00 => {
+                buf.push(0x01);
+                buf.push(0x01);
+            }
+            0x01 => {
+                buf.push(0x01);
+                buf.push(0x02);
+            }
+            _ => buf.push(b),
+        }
+    }
+    buf.push(0x00); // terminator
+}
+
+pub fn decode_bytes(cursor: &mut &[u8]) -> Result<Vec<u8>, DecodeError> {
+    let mut result = Vec::new();
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input in bytes".into());
+        }
+        let b = cursor[0];
+        *cursor = &cursor[1..];
+        match b {
+            0x00 => return Ok(result),
+            0x01 => {
+                if cursor.is_empty() {
+                    return Err("unexpected end of input after escape byte".into());
+                }
+                let next = cursor[0];
+                *cursor = &cursor[1..];
+                match next {
+                    0x01 => result.push(0x00),
+                    0x02 => result.push(0x01),
+                    _ => {
+                        return Err(
+                            format!("invalid escape sequence: 0x01 0x{:02x}", next).into()
+                        );
+                    }
+                }
+            }
+            _ => result.push(b),
+        }
+    }
+}
+
+pub fn encode_string(value: &str, buf: &mut Vec<u8>) {
+    encode_bytes(value.as_bytes(), buf);
+}
+
+pub fn decode_string(cursor: &mut &[u8]) -> Result<String, DecodeError> {
+    let bytes = decode_bytes(cursor)?;
+    String::from_utf8(bytes).map_err(|e| format!("invalid UTF-8: {}", e).into())
+}
+
+// ---------------------------------------------------------------------------
+// Derived types
+// ---------------------------------------------------------------------------
+
+pub fn encode_instant(value: &DateTime<Utc>, buf: &mut Vec<u8>) {
+    encode_i64(value.timestamp_micros(), buf);
+}
+
+pub fn decode_instant(cursor: &mut &[u8]) -> Result<DateTime<Utc>, DecodeError> {
+    let micros = decode_i64(cursor)?;
+    micros_to_datetime(micros).map_err(|e| format!("invalid instant: {}", e).into())
+}
+
+pub fn encode_uuid(value: &Uuid, buf: &mut Vec<u8>) {
+    buf.extend_from_slice(value.as_bytes());
+}
+
+pub fn decode_uuid(cursor: &mut &[u8]) -> Result<Uuid, DecodeError> {
+    if cursor.len() < 16 {
+        return Err("not enough bytes for UUID".into());
+    }
+    let bytes: [u8; 16] = cursor[..16].try_into().unwrap();
+    *cursor = &cursor[16..];
+    Ok(Uuid::from_bytes(bytes))
+}
+
+pub fn encode_keyword(value: &Keyword, buf: &mut Vec<u8>) {
+    let ns = value.namespace().unwrap_or("");
+    encode_string(ns, buf);
+    encode_string(value.name(), buf);
+}
+
+pub fn decode_keyword(cursor: &mut &[u8]) -> Result<Keyword, DecodeError> {
+    let ns = decode_string(cursor)?;
+    let name = decode_string(cursor)?;
+    if ns.is_empty() {
+        Ok(Keyword::plain(name))
+    } else {
+        Ok(Keyword::namespaced(ns, name))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tagged DataType dispatch
+// ---------------------------------------------------------------------------
+
+pub fn encode_datatype(value: &DataType, buf: &mut Vec<u8>) {
+    buf.push(data_type_tag(value));
+    match value {
+        DataType::BigInt(v) => encode_i128(*v, buf),
+        DataType::Boolean(v) => encode_bool(*v, buf),
+        DataType::Bytes(v) => encode_bytes(v, buf),
+        DataType::Double(v) => encode_f64(*v, buf),
+        DataType::Float(v) => encode_f32(*v, buf),
+        DataType::Instant(v) => encode_instant(v, buf),
+        DataType::Keyword(v) => encode_keyword(v, buf),
+        DataType::Long(v) => encode_i64(*v, buf),
+        DataType::String(v) => encode_string(v, buf),
+        DataType::Tuple(v) => encode_composite(v, buf),
+        DataType::Uuid(v) => encode_uuid(v, buf),
+        DataType::Vector(v) => encode_composite(v, buf),
+        DataType::Map(v) => encode_map(v, buf),
+    }
+}
+
+fn encode_composite(elements: &[DataType], buf: &mut Vec<u8>) {
+    for elem in elements {
+        encode_datatype(elem, buf);
+    }
+    buf.push(0x00); // end-of-composite marker
+}
+
+fn encode_map(map: &BTreeMap<String, DataType>, buf: &mut Vec<u8>) {
+    for (key, value) in map {
+        buf.push(TAG_STRING);
+        encode_string(key, buf);
+        encode_datatype(value, buf);
+    }
+    buf.push(0x00); // end-of-composite marker
+}
+
+pub fn decode_datatype(cursor: &mut &[u8]) -> Result<DataType, DecodeError> {
+    if cursor.is_empty() {
+        return Err("unexpected end of input: expected type tag".into());
+    }
+    let tag = cursor[0];
+    *cursor = &cursor[1..];
+    decode_datatype_payload(tag, cursor)
+}
+
+fn decode_datatype_payload(tag: u8, cursor: &mut &[u8]) -> Result<DataType, DecodeError> {
+    match tag {
+        TAG_BIG_INT => Ok(DataType::BigInt(decode_i128(cursor)?)),
+        TAG_BOOLEAN => Ok(DataType::Boolean(decode_bool(cursor)?)),
+        TAG_BYTES => Ok(DataType::Bytes(decode_bytes(cursor)?)),
+        TAG_DOUBLE => Ok(DataType::Double(decode_f64(cursor)?)),
+        TAG_FLOAT => Ok(DataType::Float(decode_f32(cursor)?)),
+        TAG_INSTANT => Ok(DataType::Instant(decode_instant(cursor)?)),
+        TAG_KEYWORD => Ok(DataType::Keyword(decode_keyword(cursor)?)),
+        TAG_LONG => Ok(DataType::Long(decode_i64(cursor)?)),
+        TAG_STRING => Ok(DataType::String(decode_string(cursor)?)),
+        TAG_TUPLE => Ok(DataType::Tuple(decode_composite(cursor)?)),
+        TAG_UUID => Ok(DataType::Uuid(decode_uuid(cursor)?)),
+        TAG_VECTOR => Ok(DataType::Vector(decode_composite(cursor)?)),
+        TAG_MAP => Ok(DataType::Map(decode_map(cursor)?)),
+        _ => Err(format!("unknown type tag: 0x{:02x}", tag).into()),
+    }
+}
+
+fn decode_composite(cursor: &mut &[u8]) -> Result<Vec<DataType>, DecodeError> {
+    let mut elements = Vec::new();
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input in composite".into());
+        }
+        if cursor[0] == 0x00 {
+            *cursor = &cursor[1..]; // consume end marker
+            return Ok(elements);
+        }
+        elements.push(decode_datatype(cursor)?);
+    }
+}
+
+fn decode_map(cursor: &mut &[u8]) -> Result<BTreeMap<String, DataType>, DecodeError> {
+    let mut map = BTreeMap::new();
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input in map".into());
+        }
+        if cursor[0] == 0x00 {
+            *cursor = &cursor[1..]; // consume end marker
+            return Ok(map);
+        }
+        // Read key: expect TAG_STRING
+        let key_tag = cursor[0];
+        *cursor = &cursor[1..];
+        if key_tag != TAG_STRING {
+            return Err(format!("expected TAG_STRING for map key, got 0x{:02x}", key_tag).into());
+        }
+        let key = decode_string(cursor)?;
+        let value = decode_datatype(cursor)?;
+        map.insert(key, value);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// skip_datatype — advance cursor past one encoded DataType
+// ---------------------------------------------------------------------------
+
+pub fn skip_datatype(cursor: &mut &[u8]) -> Result<(), DecodeError> {
+    if cursor.is_empty() {
+        return Err("unexpected end of input: expected type tag".into());
+    }
+    let tag = cursor[0];
+    *cursor = &cursor[1..];
+    match tag {
+        TAG_BIG_INT => skip_n(cursor, 16),
+        TAG_BOOLEAN => skip_n(cursor, 1),
+        TAG_BYTES => skip_terminated(cursor),
+        TAG_DOUBLE => skip_n(cursor, 8),
+        TAG_FLOAT => skip_n(cursor, 4),
+        TAG_INSTANT => skip_n(cursor, 8),
+        TAG_KEYWORD => {
+            skip_terminated(cursor)?;
+            skip_terminated(cursor)
+        }
+        TAG_LONG => skip_n(cursor, 8),
+        TAG_STRING => skip_terminated(cursor),
+        TAG_UUID => skip_n(cursor, 16),
+        TAG_TUPLE | TAG_VECTOR => skip_composite(cursor),
+        TAG_MAP => skip_map(cursor),
+        _ => Err(format!("unknown type tag in skip: 0x{:02x}", tag).into()),
+    }
+}
+
+fn skip_n(cursor: &mut &[u8], n: usize) -> Result<(), DecodeError> {
+    if cursor.len() < n {
+        return Err("not enough bytes to skip".into());
+    }
+    *cursor = &cursor[n..];
+    Ok(())
+}
+
+fn skip_terminated(cursor: &mut &[u8]) -> Result<(), DecodeError> {
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input skipping terminated bytes".into());
+        }
+        let b = cursor[0];
+        *cursor = &cursor[1..];
+        match b {
+            0x00 => return Ok(()),
+            0x01 => {
+                if cursor.is_empty() {
+                    return Err("unexpected end of input after escape byte".into());
+                }
+                *cursor = &cursor[1..];
+            }
+            _ => {}
+        }
+    }
+}
+
+fn skip_composite(cursor: &mut &[u8]) -> Result<(), DecodeError> {
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input in composite".into());
+        }
+        if cursor[0] == 0x00 {
+            *cursor = &cursor[1..];
+            return Ok(());
+        }
+        skip_datatype(cursor)?;
+    }
+}
+
+fn skip_map(cursor: &mut &[u8]) -> Result<(), DecodeError> {
+    loop {
+        if cursor.is_empty() {
+            return Err("unexpected end of input in map".into());
+        }
+        if cursor[0] == 0x00 {
+            *cursor = &cursor[1..];
+            return Ok(());
+        }
+        skip_datatype(cursor)?; // key (TAG_STRING + terminated)
+        skip_datatype(cursor)?; // value
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait implementations on DataType
+// ---------------------------------------------------------------------------
+
+impl Encode for DataType {
+    fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        encode_datatype(self, &mut buf);
+        buf
+    }
+}
+
+impl Decode for DataType {
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut cursor = buf;
+        let result = decode_datatype(&mut cursor)?;
+        if !cursor.is_empty() {
+            return Err(format!(
+                "trailing bytes after decode: {} bytes remaining",
+                cursor.len()
+            )
+            .into());
+        }
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    // --- Spec value table tests ---
+
+    #[test]
+    fn i64_encoding_table() {
+        let cases: Vec<(i64, Vec<u8>)> = vec![
+            (i64::MIN, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            (-1, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (0, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            (1, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+            (i64::MAX, vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+        ];
+        for (value, expected) in cases {
+            let mut buf = Vec::new();
+            encode_i64(value, &mut buf);
+            assert_eq!(buf, expected, "i64 {} encoded incorrectly", value);
+        }
+    }
+
+    #[test]
+    fn bytes_encoding_table() {
+        let cases: Vec<(&[u8], Vec<u8>)> = vec![
+            (&[], vec![0x00]),
+            (b"hello", vec![b'h', b'e', b'l', b'l', b'o', 0x00]),
+            (&[0x00], vec![0x01, 0x01, 0x00]),
+            (&[0x01], vec![0x01, 0x02, 0x00]),
+            (&[0x00, 0x01], vec![0x01, 0x01, 0x01, 0x02, 0x00]),
+        ];
+        for (input, expected) in cases {
+            let mut buf = Vec::new();
+            encode_bytes(input, &mut buf);
+            assert_eq!(buf, expected, "bytes {:?} encoded incorrectly", input);
+        }
+    }
+
+    // --- Round-trip tests ---
+
+    #[test]
+    fn roundtrip_i64() {
+        for &v in &[i64::MIN, -1_000_000, -1, 0, 1, 1_000_000, i64::MAX] {
+            let mut buf = Vec::new();
+            encode_i64(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_i64(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_i128() {
+        for &v in &[i128::MIN, -1, 0, 1, i128::MAX] {
+            let mut buf = Vec::new();
+            encode_i128(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_i128(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_u64() {
+        for &v in &[0u64, 1, u64::MAX / 2, u64::MAX] {
+            let mut buf = Vec::new();
+            encode_u64(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_u64(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_f64() {
+        for &v in &[f64::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f64::INFINITY, f64::NAN] {
+            let mut buf = Vec::new();
+            encode_f64(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            let decoded = decode_f64(&mut cursor).unwrap();
+            if v.is_nan() {
+                assert!(decoded.is_nan());
+            } else {
+                assert_eq!(decoded.to_bits(), v.to_bits(), "f64 {} round-trip failed", v);
+            }
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_f32() {
+        for &v in &[f32::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f32::INFINITY, f32::NAN] {
+            let mut buf = Vec::new();
+            encode_f32(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            let decoded = decode_f32(&mut cursor).unwrap();
+            if v.is_nan() {
+                assert!(decoded.is_nan());
+            } else {
+                assert_eq!(decoded.to_bits(), v.to_bits(), "f32 {} round-trip failed", v);
+            }
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_bool() {
+        for &v in &[false, true] {
+            let mut buf = Vec::new();
+            encode_bool(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_bool(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_bytes() {
+        let cases: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![0x00],
+            vec![0x01],
+            vec![0x00, 0x01, 0x02, 0xFF],
+            b"hello world".to_vec(),
+        ];
+        for input in cases {
+            let mut buf = Vec::new();
+            encode_bytes(&input, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_bytes(&mut cursor).unwrap(), input);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_string() {
+        for v in &["", "hello", "hello world", "\u{1F600}", "abc\x00def"] {
+            let mut buf = Vec::new();
+            encode_string(v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_string(&mut cursor).unwrap(), *v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_instant() {
+        let instants = vec![
+            Utc.timestamp_opt(0, 0).unwrap(),
+            Utc.timestamp_opt(1_000_000, 0).unwrap(),
+            Utc.timestamp_opt(-1, 999_000_000).unwrap(), // just before epoch
+            Utc.timestamp_micros(1_234_567_890_123_456).unwrap(),
+        ];
+        for v in instants {
+            let mut buf = Vec::new();
+            encode_instant(&v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_instant(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_uuid() {
+        let uuids = vec![
+            Uuid::nil(),
+            Uuid::max(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+        ];
+        for v in uuids {
+            let mut buf = Vec::new();
+            encode_uuid(&v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_uuid(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn roundtrip_keyword() {
+        let keywords = vec![
+            Keyword::plain("foo"),
+            Keyword::namespaced("db", "ident"),
+            Keyword::namespaced("my.ns", "attr"),
+        ];
+        for v in keywords {
+            let mut buf = Vec::new();
+            encode_keyword(&v, &mut buf);
+            let mut cursor = buf.as_slice();
+            assert_eq!(decode_keyword(&mut cursor).unwrap(), v);
+            assert!(cursor.is_empty());
+        }
+    }
+
+    // --- DataType round-trip tests ---
+
+    #[test]
+    fn roundtrip_datatype_all_variants() {
+        let values = vec![
+            DataType::BigInt(42),
+            DataType::BigInt(i128::MIN),
+            DataType::Boolean(true),
+            DataType::Boolean(false),
+            DataType::Bytes(vec![0x00, 0x01, 0xFF]),
+            DataType::Double(3.14),
+            DataType::Float(2.5),
+            DataType::Instant(Utc.timestamp_opt(1_000_000, 0).unwrap()),
+            DataType::Keyword(Keyword::plain("foo")),
+            DataType::Keyword(Keyword::namespaced("db", "ident")),
+            DataType::Long(42),
+            DataType::Long(i64::MIN),
+            DataType::String("hello".to_string()),
+            DataType::String("".to_string()),
+            DataType::Tuple(vec![DataType::Long(1), DataType::String("a".to_string())]),
+            DataType::Uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            DataType::Vector(vec![DataType::Long(1), DataType::Long(2)]),
+            DataType::Map({
+                let mut m = BTreeMap::new();
+                m.insert("key".to_string(), DataType::Long(42));
+                m
+            }),
+        ];
+        for v in values {
+            let encoded = v.encode();
+            let decoded = DataType::decode(&encoded).unwrap();
+            assert_eq!(decoded, v, "DataType round-trip failed for {:?}", v);
+        }
+    }
+
+    #[test]
+    fn roundtrip_datatype_empty_composites() {
+        let values = vec![
+            DataType::Tuple(vec![]),
+            DataType::Vector(vec![]),
+            DataType::Map(BTreeMap::new()),
+            DataType::Bytes(vec![]),
+            DataType::String(String::new()),
+        ];
+        for v in values {
+            let encoded = v.encode();
+            let decoded = DataType::decode(&encoded).unwrap();
+            assert_eq!(decoded, v);
+        }
+    }
+
+    #[test]
+    fn roundtrip_datatype_nested_composite() {
+        let nested = DataType::Vector(vec![
+            DataType::Tuple(vec![DataType::Long(1), DataType::String("inner".to_string())]),
+            DataType::Map({
+                let mut m = BTreeMap::new();
+                m.insert("k".to_string(), DataType::Boolean(true));
+                m
+            }),
+        ]);
+        let encoded = nested.encode();
+        let decoded = DataType::decode(&encoded).unwrap();
+        assert_eq!(decoded, nested);
+    }
+
+    // --- Order-preservation tests ---
+
+    #[test]
+    fn order_i64() {
+        let values = vec![i64::MIN, -1_000, -1, 0, 1, 1_000, i64::MAX];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_i64(window[0], &mut a_buf);
+            encode_i64(window[1], &mut b_buf);
+            assert!(
+                a_buf < b_buf,
+                "{} should encode before {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    fn order_i128() {
+        let values = vec![i128::MIN, -1, 0, 1, i128::MAX];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_i128(window[0], &mut a_buf);
+            encode_i128(window[1], &mut b_buf);
+            assert!(a_buf < b_buf);
+        }
+    }
+
+    #[test]
+    fn order_u64() {
+        let values = vec![0u64, 1, 100, u64::MAX];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_u64(window[0], &mut a_buf);
+            encode_u64(window[1], &mut b_buf);
+            assert!(a_buf < b_buf);
+        }
+    }
+
+    #[test]
+    fn order_f64() {
+        let values = vec![f64::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f64::INFINITY];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_f64(window[0], &mut a_buf);
+            encode_f64(window[1], &mut b_buf);
+            assert!(
+                a_buf <= b_buf,
+                "{} should encode <= {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    fn order_f32() {
+        let values = vec![f32::NEG_INFINITY, -1.5, 0.0, 1.5, f32::INFINITY];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_f32(window[0], &mut a_buf);
+            encode_f32(window[1], &mut b_buf);
+            assert!(a_buf < b_buf);
+        }
+    }
+
+    #[test]
+    fn order_bool() {
+        let mut f_buf = Vec::new();
+        let mut t_buf = Vec::new();
+        encode_bool(false, &mut f_buf);
+        encode_bool(true, &mut t_buf);
+        assert!(f_buf < t_buf);
+    }
+
+    #[test]
+    fn order_string() {
+        let values = vec!["", "a", "aa", "ab", "b"];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_string(window[0], &mut a_buf);
+            encode_string(window[1], &mut b_buf);
+            assert!(
+                a_buf < b_buf,
+                "{:?} should encode before {:?}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    fn order_bytes() {
+        let values: Vec<Vec<u8>> = vec![vec![], vec![0x00], vec![0x00, 0x00], vec![0x01], vec![0xFF]];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_bytes(&window[0], &mut a_buf);
+            encode_bytes(&window[1], &mut b_buf);
+            assert!(
+                a_buf < b_buf,
+                "{:?} should encode before {:?}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    fn order_keyword() {
+        let values = vec![
+            Keyword::plain("a"),        // empty ns sorts first
+            Keyword::plain("b"),
+            Keyword::namespaced("a", "a"),
+            Keyword::namespaced("a", "b"),
+            Keyword::namespaced("b", "a"),
+        ];
+        for window in values.windows(2) {
+            let mut a_buf = Vec::new();
+            let mut b_buf = Vec::new();
+            encode_keyword(&window[0], &mut a_buf);
+            encode_keyword(&window[1], &mut b_buf);
+            assert!(
+                a_buf < b_buf,
+                "{:?} should encode before {:?}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    // --- Prefix-free tests ---
+
+    #[test]
+    fn prefix_free_strings() {
+        let short = DataType::String("abc".to_string()).encode();
+        let long = DataType::String("abcd".to_string()).encode();
+        assert!(!long.starts_with(&short));
+    }
+
+    #[test]
+    fn prefix_free_bytes() {
+        let short = DataType::Bytes(vec![1, 2, 3]).encode();
+        let long = DataType::Bytes(vec![1, 2, 3, 4]).encode();
+        assert!(!long.starts_with(&short));
+    }
+
+    // --- Composite ordering tests ---
+
+    #[test]
+    fn tuple_prefix_ordering() {
+        let short = DataType::Tuple(vec![DataType::Long(1)]).encode();
+        let long = DataType::Tuple(vec![DataType::Long(1), DataType::Long(2)]).encode();
+        assert!(short < long);
+    }
+
+    #[test]
+    fn vector_prefix_ordering() {
+        let short = DataType::Vector(vec![DataType::Long(1)]).encode();
+        let long = DataType::Vector(vec![DataType::Long(1), DataType::Long(2)]).encode();
+        assert!(short < long);
+    }
+
+    // --- skip_datatype tests ---
+
+    #[test]
+    fn skip_then_decode() {
+        let first = DataType::String("skip me".to_string());
+        let second = DataType::Long(42);
+
+        let mut buf = Vec::new();
+        encode_datatype(&first, &mut buf);
+        encode_datatype(&second, &mut buf);
+
+        let mut cursor = buf.as_slice();
+        skip_datatype(&mut cursor).unwrap();
+        let decoded = decode_datatype(&mut cursor).unwrap();
+        assert_eq!(decoded, second);
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn skip_all_types() {
+        let values = vec![
+            DataType::BigInt(1),
+            DataType::Boolean(true),
+            DataType::Bytes(vec![0, 1, 2]),
+            DataType::Double(3.14),
+            DataType::Float(2.5),
+            DataType::Instant(Utc.timestamp_opt(1_000_000, 0).unwrap()),
+            DataType::Keyword(Keyword::namespaced("db", "id")),
+            DataType::Long(99),
+            DataType::String("test".to_string()),
+            DataType::Tuple(vec![DataType::Long(1)]),
+            DataType::Uuid(Uuid::nil()),
+            DataType::Vector(vec![DataType::Boolean(false)]),
+            DataType::Map({
+                let mut m = BTreeMap::new();
+                m.insert("k".to_string(), DataType::Long(1));
+                m
+            }),
+        ];
+
+        // Encode all values into one buffer, then skip them all
+        let mut buf = Vec::new();
+        for v in &values {
+            encode_datatype(v, &mut buf);
+        }
+        let sentinel = DataType::Long(999);
+        encode_datatype(&sentinel, &mut buf);
+
+        let mut cursor = buf.as_slice();
+        for _ in &values {
+            skip_datatype(&mut cursor).unwrap();
+        }
+        let decoded = decode_datatype(&mut cursor).unwrap();
+        assert_eq!(decoded, sentinel);
+        assert!(cursor.is_empty());
+    }
+
+    // --- Edge case: trailing bytes ---
+
+    #[test]
+    fn decode_trait_rejects_trailing_bytes() {
+        let mut buf = DataType::Long(1).encode();
+        buf.push(0xFF);
+        assert!(DataType::decode(&buf).is_err());
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,7 @@ use crate::protocol::{
 };
 
 // ---------------------------------------------------------------------------
-// Existing constants
+// Index key constants
 // ---------------------------------------------------------------------------
 
 // TODO should this become 2 bytes?
@@ -46,8 +46,6 @@ pub const META_INDEX: u8 = 129;
 pub const ADD: u8 = 0;
 pub const DELETE: u8 = 1;
 pub const RETRACT: u8 = 2;
-
-
 
 /// Suffix length: timestamp (8 bytes) + op (1 byte), used for end-of-key extraction.
 pub const TIMESTAMP_OP_SUFFIX: usize = TIMESTAMP_LENGTH + OP_LENGTH;
@@ -125,7 +123,7 @@ pub fn decode_i64(cursor: &mut &[u8]) -> Result<i64, DecodeError> {
 }
 
 pub fn encode_i128(value: i128, buf: &mut Vec<u8>) {
-    let encoded = (value ^ (1_i128 << 127)).to_be_bytes();
+    let encoded = (value ^ i128::MIN).to_be_bytes();
     buf.extend_from_slice(&encoded);
 }
 
@@ -135,7 +133,7 @@ pub fn decode_i128(cursor: &mut &[u8]) -> Result<i128, DecodeError> {
     }
     let bytes: [u8; 16] = cursor[..16].try_into().unwrap();
     *cursor = &cursor[16..];
-    Ok(i128::from_be_bytes(bytes) ^ (1_i128 << 127))
+    Ok(i128::from_be_bytes(bytes) ^ i128::MIN)
 }
 
 // ---------------------------------------------------------------------------
@@ -1054,8 +1052,10 @@ mod tests {
     }
 }
 
-/// Encode a timestamp as inverted big-endian i64 microseconds.
+/// Encode a timestamp as inverted big-endian i64 microseconds for index keys.
 /// Inverted so that newer timestamps sort first in ascending byte order.
+/// Note: this differs from `encode_instant` which uses standard (non-inverted)
+/// order-preserving encoding for DataType::Instant values.
 pub fn encode_timestamp(t: Instant) -> [u8; 8] {
     let micros = t.timestamp_micros();
     (!micros).to_be_bytes()

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -25,9 +25,8 @@ pub const INDEX_VERSION: u8 = 1;
 
 // TODO use these throughout the codebase
 pub const CODEC_LENGTH: usize = 1;
-// TODO: Entity IDs are encoded as DataType::Long (4-byte variant tag + 8-byte i64).
-// Revisit with schema/custom encoding — could go back to raw i64 (8 bytes).
-pub const ENTITY_LENGTH: usize = 12;
+// Entity IDs are encoded as DataType::Long (1-byte type tag + 8-byte order-preserving i64).
+pub const ENTITY_LENGTH: usize = 9;
 pub const ATTRIBUTE_LENGTH: usize = 8;
 pub const OP_LENGTH: usize = 1;
 pub const TIMESTAMP_LENGTH: usize = 8;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -109,8 +109,11 @@ pub trait Decode: Sized {
 // ---------------------------------------------------------------------------
 
 pub fn encode_i64(value: i64, buf: &mut Vec<u8>) {
-    let encoded = (value ^ i64::MIN).to_be_bytes();
-    buf.extend_from_slice(&encoded);
+    buf.extend_from_slice(&encode_i64_bytes(value));
+}
+
+pub fn encode_i64_bytes(value: i64) -> [u8; 8] {
+    (value ^ i64::MIN).to_be_bytes()
 }
 
 pub fn decode_i64(cursor: &mut &[u8]) -> Result<i64, DecodeError> {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -863,6 +863,9 @@ mod tests {
 
     #[test]
     fn order_f64() {
+        // Uses <= because -0.0 and 0.0 encode to the same bytes (IEEE 754 sortable
+        // encoding collapses them). Round-trip preserves the sign bit, but byte
+        // ordering treats them as equal.
         let values = vec![f64::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f64::INFINITY];
         for window in values.windows(2) {
             let mut a_buf = Vec::new();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4,7 +4,6 @@ use slatedb::Db;
 use slatedb::IsolationLevel;
 use anyhow::{Error, Result};
 use bincode;
-use std::io::Cursor;
 use bytes::Bytes;
 use tokio::sync::broadcast;
 use log::warn;
@@ -13,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, Document, TxOp, tx_ops_to_datoms};
-use crate::codec;
+use crate::codec::{self, Encode, encode_i64, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
@@ -21,6 +20,12 @@ use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
 use crate::clock::Instant;
+
+fn encode_i64_vec(value: i64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_i64(value, &mut buf);
+    buf
+}
 
 pub struct Indexer {
     slatedb: Arc<Db>,
@@ -39,15 +44,15 @@ pub(crate) fn write_index_entries(
     let timestamp = codec::encode_timestamp(system_time);
 
     for datom in datoms {
-        // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
-        // Revisit with schema/custom encoding.
-        let entity_id = bincode::serialize(&DataType::Long(datom.entity))?;
+        // Entity IDs encoded as DataType::Long (1-byte type tag + 8-byte order-preserving i64).
+        let entity_id = DataType::Long(datom.entity).encode();
         let attribute_id = schema_cache
             .get(&datom.attribute)
             .map(|a| a.entity_id)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-        let attribute = bincode::serialize(&attribute_id)?;
-        let value = bincode::serialize(&datom.value)?;
+        let attribute = encode_i64_vec(attribute_id);
+        let mut value = Vec::new();
+        encode_datatype(&datom.value, &mut value);
         let op_byte = match datom.op {
             DatomOp::Assert => codec::ADD,
             DatomOp::Retract => codec::RETRACT,
@@ -76,7 +81,9 @@ struct TxMeta {
 }
 
 fn tx_meta_key(tx_id: i64) -> Vec<u8> {
-    concat_bytes(&[&[codec::TX_TO_META], &bincode::serialize(&tx_id).unwrap()])
+    let mut buf = vec![codec::TX_TO_META];
+    encode_i64(tx_id, &mut buf);
+    buf
 }
 
 /// Scan all TX_TO_META keys in a snapshot and return the TxKey for the highest tx_id.
@@ -85,14 +92,13 @@ fn tx_meta_key(tx_id: i64) -> Vec<u8> {
 ///
 /// TODO: return a real "empty database" TxKey once we have one.
 ///
-/// TODO(triplox-1vr): Switch tx_meta_key() to big-endian encoding (tx_id.to_be_bytes())
-/// so byte order matches numeric order, enabling a reverse iterator for O(1) lookup
-/// instead of this full scan. Breaking change — requires migration or flag day.
+/// TX_TO_META keys are now big-endian encoded, so byte order matches numeric order.
+/// A reverse iterator could be used for O(1) lookup instead of this full scan.
 pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
     let mut iter = snapshot.scan_prefix_with_options(&[codec::TX_TO_META], &DEFAULT_SCAN_OPTIONS).await?;
     let mut latest: Option<(i64, TxMeta)> = None;
     while let Some(kv) = iter.next().await? {
-        let tx_id: i64 = bincode::deserialize(&kv.key[1..])?;
+        let tx_id: i64 = decode_i64(&mut &kv.key[1..])?;
         let meta: TxMeta = bincode::deserialize(&kv.value)?;
         if latest.as_ref().map_or(true, |(best_id, _)| tx_id > *best_id) {
             latest = Some((tx_id, meta));
@@ -156,8 +162,8 @@ impl Indexer {
             }
 
             let attribute_id = attr_schema.entity_id;
-            let entity_id_bytes = bincode::serialize(&DataType::Long(datom.entity))?;
-            let attr_id_bytes = bincode::serialize(&attribute_id)?;
+            let entity_id_bytes = DataType::Long(datom.entity).encode();
+            let attr_id_bytes = encode_i64_vec(attribute_id);
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
             // Scan EAV prefix on the transaction to find the current value.
@@ -181,7 +187,8 @@ impl Indexer {
                     }
                     Some(_) => {
                         let value_bytes = &key[eav_prefix.len()..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-                        let value: DataType = bincode::deserialize(value_bytes)?;
+                        let mut cursor = value_bytes;
+                        let value: DataType = decode_datatype(&mut cursor).map_err(|e| anyhow::anyhow!("{}", e))?;
                         old_value = Some(value);
                         break;
                     }
@@ -346,44 +353,44 @@ fn strip_atemporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Re
 
 pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, Instant, u8), Error> {
     let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::EAV, "EAV")?;
-    let mut cursor = Cursor::new(data);
-    let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
-    let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
-    let value: DataType = bincode::deserialize_from(&mut cursor)?;
+    let mut cursor = data;
+    let entity_id = decode_datatype(&mut cursor)?;
+    let attribute = decode_i64(&mut cursor)?;
+    let value = decode_datatype(&mut cursor)?;
     Ok((entity_id, attribute, value, timestamp, op))
 }
 
 pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
     let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::AVE, "AVE")?;
-    let mut cursor = Cursor::new(data);
-    let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
-    let value: DataType = bincode::deserialize_from(&mut cursor)?;
-    let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
+    let mut cursor = data;
+    let attribute = decode_i64(&mut cursor)?;
+    let value = decode_datatype(&mut cursor)?;
+    let entity_id = decode_datatype(&mut cursor)?;
     Ok((attribute, value, entity_id, timestamp, op))
 }
 
 pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
     let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::AEV, "AEV")?;
-    let mut cursor = Cursor::new(data);
-    let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
-    let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
-    let value: DataType = bincode::deserialize_from(&mut cursor)?;
+    let mut cursor = data;
+    let attribute = decode_i64(&mut cursor)?;
+    let entity_id = decode_datatype(&mut cursor)?;
+    let value = decode_datatype(&mut cursor)?;
     Ok((attribute, entity_id, value, timestamp, op))
 }
 
 pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
     let data = strip_atemporal_key(key.as_ref(), codec::AE, "AE")?;
-    let mut cursor = Cursor::new(data);
-    let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
-    let entity_id: DataType = bincode::deserialize_from(&mut cursor)?;
+    let mut cursor = data;
+    let attribute = decode_i64(&mut cursor)?;
+    let entity_id = decode_datatype(&mut cursor)?;
     Ok((attribute, entity_id))
 }
 
 pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
     let data = strip_atemporal_key(key.as_ref(), codec::AV, "AV")?;
-    let mut cursor = Cursor::new(data);
-    let attribute: i64 = bincode::deserialize_from(&mut cursor)?;
-    let value: DataType = bincode::deserialize_from(&mut cursor)?;
+    let mut cursor = data;
+    let attribute = decode_i64(&mut cursor)?;
+    let value = decode_datatype(&mut cursor)?;
     Ok((attribute, value))
 }
 
@@ -711,8 +718,8 @@ mod tests {
         assert!(bob_add, "Expected ADD for bob");
 
         // Verify AE entry exists (stores empty bytes, not the value)
-        let attr_bytes = bincode::serialize(&name_id)?;
-        let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
+        let attr_bytes = encode_i64_vec(name_id);
+        let entity_bytes = DataType::Long(100i64).encode();
         let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
         assert!(ae_val.is_empty(), "AE should store empty bytes");

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -47,7 +47,8 @@ pub(crate) fn write_index_entries(
         };
 
         // Build key components into a reusable buffer.
-        // Entity IDs are tagged as DataType::Long (1-byte tag + 8-byte order-preserving i64).
+        // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
+        // Revisit with schema/custom encoding.
         // Attributes are untagged i64 (8 bytes).
         let mut buf = Vec::new();
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -188,7 +188,7 @@ impl Indexer {
                     Some(_) => {
                         let value_bytes = &key[eav_prefix.len()..key.len() - codec::TIMESTAMP_OP_SUFFIX];
                         let mut cursor = value_bytes;
-                        let value: DataType = decode_datatype(&mut cursor).map_err(|e| anyhow::anyhow!("{}", e))?;
+                        let value: DataType = decode_datatype(&mut cursor)?;
                         old_value = Some(value);
                         break;
                     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,12 +12,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, Document, TxOp, tx_ops_to_datoms};
-use crate::codec::{self, encode_i64, encode_datatype, decode_i64, decode_datatype};
+use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
+use crate::util::concat_bytes;
 use crate::clock::Instant;
 
 pub struct Indexer {
@@ -37,64 +38,33 @@ pub(crate) fn write_index_entries(
     let timestamp = codec::encode_timestamp(system_time);
 
     for datom in datoms {
+        // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
+        // Revisit with schema/custom encoding.
+        let entity_id = DataType::Long(datom.entity).encode();
         let attribute_id = schema_cache
             .get(&datom.attribute)
             .map(|a| a.entity_id)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+        let attribute = encode_i64_bytes(attribute_id);
+        let mut value = Vec::new();
+        encode_datatype(&datom.value, &mut value);
         let op_byte = match datom.op {
             DatomOp::Assert => codec::ADD,
             DatomOp::Retract => codec::RETRACT,
         };
 
-        // Build key components into a reusable buffer.
-        // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
-        // Revisit with schema/custom encoding.
-        // Attributes are untagged i64 (8 bytes).
-        let mut buf = Vec::new();
-
-        // EAV: [prefix, entity, attribute, value, timestamp, op]
-        buf.push(codec::EAV);
-        encode_datatype(&DataType::Long(datom.entity), &mut buf);
-        encode_i64(attribute_id, &mut buf);
-        encode_datatype(&datom.value, &mut buf);
-        buf.extend_from_slice(&timestamp);
-        buf.push(op_byte);
-        txn.put(&buf, &[])?;
-
-        // AVE: [prefix, attribute, value, entity, timestamp, op]
-        buf.clear();
-        buf.push(codec::AVE);
-        encode_i64(attribute_id, &mut buf);
-        encode_datatype(&datom.value, &mut buf);
-        encode_datatype(&DataType::Long(datom.entity), &mut buf);
-        buf.extend_from_slice(&timestamp);
-        buf.push(op_byte);
-        txn.put(&buf, &[])?;
-
-        // AEV: [prefix, attribute, entity, value, timestamp, op]
-        buf.clear();
-        buf.push(codec::AEV);
-        encode_i64(attribute_id, &mut buf);
-        encode_datatype(&DataType::Long(datom.entity), &mut buf);
-        encode_datatype(&datom.value, &mut buf);
-        buf.extend_from_slice(&timestamp);
-        buf.push(op_byte);
-        txn.put(&buf, &[])?;
+        // Temporal indices include timestamp + op
+        // TODO(triplox-7fl): concat_bytes allocates intermediate Vecs per component;
+        // encoding directly into a single buffer would be faster.
+        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            buf.clear();
-            buf.push(codec::AE);
-            encode_i64(attribute_id, &mut buf);
-            encode_datatype(&DataType::Long(datom.entity), &mut buf);
-            txn.put(&buf, &[])?;
-
-            buf.clear();
-            buf.push(codec::AV);
-            encode_i64(attribute_id, &mut buf);
-            encode_datatype(&datom.value, &mut buf);
-            txn.put(&buf, &[])?;
+            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[])?;
+            txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
         }
     }
 
@@ -189,10 +159,9 @@ impl Indexer {
             }
 
             let attribute_id = attr_schema.entity_id;
-            let mut eav_prefix = Vec::new();
-            eav_prefix.push(codec::EAV);
-            encode_datatype(&DataType::Long(datom.entity), &mut eav_prefix);
-            encode_i64(attribute_id, &mut eav_prefix);
+            let entity_id_bytes = DataType::Long(datom.entity).encode();
+            let attr_id_bytes = encode_i64_bytes(attribute_id);
+            let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
             // Scan EAV prefix on the transaction to find the current value.
             // Uses async scan directly because TemporalFilterIterator is sync-only.
@@ -746,10 +715,9 @@ mod tests {
         assert!(bob_add, "Expected ADD for bob");
 
         // Verify AE entry exists (stores empty bytes, not the value)
-        let mut ae_key = Vec::new();
-        ae_key.push(codec::AE);
-        encode_i64(name_id, &mut ae_key);
-        encode_datatype(&DataType::Long(100i64), &mut ae_key);
+        let attr_bytes = encode_i64_bytes(name_id);
+        let entity_bytes = DataType::Long(100i64).encode();
+        let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
         assert!(ae_val.is_empty(), "AE should store empty bytes");
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,13 +12,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, Document, TxOp, tx_ops_to_datoms};
-use crate::codec::{self, Encode, encode_i64, encode_datatype, decode_i64, decode_datatype};
+use crate::codec::{self, encode_i64, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
-use crate::util::concat_bytes;
 use crate::clock::Instant;
 
 pub struct Indexer {
@@ -38,30 +37,63 @@ pub(crate) fn write_index_entries(
     let timestamp = codec::encode_timestamp(system_time);
 
     for datom in datoms {
-        // Entity IDs encoded as DataType::Long (1-byte type tag + 8-byte order-preserving i64).
-        let entity_id = DataType::Long(datom.entity).encode();
         let attribute_id = schema_cache
             .get(&datom.attribute)
             .map(|a| a.entity_id)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-        let attribute = (attribute_id ^ i64::MIN).to_be_bytes();
-        let mut value = Vec::new();
-        encode_datatype(&datom.value, &mut value);
         let op_byte = match datom.op {
             DatomOp::Assert => codec::ADD,
             DatomOp::Retract => codec::RETRACT,
         };
 
-        // Temporal indices include timestamp + op
-        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
+        // Build key components into a reusable buffer.
+        // Entity IDs are tagged as DataType::Long (1-byte tag + 8-byte order-preserving i64).
+        // Attributes are untagged i64 (8 bytes).
+        let mut buf = Vec::new();
+
+        // EAV: [prefix, entity, attribute, value, timestamp, op]
+        buf.push(codec::EAV);
+        encode_datatype(&DataType::Long(datom.entity), &mut buf);
+        encode_i64(attribute_id, &mut buf);
+        encode_datatype(&datom.value, &mut buf);
+        buf.extend_from_slice(&timestamp);
+        buf.push(op_byte);
+        txn.put(&buf, &[])?;
+
+        // AVE: [prefix, attribute, value, entity, timestamp, op]
+        buf.clear();
+        buf.push(codec::AVE);
+        encode_i64(attribute_id, &mut buf);
+        encode_datatype(&datom.value, &mut buf);
+        encode_datatype(&DataType::Long(datom.entity), &mut buf);
+        buf.extend_from_slice(&timestamp);
+        buf.push(op_byte);
+        txn.put(&buf, &[])?;
+
+        // AEV: [prefix, attribute, entity, value, timestamp, op]
+        buf.clear();
+        buf.push(codec::AEV);
+        encode_i64(attribute_id, &mut buf);
+        encode_datatype(&DataType::Long(datom.entity), &mut buf);
+        encode_datatype(&datom.value, &mut buf);
+        buf.extend_from_slice(&timestamp);
+        buf.push(op_byte);
+        txn.put(&buf, &[])?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[])?;
-            txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
+            buf.clear();
+            buf.push(codec::AE);
+            encode_i64(attribute_id, &mut buf);
+            encode_datatype(&DataType::Long(datom.entity), &mut buf);
+            txn.put(&buf, &[])?;
+
+            buf.clear();
+            buf.push(codec::AV);
+            encode_i64(attribute_id, &mut buf);
+            encode_datatype(&datom.value, &mut buf);
+            txn.put(&buf, &[])?;
         }
     }
 
@@ -156,9 +188,10 @@ impl Indexer {
             }
 
             let attribute_id = attr_schema.entity_id;
-            let entity_id_bytes = DataType::Long(datom.entity).encode();
-            let attr_id_bytes = (attribute_id ^ i64::MIN).to_be_bytes();
-            let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
+            let mut eav_prefix = Vec::new();
+            eav_prefix.push(codec::EAV);
+            encode_datatype(&DataType::Long(datom.entity), &mut eav_prefix);
+            encode_i64(attribute_id, &mut eav_prefix);
 
             // Scan EAV prefix on the transaction to find the current value.
             // Uses async scan directly because TemporalFilterIterator is sync-only.
@@ -712,9 +745,10 @@ mod tests {
         assert!(bob_add, "Expected ADD for bob");
 
         // Verify AE entry exists (stores empty bytes, not the value)
-        let attr_bytes = (name_id ^ i64::MIN).to_be_bytes();
-        let entity_bytes = DataType::Long(100i64).encode();
-        let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
+        let mut ae_key = Vec::new();
+        ae_key.push(codec::AE);
+        encode_i64(name_id, &mut ae_key);
+        encode_datatype(&DataType::Long(100i64), &mut ae_key);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
         assert!(ae_val.is_empty(), "AE should store empty bytes");
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -21,12 +21,6 @@ use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
 use crate::clock::Instant;
 
-fn encode_i64_vec(value: i64) -> Vec<u8> {
-    let mut buf = Vec::new();
-    encode_i64(value, &mut buf);
-    buf
-}
-
 pub struct Indexer {
     slatedb: Arc<Db>,
     schema_cache: SchemaCache,
@@ -50,7 +44,7 @@ pub(crate) fn write_index_entries(
             .get(&datom.attribute)
             .map(|a| a.entity_id)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-        let attribute = encode_i64_vec(attribute_id);
+        let attribute = (attribute_id ^ i64::MIN).to_be_bytes();
         let mut value = Vec::new();
         encode_datatype(&datom.value, &mut value);
         let op_byte = match datom.op {
@@ -163,7 +157,7 @@ impl Indexer {
 
             let attribute_id = attr_schema.entity_id;
             let entity_id_bytes = DataType::Long(datom.entity).encode();
-            let attr_id_bytes = encode_i64_vec(attribute_id);
+            let attr_id_bytes = (attribute_id ^ i64::MIN).to_be_bytes();
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
             // Scan EAV prefix on the transaction to find the current value.
@@ -718,7 +712,7 @@ mod tests {
         assert!(bob_add, "Expected ADD for bob");
 
         // Verify AE entry exists (stores empty bytes, not the value)
-        let attr_bytes = encode_i64_vec(name_id);
+        let attr_bytes = (name_id ^ i64::MIN).to_be_bytes();
         let entity_bytes = DataType::Long(100i64).encode();
         let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");

--- a/src/iterator/generic_fn_prefix_extender.rs
+++ b/src/iterator/generic_fn_prefix_extender.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
+
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
+use crate::codec::{Encode, Decode};
 use crate::datalog::Variable;
 use crate::expr::{evaluate, EvalContext, Expr};
 use crate::ops::DataType;
@@ -42,8 +45,8 @@ impl GenericFnPrefixExtender {
             .prefix_vars
             .iter()
             .map(|(var, idx)| {
-                let dt = bincode::deserialize::<DataType>(&prefix[*idx])
-                    .expect("failed to deserialize prefix variable");
+                let dt = DataType::decode(&prefix[*idx])
+                    .expect("failed to decode prefix variable");
                 (var.clone(), dt)
             })
             .collect();
@@ -55,7 +58,7 @@ impl GenericFnPrefixExtender {
 
         let ctx = EvalContext::new(bindings);
         let result = evaluate(&self.expr, &ctx)?;
-        Some(bincode::serialize(result.as_ref()).expect("failed to serialize function result").into())
+        Some(Bytes::from(result.as_ref().encode()))
     }
 }
 
@@ -90,13 +93,12 @@ impl PrefixExtender for GenericFnPrefixExtender {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
 
     use crate::algo::generic_join::{GenericJoin, SingleLevelExtender};
     use crate::expr::{BinaryExpr, BinaryOp, UnaryExpr, UnaryOp};
 
     fn serialize(dt: &DataType) -> Bytes {
-        Bytes::from(bincode::serialize(dt).unwrap())
+        Bytes::from(dt.encode())
     }
 
     #[test]
@@ -133,7 +135,7 @@ mod tests {
         let result = ext.propose(&vec![]);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(42)
         );
     }
@@ -155,7 +157,7 @@ mod tests {
         let result = ext.propose(&prefix);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(5)
         );
     }
@@ -178,7 +180,7 @@ mod tests {
         let result = ext.propose(&prefix);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(35)
         );
     }
@@ -204,7 +206,7 @@ mod tests {
         let result = ext.propose(&prefix);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(30)
         );
     }
@@ -252,7 +254,7 @@ mod tests {
         let result = ext.intersect(&prefix, &extensions);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(35)
         );
     }
@@ -310,8 +312,8 @@ mod tests {
         assert_eq!(result.len(), 3);
         // Each tuple has [original, original+1]
         for tuple in &result {
-            let original = bincode::deserialize::<DataType>(&tuple[0]).unwrap();
-            let computed = bincode::deserialize::<DataType>(&tuple[1]).unwrap();
+            let original = DataType::decode(&tuple[0]).unwrap();
+            let computed = DataType::decode(&tuple[1]).unwrap();
             match (original, computed) {
                 (DataType::Long(o), DataType::Long(c)) => assert_eq!(c, o + 1),
                 _ => panic!("unexpected types"),
@@ -372,7 +374,7 @@ mod tests {
         let result = ext.propose(&vec![]);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(3)
         );
     }

--- a/src/iterator/generic_predicate_prefix_extender.rs
+++ b/src/iterator/generic_predicate_prefix_extender.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
+use crate::codec::Decode;
 use crate::datalog::Variable;
 use crate::expr::{evaluate_as_bool, EvalContext, Expr};
 use crate::ops::DataType;
@@ -50,13 +51,13 @@ impl PrefixExtender for GenericPredicatePrefixExtender {
     }
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
-        // Pre-deserialize prefix variables once (same for all extensions).
+        // Pre-decode prefix variables once (same for all extensions).
         let prefix_values: Vec<(Variable, DataType)> = self
             .prefix_vars
             .iter()
             .map(|(var, idx)| {
-                let dt = bincode::deserialize::<DataType>(&prefix[*idx])
-                    .expect("failed to deserialize prefix variable");
+                let dt = DataType::decode(&prefix[*idx])
+                    .expect("failed to decode prefix variable");
                 (var.clone(), dt)
             })
             .collect();
@@ -64,8 +65,8 @@ impl PrefixExtender for GenericPredicatePrefixExtender {
         extensions
             .iter()
             .filter(|ext| {
-                let ext_val = bincode::deserialize::<DataType>(ext)
-                    .expect("failed to deserialize extension value");
+                let ext_val = DataType::decode(ext)
+                    .expect("failed to decode extension value");
 
                 let mut bindings: HashMap<Variable, &DataType> = prefix_values
                     .iter()
@@ -91,10 +92,11 @@ mod tests {
     use bytes::Bytes;
 
     use crate::algo::generic_join::{GenericJoin, SingleLevelExtender};
+    use crate::codec::Encode;
     use crate::expr::{BinaryExpr, BinaryOp};
 
     fn serialize(dt: &DataType) -> Bytes {
-        Bytes::from(bincode::serialize(dt).unwrap())
+        Bytes::from(dt.encode())
     }
 
     #[test]
@@ -154,11 +156,11 @@ mod tests {
         let result = ext.intersect(&vec![], &extensions);
         assert_eq!(result.len(), 2);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(25)
         );
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[1]).unwrap(),
+            DataType::decode(&result[1]).unwrap(),
             DataType::Long(10)
         );
     }
@@ -190,11 +192,11 @@ mod tests {
         let result = ext.intersect(&prefix, &extensions);
         assert_eq!(result.len(), 2);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(15)
         );
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[1]).unwrap(),
+            DataType::decode(&result[1]).unwrap(),
             DataType::Long(20)
         );
     }
@@ -226,7 +228,7 @@ mod tests {
         let result = ext.intersect(&prefix, &extensions);
         assert_eq!(result.len(), 1);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0]).unwrap(),
+            DataType::decode(&result[0]).unwrap(),
             DataType::Long(5)
         );
     }
@@ -261,11 +263,11 @@ mod tests {
 
         assert_eq!(result.len(), 2);
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[0][0]).unwrap(),
+            DataType::decode(&result[0][0]).unwrap(),
             DataType::Long(10)
         );
         assert_eq!(
-            bincode::deserialize::<DataType>(&result[1][0]).unwrap(),
+            DataType::decode(&result[1][0]).unwrap(),
             DataType::Long(20)
         );
     }

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -6,7 +6,7 @@ use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
 use crate::clock::Instant;
-use crate::codec::index_type_to_prefix;
+use crate::codec::{self, index_type_to_prefix};
 use crate::index::IndexType;
 use crate::util::make_extractor;
 
@@ -35,8 +35,8 @@ impl GenericPrefixExtender {
         participating_levels: Vec<usize>,
         as_of: Instant,
     ) -> Self {
-        let mut full_prefix = bincode::serialize(&attribute_id)
-            .expect("Failed to serialize attribute_id");
+        let mut full_prefix = Vec::new();
+        codec::encode_i64(attribute_id, &mut full_prefix);
         full_prefix.extend_from_slice(&constant_prefix);
 
         Self {
@@ -191,12 +191,12 @@ impl PrefixExtender for GenericPrefixExtender {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::Encode;
     use crate::ops::DataType;
     use crate::slate::in_memory_slate;
 
     fn encode_entity(val: i64) -> Bytes {
-        // Entity IDs are encoded as DataType::Long to match value-position encoding
-        Bytes::from(bincode::serialize(&DataType::Long(val)).unwrap())
+        Bytes::from(DataType::Long(val).encode())
     }
 
     fn encode_string(s: &str) -> Bytes {
@@ -210,9 +210,9 @@ mod tests {
         entity: i64,
     ) -> anyhow::Result<()> {
         let mut key = vec![crate::codec::AVE];
-        key.extend_from_slice(&bincode::serialize(&attribute)?);
+        codec::encode_i64(attribute, &mut key);
         key.extend_from_slice(&value);
-        key.extend_from_slice(&bincode::serialize(&DataType::Long(entity))?);
+        key.extend_from_slice(&DataType::Long(entity).encode());
         key.extend_from_slice(&crate::codec::encode_timestamp(crate::clock::st_from_unix_epoch(1_000_000)));
         key.push(crate::codec::ADD);
 
@@ -223,7 +223,7 @@ mod tests {
     async fn insert_av(slate: &slatedb::Db, attribute: i64, value: Bytes) -> anyhow::Result<()> {
         // AV is atemporal — no timestamp or op suffix
         let mut key = vec![crate::codec::AV];
-        key.extend_from_slice(&bincode::serialize(&attribute)?);
+        codec::encode_i64(attribute, &mut key);
         key.extend_from_slice(&value);
 
         slate.put(&key, b"dummy_value").await?;
@@ -389,7 +389,7 @@ mod tests {
         let slate = runtime.block_on(in_memory_slate());
         let attr_name = 42i64;
 
-        let value_bytes = Bytes::from(bincode::serialize(&DataType::String("alice".to_string()))?);
+        let value_bytes = Bytes::from(DataType::String("alice".to_string()).encode());
         runtime.block_on(insert_ave(&slate, attr_name, value_bytes.clone(), 1))?;
 
         let snapshot = runtime.block_on(slate.snapshot()).unwrap();

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -200,7 +200,7 @@ mod tests {
     }
 
     fn encode_string(s: &str) -> Bytes {
-        Bytes::from(s.as_bytes().to_vec())
+        Bytes::from(DataType::String(s.to_string()).encode())
     }
 
     async fn insert_ave(

--- a/src/query.rs
+++ b/src/query.rs
@@ -462,8 +462,7 @@ fn project_results(
                 .map(|proj| match proj {
                     Projection::GroupVar(group_pos) => {
                         let join_idx = plan.group_key_indices[*group_pos];
-                        DataType::decode(&tuple[join_idx])
-                            .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
+                        Ok::<_, Error>(DataType::decode(&tuple[join_idx])?)
                     }
                     Projection::Aggregate(_, _) => unreachable!(),
                 })
@@ -514,7 +513,7 @@ fn execute_aggregation(
                 let group_values: Vec<DataType> = plan
                     .group_key_indices
                     .iter()
-                    .map(|&idx| DataType::decode(&tuple[idx]).map_err(|e| anyhow::anyhow!("{}", e)))
+                    .map(|&idx| Ok::<_, Error>(DataType::decode(&tuple[idx])?))
                     .collect::<Result<Vec<_>, _>>()?;
                 let accs: Vec<Box<dyn Accumulator>> =
                     agg_funcs.iter().map(|f| make_accumulator(f)).collect();
@@ -526,7 +525,7 @@ fn execute_aggregation(
         let mut agg_idx = 0;
         for proj in &plan.projections {
             if let Projection::Aggregate(_, join_idx) = proj {
-                let value = DataType::decode(&tuple[*join_idx]).map_err(|e| anyhow::anyhow!("{}", e))?;
+                let value = DataType::decode(&tuple[*join_idx])?;
                 accumulators[agg_idx].accumulate(&value)?;
                 agg_idx += 1;
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,6 +22,7 @@ use crate::iterator::generic_not_prefix_extender::GenericNotPrefixExtender;
 use crate::iterator::generic_or_prefix_extender::GenericOrPrefixExtender;
 use crate::iterator::generic_predicate_prefix_extender::GenericPredicatePrefixExtender;
 use crate::iterator::generic_prefix_extender::GenericPrefixExtender;
+use crate::codec::{Encode, Decode};
 use crate::ops::DataType;
 
 /// Each inner Vec is a projected row of decoded DataType values.
@@ -315,7 +316,7 @@ fn compute_constant_prefix(pattern: &PatternClause, index_type: IndexType) -> Re
             // AVE key order: [attr, value, entity]
             // If value is constant, include it in prefix
             if let PatternElement::Constant(value) = &pattern.value {
-                Ok(bincode::serialize(value)?)
+                Ok(value.encode())
             } else {
                 Ok(vec![])
             }
@@ -324,7 +325,7 @@ fn compute_constant_prefix(pattern: &PatternClause, index_type: IndexType) -> Re
             // AEV key order: [attr, entity, value]
             // If entity is constant, include it in prefix
             if let PatternElement::Constant(entity) = &pattern.entity {
-                Ok(bincode::serialize(entity)?)
+                Ok(entity.encode())
             } else {
                 Ok(vec![])
             }
@@ -461,7 +462,7 @@ fn project_results(
                 .map(|proj| match proj {
                     Projection::GroupVar(group_pos) => {
                         let join_idx = plan.group_key_indices[*group_pos];
-                        bincode::deserialize::<DataType>(&tuple[join_idx])
+                        DataType::decode(&tuple[join_idx])
                             .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
                     }
                     Projection::Aggregate(_, _) => unreachable!(),
@@ -513,7 +514,7 @@ fn execute_aggregation(
                 let group_values: Vec<DataType> = plan
                     .group_key_indices
                     .iter()
-                    .map(|&idx| bincode::deserialize::<DataType>(&tuple[idx]))
+                    .map(|&idx| DataType::decode(&tuple[idx]).map_err(|e| anyhow::anyhow!("{}", e)))
                     .collect::<Result<Vec<_>, _>>()?;
                 let accs: Vec<Box<dyn Accumulator>> =
                     agg_funcs.iter().map(|f| make_accumulator(f)).collect();
@@ -525,7 +526,7 @@ fn execute_aggregation(
         let mut agg_idx = 0;
         for proj in &plan.projections {
             if let Projection::Aggregate(_, join_idx) = proj {
-                let value = bincode::deserialize::<DataType>(&tuple[*join_idx])?;
+                let value = DataType::decode(&tuple[*join_idx]).map_err(|e| anyhow::anyhow!("{}", e))?;
                 accumulators[agg_idx].accumulate(&value)?;
                 agg_idx += 1;
             }


### PR DESCRIPTION
## Summary
- Implement order-preserving binary codec for all DataType variants (`src/codec.rs`), ensuring `memcmp(encode(a), encode(b))` matches logical ordering
- Migrate all index key encoding/decoding from bincode to the new codec across indexer, query, and iterator modules
- TX_TO_SEQ keys now use big-endian encoding, fixing byte-order vs numeric-order mismatch

## Details

The codec supports:
- Signed integers (XOR sign bit + big-endian), unsigned integers, floats (IEEE 754 sortable)
- Variable-length types (strings, bytes, keywords) via escaped-terminated encoding
- Tagged `DataType` dispatch with 1-byte type tags
- Composite types (tuple, vector, map) with end markers

Entity IDs stay tagged as `DataType::Long` (9 bytes) for uniform decoding in the generic join. Attributes are untagged i64 (8 bytes). Bincode is retained for TxMeta values, TxOp log, and file_log records.

## Test plan
- [x] All 32 codec unit tests pass
- [x] All 303 unit tests pass
- [x] All 11 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)