### PR TITLE
feat: support retract (explicit and auto-generated)

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -5,6 +5,7 @@ use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::ops::tx_ops_to_datoms;
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
+use crate::slate::DEFAULT_WRITE_OPTIONS;
 use crate::util::concat_bytes;
 
 const META_KEY_VERSION: &[u8] = b"version";
@@ -34,7 +35,7 @@ pub async fn init_db(slatedb: Arc<Db>) -> SchemaCache {
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&key, version.as_bytes()).unwrap();
-            txn.commit().await.unwrap();
+            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await.unwrap();
 
             cache
         }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
-use slatedb::Db;
+use slatedb::{Db, IsolationLevel};
 use crate::clock::{self, st_from_unix_epoch};
 use crate::codec;
-use crate::indexer::build_index_write_batch;
+use crate::indexer::write_index_entries;
 use crate::ops::tx_ops_to_datoms;
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
-use crate::slate::DEFAULT_WRITE_OPTIONS;
 use crate::util::concat_bytes;
 
 const META_KEY_VERSION: &[u8] = b"version";
@@ -29,12 +28,13 @@ pub async fn init_db(slatedb: Arc<Db>) -> SchemaCache {
             let datoms = tx_ops_to_datoms(&tx_ops, st_from_unix_epoch(0)).unwrap();
             let mut cache = SchemaCache::new();
             cache.process_tx(SchemaCache::validate_schema_attrs(&datoms).unwrap());
-            let write_batch = build_index_write_batch(&datoms, &cache, clock::st_from_unix_epoch(0)).unwrap();
-            slatedb.write_with_options(write_batch, &DEFAULT_WRITE_OPTIONS).await.unwrap();
 
+            let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();
+            write_index_entries(&txn, &datoms, &cache, clock::st_from_unix_epoch(0)).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
-            slatedb.put(&key, version.as_bytes()).await.expect("Failed to write version to META_INDEX");
+            txn.put(&key, version.as_bytes()).unwrap();
+            txn.commit().await.unwrap();
 
             cache
         }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused)]
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use slatedb::Db;
 use slatedb::IsolationLevel;
@@ -58,11 +59,10 @@ pub(crate) fn write_index_entries(
         txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
         txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
 
-        // AE stores the current value for (attribute, entity) — overwritten on each Assert.
-        // AV is atemporal and purely additive.
+        // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value)?;
+            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[])?;
             txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
         }
     }
@@ -126,27 +126,23 @@ impl Indexer {
     /// Transact a set of operations, automatically retracting old values for
     /// cardinality:one attributes when a new value is asserted.
     ///
-    /// Uses a SlateDB transaction for atomic read-then-write: the AE index lookup
+    /// Uses a SlateDB transaction for atomic read-then-write: the EAV index scan
     /// and all index writes happen in a single transaction.
-    ///
-    /// TODO: If AE/AV indices are dropped in favor of 3 covering indices (EAV/AVE/AEV),
-    /// the current-value lookup must switch to an AEV prefix scan.
     pub async fn transact_tx(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
-        let mut datoms = tx_ops_to_datoms(&tx_ops, tx_key.system_time)?;
+        let datoms = tx_ops_to_datoms(&tx_ops, tx_key.system_time)?;
 
         let new_schema_attrs = self.schema_cache.validate_tx(&datoms)?;
 
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
 
-        // For each Assert datom, look up the current value via AE index.
+        // For each Assert datom, scan EAV for the current value of (entity, attribute).
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
-        // TODO: attribute_id lookup + serialization happens twice per Assert datom
-        // (once here, once in the write loop below). Cache and reuse.
-        let mut resolved_datoms = Vec::with_capacity(datoms.len());
+        // Collect into HashSet to deduplicate explicit + auto-generated retractions.
+        let mut resolved_datoms: HashSet<Datom> = HashSet::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
-                resolved_datoms.push(datom);
+                resolved_datoms.insert(datom);
                 continue;
             }
             let attribute_id = self.schema_cache
@@ -155,14 +151,44 @@ impl Indexer {
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
             let entity_id_bytes = bincode::serialize(&DataType::Long(datom.entity))?;
             let attr_id_bytes = bincode::serialize(&attribute_id)?;
-            let ae_key = concat_bytes(&[&[codec::AE], &attr_id_bytes, &entity_id_bytes]);
+            let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
-            if let Some(old_value_bytes) = txn.get(&ae_key).await? {
-                let old_value: DataType = bincode::deserialize(&old_value_bytes)?;
+            // Scan EAV prefix on the transaction to find the current value.
+            // Resolves temporal versions inline: finds the newest entry <= tx time
+            // and checks whether it's an assert or retract.
+            let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
+            let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+            let mut old_value: Option<DataType> = None;
+            while let Some(kv) = iter.next().await? {
+                let key = &kv.key;
+                if key.len() < codec::TIMESTAMP_OP_SUFFIX {
+                    continue;
+                }
+                let ts = &key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH];
+                // Inverted encoding: encoded_T >= as_of_encoded means real_T <= as_of
+                if ts >= &as_of_encoded[..] {
+                    let op = key[key.len() - 1];
+                    if op == codec::RETRACT {
+                        old_value = None;
+                    } else {
+                        // Extract value from EAV key: [prefix(1) | entity | attr | value | ts | op]
+                        let data = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+                        let mut cursor = Cursor::new(data);
+                        let _entity: DataType = bincode::deserialize_from(&mut cursor)?;
+                        let _attr: i64 = bincode::deserialize_from(&mut cursor)?;
+                        let value: DataType = bincode::deserialize_from(&mut cursor)?;
+                        old_value = Some(value);
+                    }
+                    break; // Newest valid entry found, stop scanning
+                }
+                // ts < as_of_encoded means this entry is newer than as_of — skip it
+            }
+
+            if let Some(old_value) = old_value {
                 if old_value == datom.value {
                     continue; // same value, drop the datom
                 }
-                resolved_datoms.push(Datom {
+                resolved_datoms.insert(Datom {
                     entity: datom.entity,
                     attribute: datom.attribute.clone(),
                     value: old_value,
@@ -170,9 +196,9 @@ impl Indexer {
                     op: DatomOp::Retract,
                 });
             }
-            resolved_datoms.push(datom);
+            resolved_datoms.insert(datom);
         }
-        let datoms = resolved_datoms;
+        let datoms: Vec<Datom> = resolved_datoms.into_iter().collect();
 
         write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
 
@@ -704,13 +730,12 @@ mod tests {
         assert!(alice_retract, "Expected RETRACT for alice");
         assert!(bob_add, "Expected ADD for bob");
 
-        // Verify AE stores "bob" as current value
+        // Verify AE entry exists (stores empty bytes, not the value)
         let attr_bytes = bincode::serialize(&name_id)?;
         let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
         let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
-        let current: DataType = bincode::deserialize(&ae_val)?;
-        assert_eq!(current, DataType::String("bob".to_string()));
+        assert!(ae_val.is_empty(), "AE should store empty bytes");
 
         Ok(())
     }
@@ -757,7 +782,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ae_stores_value() -> Result<(), Error> {
+    async fn test_ae_stores_empty_bytes() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
@@ -767,14 +792,13 @@ mod tests {
         map.insert("name".to_string(), DataType::String("alice".to_string()));
         indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
 
-        // Verify AE stores the serialized value, not empty bytes
+        // Verify AE stores empty bytes (not the value)
         let name_id: i64 = 50;
         let attr_bytes = bincode::serialize(&name_id)?;
         let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
         let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
         let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
-        let value: DataType = bincode::deserialize(&ae_val)?;
-        assert_eq!(value, DataType::String("alice".to_string()));
+        assert!(ae_val.is_empty(), "AE should store empty bytes");
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, Document, TxOp, tx_ops_to_datoms};
 use crate::codec;
+use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
@@ -154,8 +155,9 @@ impl Indexer {
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
             // Scan EAV prefix on the transaction to find the current value.
-            // Resolves temporal versions inline: finds the newest entry <= tx time
-            // and checks whether it's an assert or retract.
+            // Uses async scan directly because TemporalFilterIterator is sync-only.
+            // TODO(triplox-vbc): switch to TemporalFilterIterator once the iterator
+            // layer becomes fully async.
             let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
             let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
             let mut old_value: Option<DataType> = None;
@@ -164,24 +166,25 @@ impl Indexer {
                 if key.len() < codec::TIMESTAMP_OP_SUFFIX {
                     continue;
                 }
-                let ts = &key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH];
-                // Inverted encoding: encoded_T >= as_of_encoded means real_T <= as_of
-                if ts >= &as_of_encoded[..] {
-                    let op = key[key.len() - 1];
-                    if op == codec::RETRACT {
+                match temporal_filter_iterator::resolve_temporal_key(key, &as_of_encoded) {
+                    Some(op) if op == codec::RETRACT => {
                         old_value = None;
-                    } else {
+                        break;
+                    }
+                    Some(_) => {
                         // Extract value from EAV key: [prefix(1) | entity | attr | value | ts | op]
-                        let data = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+                        let data = &key[1..temporal_filter_iterator::logical_key(key).len() + 1];
                         let mut cursor = Cursor::new(data);
                         let _entity: DataType = bincode::deserialize_from(&mut cursor)?;
                         let _attr: i64 = bincode::deserialize_from(&mut cursor)?;
                         let value: DataType = bincode::deserialize_from(&mut cursor)?;
                         old_value = Some(value);
+                        break;
                     }
-                    break; // Newest valid entry found, stop scanning
+                    None => {
+                        // Entry is newer than as_of — skip it
+                    }
                 }
-                // ts < as_of_encoded means this entry is newer than as_of — skip it
             }
 
             if let Some(old_value) = old_value {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -156,8 +156,9 @@ impl Indexer {
 
             // Scan EAV prefix on the transaction to find the current value.
             // Uses async scan directly because TemporalFilterIterator is sync-only.
-            // TODO(triplox-vbc): switch to TemporalFilterIterator once the iterator
-            // layer becomes fully async.
+            // This duplicates the temporal resolution logic from advance_to_next_valid().
+            // TODO(triplox-vbc): unify with TemporalFilterIterator once the iterator
+            // layer becomes fully async, eliminating this duplication.
             let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
             let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
             let mut old_value: Option<DataType> = None;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -175,12 +175,8 @@ impl Indexer {
                         break;
                     }
                     Some(_) => {
-                        // Extract value from EAV key: [prefix(1) | entity | attr | value | ts | op]
-                        let data = &key[1..temporal_filter_iterator::logical_key(key).len() + 1];
-                        let mut cursor = Cursor::new(data);
-                        let _entity: DataType = bincode::deserialize_from(&mut cursor)?;
-                        let _attr: i64 = bincode::deserialize_from(&mut cursor)?;
-                        let value: DataType = bincode::deserialize_from(&mut cursor)?;
+                        let value_bytes = &key[eav_prefix.len()..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+                        let value: DataType = bincode::deserialize(value_bytes)?;
                         old_value = Some(value);
                         break;
                     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -141,10 +141,10 @@ impl Indexer {
         // For each Assert datom, look up the current value via AE index.
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
-        let mut filtered_datoms = Vec::with_capacity(datoms.len());
+        let mut resolved_datoms = Vec::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
-                filtered_datoms.push(datom);
+                resolved_datoms.push(datom);
                 continue;
             }
             let attribute_id = self.schema_cache
@@ -160,7 +160,7 @@ impl Indexer {
                 if old_value == datom.value {
                     continue; // same value, drop the datom
                 }
-                filtered_datoms.push(Datom {
+                resolved_datoms.push(Datom {
                     entity: datom.entity,
                     attribute: datom.attribute.clone(),
                     value: old_value,
@@ -168,9 +168,9 @@ impl Indexer {
                     op: DatomOp::Retract,
                 });
             }
-            filtered_datoms.push(datom);
+            resolved_datoms.push(datom);
         }
-        let datoms = filtered_datoms;
+        let datoms = resolved_datoms;
 
         // Write all index entries within the transaction
         let timestamp = codec::encode_timestamp(tx_key.system_time);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -139,10 +139,12 @@ impl Indexer {
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
 
         // For each Assert datom, look up the current value via AE index.
-        // If an old value exists and differs, add a Retract datom.
-        let mut retractions = Vec::new();
-        for datom in &datoms {
+        // If the old value equals the new value, drop the datom (no-op).
+        // If the old value differs, add a Retract datom for the old value.
+        let mut filtered_datoms = Vec::with_capacity(datoms.len());
+        for datom in datoms {
             if datom.op != DatomOp::Assert {
+                filtered_datoms.push(datom);
                 continue;
             }
             let attribute_id = self.schema_cache
@@ -155,18 +157,20 @@ impl Indexer {
 
             if let Some(old_value_bytes) = txn.get(&ae_key).await? {
                 let old_value: DataType = bincode::deserialize(&old_value_bytes)?;
-                if old_value != datom.value {
-                    retractions.push(Datom {
-                        entity: datom.entity,
-                        attribute: datom.attribute.clone(),
-                        value: old_value,
-                        tx: datom.tx,
-                        op: DatomOp::Retract,
-                    });
+                if old_value == datom.value {
+                    continue; // same value, drop the datom
                 }
+                filtered_datoms.push(Datom {
+                    entity: datom.entity,
+                    attribute: datom.attribute.clone(),
+                    value: old_value,
+                    tx: datom.tx,
+                    op: DatomOp::Retract,
+                });
             }
+            filtered_datoms.push(datom);
         }
-        datoms.extend(retractions);
+        let datoms = filtered_datoms;
 
         // Write all index entries within the transaction
         let timestamp = codec::encode_timestamp(tx_key.system_time);
@@ -747,14 +751,14 @@ mod tests {
         map.insert("name".to_string(), DataType::String("alice".to_string()));
         indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
 
-        // Second tx: assert same name="alice" — should NOT generate a retraction
+        // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
         indexer.transact_tx(tx2, vec![TxOp::Put(Document(map))]).await?;
 
-        // Count EAV entries for entity 100, name attr — should be 2 ADDs, 0 RETRACTs
+        // Count EAV entries for entity 100, name attr — should be 1 ADD, 0 RETRACTs
         let name_id: i64 = 50;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
@@ -770,7 +774,7 @@ mod tests {
                 _ => {}
             }
         }
-        assert_eq!(add_count, 2, "Expected 2 ADD entries (one per tx)");
+        assert_eq!(add_count, 1, "Expected 1 ADD entry (second tx dropped)");
         assert_eq!(retract_count, 0, "Expected no RETRACT entries");
 
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 use slatedb::Db;
-use slatedb::WriteBatch;
 use slatedb::IsolationLevel;
 use anyhow::{Error, Result};
 use bincode;
@@ -30,13 +29,14 @@ pub struct Indexer {
     tx_completion_sender: broadcast::Sender<(TxKey, Result<(), Arc<anyhow::Error>>)>,
 }
 
-pub(crate) fn build_index_write_batch(
+/// Write index entries for datoms into a SlateDB transaction.
+pub(crate) fn write_index_entries(
+    txn: &slatedb::DbTransaction,
     datoms: &[Datom],
     schema_cache: &SchemaCache,
     system_time: Instant,
-) -> Result<WriteBatch, Error> {
+) -> Result<(), Error> {
     let timestamp = codec::encode_timestamp(system_time);
-    let mut write_batch = WriteBatch::new();
 
     for datom in datoms {
         // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
@@ -54,20 +54,20 @@ pub(crate) fn build_index_write_batch(
         };
 
         // Temporal indices include timestamp + op
-        write_batch.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[]);
-        write_batch.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[]);
-        write_batch.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[]);
+        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
 
         // AE stores the current value for (attribute, entity) — overwritten on each Assert.
         // AV is atemporal and purely additive.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            write_batch.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value);
-            write_batch.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[]);
+            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value)?;
+            txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
         }
     }
 
-    Ok(write_batch)
+    Ok(())
 }
 
 /// Metadata stored per transaction in SlateDB (keyed by tx_id under TX_TO_META prefix).
@@ -174,33 +174,7 @@ impl Indexer {
         }
         let datoms = resolved_datoms;
 
-        // Write all index entries within the transaction
-        let timestamp = codec::encode_timestamp(tx_key.system_time);
-        for datom in &datoms {
-            let entity_id = bincode::serialize(&DataType::Long(datom.entity))?;
-            let attribute_id = self.schema_cache
-                .get(&datom.attribute)
-                .map(|a| a.entity_id)
-                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-            let attribute = bincode::serialize(&attribute_id)?;
-            let value = bincode::serialize(&datom.value)?;
-            let op_byte = match datom.op {
-                DatomOp::Assert => codec::ADD,
-                DatomOp::Retract => codec::RETRACT,
-            };
-
-            // Temporal indices include timestamp + op
-            txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
-            txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
-            txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
-
-            // AE stores the current value — overwritten on each Assert.
-            // AV is atemporal and purely additive.
-            if datom.op == DatomOp::Assert {
-                txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value)?;
-                txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
-            }
-        }
+        write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
 
         // Persist tx_id -> system_time mapping
         let meta = TxMeta { system_time: tx_key.system_time };

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -18,7 +18,7 @@ use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
-use crate::slate::DEFAULT_SCAN_OPTIONS;
+use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
 use crate::clock::Instant;
 
@@ -206,7 +206,7 @@ impl Indexer {
         let meta = TxMeta { system_time: tx_key.system_time };
         txn.put(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?)?;
 
-        txn.commit().await?;
+        txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
 
         // Update schema cache after commit so new attributes are only visible
         // in subsequent transactions.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -141,6 +141,8 @@ impl Indexer {
         // For each Assert datom, look up the current value via AE index.
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
+        // TODO: attribute_id lookup + serialization happens twice per Assert datom
+        // (once here, once in the write loop below). Cache and reuse.
         let mut resolved_datoms = Vec::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -140,6 +140,7 @@ impl Indexer {
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
+        let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
         let mut resolved_datoms: HashSet<Datom> = HashSet::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
@@ -159,14 +160,15 @@ impl Indexer {
             // This duplicates the temporal resolution logic from advance_to_next_valid().
             // TODO(triplox-vbc): unify with TemporalFilterIterator once the iterator
             // layer becomes fully async, eliminating this duplication.
-            let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
             let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
             let mut old_value: Option<DataType> = None;
             while let Some(kv) = iter.next().await? {
                 let key = &kv.key;
-                if key.len() < codec::TIMESTAMP_OP_SUFFIX {
-                    continue;
-                }
+                assert!(
+                    key.len() >= codec::TIMESTAMP_OP_SUFFIX,
+                    "Key too short ({} bytes) to contain timestamp + op suffix",
+                    key.len()
+                );
                 match temporal_filter_iterator::resolve_temporal_key(key, &as_of_encoded) {
                     Some(op) if op == codec::RETRACT => {
                         old_value = None;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use slatedb::Db;
 use slatedb::WriteBatch;
+use slatedb::IsolationLevel;
 use anyhow::{Error, Result};
 use bincode;
 use std::io::Cursor;
@@ -57,9 +58,11 @@ pub(crate) fn build_index_write_batch(
         write_batch.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[]);
         write_batch.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[]);
 
-        // AE/AV are atemporal and purely additive — retractions are not written
+        // AE stores the current value for (attribute, entity) — overwritten on each Assert.
+        // AV is atemporal and purely additive.
+        // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            write_batch.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[]);
+            write_batch.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value);
             write_batch.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[]);
         }
     }
@@ -120,24 +123,88 @@ impl Indexer {
         &self.schema_cache
     }
 
-    // TODO(triplox-5ox): Before writing, retract old values for :db.cardinality/one attributes
-    // when a Put/Add overwrites an existing entity+attribute pair.
+    /// Transact a set of operations, automatically retracting old values for
+    /// cardinality:one attributes when a new value is asserted.
+    ///
+    /// Uses a SlateDB transaction for atomic read-then-write: the AE index lookup
+    /// and all index writes happen in a single transaction.
+    ///
+    /// TODO: If AE/AV indices are dropped in favor of 3 covering indices (EAV/AVE/AEV),
+    /// the current-value lookup must switch to an AEV prefix scan.
     pub async fn transact_tx(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
-        let datoms = tx_ops_to_datoms(&tx_ops, tx_key.system_time)?;
+        let mut datoms = tx_ops_to_datoms(&tx_ops, tx_key.system_time)?;
 
         let new_schema_attrs = self.schema_cache.validate_tx(&datoms)?;
 
-        let write_batch = build_index_write_batch(&datoms, &self.schema_cache, tx_key.system_time)?;
+        let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
 
-        self.slatedb.write_with_options(write_batch, &DEFAULT_WRITE_OPTIONS).await?;
+        // For each Assert datom, look up the current value via AE index.
+        // If an old value exists and differs, add a Retract datom.
+        let mut retractions = Vec::new();
+        for datom in &datoms {
+            if datom.op != DatomOp::Assert {
+                continue;
+            }
+            let attribute_id = self.schema_cache
+                .get(&datom.attribute)
+                .map(|a| a.entity_id)
+                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+            let entity_id_bytes = bincode::serialize(&DataType::Long(datom.entity))?;
+            let attr_id_bytes = bincode::serialize(&attribute_id)?;
+            let ae_key = concat_bytes(&[&[codec::AE], &attr_id_bytes, &entity_id_bytes]);
 
-        // Update schema cache after write so new attributes are only visible
-        // in subsequent transactions.
-        self.schema_cache.process_tx(new_schema_attrs);
+            if let Some(old_value_bytes) = txn.get(&ae_key).await? {
+                let old_value: DataType = bincode::deserialize(&old_value_bytes)?;
+                if old_value != datom.value {
+                    retractions.push(Datom {
+                        entity: datom.entity,
+                        attribute: datom.attribute.clone(),
+                        value: old_value,
+                        tx: datom.tx,
+                        op: DatomOp::Retract,
+                    });
+                }
+            }
+        }
+        datoms.extend(retractions);
+
+        // Write all index entries within the transaction
+        let timestamp = codec::encode_timestamp(tx_key.system_time);
+        for datom in &datoms {
+            let entity_id = bincode::serialize(&DataType::Long(datom.entity))?;
+            let attribute_id = self.schema_cache
+                .get(&datom.attribute)
+                .map(|a| a.entity_id)
+                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+            let attribute = bincode::serialize(&attribute_id)?;
+            let value = bincode::serialize(&datom.value)?;
+            let op_byte = match datom.op {
+                DatomOp::Assert => codec::ADD,
+                DatomOp::Retract => codec::RETRACT,
+            };
+
+            // Temporal indices include timestamp + op
+            txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
+            txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
+            txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
+
+            // AE stores the current value — overwritten on each Assert.
+            // AV is atemporal and purely additive.
+            if datom.op == DatomOp::Assert {
+                txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &value)?;
+                txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
+            }
+        }
 
         // Persist tx_id -> system_time mapping
         let meta = TxMeta { system_time: tx_key.system_time };
-        self.slatedb.put_with_options(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?, &Default::default(), &DEFAULT_WRITE_OPTIONS).await?;
+        txn.put(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?)?;
+
+        txn.commit().await?;
+
+        // Update schema cache after commit so new attributes are only visible
+        // in subsequent transactions.
+        self.schema_cache.process_tx(new_schema_attrs);
 
         // Update latest indexed tx and broadcast completion
         self.latest_indexed_tx = Some(tx_key);
@@ -612,6 +679,122 @@ mod tests {
             assert!(result.is_ok(), "Task should complete before timeout");
             assert!(result.unwrap()?.is_ok(), "Task should succeed");
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_retract_on_overwrite() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+
+        // First tx: assert name="alice" for entity 100
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let mut map = BTreeMap::new();
+        map.insert("db/id".to_string(), DataType::Long(100));
+        map.insert("name".to_string(), DataType::String("alice".to_string()));
+        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
+
+        // Second tx: assert name="bob" for same entity — should auto-retract "alice"
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let mut map = BTreeMap::new();
+        map.insert("db/id".to_string(), DataType::Long(100));
+        map.insert("name".to_string(), DataType::String("bob".to_string()));
+        indexer.transact_tx(tx2, vec![TxOp::Put(Document(map))]).await?;
+
+        // Scan EAV for entity 100 — expect: alice ADD, alice RETRACT, bob ADD
+        let name_id: i64 = 50;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut alice_add = false;
+        let mut alice_retract = false;
+        let mut bob_add = false;
+        while let Some(kv) = iter.next().await? {
+            let (entity_id, attribute, value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if entity_id != DataType::Long(100) || attribute != name_id {
+                continue;
+            }
+            match (&value, op) {
+                (DataType::String(s), codec::ADD) if s == "alice" => alice_add = true,
+                (DataType::String(s), codec::RETRACT) if s == "alice" => alice_retract = true,
+                (DataType::String(s), codec::ADD) if s == "bob" => bob_add = true,
+                _ => {}
+            }
+        }
+        assert!(alice_add, "Expected ADD for alice");
+        assert!(alice_retract, "Expected RETRACT for alice");
+        assert!(bob_add, "Expected ADD for bob");
+
+        // Verify AE stores "bob" as current value
+        let attr_bytes = bincode::serialize(&name_id)?;
+        let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
+        let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
+        let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
+        let current: DataType = bincode::deserialize(&ae_val)?;
+        assert_eq!(current, DataType::String("bob".to_string()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_same_value_no_retract() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+
+        // First tx: assert name="alice"
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let mut map = BTreeMap::new();
+        map.insert("db/id".to_string(), DataType::Long(100));
+        map.insert("name".to_string(), DataType::String("alice".to_string()));
+        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
+
+        // Second tx: assert same name="alice" — should NOT generate a retraction
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let mut map = BTreeMap::new();
+        map.insert("db/id".to_string(), DataType::Long(100));
+        map.insert("name".to_string(), DataType::String("alice".to_string()));
+        indexer.transact_tx(tx2, vec![TxOp::Put(Document(map))]).await?;
+
+        // Count EAV entries for entity 100, name attr — should be 2 ADDs, 0 RETRACTs
+        let name_id: i64 = 50;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut add_count = 0;
+        let mut retract_count = 0;
+        while let Some(kv) = iter.next().await? {
+            let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if entity_id != DataType::Long(100) || attribute != name_id {
+                continue;
+            }
+            match op {
+                codec::ADD => add_count += 1,
+                codec::RETRACT => retract_count += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(add_count, 2, "Expected 2 ADD entries (one per tx)");
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ae_stores_value() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let mut map = BTreeMap::new();
+        map.insert("db/id".to_string(), DataType::Long(100));
+        map.insert("name".to_string(), DataType::String("alice".to_string()));
+        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
+
+        // Verify AE stores the serialized value, not empty bytes
+        let name_id: i64 = 50;
+        let attr_bytes = bincode::serialize(&name_id)?;
+        let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
+        let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
+        let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
+        let value: DataType = bincode::deserialize(&ae_val)?;
+        assert_eq!(value, DataType::String("alice".to_string()));
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, unused)]
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use slatedb::Db;
@@ -20,7 +18,7 @@ use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
-use crate::slate::{DEFAULT_READ_OPTIONS, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
+use crate::slate::DEFAULT_SCAN_OPTIONS;
 use crate::util::concat_bytes;
 use crate::clock::Instant;
 
@@ -783,25 +781,4 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_ae_stores_empty_bytes() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
-        let mut indexer = bootstrapped_indexer(slate.clone()).await;
-
-        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("alice".to_string()));
-        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
-
-        // Verify AE stores empty bytes (not the value)
-        let name_id: i64 = 50;
-        let attr_bytes = bincode::serialize(&name_id)?;
-        let entity_bytes = bincode::serialize(&DataType::Long(100i64))?;
-        let ae_key = concat_bytes(&[&[codec::AE], &attr_bytes, &entity_bytes]);
-        let ae_val = slate.get(&ae_key).await?.expect("AE entry should exist");
-        assert!(ae_val.is_empty(), "AE should store empty bytes");
-
-        Ok(())
-    }
 }

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -3,8 +3,6 @@ use bytes::Bytes;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
-use slatedb::DbRead;
-
 use crate::slate::DEFAULT_SCAN_OPTIONS;
 
 pub(crate) trait Index {
@@ -29,7 +27,7 @@ pub(crate) struct SlateIterator {
 impl SlateIterator {
     pub fn new(
         prefix: &[u8],
-        slate: &(impl DbRead + Sync),
+        slate: &slatedb::DbSnapshot,
         handle: Handle,
         extractor: Extractor,
     ) -> Result<Self, Error> {
@@ -259,7 +257,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
+            let mut iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("aa")));
@@ -284,7 +282,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
+            let mut iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
 
             iter.seek(Bytes::from("cc")).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("cc")));
@@ -304,7 +302,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
+            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
         }).await.unwrap();
@@ -323,7 +321,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
+            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
             let count = iter.count().unwrap();
             // TODO: count() currently returns 100 as estimate_key_count is not on DbSnapshot
             assert_eq!(count, 100);

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -3,6 +3,8 @@ use bytes::Bytes;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
+use slatedb::DbRead;
+
 use crate::slate::DEFAULT_SCAN_OPTIONS;
 
 pub(crate) trait Index {
@@ -27,7 +29,7 @@ pub(crate) struct SlateIterator {
 impl SlateIterator {
     pub fn new(
         prefix: &[u8],
-        slate: &slatedb::DbSnapshot,
+        slate: &(impl DbRead + Sync),
         handle: Handle,
         extractor: Extractor,
     ) -> Result<Self, Error> {
@@ -257,7 +259,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
+            let mut iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("aa")));
@@ -282,7 +284,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
+            let mut iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
 
             iter.seek(Bytes::from("cc")).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("cc")));
@@ -302,7 +304,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
+            let iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
         }).await.unwrap();
@@ -321,7 +323,7 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor).unwrap();
+            let iter = SlateIterator::new(PFX, &*snapshot, handle, extractor).unwrap();
             let count = iter.count().unwrap();
             // TODO: count() currently returns 100 as estimate_key_count is not on DbSnapshot
             assert_eq!(count, 100);

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -3,8 +3,6 @@ use bytes::Bytes;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
-use slatedb::DbRead;
-
 use crate::clock::Instant;
 use crate::codec;
 use crate::slate::DEFAULT_SCAN_OPTIONS;
@@ -32,19 +30,33 @@ pub(crate) struct TemporalFilterIterator {
 }
 
 /// Extract the logical key from a full key (everything except timestamp + op suffix).
-fn logical_key(key: &[u8]) -> &[u8] {
+pub(crate) fn logical_key(key: &[u8]) -> &[u8] {
     &key[..key.len() - codec::TIMESTAMP_OP_SUFFIX]
 }
 
 /// Extract the encoded timestamp bytes from a full key.
-fn timestamp_bytes(key: &[u8]) -> &[u8] {
+pub(crate) fn timestamp_bytes(key: &[u8]) -> &[u8] {
     &key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]
+}
+
+/// Resolve a temporal key against an as-of timestamp.
+///
+/// Returns `Some(op_byte)` if the key's timestamp <= as_of (i.e. it is the newest
+/// valid entry), or `None` if the entry is newer than as_of and should be skipped.
+pub(crate) fn resolve_temporal_key(key: &[u8], as_of_encoded: &[u8; 8]) -> Option<u8> {
+    let ts = timestamp_bytes(key);
+    // Inverted encoding: encoded_T >= as_of_encoded means real_T <= as_of
+    if ts >= &as_of_encoded[..] {
+        Some(key[key.len() - 1])
+    } else {
+        None
+    }
 }
 
 impl TemporalFilterIterator {
     pub fn new(
         prefix: &[u8],
-        slate: &(impl DbRead + Sync),
+        slate: &slatedb::DbSnapshot,
         handle: Handle,
         extractor: Extractor,
         as_of: Instant,
@@ -100,25 +112,22 @@ impl TemporalFilterIterator {
                         key.len()
                     );
 
-                    let ts = timestamp_bytes(&key);
-                    // Inverted encoding: smaller encoded bytes = newer real time.
-                    // We want real_T <= as_of, i.e. encoded_T >= as_of_encoded.
-                    if ts >= &self.as_of_encoded[..] {
-                        // This is the newest valid entry for this logical key group.
-                        // Check the op byte: if retracted, skip the entire group.
-                        let op = key[key.len() - 1];
-                        if op == codec::RETRACT {
+                    match resolve_temporal_key(&key, &self.as_of_encoded) {
+                        Some(op) if op == codec::RETRACT => {
                             if !self.seek_past_logical_key(&key)? {
                                 self.current_key = None;
                                 return Ok(());
                             }
                             continue;
                         }
-                        self.current_key = Some(key);
-                        return Ok(());
+                        Some(_) => {
+                            self.current_key = Some(key);
+                            return Ok(());
+                        }
+                        None => {
+                            // Entry is newer than as_of — skip it, keep scanning.
+                        }
                     }
-                    // ts < as_of_encoded means this entry is newer than as_of — skip it,
-                    // but we're still in the same or a new group, keep scanning.
                 }
             }
         }
@@ -218,7 +227,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
             ).unwrap();
 
             assert!(iter.has_next());
@@ -243,7 +252,7 @@ mod tests {
             // Query as-of t1 — should see alice (t2 is in the future)
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snapshot, handle, extractor, t1,
+                PFX, &snapshot, handle, extractor, t1,
             ).unwrap();
 
             assert!(iter.has_next());
@@ -265,7 +274,7 @@ mod tests {
             // Query as-of before t1 — should see nothing
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
             ).unwrap();
 
             assert!(!iter.has_next());
@@ -289,7 +298,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
             ).unwrap();
 
             // Should see alice and bob (deduplicated)
@@ -326,7 +335,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t0,
+                PFX, &snap, handle, extractor, t0,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -337,7 +346,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t1,
+                PFX, &snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -350,7 +359,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t2,
+                PFX, &snap, handle, extractor, t2,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -361,7 +370,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t3,
+                PFX, &snap, handle, extractor, t3,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -386,7 +395,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
             ).unwrap();
 
             // Initially at alice
@@ -427,7 +436,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t1,
+                PFX, &snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -442,7 +451,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t2,
+                PFX, &snap, handle, extractor, t2,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
             iter.next().unwrap();
@@ -471,7 +480,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t1,
+                PFX, &snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         }).await.unwrap();
@@ -482,7 +491,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t2,
+                PFX, &snap, handle, extractor, t2,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -493,7 +502,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &*snap, handle, extractor, t3,
+                PFX, &snap, handle, extractor, t3,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         }).await.unwrap();

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -3,6 +3,8 @@ use bytes::Bytes;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
+use slatedb::DbRead;
+
 use crate::clock::Instant;
 use crate::codec;
 use crate::slate::DEFAULT_SCAN_OPTIONS;
@@ -42,7 +44,7 @@ fn timestamp_bytes(key: &[u8]) -> &[u8] {
 impl TemporalFilterIterator {
     pub fn new(
         prefix: &[u8],
-        slate: &slatedb::DbSnapshot,
+        slate: &(impl DbRead + Sync),
         handle: Handle,
         extractor: Extractor,
         as_of: Instant,
@@ -216,7 +218,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
             ).unwrap();
 
             assert!(iter.has_next());
@@ -241,7 +243,7 @@ mod tests {
             // Query as-of t1 — should see alice (t2 is in the future)
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, t1,
+                PFX, &*snapshot, handle, extractor, t1,
             ).unwrap();
 
             assert!(iter.has_next());
@@ -263,7 +265,7 @@ mod tests {
             // Query as-of before t1 — should see nothing
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
+                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
             ).unwrap();
 
             assert!(!iter.has_next());
@@ -287,7 +289,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
+                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
             ).unwrap();
 
             // Should see alice and bob (deduplicated)
@@ -324,7 +326,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t0,
+                PFX, &*snap, handle, extractor, t0,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -335,7 +337,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t1,
+                PFX, &*snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -348,7 +350,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t2,
+                PFX, &*snap, handle, extractor, t2,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -359,7 +361,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t3,
+                PFX, &*snap, handle, extractor, t3,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -384,7 +386,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &*snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
             ).unwrap();
 
             // Initially at alice
@@ -425,7 +427,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t1,
+                PFX, &*snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -440,7 +442,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t2,
+                PFX, &*snap, handle, extractor, t2,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
             iter.next().unwrap();
@@ -469,7 +471,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t1,
+                PFX, &*snap, handle, extractor, t1,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         }).await.unwrap();
@@ -480,7 +482,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t2,
+                PFX, &*snap, handle, extractor, t2,
             ).unwrap();
             assert!(!iter.has_next());
         }).await.unwrap();
@@ -491,7 +493,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t3,
+                PFX, &*snap, handle, extractor, t3,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         }).await.unwrap();

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -300,17 +300,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_temporal_filter_add_add_cycle() {
-        // TODO: update to add_retract_add cycle
-        // Same (E, A, V) added at T1 and T2.
-        // Query as-of T1 sees it once, as-of T2 sees it once, as-of T0 sees nothing.
+    async fn test_temporal_filter_add_retract_add_cycle() {
+        // Same (E, A, V) added at T1, retracted at T2, re-added at T3.
+        // as-of T0: nothing
+        // as-of T1: alice visible
+        // as-of T2: alice hidden (retracted)
+        // as-of T3: alice visible again (re-added)
         let slate = in_memory_slate().await;
         let t0 = st_from_unix_epoch(500_000);
         let t1 = st_from_unix_epoch(1_000_000);
         let t2 = st_from_unix_epoch(2_000_000);
+        let t3 = st_from_unix_epoch(3_000_000);
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
-        slate.put(&make_key(PFX, b"alice", t2, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
+        slate.put(&make_key(PFX, b"alice", t3, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
 
@@ -325,7 +329,7 @@ mod tests {
             assert!(!iter.has_next());
         }).await.unwrap();
 
-        // as-of T1: alice once
+        // as-of T1: alice visible
         let handle = tokio::runtime::Handle::current();
         let snap = snapshot.clone();
         tokio::task::spawn_blocking(move || {
@@ -338,13 +342,24 @@ mod tests {
             assert!(!iter.has_next());
         }).await.unwrap();
 
-        // as-of T2: alice once (deduplicated)
+        // as-of T2: alice hidden (retracted)
+        let handle = tokio::runtime::Handle::current();
+        let snap = snapshot.clone();
+        tokio::task::spawn_blocking(move || {
+            let extractor = make_test_extractor(PFX.len());
+            let iter = TemporalFilterIterator::new(
+                PFX, &snap, handle, extractor, t2,
+            ).unwrap();
+            assert!(!iter.has_next());
+        }).await.unwrap();
+
+        // as-of T3: alice visible again (re-added)
         let handle = tokio::runtime::Handle::current();
         let snap = snapshot.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snap, handle, extractor, t2,
+                PFX, &snap, handle, extractor, t3,
             ).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -56,6 +56,29 @@ pub enum DataType {
 }
 
 
+impl Eq for DataType {}
+
+impl std::hash::Hash for DataType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            DataType::BigInt(v) => v.hash(state),
+            DataType::Boolean(v) => v.hash(state),
+            DataType::Bytes(v) => v.hash(state),
+            DataType::Double(v) => v.to_bits().hash(state),
+            DataType::Float(v) => v.to_bits().hash(state),
+            DataType::Instant(v) => v.hash(state),
+            DataType::Keyword(v) => v.hash(state),
+            DataType::Long(v) => v.hash(state),
+            DataType::String(v) => v.hash(state),
+            DataType::Tuple(v) => v.hash(state),
+            DataType::Uuid(v) => v.hash(state),
+            DataType::Vector(v) => v.hash(state),
+            DataType::Map(v) => v.hash(state),
+        }
+    }
+}
+
 impl DataType {
     /// Return the ValueType corresponding to this DataType's variant.
     pub fn value_type(&self) -> crate::schema::ValueType {
@@ -141,7 +164,7 @@ pub enum TxOp {
     Erase(EntityId),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DatomOp {
     Assert,
     Retract,
@@ -149,7 +172,7 @@ pub enum DatomOp {
 
 /// A normalized fact: (entity, attribute, value, tx, op).
 /// The attribute is an unresolved string name.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Datom {
     pub entity: i64,
     pub attribute: String, // TODO(triplox-gaz): avoid cloning, consider Cow or interning


### PR DESCRIPTION
## Summary

- Support explicit retract operations alongside auto-generated retractions
- Automatically retract old values when a new value is asserted for the same (entity, attribute) pair (cardinality:one semantics)
- Replace AE point-lookup with EAV prefix scan + temporal resolution for current-value lookup, fixing stale AE entries left by explicit retractions
- AE index reverted to storing empty bytes (no longer used for value lookups)
- `transact_tx()` migrated from `WriteBatch` to SlateDB's `DbTransaction` API for atomic read-then-write
- `HashSet<Datom>` for deduplicating explicit + auto-generated retractions
- `Hash + Eq` added to `DatomOp`, `DataType`, and `Datom`
- Shared temporal resolution helpers extracted from `TemporalFilterIterator`
- Transaction commits use `DEFAULT_WRITE_OPTIONS` for consistency

## Test plan

- [x] `test_retract_on_overwrite` — verifies RETRACT for old value and ADD for new value in EAV, and AE stores empty bytes
- [x] `test_same_value_no_retract` — re-asserting the same value generates no retraction
- [x] `test_temporal_filter_add_retract_add_cycle` — add/retract/re-add visibility at each timestamp
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)