### PR TITLE
refactor: remove Triple struct, inline into TxOp

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -190,7 +190,7 @@ mod tests {
     use crate::datalog::{FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern, WhereClause};
     use crate::expr::{BinaryExpr, BinaryOp, Expr};
     use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
-    use crate::ops::{Attribute, DataType, Document, EntityId, Triple, TxOp};
+    use crate::ops::{Attribute, DataType, Document, EntityId, TxOp};
     use crate::schema::test_schema_tx;
     // "name" has entity_id 50, "age" 51, "email" 52, "follows" 53 from test_schema_tx
     use crate::transaction::TransactionResult;
@@ -344,12 +344,11 @@ mod tests {
         define_test_schema(&node).await;
 
         // Use entity ID 100 to avoid reserved bootstrap range (1-31)
-        let triple = Triple {
-            entity: EntityId::new(100),
+        let tx_ops = vec![TxOp::Add {
+            entity_id: EntityId::new(100),
             attribute: Attribute("email".to_string()),
             value: DataType::String("test@example.com".to_string()),
-        };
-        let tx_ops = vec![TxOp::Add(triple)];
+        }];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -132,19 +132,11 @@ impl_from_for_enum!(
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Document(pub BTreeMap<String, DataType>);
 
-// either extend this with t and op as options or create another type for running through indices
-// make value optional ?
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Triple {
-    pub entity: EntityId,
-    pub attribute: Attribute,
-    pub value: DataType,
-}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(Document),
-    Add(Triple),
-    Retract(Triple),
+    Add { entity_id: EntityId, attribute: Attribute, value: DataType },
+    Retract { entity_id: EntityId, attribute: Attribute, value: DataType },
     Delete(EntityId),
     Erase(EntityId),
 }
@@ -191,18 +183,18 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: Instant) -> Result<Vec<Datom>> {
                     });
                 }
             }
-            TxOp::Add(Triple { entity, attribute, value }) => {
+            TxOp::Add { entity_id, attribute, value } => {
                 datoms.push(Datom {
-                    entity: entity.0,
+                    entity: entity_id.0,
                     attribute: attribute.0.clone(),
                     value: value.clone(),
                     tx,
                     op: DatomOp::Assert,
                 });
             }
-            TxOp::Retract(Triple { entity, attribute, value }) => {
+            TxOp::Retract { entity_id, attribute, value } => {
                 datoms.push(Datom {
-                    entity: entity.0,
+                    entity: entity_id.0,
                     attribute: attribute.0.clone(),
                     value: value.clone(),
                     tx,
@@ -276,11 +268,11 @@ mod tests {
 
     #[test]
     fn test_op_add() {
-        let op = TxOp::Add(Triple {
-            entity: EntityId(1),
+        let op = TxOp::Add {
+            entity_id: EntityId(1),
             attribute: Attribute("string".to_string()),
             value: DataType::String("string_value".to_string()),
-        });
+        };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
@@ -288,11 +280,11 @@ mod tests {
 
     #[test]
     fn test_op_retract() {
-        let op = TxOp::Retract(Triple {
-            entity: EntityId(1),
+        let op = TxOp::Retract {
+            entity_id: EntityId(1),
             attribute: Attribute("string".to_string()),
             value: DataType::String("string_value".to_string()),
-        });
+        };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
@@ -333,11 +325,11 @@ mod tests {
     #[test]
     fn test_tx_ops_to_datoms_add() {
         let tx = crate::clock::st_from_unix_epoch(1000);
-        let ops = vec![TxOp::Add(Triple {
-            entity: EntityId(200),
+        let ops = vec![TxOp::Add {
+            entity_id: EntityId(200),
             attribute: Attribute("name".to_string()),
             value: DataType::String("bob".to_string()),
-        })];
+        }];
 
         let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
         assert_eq!(datoms.len(), 1);
@@ -350,11 +342,11 @@ mod tests {
     #[test]
     fn test_tx_ops_to_datoms_retract() {
         let tx = crate::clock::st_from_unix_epoch(1000);
-        let ops = vec![TxOp::Retract(Triple {
-            entity: EntityId(200),
+        let ops = vec![TxOp::Retract {
+            entity_id: EntityId(200),
             attribute: Attribute("name".to_string()),
             value: DataType::String("bob".to_string()),
-        })];
+        }];
 
         let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
         assert_eq!(datoms.len(), 1);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -11,7 +11,7 @@ use edn::symbols::Keyword;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use uuid::Uuid;
 
-use crate::ops::{Attribute, DataType, Document, EntityId, Triple, TxOp};
+use crate::ops::{Attribute, DataType, Document, EntityId, TxOp};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -406,10 +406,10 @@ fn encode_data_type_map(buf: &mut Vec<u8>, map: &BTreeMap<String, DataType>) {
 // Wire Encoding: TxOp
 // ---------------------------------------------------------------------------
 
-fn encode_triple(buf: &mut Vec<u8>, triple: &Triple) {
-    encode_i64(buf, triple.entity.0);
-    encode_string(buf, &triple.attribute.0);
-    encode_data_type(buf, &triple.value);
+fn encode_eav(buf: &mut Vec<u8>, entity_id: &EntityId, attribute: &Attribute, value: &DataType) {
+    encode_i64(buf, entity_id.0);
+    encode_string(buf, &attribute.0);
+    encode_data_type(buf, value);
 }
 
 fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
@@ -418,13 +418,13 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
             encode_u8(buf, TXOP_PUT);
             encode_data_type_map(buf, &doc.0);
         }
-        TxOp::Add(triple) => {
+        TxOp::Add { entity_id, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
-            encode_triple(buf, triple);
+            encode_eav(buf, entity_id, attribute, value);
         }
-        TxOp::Retract(triple) => {
+        TxOp::Retract { entity_id, attribute, value } => {
             encode_u8(buf, TXOP_RETRACT);
-            encode_triple(buf, triple);
+            encode_eav(buf, entity_id, attribute, value);
         }
         TxOp::Delete(eid) => {
             encode_u8(buf, TXOP_DELETE);
@@ -650,15 +650,11 @@ fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType
 // Wire Decoding: TxOp
 // ---------------------------------------------------------------------------
 
-fn decode_triple(cursor: &mut Cursor) -> Result<Triple> {
-    let entity = EntityId(cursor.read_i64()?);
+fn decode_eav(cursor: &mut Cursor) -> Result<(EntityId, Attribute, DataType)> {
+    let entity_id = EntityId(cursor.read_i64()?);
     let attribute = Attribute(cursor.read_string()?);
     let value = decode_data_type(cursor)?;
-    Ok(Triple {
-        entity,
-        attribute,
-        value,
-    })
+    Ok((entity_id, attribute, value))
 }
 
 fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
@@ -668,8 +664,14 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
             let map = decode_data_type_map(cursor)?;
             Ok(TxOp::Put(Document(map)))
         }
-        TXOP_ADD => Ok(TxOp::Add(decode_triple(cursor)?)),
-        TXOP_RETRACT => Ok(TxOp::Retract(decode_triple(cursor)?)),
+        TXOP_ADD => {
+            let (entity_id, attribute, value) = decode_eav(cursor)?;
+            Ok(TxOp::Add { entity_id, attribute, value })
+        }
+        TXOP_RETRACT => {
+            let (entity_id, attribute, value) = decode_eav(cursor)?;
+            Ok(TxOp::Retract { entity_id, attribute, value })
+        }
         TXOP_DELETE => Ok(TxOp::Delete(EntityId(cursor.read_i64()?))),
         TXOP_ERASE => Ok(TxOp::Erase(EntityId(cursor.read_i64()?))),
         _ => bail!("Unknown TxOp tag: {}", tag),
@@ -1221,21 +1223,21 @@ mod tests {
 
     #[test]
     fn test_tx_op_add() {
-        let op = TxOp::Add(Triple {
-            entity: EntityId(42),
+        let op = TxOp::Add {
+            entity_id: EntityId(42),
             attribute: Attribute("email".to_string()),
             value: DataType::String("test@example.com".to_string()),
-        });
+        };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_retract() {
-        let op = TxOp::Retract(Triple {
-            entity: EntityId(42),
+        let op = TxOp::Retract {
+            entity_id: EntityId(42),
             attribute: Attribute("email".to_string()),
             value: DataType::String("old@example.com".to_string()),
-        });
+        };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,7 @@ use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
 use crate::datalog::{FindElement, FindSpec, PatternElement, Query, TriplePattern, WhereClause};
-use crate::ops::{Attribute, DataType, Datom, DatomOp, Document, EntityId, Triple, TxOp};
+use crate::ops::{Attribute, DataType, Datom, DatomOp, Document, EntityId, TxOp};
 use crate::query::{execute_query, validate_query};
 
 // --- Reserved entity IDs ---
@@ -272,11 +272,11 @@ fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
 /// Build a Put operation for an enum entity (value type or cardinality).
 /// Enum entities only have db/ident.
 fn enum_entity(id: i64, ns: &str, name: &str) -> TxOp {
-    TxOp::Add(Triple {
-        entity: EntityId(id),
+    TxOp::Add {
+        entity_id: EntityId(id),
         attribute: Attribute("db/ident".to_string()),
         value: DataType::Keyword(Keyword::namespaced(ns, name)),
-    })
+    }
 }
 
 /// Build the bootstrap schema transaction.
@@ -458,7 +458,7 @@ mod tests {
                 Some(DataType::Long(id)) => *id,
                 _ => panic!("Expected db/id Long"),
             },
-            TxOp::Add(Triple { entity, .. }) => entity.0,
+            TxOp::Add { entity_id, .. } => entity_id.0,
             _ => panic!("Expected Put or Add"),
         }).collect();
         ids.sort();


### PR DESCRIPTION
## Summary
- Removed the `Triple` struct from `ops.rs` — it was never used independently, only inside `TxOp::Add` and `TxOp::Retract`
- Inlined its fields (`entity_id`, `attribute`, `value`) directly into the `TxOp::Add` and `TxOp::Retract` enum variants
- Updated all consumers: `protocol.rs` (wire codec), `schema.rs` (bootstrap), `node.rs` (tests)

## Test plan
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)