### PR TITLE
Remove Basis struct, replace with TxKey everywhere

### DIFF
--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -54,7 +54,6 @@ The server checks the version:
 | `E` (0x45) | Execute     | Submit a transaction            |
 | `S` (0x53) | Subscribe   | Start a live query subscription |
 | `U` (0x55) | Unsubscribe | Cancel the active subscription  |
-| `F` (0x46) | BasisForTx  | Look up basis for a transaction |
 | `X` (0x58) | Terminate   | Close the connection            |
 
 ### Backend Messages (Server to Client)
@@ -70,7 +69,6 @@ The server checks the version:
 | `Z` (0x5A) | ReadyForQuery       | Server is ready for the next request     |
 | `Y` (0x59) | TxKey               | Transaction submitted (fire-and-forget)  |
 | `G` (0x47) | TxResult            | Transaction outcome (awaited indexing)   |
-| `A` (0x41) | BasisResult         | Basis for a transaction                  |
 | `N` (0x4E) | UnsubscribeComplete | Subscription cancelled                   |
 | `K` (0x4B) | Heartbeat           | Subscription keepalive                   |
 | `W` (0x57) | ErrorResponse       | Error                                    |
@@ -99,13 +97,12 @@ Sent after successful version negotiation.
 
 ### 4.3 OpenDb (Frontend, `O`)
 
-Open a DB snapshot. The server pins a point-in-time database view and returns a handle the client uses for subsequent queries. Either all three basis fields are present (pinned snapshot) or all three are absent (latest indexed).
+Open a DB snapshot. The server pins a point-in-time database view and returns a handle the client uses for subsequent queries. Either both basis fields are present (pinned snapshot) or both are absent (latest indexed).
 
 | Field             | Type            | Description                                          |
 |-------------------|-----------------|------------------------------------------------------|
 | basis_tx_id       | Option\<i64\>   | If set, snapshot at this tx; otherwise latest indexed |
 | basis_system_time | Option\<i64\>   | Microseconds since epoch of the tx                   |
-| basis_seq_num     | Option\<u64\>   | Sequence number for the snapshot                     |
 
 ### 4.4 DbOpened (Backend, `H`)
 
@@ -144,7 +141,7 @@ Sent when the server is ready for the next client request. Acts as a sync/flush 
 |--------|------|------------------------------------------------|
 | status | u8   | `I` (0x49) = idle, `S` (0x53) = subscribed    |
 
-Sent after: AuthenticationOk, DbOpened, DbClosed, DataRow (end of query results), TxKey, TxResult, BasisResult, UnsubscribeComplete, non-fatal ErrorResponse.
+Sent after: AuthenticationOk, DbOpened, DbClosed, DataRow (end of query results), TxKey, TxResult, UnsubscribeComplete, non-fatal ErrorResponse.
 
 ### 4.8 Query (Frontend, `Q`)
 
@@ -238,33 +235,11 @@ Returned for awaited transactions (Execute with `await_indexing = true`). Maps d
 | status        | u8              | 0 = committed, 1 = aborted                          |
 | tx_id         | i64             | Transaction ID assigned by the server                |
 | system_time   | Instant         | Timestamp of the transaction (microseconds since epoch) |
-| seq_num       | u64             | Database sequence number (meaningful when status = 0) |
 | error_message | Option\<String\>| Present if status = aborted                          |
 
-> **TODO**: TxKey and TxResult will likely be collapsed into a single message once we have a good and unique format for a Basis.
+> **TODO**: TxKey and TxResult will likely be collapsed into a single message once we have a good and unique format.
 
-### 4.14 BasisForTx (Frontend, `F`)
-
-Look up the `Basis` (tx_key + seq_num) for a previously committed transaction. The server waits until the transaction has been indexed before responding.
-
-| Field       | Type | Description                                             |
-|-------------|------|---------------------------------------------------------|
-| tx_id       | i64  | Transaction ID to look up                               |
-| system_time | i64  | Timestamp of the transaction (microseconds since epoch) |
-
-Server responds with `BasisResult` followed by `ReadyForQuery`, or `ErrorResponse` + `ReadyForQuery` if the transaction is unknown.
-
-### 4.15 BasisResult (Backend, `A`)
-
-Returns the full basis for a transaction.
-
-| Field       | Type | Description                                             |
-|-------------|------|---------------------------------------------------------|
-| tx_id       | i64  | Transaction ID                                          |
-| system_time | i64  | Timestamp of the transaction (microseconds since epoch) |
-| seq_num     | u64  | Database sequence number                                |
-
-### 4.16 Subscribe (Frontend, `S`)
+### 4.14 Subscribe (Frontend, `S`)
 
 Start a live push subscription. Blocks the connection until cancelled.
 
@@ -283,7 +258,7 @@ On receiving Subscribe, the server:
 
 While subscribed, the only valid client messages are Unsubscribe and Terminate. The server concurrently reads client messages and writes subscription data using asynchronous I/O.
 
-### 4.17 DataBatchComplete (Backend, `B`)
+### 4.15 DataBatchComplete (Backend, `B`)
 
 Marks the end of a batch of DataRow messages produced by a single transaction within a subscription stream.
 
@@ -293,13 +268,13 @@ Marks the end of a batch of DataRow messages produced by a single transaction wi
 
 The server flushes its write buffer after sending DataBatchComplete. Clients use this to group rows by originating transaction.
 
-### 4.18 Unsubscribe (Frontend, `U`)
+### 4.16 Unsubscribe (Frontend, `U`)
 
 Cancel the active subscription.
 
 Payload: empty (length = 4).
 
-### 4.19 UnsubscribeComplete (Backend, `N`)
+### 4.17 UnsubscribeComplete (Backend, `N`)
 
 Confirms the subscription has been torn down.
 
@@ -307,7 +282,7 @@ Payload: empty (length = 4).
 
 Followed by ReadyForQuery with status `I`.
 
-### 4.20 ErrorResponse (Backend, `W`)
+### 4.18 ErrorResponse (Backend, `W`)
 
 | Field    | Type            | Description                                         |
 |----------|-----------------|-----------------------------------------------------|
@@ -321,7 +296,7 @@ Followed by ReadyForQuery with status `I`.
 
 **Non-fatal** errors (e.g. bad query syntax): the server sends ErrorResponse followed by ReadyForQuery, allowing the client to continue. The `severity` byte is `E` (0x45).
 
-### 4.21 Terminate (Frontend, `X`)
+### 4.19 Terminate (Frontend, `X`)
 
 Graceful connection close.
 
@@ -329,7 +304,7 @@ Payload: empty (length = 4).
 
 The server closes the TCP connection after receiving this. No response is sent.
 
-### 4.22 Heartbeat (Backend, `K`)
+### 4.20 Heartbeat (Backend, `K`)
 
 Sent by the server during an active subscription when no data has been sent within the keepalive interval (see [Section 12](#12-connection-keepalive-and-timeouts)). The client MUST silently ignore this message (no response required).
 
@@ -516,14 +491,14 @@ Subscription uses **in-band** Unsubscribe. The server concurrently reads client 
 
 ### Valid Messages Per State
 
-| State           | Valid Frontend Messages                            | Server Sends                                                |
-|-----------------|----------------------------------------------------|-------------------------------------------------------------|
-| Startup         | Startup                                            | AuthenticationOk + ReadyForQuery, or ErrorResponse + close  |
-| Idle            | OpenDb, CloseDb, Query, Execute, Subscribe, Terminate | --                                                       |
-| QueryInProgress | *(client waits)*                                   | RowDescription, DataRow, ReadyForQuery                      |
-| Executing       | *(client waits)*                                   | TxResult, ReadyForQuery                                     |
-| Subscribed      | Unsubscribe, Terminate                             | RowDescription, DataRow, DataBatchComplete, Heartbeat, ErrorResponse |
-| Closed          | *(none)*                                           | *(none)*                                                    |
+| State           | Valid Frontend Messages                                | Server Sends                                                        |
+|-----------------|--------------------------------------------------------|---------------------------------------------------------------------|
+| Startup         | Startup                                                | AuthenticationOk + ReadyForQuery, or ErrorResponse + close          |
+| Idle            | OpenDb, CloseDb, Query, Execute, Subscribe, Terminate  | --                                                                  |
+| QueryInProgress | *(client waits)*                                       | RowDescription, DataRow, ReadyForQuery                              |
+| Executing       | *(client waits)*                                       | TxResult, ReadyForQuery                                             |
+| Subscribed      | Unsubscribe, Terminate                                 | RowDescription, DataRow, DataBatchComplete, Heartbeat, ErrorResponse |
+| Closed          | *(none)*                                               | *(none)*                                                            |
 
 ---
 
@@ -769,21 +744,7 @@ system_time : i64        (microseconds since Unix epoch)
 status        : u8         (0 = committed, 1 = aborted)
 tx_id         : i64
 system_time   : i64        (microseconds since Unix epoch)
-seq_num       : u64
 error_message : Option<String>
-```
-
-**BasisForTx** (`F`):
-```
-tx_id       : i64
-system_time : i64        (microseconds since Unix epoch)
-```
-
-**BasisResult** (`A`):
-```
-tx_id       : i64
-system_time : i64        (microseconds since Unix epoch)
-seq_num     : u64
 ```
 
 **Subscribe** (`S`):

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -45,8 +45,8 @@ async fn main() -> Result<()> {
     ];
     let result = node.execute_tx(schema_ops).await?;
     match &result {
-        TransactionResult::TxCommited(basis) => {
-            println!("Schema defined (tx_id={}).", basis.tx_key.tx_id);
+        TransactionResult::TxCommited(tx_key) => {
+            println!("Schema defined (tx_id={}).", tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {
             anyhow::bail!("Schema transaction aborted: {err}");
@@ -67,8 +67,8 @@ async fn main() -> Result<()> {
     let data_ops = vec![TxOp::Put(Document(alice)), TxOp::Put(Document(bob))];
     let result = node.execute_tx(data_ops).await?;
     match &result {
-        TransactionResult::TxCommited(basis) => {
-            println!("Data inserted (tx_id={}).", basis.tx_key.tx_id);
+        TransactionResult::TxCommited(tx_key) => {
+            println!("Data inserted (tx_id={}).", tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {
             anyhow::bail!("Data transaction aborted: {err}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
 use crate::datalog::{FindElement, FindSpec, OrBranch, PatternElement, Query, WhereClause};
-use crate::node::{Basis, Database, QueryNode, SubmitNode, TransactionResult, TxKey};
+use crate::node::{Database, QueryNode, SubmitNode, TransactionResult, TxKey};
 use crate::ops::{DataType, TxOp};
 use crate::protocol::*;
 use crate::query::QueryResult;
@@ -75,19 +75,18 @@ impl ClientNode {
         })
     }
 
-    async fn open_db(&self, basis: Option<Basis>) -> Result<ClientDb> {
+    async fn open_db(&self, tx_key: Option<TxKey>) -> Result<ClientDb> {
         let mut conn = self.conn.lock().await;
-        let (basis_tx_id, basis_system_time, basis_seq_num) = match &basis {
-            None => (None, None, None),
-            Some(b) => (
-                Some(b.tx_key.tx_id),
-                Some(b.tx_key.system_time.timestamp_micros()),
-                Some(b.seq_num),
+        let (basis_tx_id, basis_system_time) = match &tx_key {
+            None => (None, None),
+            Some(tk) => (
+                Some(tk.tx_id),
+                Some(tk.system_time.timestamp_micros()),
             ),
         };
         write_frontend_message(
             &mut conn.writer,
-            &FrontendMessage::OpenDb { basis_tx_id, basis_system_time, basis_seq_num },
+            &FrontendMessage::OpenDb { basis_tx_id, basis_system_time },
         )
         .await?;
         conn.writer.flush().await?;
@@ -115,46 +114,6 @@ impl ClientNode {
             tx_id,
             conn: self.conn.clone(),
         })
-    }
-
-    /// Look up the full Basis for a previously submitted transaction.
-    /// The server waits until the transaction has been indexed before responding.
-    pub async fn basis_for_tx(&self, tx_key: TxKey) -> Result<Basis> {
-        let mut conn = self.conn.lock().await;
-        write_frontend_message(
-            &mut conn.writer,
-            &FrontendMessage::BasisForTx {
-                tx_id: tx_key.tx_id,
-                system_time: tx_key.system_time.timestamp_micros(),
-            },
-        )
-        .await?;
-        conn.writer.flush().await?;
-
-        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-        let basis = match msg {
-            BackendMessage::BasisResult { tx_id, system_time, seq_num } => {
-                let dt = crate::protocol::micros_to_datetime(system_time)?;
-                Basis {
-                    tx_key: TxKey { tx_id, system_time: dt },
-                    seq_num,
-                }
-            }
-            BackendMessage::ErrorResponse { message, .. } => {
-                read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-                bail!("BasisForTx error: {}", message);
-            }
-            other => bail!("Expected BasisResult, got {:?}", other),
-        };
-
-        // Expect ReadyForQuery
-        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-        match msg {
-            BackendMessage::ReadyForQuery { .. } => {}
-            other => bail!("Expected ReadyForQuery, got {:?}", other),
-        }
-
-        Ok(basis)
     }
 
     /// Gracefully close the connection.
@@ -221,13 +180,12 @@ impl SubmitNode for ClientNode {
                 status,
                 tx_id,
                 system_time,
-                seq_num,
                 error_message,
             } => {
                 let dt = crate::protocol::micros_to_datetime(system_time)?;
                 let tx_key = TxKey { tx_id, system_time: dt };
                 if status == 0 {
-                    TransactionResult::TxCommited(Basis { tx_key, seq_num })
+                    TransactionResult::TxCommited(tx_key)
                 } else {
                     let err_msg =
                         error_message.unwrap_or_else(|| "transaction aborted".to_string());
@@ -260,8 +218,8 @@ impl QueryNode for ClientNode {
         self.open_db(None).await
     }
 
-    async fn db_with_basis(&self, basis: Basis) -> Result<ClientDb, Error> {
-        self.open_db(Some(basis)).await
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<ClientDb, Error> {
+        self.open_db(Some(tx_key)).await
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -22,7 +22,8 @@ pub const AEV: u8 = 2;
 pub const AE: u8 = 3;
 pub const AV: u8 = 4;
 
-pub const TX_TO_SEQ: u8 = 6;
+/// Prefix for tx_id → TxMeta (system_time) mapping in SlateDB.
+pub const TX_TO_META: u8 = 6;
 
 pub const STATS_INDEX: u8 = 128;
 pub const META_INDEX: u8 = 129;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -16,7 +16,7 @@ use crate::log::{Record, Subscriber};
 use crate::ops::{Attribute, Document, Triple, TxOp};
 use crate::codec;
 use crate::schema::SchemaCache;
-use crate::transaction::{Basis, TxKey};
+use crate::transaction::TxKey;
 use crate::ops::DataType;
 use crate::slate::{DEFAULT_READ_OPTIONS, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
@@ -25,8 +25,8 @@ use crate::clock::Instant;
 pub struct Indexer {
     slatedb: Arc<Db>,
     schema_cache: SchemaCache,
-    latest_indexed_tx: Option<(TxKey, u64)>,
-    tx_completion_sender: broadcast::Sender<(TxKey, Result<u64, Arc<anyhow::Error>>)>,
+    latest_indexed_tx: Option<TxKey>,
+    tx_completion_sender: broadcast::Sender<(TxKey, Result<(), Arc<anyhow::Error>>)>,
 }
 
 struct TxIndexKeys {
@@ -142,29 +142,27 @@ pub(crate) fn build_index_write_batch(
     Ok(write_batch)
 }
 
-/// Interim mapping stored in SlateDB to look up seq_num (and system_time) by tx_id.
-/// Will be replaced when SlateDB exposes WriteHandle.seqnum() (PR #1247).
+/// Metadata stored per transaction in SlateDB (keyed by tx_id under TX_TO_META prefix).
 #[derive(Serialize, Deserialize)]
 struct TxMeta {
-    seq_num: u64,
     system_time: Instant,
 }
 
-fn tx_to_seq_key(tx_id: i64) -> Vec<u8> {
-    concat_bytes(&[&[codec::TX_TO_SEQ], &bincode::serialize(&tx_id).unwrap()])
+fn tx_meta_key(tx_id: i64) -> Vec<u8> {
+    concat_bytes(&[&[codec::TX_TO_META], &bincode::serialize(&tx_id).unwrap()])
 }
 
-/// Scan all TX_TO_SEQ keys in a snapshot and return the Basis for the highest tx_id.
-/// If the snapshot contains no TX_TO_SEQ entries, returns a sentinel basis
-/// (tx_id=0, system_time=epoch, seq_num=0).
+/// Scan all TX_TO_META keys in a snapshot and return the TxKey for the highest tx_id.
+/// If the snapshot contains no TX_TO_META entries, returns a sentinel TxKey
+/// (tx_id=0, system_time=epoch).
 ///
-/// TODO: return a real "empty database" basis once we have one.
+/// TODO: return a real "empty database" TxKey once we have one.
 ///
-/// TODO(triplox-1vr): Switch tx_to_seq_key() to big-endian encoding (tx_id.to_be_bytes())
+/// TODO(triplox-1vr): Switch tx_meta_key() to big-endian encoding (tx_id.to_be_bytes())
 /// so byte order matches numeric order, enabling a reverse iterator for O(1) lookup
 /// instead of this full scan. Breaking change — requires migration or flag day.
-pub async fn latest_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<Basis> {
-    let mut iter = snapshot.scan_prefix_with_options(&[codec::TX_TO_SEQ], &DEFAULT_SCAN_OPTIONS).await?;
+pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
+    let mut iter = snapshot.scan_prefix_with_options(&[codec::TX_TO_META], &DEFAULT_SCAN_OPTIONS).await?;
     let mut latest: Option<(i64, TxMeta)> = None;
     while let Some(kv) = iter.next().await? {
         let tx_id: i64 = bincode::deserialize(&kv.key[1..])?;
@@ -173,25 +171,13 @@ pub async fn latest_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> 
             latest = Some((tx_id, meta));
         }
     }
-    Ok(latest.map(|(tx_id, meta)| Basis {
-        tx_key: TxKey { tx_id, system_time: meta.system_time },
-        seq_num: meta.seq_num,
-    }).unwrap_or_else(|| Basis {
-        tx_key: TxKey { tx_id: 0, system_time: crate::clock::st_from_unix_epoch(0) },
-        seq_num: 0,
+    Ok(latest.map(|(tx_id, meta)| TxKey {
+        tx_id,
+        system_time: meta.system_time,
+    }).unwrap_or_else(|| TxKey {
+        tx_id: 0,
+        system_time: crate::clock::st_from_unix_epoch(0),
     }))
-}
-
-/// Look up the Basis for a given tx_id from SlateDB.
-/// Returns None if no mapping exists for that tx_id.
-pub async fn get_basis_for_tx(slatedb: Arc<Db>, tx_id: i64) -> Option<Basis> {
-    let key = tx_to_seq_key(tx_id);
-    let bytes = slatedb.get_with_options(&key, &DEFAULT_READ_OPTIONS).await.ok()??;
-    let meta: TxMeta = bincode::deserialize(&bytes).ok()?;
-    Some(Basis {
-        tx_key: TxKey { tx_id, system_time: meta.system_time },
-        seq_num: meta.seq_num,
-    })
 }
 
 impl Indexer {
@@ -224,18 +210,16 @@ impl Indexer {
         // tradeoff (see TODO).
         self.schema_cache.process_tx(&tx_ops)?;
 
-        let seq_num = self.slatedb.last_committed_seq();
-
-        // Persist tx_id -> seq_num mapping (interim, see SlateDB PR #1247)
-        let meta = TxMeta { seq_num, system_time: tx_key.system_time };
-        self.slatedb.put(&tx_to_seq_key(tx_key.tx_id), &bincode::serialize(&meta)?).await;
+        // Persist tx_id -> system_time mapping
+        let meta = TxMeta { system_time: tx_key.system_time };
+        self.slatedb.put(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?).await;
 
         // Update latest indexed tx and broadcast completion
-        self.latest_indexed_tx = Some((tx_key, seq_num));
+        self.latest_indexed_tx = Some(tx_key);
 
         // Send notification (warn if no receivers, matching memory_log.rs:51-52)
         // TODO: verify if warning on no receivers is idiomatic Rust broadcast channel pattern
-        if let Err(e) = self.tx_completion_sender.send((tx_key, Ok(seq_num))) {
+        if let Err(e) = self.tx_completion_sender.send((tx_key, Ok(()))) {
             warn!("No receivers for indexed transaction {}: {}", tx_key.tx_id, e);
         }
 
@@ -264,7 +248,7 @@ impl Indexer {
     /// let future = indexer.read().await.await_tx(tx_key);
     /// tokio::time::timeout(Duration::from_millis(500), future).await??;
     /// ```
-    pub fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<u64, Error>> + 'static {
+    pub fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<(), Error>> + 'static {
         // Capture everything we need from self (clone/copy)
         let latest_tx = self.latest_indexed_tx;
         let mut rx = self.tx_completion_sender.subscribe();
@@ -272,9 +256,9 @@ impl Indexer {
         // Return a future that doesn't borrow self
         async move {
             // Fast path: Check if already indexed
-            if let Some((latest_key, seq_num)) = latest_tx {
+            if let Some(latest_key) = latest_tx {
                 if tx_key <= latest_key {
-                    return Ok(seq_num);
+                    return Ok(());
                 }
             }
 
@@ -504,7 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tx_to_seq_mapping_written() -> Result<(), Error> {
+    async fn test_tx_meta_written() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
@@ -515,25 +499,24 @@ mod tests {
         let tx_ops = vec![TxOp::Put(Document(map))];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        let basis = get_basis_for_tx(slate.clone(), 42).await;
-        assert!(basis.is_some(), "Should find basis for tx_id 42");
-        let basis = basis.unwrap();
-        assert_eq!(basis.tx_key.tx_id, 42);
-        assert_eq!(basis.tx_key.system_time, st_from_unix_epoch(1000));
-        assert!(basis.seq_num > 0, "seq_num should be positive after a write");
+        let snapshot = Arc::new(slate.snapshot().await?);
+        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        assert_eq!(latest.tx_id, 42);
+        assert_eq!(latest.system_time, st_from_unix_epoch(1000));
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_tx_to_seq_mapping_not_found() -> Result<(), Error> {
+    async fn test_tx_meta_empty_db() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
-        let basis = get_basis_for_tx(slate.clone(), 999).await;
-        assert!(basis.is_none(), "Should return None for non-existent tx_id");
+        let snapshot = Arc::new(slate.snapshot().await?);
+        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        assert_eq!(latest.tx_id, 0, "Should return sentinel for empty DB");
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_tx_to_seq_multiple_txs() -> Result<(), Error> {
+    async fn test_tx_meta_latest_wins() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
@@ -548,12 +531,10 @@ mod tests {
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let basis0 = get_basis_for_tx(slate.clone(), 1).await.unwrap();
-        let basis1 = get_basis_for_tx(slate.clone(), 2).await.unwrap();
-        let basis2 = get_basis_for_tx(slate.clone(), 3).await.unwrap();
-
-        assert!(basis0.seq_num < basis1.seq_num);
-        assert!(basis1.seq_num < basis2.seq_num);
+        let snapshot = Arc::new(slate.snapshot().await?);
+        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        assert_eq!(latest.tx_id, 3, "Should return highest tx_id");
+        assert_eq!(latest.system_time, st_from_unix_epoch(300));
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub mod protocol;
 pub mod server;
 pub mod client;
 
-pub use node::{Basis, Database, Node, QueryNode, SubmitNode, TransactionResult, TxKey, DB};
+pub use node::{Database, Node, QueryNode, SubmitNode, TransactionResult, TxKey, DB};

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,7 +15,7 @@ use crate::memory_log::MemoryLog;
 use crate::ops::TxOp;
 use crate::query::{execute_query, validate_query, QueryResult};
 use crate::slate::{in_memory_slate, local_slate};
-pub use crate::transaction::{Basis, TransactionResult, TxKey};
+pub use crate::transaction::{TransactionResult, TxKey};
 use tokio_util::sync::CancellationToken;
 
 #[allow(async_fn_in_trait)]
@@ -33,14 +33,14 @@ pub trait Database {
 pub trait QueryNode {
     type DB: Database;
     async fn db(&self) -> Result<Self::DB, Error>;
-    async fn db_with_basis(&self, basis: Basis) -> Result<Self::DB, Error>;
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<Self::DB, Error>;
 }
 
 pub struct DB {
     snapshot: Arc<slatedb::DbSnapshot>,
     attribute_map: HashMap<String, i64>,
     handle: Handle,
-    basis: Basis,
+    tx_key: TxKey,
 }
 
 #[allow(unused)]
@@ -48,18 +48,18 @@ pub struct Eid {}
 
 #[allow(unused)]
 impl DB {
-    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle, basis: Basis) -> Self {
-        Self { snapshot, attribute_map, handle, basis }
+    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey) -> Self {
+        Self { snapshot, attribute_map, handle, tx_key }
     }
 
-    /// Construct a DB from a snapshot by scanning TX_TO_SEQ keys to find the latest basis.
+    /// Construct a DB from a snapshot by scanning TX_TO_META keys to find the latest TxKey.
     pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
-        let basis = crate::indexer::latest_basis_from_snapshot(&snapshot).await?;
-        Ok(Self { snapshot, attribute_map, handle, basis })
+        let tx_key = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
+        Ok(Self { snapshot, attribute_map, handle, tx_key })
     }
 
-    pub fn basis(&self) -> &Basis {
-        &self.basis
+    pub fn tx_key(&self) -> &TxKey {
+        &self.tx_key
     }
 
     pub fn entity(&self, _eid: Eid) {
@@ -77,7 +77,7 @@ impl Database for DB {
         let handle = self.handle.clone();
         let attribute_map = self.attribute_map.clone();
         let query = query.clone();
-        let as_of = self.basis.tx_key.system_time;
+        let as_of = self.tx_key.system_time;
 
         tokio::task::spawn_blocking(move || {
             execute_query(&query, snapshot, handle, &attribute_map, as_of)
@@ -138,15 +138,6 @@ impl Node<FileLog> {
 }
 
 impl<L: TxLog> Node<L> {
-    /// Look up the Basis for a given TxKey from the persisted index.
-    /// Returns None if the tx_id has not been indexed yet.
-    pub async fn basis_for_tx(&self, tx_key: TxKey) -> Result<Basis, Error> {
-        self.indexer.read().await.await_tx(tx_key).await?;
-        crate::indexer::get_basis_for_tx(self.slatedb.clone(), tx_key.tx_id)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("No basis found for tx {}", tx_key.tx_id))
-    }
-
     pub async fn close(self) {
         self.subscription.cancel();
         self.slatedb.close().await.unwrap();
@@ -166,7 +157,7 @@ impl<L: TxLog> SubmitNode for Node<L> {
 
         let wait_future = self.indexer.read().await.await_tx(tx_key);
         match wait_future.await {
-            Ok(seq_num) => Ok(TransactionResult::TxCommited(Basis { tx_key, seq_num })),
+            Ok(()) => Ok(TransactionResult::TxCommited(tx_key)),
             Err(e) => Ok(TransactionResult::TxAborted(tx_key, e.into())),
         }
     }
@@ -180,11 +171,11 @@ impl<L: TxLog> QueryNode for Node<L> {
         let handle = Handle::current();
         DB::from_latest_snapshot(snapshot, attribute_map, handle).await
     }
-    async fn db_with_basis(&self, basis: Basis) -> Result<DB, Error> {
-        let snapshot = self.slatedb.snapshot_as_of(basis.seq_num).await?;
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
+        let snapshot = self.slatedb.snapshot().await?;
         let attribute_map = self.indexer.read().await.schema_cache().attribute_map();
         let handle = Handle::current();
-        Ok(DB::new(snapshot, attribute_map, handle, basis))
+        Ok(DB::new(snapshot, attribute_map, handle, tx_key))
     }
 }
 
@@ -706,7 +697,7 @@ mod tests {
     // TODO(triplox-5ox): Once cardinality/one override is implemented, update this test to use
     // the same entity in both transactions and verify only the latest value is returned.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_db_with_basis_time_travel() {
+    async fn test_db_as_of_time_travel() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -714,8 +705,8 @@ mod tests {
         doc1.insert("db/id".to_string(), DataType::Long(100));
         doc1.insert("name".to_string(), DataType::String("alice".to_string()));
 
-        let basis1 = match node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
+        let tx_key1 = match node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap() {
+            TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx1 should commit"),
         };
 
@@ -723,8 +714,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        let basis2 = match node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
+        let tx_key2 = match node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap() {
+            TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx2 should commit"),
         };
 
@@ -740,69 +731,20 @@ mod tests {
             })],
         };
 
-        // db_with_basis(basis1): should only see entity 100
-        let db1 = node.db_with_basis(basis1).await.unwrap();
+        // db_as_of(tx_key1): should only see entity 100
+        let db1 = node.db_as_of(tx_key1).await.unwrap();
         let result1 = db1.query(&query).await.unwrap();
         assert_eq!(result1.len(), 1);
         assert_eq!(result1[0], vec![DataType::Long(100), DataType::String("alice".to_string())]);
 
-        // db_with_basis(basis2): should see both entities
-        let db2 = node.db_with_basis(basis2).await.unwrap();
+        // db_as_of(tx_key2): should see both entities
+        let db2 = node.db_as_of(tx_key2).await.unwrap();
         let result2 = db2.query(&query).await.unwrap();
         assert_eq!(result2.len(), 2);
         assert!(result2.contains(&vec![DataType::Long(100), DataType::String("alice".to_string())]));
         assert!(result2.contains(&vec![DataType::Long(101), DataType::String("bob".to_string())]));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_basis_for_tx_returns_correct_seq_num_per_tx() {
-        // basis_for_tx should return the seq_num corresponding to the specific tx,
-        // not the latest indexed tx's seq_num.
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-
-        // Tx1: entity 1 with name "alice"
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("db/id".to_string(), DataType::Long(1));
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let basis1_from_execute = match node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
-            _ => panic!("Tx1 should commit"),
-        };
-
-        // Tx2: entity 2 with name "bob"
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("db/id".to_string(), DataType::Long(2));
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        let basis2_from_execute = match node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
-            _ => panic!("Tx2 should commit"),
-        };
-
-        // Both txs are now indexed. Call basis_for_tx for each.
-        // BUG: basis_for_tx hits the fast path and returns the latest indexed seq_num
-        // for both, instead of the seq_num specific to each tx.
-        let basis1 = node.basis_for_tx(basis1_from_execute.tx_key).await.unwrap();
-        let basis2 = node.basis_for_tx(basis2_from_execute.tx_key).await.unwrap();
-
-        // The two bases must have different seq_nums since they are different transactions
-        assert_ne!(
-            basis1.seq_num, basis2.seq_num,
-            "basis_for_tx(tx1) and basis_for_tx(tx2) should have different seq_nums, \
-             but both returned {}",
-            basis1.seq_num
-        );
-
-        // basis1.seq_num should be less than basis2.seq_num
-        assert!(
-            basis1.seq_num < basis2.seq_num,
-            "basis1.seq_num ({}) should be less than basis2.seq_num ({})",
-            basis1.seq_num,
-            basis2.seq_num
-        );
-    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_local_node_survives_restart() {
@@ -864,7 +806,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_db_with_basis_pins_snapshot() {
+    async fn test_db_as_of_pins_snapshot() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -873,8 +815,8 @@ mod tests {
         doc1.insert("db/id".to_string(), DataType::Long(1));
         doc1.insert("name".to_string(), DataType::String("alice".to_string()));
         let result1 = node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        let basis1 = match result1 {
-            TransactionResult::TxCommited(b) => b,
+        let tx_key1 = match result1 {
+            TransactionResult::TxCommited(tk) => tk,
             _ => panic!("Expected TxCommited"),
         };
 
@@ -884,8 +826,8 @@ mod tests {
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
         node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
 
-        // db_with_basis pinned to first tx should only see alice
-        let db = node.db_with_basis(basis1).await.unwrap();
+        // db_as_of pinned to first tx should only see alice
+        let db = node.db_as_of(tx_key1).await.unwrap();
         let query = Query {
             find: FindSpec::FindRel(vec![
                 FindElement::Variable("?e".to_string()),
@@ -898,7 +840,7 @@ mod tests {
             })],
         };
         let results = db.query(&query).await.unwrap();
-        assert_eq!(results.len(), 1, "basis-pinned DB should only see alice, got {:?}", results);
+        assert_eq!(results.len(), 1, "as-of-pinned DB should only see alice, got {:?}", results);
         assert_eq!(results[0], vec![DataType::Long(1), DataType::String("alice".to_string())]);
 
         // latest db should see both
@@ -910,13 +852,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_db_on_fresh_node_returns_sentinel_basis() {
+    async fn test_db_on_fresh_node_returns_sentinel_tx_key() {
         let node = Node::memory_node().await;
 
         let db = node.db().await.unwrap();
-        let basis = db.basis();
-        assert_eq!(basis.tx_key.tx_id, 0);
-        assert_eq!(basis.seq_num, 0);
+        let tx_key = db.tx_key();
+        assert_eq!(tx_key.tx_id, 0);
 
         node.close().await;
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -48,7 +48,6 @@ pub const MSG_QUERY: u8 = b'Q';
 pub const MSG_EXECUTE: u8 = b'E';
 pub const MSG_SUBSCRIBE: u8 = b'S';
 pub const MSG_UNSUBSCRIBE: u8 = b'U';
-pub const MSG_BASIS_FOR_TX: u8 = b'F';
 pub const MSG_TERMINATE: u8 = b'X';
 
 // Backend message type bytes
@@ -63,7 +62,6 @@ pub const MSG_TX_KEY: u8 = b'Y';
 pub const MSG_TX_RESULT: u8 = b'G';
 pub const MSG_UNSUBSCRIBE_COMPLETE: u8 = b'N';
 pub const MSG_HEARTBEAT: u8 = b'K';
-pub const MSG_BASIS_RESULT: u8 = b'A';
 pub const MSG_ERROR_RESPONSE: u8 = b'W';
 
 // ReadyForQuery status bytes
@@ -183,7 +181,6 @@ pub enum FrontendMessage {
     OpenDb {
         basis_tx_id: Option<i64>,
         basis_system_time: Option<i64>,
-        basis_seq_num: Option<u64>,
     },
     CloseDb {
         db_id: u32,
@@ -201,10 +198,6 @@ pub enum FrontendMessage {
         db_id: u32,
     },
     Unsubscribe,
-    BasisForTx {
-        tx_id: i64,
-        system_time: i64,
-    },
     Terminate,
 }
 
@@ -244,13 +237,7 @@ pub enum BackendMessage {
         status: u8,
         tx_id: i64,
         system_time: i64,
-        seq_num: u64,
         error_message: Option<String>,
-    },
-    BasisResult {
-        tx_id: i64,
-        system_time: i64,
-        seq_num: u64,
     },
     UnsubscribeComplete,
     Heartbeat,
@@ -716,10 +703,9 @@ fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
             encode_u16(buf, *version_minor);
             encode_string_map(buf, params);
         }
-        FrontendMessage::OpenDb { basis_tx_id, basis_system_time, basis_seq_num } => {
+        FrontendMessage::OpenDb { basis_tx_id, basis_system_time } => {
             encode_option_i64(buf, basis_tx_id);
             encode_option_i64(buf, basis_system_time);
-            encode_option_u64(buf, basis_seq_num);
         }
         FrontendMessage::CloseDb { db_id } => {
             encode_u32(buf, *db_id);
@@ -746,10 +732,6 @@ fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
             encode_u32(buf, *db_id);
         }
         FrontendMessage::Unsubscribe => {}
-        FrontendMessage::BasisForTx { tx_id, system_time } => {
-            encode_i64(buf, *tx_id);
-            encode_i64(buf, *system_time);
-        }
         FrontendMessage::Terminate => {}
     }
 }
@@ -790,19 +772,12 @@ fn encode_backend_payload(buf: &mut Vec<u8>, msg: &BackendMessage) {
             status,
             tx_id,
             system_time,
-            seq_num,
             error_message,
         } => {
             encode_u8(buf, *status);
             encode_i64(buf, *tx_id);
             encode_i64(buf, *system_time);
-            encode_u64(buf, *seq_num);
             encode_option_string(buf, error_message);
-        }
-        BackendMessage::BasisResult { tx_id, system_time, seq_num } => {
-            encode_i64(buf, *tx_id);
-            encode_i64(buf, *system_time);
-            encode_u64(buf, *seq_num);
         }
         BackendMessage::UnsubscribeComplete => {}
         BackendMessage::Heartbeat => {}
@@ -831,7 +806,6 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
         MSG_OPEN_DB => Ok(FrontendMessage::OpenDb {
             basis_tx_id: cursor.read_option_i64()?,
             basis_system_time: cursor.read_option_i64()?,
-            basis_seq_num: cursor.read_option_u64()?,
         }),
         MSG_CLOSE_DB => Ok(FrontendMessage::CloseDb {
             db_id: cursor.read_u32()?,
@@ -853,10 +827,6 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
             db_id: cursor.read_u32()?,
         }),
         MSG_UNSUBSCRIBE => Ok(FrontendMessage::Unsubscribe),
-        MSG_BASIS_FOR_TX => Ok(FrontendMessage::BasisForTx {
-            tx_id: cursor.read_i64()?,
-            system_time: cursor.read_i64()?,
-        }),
         MSG_TERMINATE => Ok(FrontendMessage::Terminate),
         _ => bail!("Unknown frontend message type: 0x{:02x}", msg_type),
     }
@@ -909,13 +879,7 @@ fn decode_backend_payload(
             status: cursor.read_u8()?,
             tx_id: cursor.read_i64()?,
             system_time: cursor.read_i64()?,
-            seq_num: cursor.read_u64()?,
             error_message: cursor.read_option_string()?,
-        }),
-        MSG_BASIS_RESULT => Ok(BackendMessage::BasisResult {
-            tx_id: cursor.read_i64()?,
-            system_time: cursor.read_i64()?,
-            seq_num: cursor.read_u64()?,
         }),
         MSG_UNSUBSCRIBE_COMPLETE => Ok(BackendMessage::UnsubscribeComplete),
         MSG_HEARTBEAT => Ok(BackendMessage::Heartbeat),
@@ -1012,7 +976,6 @@ pub async fn write_frontend_message<W: AsyncWrite + Unpin>(
                 FrontendMessage::Execute { .. } => MSG_EXECUTE,
                 FrontendMessage::Subscribe { .. } => MSG_SUBSCRIBE,
                 FrontendMessage::Unsubscribe => MSG_UNSUBSCRIBE,
-                FrontendMessage::BasisForTx { .. } => MSG_BASIS_FOR_TX,
                 FrontendMessage::Terminate => MSG_TERMINATE,
                 FrontendMessage::Startup { .. } => unreachable!(),
             };
@@ -1072,7 +1035,6 @@ pub async fn write_backend_message<W: AsyncWrite + Unpin>(
         BackendMessage::ReadyForQuery { .. } => MSG_READY_FOR_QUERY,
         BackendMessage::TxKey { .. } => MSG_TX_KEY,
         BackendMessage::TxResult { .. } => MSG_TX_RESULT,
-        BackendMessage::BasisResult { .. } => MSG_BASIS_RESULT,
         BackendMessage::UnsubscribeComplete => MSG_UNSUBSCRIBE_COMPLETE,
         BackendMessage::Heartbeat => MSG_HEARTBEAT,
         BackendMessage::ErrorResponse { .. } => MSG_ERROR_RESPONSE,
@@ -1308,29 +1270,14 @@ mod tests {
         let msg = FrontendMessage::OpenDb {
             basis_tx_id: Some(42),
             basis_system_time: Some(1700000000000000),
-            basis_seq_num: Some(7),
         };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
 
         let msg = FrontendMessage::OpenDb {
             basis_tx_id: None,
             basis_system_time: None,
-            basis_seq_num: None,
         };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
-    }
-
-    #[tokio::test]
-    async fn test_basis_for_tx_roundtrip() {
-        let msg = FrontendMessage::BasisForTx { tx_id: 42, system_time: 1700000000000000 };
-        assert_eq!(roundtrip_frontend(&msg).await, msg);
-
-        let msg = BackendMessage::BasisResult {
-            tx_id: 42,
-            system_time: 1_000_000,
-            seq_num: 7,
-        };
-        assert_eq!(roundtrip_backend(&msg).await, msg);
     }
 
     #[tokio::test]
@@ -1475,7 +1422,6 @@ mod tests {
             status: 0,
             tx_id: 42,
             system_time: 1700000000000000,
-            seq_num: 7,
             error_message: None,
         };
         assert_eq!(roundtrip_backend(&msg).await, msg);
@@ -1487,7 +1433,6 @@ mod tests {
             status: 1,
             tx_id: 42,
             system_time: 1700000000000000,
-            seq_num: 0,
             error_message: Some("transaction aborted: constraint violation".to_string()),
         };
         assert_eq!(roundtrip_backend(&msg).await, msg);

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::log::TxLog;
-use crate::node::{Basis, Database, Node, QueryNode, SubmitNode, TransactionResult, DB};
+use crate::node::{Database, Node, QueryNode, SubmitNode, TransactionResult, DB};
 use crate::parse::parse_query;
 use crate::protocol::*;
 use crate::query::QueryResult;
@@ -414,8 +414,8 @@ async fn handle_connection<L: TxLog + 'static>(
                 return Ok(());
             }
 
-            FrontendMessage::OpenDb { basis_tx_id, basis_system_time, basis_seq_num } => {
-                match handle_open_db(&node, &db_cache, &mut conn_state, basis_tx_id, basis_system_time, basis_seq_num).await {
+            FrontendMessage::OpenDb { basis_tx_id, basis_system_time } => {
+                match handle_open_db(&node, &db_cache, &mut conn_state, basis_tx_id, basis_system_time).await {
                     Ok((db_id, tx_id)) => {
                         write_backend_message(
                             &mut writer,
@@ -537,18 +537,6 @@ async fn handle_connection<L: TxLog + 'static>(
                 ready_for_query_flush(&mut writer).await?;
             }
 
-            FrontendMessage::BasisForTx { tx_id, system_time } => {
-                match handle_basis_for_tx(&node, tx_id, system_time).await {
-                    Ok(basis_msg) => {
-                        write_backend_message(&mut writer, &basis_msg).await?;
-                    }
-                    Err(e) => {
-                        write_error_response(&mut writer, SEVERITY_ERROR, e).await?;
-                    }
-                }
-                ready_for_query_flush(&mut writer).await?;
-            }
-
             FrontendMessage::Startup { .. } => {
                 write_backend_message(
                     &mut writer,
@@ -579,32 +567,30 @@ async fn handle_open_db<L: TxLog + 'static>(
     conn_state: &mut ConnectionState,
     basis_tx_id: Option<i64>,
     basis_system_time: Option<i64>,
-    basis_seq_num: Option<u64>,
 ) -> Result<(u32, i64)> {
-    let (arc_db, tx_id) = match (basis_tx_id, basis_system_time, basis_seq_num) {
-        (None, None, None) => {
+    let (arc_db, tx_id) = match (basis_tx_id, basis_system_time) {
+        (None, None) => {
             // TODO: on cache hit, `db` is created and immediately dropped.
             // Consider a DbCache::get_or_insert API to avoid the waste.
             let db = node.db().await?;
-            let tx_id = db.basis().tx_key.tx_id;
+            let tx_id = db.tx_key().tx_id;
             let arc_db = db_cache.acquire(tx_id, || async move { Ok(db) }).await?;
             (arc_db, tx_id)
         }
-        (Some(tid), Some(st), Some(seq)) => {
+        (Some(tid), Some(st)) => {
             let system_time = crate::protocol::micros_to_datetime(st)?;
             let tx_key = crate::transaction::TxKey {
                 tx_id: tid,
                 system_time,
             };
-            let basis = Basis { tx_key, seq_num: seq };
-            let tx_id = basis.tx_key.tx_id;
+            let tx_id = tx_key.tx_id;
             let node = node.clone();
             let arc_db = db_cache.acquire(tx_id, || async move {
-                node.db_with_basis(basis).await
+                node.db_as_of(tx_key).await
             }).await?;
             (arc_db, tx_id)
         }
-        _ => bail!("OpenDb requires all three basis fields or none"),
+        _ => bail!("OpenDb requires both basis fields or none"),
     };
 
     let db_id = conn_state.allocate_handle(tx_id, arc_db)?;
@@ -638,23 +624,6 @@ async fn handle_query(
     Ok((result, find_vars))
 }
 
-async fn handle_basis_for_tx<L: TxLog + 'static>(
-    node: &Arc<Node<L>>,
-    tx_id: i64,
-    system_time: i64,
-) -> Result<BackendMessage> {
-    let tx_key = crate::transaction::TxKey {
-        tx_id,
-        system_time: crate::protocol::micros_to_datetime(system_time)?,
-    };
-    let basis = node.basis_for_tx(tx_key).await?;
-    Ok(BackendMessage::BasisResult {
-        tx_id: basis.tx_key.tx_id,
-        system_time: basis.tx_key.system_time.timestamp_micros(),
-        seq_num: basis.seq_num,
-    })
-}
-
 async fn handle_execute<L: TxLog + 'static>(
     node: &Arc<Node<L>>,
     ops: Vec<crate::ops::TxOp>,
@@ -663,18 +632,16 @@ async fn handle_execute<L: TxLog + 'static>(
     if await_indexing {
         let result = node.execute_tx(ops).await?;
         match result {
-            TransactionResult::TxCommited(basis) => Ok(BackendMessage::TxResult {
+            TransactionResult::TxCommited(tx_key) => Ok(BackendMessage::TxResult {
                 status: 0,
-                tx_id: basis.tx_key.tx_id,
-                system_time: basis.tx_key.system_time.timestamp_micros(),
-                seq_num: basis.seq_num,
+                tx_id: tx_key.tx_id,
+                system_time: tx_key.system_time.timestamp_micros(),
                 error_message: None,
             }),
             TransactionResult::TxAborted(tx_key, err) => Ok(BackendMessage::TxResult {
                 status: 1,
                 tx_id: tx_key.tx_id,
                 system_time: tx_key.system_time.timestamp_micros(),
-                seq_num: 0,
                 error_message: Some(err.to_string()),
             }),
         }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,14 +10,8 @@ pub struct TxKey {
     pub system_time: Instant
 }
 
-#[derive(Clone, Debug)]
-pub struct Basis {
-    pub tx_key: TxKey,
-    pub seq_num: u64,
-}
-
 #[derive(Debug)]
 pub enum TransactionResult {
-    TxCommited(Basis),
+    TxCommited(TxKey),
     TxAborted(TxKey, Box<dyn Error>),
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -10,7 +10,7 @@ use triplox::ops::{DataType, Document, TxOp};
 use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
-use triplox::{Basis, TransactionResult};
+use triplox::TransactionResult;
 
 async fn define_test_schema(client: &ClientNode) {
     let result = client.execute_tx(test_schema_tx()).await.unwrap();
@@ -173,7 +173,7 @@ async fn test_two_connections() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_execute_tx_returns_basis_with_seq_num() {
+async fn test_execute_tx_returns_tx_key() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
@@ -184,8 +184,8 @@ async fn test_execute_tx_returns_basis_with_seq_num() {
     let result = client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
 
     match result {
-        TransactionResult::TxCommited(basis) => {
-            assert!(basis.seq_num > 0, "seq_num should be positive after indexing");
+        TransactionResult::TxCommited(tx_key) => {
+            assert!(tx_key.tx_id > 0, "tx_id should be positive after indexing");
         }
         _ => panic!("Expected TxCommited"),
     }
@@ -195,7 +195,7 @@ async fn test_execute_tx_returns_basis_with_seq_num() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_db_with_basis() {
+async fn test_db_as_of() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
@@ -205,8 +205,8 @@ async fn test_db_with_basis() {
     doc1.insert("db/id".to_string(), DataType::Long(1));
     doc1.insert("name".to_string(), DataType::String("alice".to_string()));
     let result1 = client.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-    let basis1 = match result1 {
-        TransactionResult::TxCommited(b) => b,
+    let tx_key1 = match result1 {
+        TransactionResult::TxCommited(tk) => tk,
         _ => panic!("Expected TxCommited"),
     };
 
@@ -216,45 +216,13 @@ async fn test_db_with_basis() {
     doc2.insert("name".to_string(), DataType::String("bob".to_string()));
     client.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
 
-    // Open DB pinned to basis after first tx — should only see alice
-    let db = client.db_with_basis(basis1).await.unwrap();
+    // Open DB pinned to tx_key after first tx — should only see alice
+    let db = client.db_as_of(tx_key1).await.unwrap();
     let result = db
         .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0], vec![DataType::Long(1), DataType::String("alice".to_string())]);
-
-    db.close().await.unwrap();
-    client.close().await.unwrap();
-    token.cancel();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_basis_for_tx_after_submit() {
-    let (addr, token) = start_test_server().await;
-    let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
-
-    // Fire-and-forget submit
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(1));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    let tx_key = client.submit_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
-
-    // Look up the full basis (server waits for indexing)
-    let basis = client.basis_for_tx(tx_key.clone()).await.unwrap();
-    assert_eq!(basis.tx_key.tx_id, tx_key.tx_id);
-    assert_eq!(basis.tx_key.system_time, tx_key.system_time);
-    assert!(basis.seq_num > 0, "seq_num should be positive after indexing");
-
-    // The basis should be usable to pin a DB snapshot
-    let db = client.db_with_basis(basis).await.unwrap();
-    let result = db
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
-        .await
-        .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::Long(1), DataType::String("alice".to_string())]);
 

--- a/triplox-jvm/src/main/clojure/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/triplox/api.clj
@@ -31,7 +31,6 @@
     {:tx-id (.txId result)
      :system-time (.systemTime result)
      :committed? (.isCommitted result)
-     :seq-num (.seqNum result)
      :error-message (.errorMessage result)}))
 
 (defn submit-tx

--- a/triplox-jvm/src/main/java/io/triplox/client/BackendMessage.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/BackendMessage.java
@@ -14,7 +14,7 @@ public sealed interface BackendMessage {
     record DataBatchComplete(long txId) implements BackendMessage {}
     record ReadyForQuery(byte status) implements BackendMessage {}
     record TxKey(long txId, long systemTime) implements BackendMessage {}
-    record TxResult(byte status, long txId, long systemTime, long seqNum, String errorMessage) implements BackendMessage {}
+    record TxResult(byte status, long txId, long systemTime, String errorMessage) implements BackendMessage {}
     record UnsubscribeComplete() implements BackendMessage {}
     record Heartbeat() implements BackendMessage {}
     record ErrorResponse(byte severity, short code, String message, String detail, String hint) implements BackendMessage {}

--- a/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
@@ -140,7 +140,7 @@ public class TriploxNode implements AutoCloseable {
         if (msg instanceof BackendMessage.TxResult txResult) {
             expectReadyForQuery();
             return new TxResultValue(txResult.status(), txResult.txId(),
-                    txResult.systemTime(), txResult.seqNum(), txResult.errorMessage());
+                    txResult.systemTime(), txResult.errorMessage());
         }
         throw unexpectedMessage("TxResult", msg);
     }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxResultValue.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxResultValue.java
@@ -3,6 +3,6 @@ package io.triplox.client;
 /**
  * Result of an awaited transaction.
  */
-public record TxResultValue(byte status, long txId, long systemTime, long seqNum, String errorMessage) {
+public record TxResultValue(byte status, long txId, long systemTime, String errorMessage) {
     public boolean isCommitted() { return status == 0; }
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
@@ -46,7 +46,6 @@ public final class WireCodec {
         writeFramed(out, MSG_OPEN_DB, dos -> {
             DataTypeCodec.encodeOptionalLong(dos, basisTxId);  // basis_tx_id
             DataTypeCodec.encodeOptionalLong(dos, null);       // basis_system_time
-            DataTypeCodec.encodeOptionalLong(dos, null);       // basis_seq_num
         });
     }
 
@@ -172,7 +171,7 @@ public final class WireCodec {
             case MSG_TX_KEY -> new BackendMessage.TxKey(in.readLong(), in.readLong());
 
             case MSG_TX_RESULT -> new BackendMessage.TxResult(
-                    in.readByte(), in.readLong(), in.readLong(), in.readLong(),
+                    in.readByte(), in.readLong(), in.readLong(),
                     DataTypeCodec.decodeOptionalString(in));
 
             case MSG_UNSUBSCRIBE_COMPLETE -> new BackendMessage.UnsubscribeComplete();

--- a/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
@@ -163,7 +163,6 @@ class WireCodecTest {
         dos.writeByte(0); // committed
         dos.writeLong(42);
         dos.writeLong(1700000000000000L);
-        dos.writeLong(7);
         DataTypeCodec.encodeOptionalString(dos, null);
         dos.flush();
 
@@ -174,7 +173,6 @@ class WireCodecTest {
                 new ByteArrayInputStream(frame.toByteArray()));
         assertEquals(0, msg.status());
         assertEquals(42, msg.txId());
-        assertEquals(7, msg.seqNum());
         assertNull(msg.errorMessage());
     }
 
@@ -185,7 +183,6 @@ class WireCodecTest {
         dos.writeByte(1); // aborted
         dos.writeLong(42);
         dos.writeLong(1700000000000000L);
-        dos.writeLong(0);
         DataTypeCodec.encodeOptionalString(dos, "constraint violation");
         dos.flush();
 
@@ -326,7 +323,7 @@ class WireCodecTest {
         var dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(MSG_OPEN_DB, dis.readByte());
         int length = dis.readInt();
-        assertEquals(7, length); // 4 + 3x 1 byte None tags (basis_tx_id, basis_system_time, basis_seq_num)
+        assertEquals(6, length); // 4 + 2x 1 byte None tags (basis_tx_id, basis_system_time)
 
         baos = new ByteArrayOutputStream();
         WireCodec.writeOpenDb(baos, 42L);
@@ -334,6 +331,6 @@ class WireCodecTest {
         dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(MSG_OPEN_DB, dis.readByte());
         length = dis.readInt();
-        assertEquals(15, length); // 4 + (1 tag + 8 i64) + 1 None + 1 None
+        assertEquals(14, length); // 4 + (1 tag + 8 i64) + 1 None
     }
 }


### PR DESCRIPTION
## Summary

- Remove the `Basis` struct (`TxKey` + `seq_num`) — with PR #17 baking timestamps into index keys and using `TemporalFilterIterator`, SlateDB's `snapshot_as_of(seq_num)` is no longer needed
- Rename `db_with_basis()` → `db_as_of()` on the `QueryNode` trait, using `snapshot()` instead of `snapshot_as_of()`
- Delete `basis_for_tx()` from `Node` and `ClientNode`
- Remove `BasisForTx`/`BasisResult` wire protocol messages entirely
- Remove `seq_num` from `TxResult` and `basis_seq_num` from `OpenDb` messages
- Rename `TX_TO_SEQ` → `TX_TO_META` (kept for future transaction entities)
- Update triplox-jvm client (Java + Clojure) to match

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — 287 unit tests pass
- [x] `cargo test --test client_server_test` — 10 Rust integration tests pass
- [x] `./gradlew test` — JVM unit tests pass
- [x] `./gradlew integrationTest` — JVM integration tests pass against dev server
- [x] `cargo build` in `examples/` — example builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)