### PR TITLE
feat: implement aggregate execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ bd close <id>         # Complete work
 bd sync               # Sync with git
 ```
 
+## Style
+
+Keep comments to one line where possible. Multi-line is fine for complex logic.
+
 ## Git
 
 Only commit and push when explicitly asked to by the user.

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,0 +1,314 @@
+use std::collections::HashSet;
+
+use anyhow::{anyhow, Result};
+
+use crate::datalog::AggregateFunc;
+use crate::ops::DataType;
+
+/// Convert a DataType to an f64 for numeric aggregation.
+fn datatype_to_f64(dt: &DataType) -> Result<f64> {
+    match dt {
+        DataType::Long(n) => Ok(*n as f64),
+        DataType::Double(n) => Ok(*n),
+        DataType::Float(n) => Ok(*n as f64),
+        DataType::BigInt(n) => Ok(*n as f64),
+        other => Err(anyhow!("cannot convert {:?} to numeric for aggregation", other)),
+    }
+}
+
+/// Trait for aggregate accumulators.
+pub trait Accumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()>;
+    fn finalize(&self) -> Result<DataType>;
+}
+
+struct CountAccumulator {
+    count: i64,
+}
+
+impl Accumulator for CountAccumulator {
+    fn accumulate(&mut self, _value: &DataType) -> Result<()> {
+        self.count += 1;
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        Ok(DataType::Long(self.count))
+    }
+}
+
+struct CountDistinctAccumulator {
+    seen: HashSet<Vec<u8>>,
+}
+
+impl Accumulator for CountDistinctAccumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()> {
+        let bytes = bincode::serialize(value)?;
+        self.seen.insert(bytes);
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        Ok(DataType::Long(self.seen.len() as i64))
+    }
+}
+
+enum NumericAccum {
+    Long(i64),
+    Double(f64),
+}
+
+struct SumAccumulator {
+    accum: Option<NumericAccum>,
+}
+
+impl Accumulator for SumAccumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()> {
+        match (&mut self.accum, value) {
+            (None, DataType::Long(n)) => {
+                self.accum = Some(NumericAccum::Long(*n));
+            }
+            (None, DataType::Double(n)) => {
+                self.accum = Some(NumericAccum::Double(*n));
+            }
+            (Some(NumericAccum::Long(acc)), DataType::Long(n)) => {
+                *acc = acc
+                    .checked_add(*n)
+                    .ok_or_else(|| anyhow!("integer overflow in sum"))?;
+            }
+            (Some(NumericAccum::Long(acc)), DataType::Double(n)) => {
+                self.accum = Some(NumericAccum::Double(*acc as f64 + n));
+            }
+            (Some(NumericAccum::Double(acc)), DataType::Long(n)) => {
+                *acc += *n as f64;
+            }
+            (Some(NumericAccum::Double(acc)), DataType::Double(n)) => {
+                *acc += n;
+            }
+            (_, DataType::Float(n)) => {
+                let n = *n as f64;
+                match &mut self.accum {
+                    None => self.accum = Some(NumericAccum::Double(n)),
+                    Some(NumericAccum::Long(acc)) => {
+                        self.accum = Some(NumericAccum::Double(*acc as f64 + n));
+                    }
+                    Some(NumericAccum::Double(acc)) => *acc += n,
+                }
+            }
+            (_, DataType::BigInt(n)) => {
+                let n = *n as f64;
+                match &mut self.accum {
+                    None => self.accum = Some(NumericAccum::Double(n)),
+                    Some(NumericAccum::Long(acc)) => {
+                        self.accum = Some(NumericAccum::Double(*acc as f64 + n));
+                    }
+                    Some(NumericAccum::Double(acc)) => *acc += n,
+                }
+            }
+            (_, other) => {
+                return Err(anyhow!("sum: cannot aggregate non-numeric value {:?}", other));
+            }
+        }
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        match &self.accum {
+            Some(NumericAccum::Long(n)) => Ok(DataType::Long(*n)),
+            Some(NumericAccum::Double(n)) => Ok(DataType::Double(*n)),
+            None => Err(anyhow!("sum: no values accumulated")),
+        }
+    }
+}
+
+struct AvgAccumulator {
+    sum: f64,
+    count: i64,
+}
+
+impl Accumulator for AvgAccumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()> {
+        self.sum += datatype_to_f64(value)?;
+        self.count += 1;
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        if self.count == 0 {
+            return Err(anyhow!("avg: no values accumulated"));
+        }
+        Ok(DataType::Double(self.sum / self.count as f64))
+    }
+}
+
+struct MinAccumulator {
+    current: Option<DataType>,
+}
+
+impl Accumulator for MinAccumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()> {
+        match &self.current {
+            None => {
+                self.current = Some(value.clone());
+            }
+            Some(current) => {
+                let ord = current
+                    .partial_compare(value)
+                    .ok_or_else(|| anyhow!("min: incomparable types"))?;
+                if ord == std::cmp::Ordering::Greater {
+                    self.current = Some(value.clone());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        self.current
+            .clone()
+            .ok_or_else(|| anyhow!("min: no values accumulated"))
+    }
+}
+
+struct MaxAccumulator {
+    current: Option<DataType>,
+}
+
+impl Accumulator for MaxAccumulator {
+    fn accumulate(&mut self, value: &DataType) -> Result<()> {
+        match &self.current {
+            None => {
+                self.current = Some(value.clone());
+            }
+            Some(current) => {
+                let ord = current
+                    .partial_compare(value)
+                    .ok_or_else(|| anyhow!("max: incomparable types"))?;
+                if ord == std::cmp::Ordering::Less {
+                    self.current = Some(value.clone());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finalize(&self) -> Result<DataType> {
+        self.current
+            .clone()
+            .ok_or_else(|| anyhow!("max: no values accumulated"))
+    }
+}
+
+pub fn make_accumulator(func: &AggregateFunc) -> Box<dyn Accumulator> {
+    match func {
+        AggregateFunc::Count => Box::new(CountAccumulator { count: 0 }),
+        AggregateFunc::CountDistinct => Box::new(CountDistinctAccumulator {
+            seen: HashSet::new(),
+        }),
+        AggregateFunc::Sum => Box::new(SumAccumulator { accum: None }),
+        AggregateFunc::Avg => Box::new(AvgAccumulator { sum: 0.0, count: 0 }),
+        AggregateFunc::Min => Box::new(MinAccumulator { current: None }),
+        AggregateFunc::Max => Box::new(MaxAccumulator { current: None }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count() {
+        let mut acc = make_accumulator(&AggregateFunc::Count);
+        acc.accumulate(&DataType::Long(1)).unwrap();
+        acc.accumulate(&DataType::Long(2)).unwrap();
+        acc.accumulate(&DataType::Long(3)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(3));
+    }
+
+    #[test]
+    fn test_count_distinct() {
+        let mut acc = make_accumulator(&AggregateFunc::CountDistinct);
+        acc.accumulate(&DataType::Long(1)).unwrap();
+        acc.accumulate(&DataType::Long(2)).unwrap();
+        acc.accumulate(&DataType::Long(1)).unwrap();
+        acc.accumulate(&DataType::Long(3)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(3));
+    }
+
+    #[test]
+    fn test_sum_long() {
+        let mut acc = make_accumulator(&AggregateFunc::Sum);
+        acc.accumulate(&DataType::Long(10)).unwrap();
+        acc.accumulate(&DataType::Long(20)).unwrap();
+        acc.accumulate(&DataType::Long(30)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(60));
+    }
+
+    #[test]
+    fn test_sum_double() {
+        let mut acc = make_accumulator(&AggregateFunc::Sum);
+        acc.accumulate(&DataType::Double(1.5)).unwrap();
+        acc.accumulate(&DataType::Double(2.5)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Double(4.0));
+    }
+
+    #[test]
+    fn test_sum_mixed_promotes_to_double() {
+        let mut acc = make_accumulator(&AggregateFunc::Sum);
+        acc.accumulate(&DataType::Long(10)).unwrap();
+        acc.accumulate(&DataType::Double(1.5)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Double(11.5));
+    }
+
+    #[test]
+    fn test_sum_non_numeric_error() {
+        let mut acc = make_accumulator(&AggregateFunc::Sum);
+        let result = acc.accumulate(&DataType::String("hello".into()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_avg() {
+        let mut acc = make_accumulator(&AggregateFunc::Avg);
+        acc.accumulate(&DataType::Long(10)).unwrap();
+        acc.accumulate(&DataType::Long(20)).unwrap();
+        acc.accumulate(&DataType::Long(30)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Double(20.0));
+    }
+
+    #[test]
+    fn test_min() {
+        let mut acc = make_accumulator(&AggregateFunc::Min);
+        acc.accumulate(&DataType::Long(30)).unwrap();
+        acc.accumulate(&DataType::Long(10)).unwrap();
+        acc.accumulate(&DataType::Long(20)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(10));
+    }
+
+    #[test]
+    fn test_max() {
+        let mut acc = make_accumulator(&AggregateFunc::Max);
+        acc.accumulate(&DataType::Long(10)).unwrap();
+        acc.accumulate(&DataType::Long(30)).unwrap();
+        acc.accumulate(&DataType::Long(20)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(30));
+    }
+
+    #[test]
+    fn test_min_string() {
+        let mut acc = make_accumulator(&AggregateFunc::Min);
+        acc.accumulate(&DataType::String("charlie".into())).unwrap();
+        acc.accumulate(&DataType::String("alice".into())).unwrap();
+        acc.accumulate(&DataType::String("bob".into())).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::String("alice".into()));
+    }
+
+    #[test]
+    fn test_max_double() {
+        let mut acc = make_accumulator(&AggregateFunc::Max);
+        acc.accumulate(&DataType::Double(1.5)).unwrap();
+        acc.accumulate(&DataType::Double(3.5)).unwrap();
+        acc.accumulate(&DataType::Double(2.5)).unwrap();
+        assert_eq!(acc.finalize().unwrap(), DataType::Double(3.5));
+    }
+}

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -21,7 +21,7 @@ fn datatype_to_f64(dt: &DataType) -> Result<f64> {
 // eager f64 conversion — e.g. avg over integers should accumulate as (i64 sum, i64 count).
 
 /// Trait for aggregate accumulators.
-pub trait Accumulator {
+pub(crate) trait Accumulator {
     fn accumulate(&mut self, value: &DataType) -> Result<()>;
     fn finalize(&self) -> Result<DataType>;
 }
@@ -203,7 +203,7 @@ impl Accumulator for MaxAccumulator {
     }
 }
 
-pub fn make_accumulator(func: &AggregateFunc) -> Box<dyn Accumulator> {
+pub(crate) fn make_accumulator(func: &AggregateFunc) -> Box<dyn Accumulator> {
     match func {
         AggregateFunc::Count => Box::new(CountAccumulator { count: 0 }),
         AggregateFunc::CountDistinct => Box::new(CountDistinctAccumulator {

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -116,7 +116,7 @@ impl Accumulator for SumAccumulator {
         match &self.accum {
             Some(NumericAccum::Long(n)) => Ok(DataType::Long(*n)),
             Some(NumericAccum::Double(n)) => Ok(DataType::Double(*n)),
-            None => Err(anyhow!("sum: no values accumulated")),
+            None => Ok(DataType::Long(0)),
         }
     }
 }
@@ -310,5 +310,41 @@ mod tests {
         acc.accumulate(&DataType::Double(3.5)).unwrap();
         acc.accumulate(&DataType::Double(2.5)).unwrap();
         assert_eq!(acc.finalize().unwrap(), DataType::Double(3.5));
+    }
+
+    #[test]
+    fn test_count_empty() {
+        let acc = make_accumulator(&AggregateFunc::Count);
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(0));
+    }
+
+    #[test]
+    fn test_count_distinct_empty() {
+        let acc = make_accumulator(&AggregateFunc::CountDistinct);
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(0));
+    }
+
+    #[test]
+    fn test_sum_empty() {
+        let acc = make_accumulator(&AggregateFunc::Sum);
+        assert_eq!(acc.finalize().unwrap(), DataType::Long(0));
+    }
+
+    #[test]
+    fn test_avg_empty_errors() {
+        let acc = make_accumulator(&AggregateFunc::Avg);
+        assert!(acc.finalize().is_err());
+    }
+
+    #[test]
+    fn test_min_empty_errors() {
+        let acc = make_accumulator(&AggregateFunc::Min);
+        assert!(acc.finalize().is_err());
+    }
+
+    #[test]
+    fn test_max_empty_errors() {
+        let acc = make_accumulator(&AggregateFunc::Max);
+        assert!(acc.finalize().is_err());
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -17,6 +17,9 @@ fn datatype_to_f64(dt: &DataType) -> Result<f64> {
     }
 }
 
+// TODO: use schema type info and type promotion rules (like Postgres) instead of
+// eager f64 conversion — e.g. avg over integers should accumulate as (i64 sum, i64 count).
+
 /// Trait for aggregate accumulators.
 pub trait Accumulator {
     fn accumulate(&mut self, value: &DataType) -> Result<()>;

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::datalog::AggregateFunc;
 use crate::ops::DataType;
 
+// TODO: loses precision for i64 values > 2^53
 /// Convert a DataType to an f64 for numeric aggregation.
 fn datatype_to_f64(dt: &DataType) -> Result<f64> {
     match dt {

--- a/src/client.rs
+++ b/src/client.rs
@@ -363,7 +363,7 @@ fn find_element_to_edn(elem: &FindElement, s: &mut String) -> Result<()> {
         FindElement::Variable(v) => s.push_str(v),
         FindElement::Aggregate(func, arg) => {
             s.push('(');
-            s.push_str(func);
+            s.push_str(&func.to_string());
             s.push(' ');
             s.push_str(arg);
             s.push(')');

--- a/src/datalog.rs
+++ b/src/datalog.rs
@@ -42,6 +42,7 @@ impl std::fmt::Display for AggregateFunc {
 pub enum FindElement {
     Variable(Variable),
     PullExpr(PullExpr),
+    /// Only bare variables supported — no expression args, bypasses the expression engine.
     Aggregate(AggregateFunc, Variable),
 }
 

--- a/src/datalog.rs
+++ b/src/datalog.rs
@@ -16,10 +16,33 @@ pub enum PullExpr {}
 pub type Variable = String;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AggregateFunc {
+    Count,
+    CountDistinct,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+impl std::fmt::Display for AggregateFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Count => write!(f, "count"),
+            Self::CountDistinct => write!(f, "count-distinct"),
+            Self::Sum => write!(f, "sum"),
+            Self::Avg => write!(f, "avg"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FindElement {
     Variable(Variable),
     PullExpr(PullExpr),
-    Aggregate(String, String),
+    Aggregate(AggregateFunc, Variable),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod aggregate;
 mod algo;
 mod bootstrap;
 mod clock;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -535,6 +535,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_aggregate_find() {
+        let q = parse_both(
+            "[:find ?dept (count ?e) (avg ?salary) :where [?e :dept ?dept] [?e :salary ?salary]]",
+            "{:find [?dept (count ?e) (avg ?salary)] :where [[?e :dept ?dept] [?e :salary ?salary]]}",
+        );
+        assert_eq!(
+            q.find,
+            FindSpec::FindRel(vec![
+                FindElement::Variable("?dept".into()),
+                FindElement::Aggregate(AggregateFunc::Count, "?e".into()),
+                FindElement::Aggregate(AggregateFunc::Avg, "?salary".into()),
+            ])
+        );
+        assert_eq!(q.where_clauses.len(), 2);
+    }
+
+    #[test]
+    fn parse_unknown_aggregate_errors() {
+        let result = parse_query("[:find (foobar ?x) :where [?x :a _]]");
+        assert!(result.unwrap_err().to_string().contains("unknown aggregate function"));
+    }
+
+    #[test]
     fn parse_negative_integer_in_value() {
         let q = parse_both(
             "[:find ?x :where [?x :foo/bar -5]]",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,8 +5,8 @@ use edn::query as eq;
 use edn::Keyword;
 
 use crate::datalog::{
-    FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern, Variable,
-    WhereClause,
+    AggregateFunc, FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern,
+    Variable, WhereClause,
 };
 use crate::expr::{BinaryExpr, BinaryOp, Expr};
 use crate::ops::DataType;
@@ -47,17 +47,36 @@ fn convert_find_spec(spec: eq::FindSpec) -> Result<FindSpec> {
     }
 }
 
+fn parse_aggregate_func(name: &str) -> Result<AggregateFunc> {
+    match name {
+        "count" => Ok(AggregateFunc::Count),
+        "count-distinct" => Ok(AggregateFunc::CountDistinct),
+        "sum" => Ok(AggregateFunc::Sum),
+        "avg" => Ok(AggregateFunc::Avg),
+        "min" => Ok(AggregateFunc::Min),
+        "max" => Ok(AggregateFunc::Max),
+        _ => Err(anyhow!("unknown aggregate function: {}", name)),
+    }
+}
+
 fn convert_element(elem: eq::Element) -> Result<FindElement> {
     match elem {
         eq::Element::Variable(v) => Ok(FindElement::Variable(var_to_string(&v))),
         eq::Element::Aggregate(agg) => {
             let func_name = agg.func.0.to_string();
-            let arg_str = agg
-                .args
-                .first()
-                .map(|a| format!("{}", a))
-                .unwrap_or_default();
-            Ok(FindElement::Aggregate(func_name, arg_str))
+            let func = parse_aggregate_func(&func_name)?;
+            if agg.args.len() != 1 {
+                return Err(anyhow!(
+                    "aggregate function '{}' requires exactly 1 argument, got {}",
+                    func_name,
+                    agg.args.len()
+                ));
+            }
+            let var = match &agg.args[0] {
+                eq::FnArg::Variable(v) => var_to_string(v),
+                other => return Err(anyhow!("aggregate argument must be a variable, got {:?}", other)),
+            };
+            Ok(FindElement::Aggregate(func, var))
         }
         eq::Element::Corresponding(_) | eq::Element::Pull(_) => {
             Err(anyhow!("pull and corresponding elements are not yet supported"))

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -515,8 +516,8 @@ pub fn execute_aggregation(
         }
 
         let (_, accumulators) = match groups.entry(group_key) {
-            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-            std::collections::hash_map::Entry::Vacant(e) => {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(e) => {
                 let group_values: Vec<DataType> = plan
                     .group_indices
                     .iter()

--- a/src/query.rs
+++ b/src/query.rs
@@ -379,24 +379,6 @@ pub fn compile_pattern(
     ))
 }
 
-/// Create indices for projecting find variables from join results.
-pub fn compile_find(find: &FindSpec, var_index: &HashMap<&Variable, usize>) -> Result<Vec<usize>, Error> {
-    match find {
-        FindSpec::FindRel(elements) => elements
-            .iter()
-            .map(|elem| match elem {
-                FindElement::Variable(var) => var_index
-                    .get(var)
-                    .copied()
-                    .ok_or_else(|| anyhow::anyhow!("Find variable {} not in where clauses", var)),
-                _ => Err(anyhow::anyhow!(
-                    "Only Variable find elements supported in MVP"
-                )),
-            })
-            .collect(),
-    }
-}
-
 /// How to produce one column of the output row.
 pub enum Projection {
     /// A non-aggregate variable: take from group key at `group_indices[idx]`.
@@ -826,29 +808,7 @@ mod tests {
         assert_eq!(order, vec!["?e"]);
     }
 
-    #[test]
-    fn test_compile_find() {
-        let find = FindSpec::FindRel(vec![
-            FindElement::Variable("?name".to_string()),
-            FindElement::Variable("?e".to_string()),
-        ]);
-        let join_order = vec!["?e".to_string(), "?name".to_string()];
-        let var_index = build_var_index(&join_order);
 
-        let indices = compile_find(&find, &var_index).unwrap();
-        // ?name is at index 1, ?e is at index 0
-        assert_eq!(indices, vec![1, 0]);
-    }
-
-    #[test]
-    fn test_compile_find_missing_variable() {
-        let find = FindSpec::FindRel(vec![FindElement::Variable("?missing".to_string())]);
-        let join_order = vec!["?e".to_string(), "?name".to_string()];
-        let var_index = build_var_index(&join_order);
-
-        let result = compile_find(&find, &var_index);
-        assert!(result.is_err());
-    }
 
     #[test]
     fn test_query_variable_order_with_or_clause() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -380,7 +380,7 @@ pub fn compile_pattern(
 }
 
 /// How to produce one column of the output row.
-pub enum Projection {
+pub(crate) enum Projection {
     /// A non-aggregate variable: take from group key at `group_indices[idx]`.
     GroupVar(usize),
     /// An aggregate: func + join-order index of the aggregate variable.
@@ -388,7 +388,7 @@ pub enum Projection {
 }
 
 /// Compiled find plan that describes how to project + aggregate results.
-pub struct FindPlan {
+pub(crate) struct FindPlan {
     /// Join-order indices of the non-aggregate find variables (group-by keys).
     pub group_indices: Vec<usize>,
     /// One projection per find element.
@@ -398,7 +398,7 @@ pub struct FindPlan {
 }
 
 /// Compile a find spec into a FindPlan.
-pub fn compile_find_plan(
+fn compile_find_plan(
     find: &FindSpec,
     var_index: &HashMap<&Variable, usize>,
 ) -> Result<FindPlan, Error> {
@@ -441,7 +441,7 @@ pub fn compile_find_plan(
 }
 
 /// Execute aggregation over join results according to the find plan.
-pub fn execute_aggregation(
+fn execute_aggregation(
     results: Vec<ResultTuple>,
     plan: &FindPlan,
 ) -> Result<QueryResult, Error> {
@@ -511,7 +511,7 @@ pub fn execute_aggregation(
             }
         };
 
-        // Feed values to accumulators
+        // TODO: skip deserialization for Count (value is ignored)
         let mut agg_idx = 0;
         for proj in &plan.projections {
             if let Projection::Aggregate(_, join_idx) = proj {

--- a/src/query.rs
+++ b/src/query.rs
@@ -497,9 +497,11 @@ pub fn execute_aggregation(
         })
         .collect();
 
-    // When there are no group-by variables, all rows collapse into a single
-    // group. Seed it so that empty input still produces one output row
-    // (e.g. (count ?e) on no matches → [[0]]).
+    // When there are no group-by variables (all-aggregate query), all rows
+    // collapse into a single group. Seed it so that empty input still
+    // produces one output row (e.g. (count ?e) on no matches → [[0]]).
+    // This works because the concatenated group key for zero indices is
+    // the empty vec, matching this seeded entry.
     if plan.group_indices.is_empty() {
         let accs: Vec<Box<dyn Accumulator>> =
             agg_funcs.iter().map(|f| make_accumulator(f)).collect();
@@ -507,14 +509,13 @@ pub fn execute_aggregation(
     }
 
     for tuple in &results {
-        // Build group key from raw bytes (length-prefixed to avoid ambiguity).
-        // This avoids deserializing group columns on every tuple — we only
-        // deserialize once per distinct group when inserting into the map.
+        // Build group key by concatenating raw serialized bytes of group
+        // columns. Bincode is self-delimiting (enum discriminants + length
+        // prefixes for variable-size data), so concatenation is unambiguous.
+        // Group values are only deserialized once per distinct group.
         let mut group_key = Vec::new();
         for &idx in &plan.group_indices {
-            let bytes = &tuple[idx];
-            group_key.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
-            group_key.extend_from_slice(bytes);
+            group_key.extend_from_slice(&tuple[idx]);
         }
 
         let (_, accumulators) = match groups.entry(group_key) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,9 +8,10 @@ use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple};
 use crate::clock::Instant;
+use crate::aggregate::{make_accumulator, Accumulator};
 use crate::datalog::{
-    FindElement, FindSpec, FnExpr, OrBranch, PatternClause, PatternElement, Query, TriplePattern,
-    Variable, WhereClause,
+    AggregateFunc, FindElement, FindSpec, FnExpr, OrBranch, PatternClause, PatternElement, Query,
+    TriplePattern, Variable, WhereClause,
 };
 use crate::expr::{expr_variables, Expr};
 use crate::index::IndexType;
@@ -395,6 +396,179 @@ pub fn compile_find(find: &FindSpec, var_index: &HashMap<&Variable, usize>) -> R
     }
 }
 
+/// How to produce one column of the output row.
+pub enum Projection {
+    /// A non-aggregate variable: take from group key at `group_indices[idx]`.
+    GroupVar(usize),
+    /// An aggregate: func + join-order index of the aggregate variable.
+    Aggregate(AggregateFunc, usize),
+}
+
+/// Compiled find plan that describes how to project + aggregate results.
+pub struct FindPlan {
+    /// Join-order indices of the non-aggregate find variables (group-by keys).
+    pub group_indices: Vec<usize>,
+    /// One projection per find element.
+    pub projections: Vec<Projection>,
+    /// Whether any aggregation is needed.
+    pub has_aggregates: bool,
+}
+
+/// Compile a find spec into a FindPlan.
+pub fn compile_find_plan(
+    find: &FindSpec,
+    var_index: &HashMap<&Variable, usize>,
+) -> Result<FindPlan, Error> {
+    let elements = match find {
+        FindSpec::FindRel(elements) => elements,
+    };
+
+    let mut group_indices = Vec::new();
+    let mut projections = Vec::new();
+    let mut has_aggregates = false;
+
+    for elem in elements {
+        match elem {
+            FindElement::Variable(var) => {
+                let idx = *var_index
+                    .get(var)
+                    .ok_or_else(|| anyhow::anyhow!("Find variable {} not in where clauses", var))?;
+                let group_pos = group_indices.len();
+                group_indices.push(idx);
+                projections.push(Projection::GroupVar(group_pos));
+            }
+            FindElement::Aggregate(func, var) => {
+                has_aggregates = true;
+                let idx = *var_index.get(var).ok_or_else(|| {
+                    anyhow::anyhow!("Aggregate variable {} not in where clauses", var)
+                })?;
+                projections.push(Projection::Aggregate(func.clone(), idx));
+            }
+            FindElement::PullExpr(_) => {
+                return Err(anyhow::anyhow!("PullExpr not supported"));
+            }
+        }
+    }
+
+    Ok(FindPlan {
+        group_indices,
+        projections,
+        has_aggregates,
+    })
+}
+
+/// Execute aggregation over join results according to the find plan.
+pub fn execute_aggregation(
+    results: Vec<ResultTuple>,
+    plan: &FindPlan,
+) -> Result<QueryResult, Error> {
+    if !plan.has_aggregates {
+        // Simple projection — backward compatible path
+        let rows: QueryResult = results
+            .into_iter()
+            .map(|tuple| {
+                plan.projections
+                    .iter()
+                    .map(|proj| match proj {
+                        Projection::GroupVar(group_pos) => {
+                            let join_idx = plan.group_indices[*group_pos];
+                            bincode::deserialize::<DataType>(&tuple[join_idx])
+                                .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
+                        }
+                        Projection::Aggregate(_, _) => unreachable!(),
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        return Ok(rows);
+    }
+
+    // Aggregation path: group by non-aggregate columns, accumulate aggregates.
+    // Key: serialized group columns; Value: (group_values, accumulators)
+    let mut groups: HashMap<Vec<u8>, (Vec<DataType>, Vec<Box<dyn Accumulator>>)> = HashMap::new();
+
+    // Count how many aggregate projections we have (for initializing accumulators)
+    let agg_funcs: Vec<&AggregateFunc> = plan
+        .projections
+        .iter()
+        .filter_map(|p| match p {
+            Projection::Aggregate(func, _) => Some(func),
+            _ => None,
+        })
+        .collect();
+
+    for tuple in &results {
+        // Build group key
+        let group_values: Vec<DataType> = plan
+            .group_indices
+            .iter()
+            .map(|&idx| bincode::deserialize::<DataType>(&tuple[idx]))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let group_key = bincode::serialize(&group_values)?;
+
+        let (_, accumulators) = groups.entry(group_key).or_insert_with(|| {
+            let accs: Vec<Box<dyn Accumulator>> =
+                agg_funcs.iter().map(|f| make_accumulator(f)).collect();
+            (group_values.clone(), accs)
+        });
+
+        // Feed values to accumulators
+        let mut agg_idx = 0;
+        for proj in &plan.projections {
+            if let Projection::Aggregate(_, join_idx) = proj {
+                let value = bincode::deserialize::<DataType>(&tuple[*join_idx])?;
+                accumulators[agg_idx].accumulate(&value)?;
+                agg_idx += 1;
+            }
+        }
+    }
+
+    // Finalize: assemble output rows
+    let mut output = Vec::with_capacity(groups.len());
+    for (_, (group_values, accumulators)) in groups {
+        let mut row = Vec::with_capacity(plan.projections.len());
+        let mut agg_idx = 0;
+        for proj in &plan.projections {
+            match proj {
+                Projection::GroupVar(group_pos) => {
+                    row.push(group_values[*group_pos].clone());
+                }
+                Projection::Aggregate(_, _) => {
+                    row.push(accumulators[agg_idx].finalize()?);
+                    agg_idx += 1;
+                }
+            }
+        }
+        output.push(row);
+    }
+
+    Ok(output)
+}
+
+/// Validate that all aggregate variables are bound by where clauses.
+fn validate_aggregate_clauses(
+    find: &FindSpec,
+    var_index: &HashMap<&Variable, usize>,
+) -> Result<(), Error> {
+    let elements = match find {
+        FindSpec::FindRel(elements) => elements,
+    };
+    for elem in elements {
+        if let FindElement::Aggregate(func, var) = elem {
+            if !var_index.contains_key(var) {
+                return Err(anyhow::anyhow!(
+                    "Aggregate variable {} in ({} {}) is not bound by where clauses",
+                    var,
+                    func,
+                    var
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Extract attribute name from a DataType constant.
 fn extract_attribute_name(data: &DataType) -> Result<String, Error> {
     match data {
@@ -467,6 +641,7 @@ pub fn validate_query(query: &Query) -> Result<(), Error> {
     validate_not_clauses(&query.where_clauses, &var_index)?;
     validate_predicate_clauses(&query.where_clauses, &var_index)?;
     validate_fn_clauses(&query.where_clauses, &var_index)?;
+    validate_aggregate_clauses(&query.find, &var_index)?;
     Ok(())
 }
 
@@ -577,20 +752,9 @@ pub fn execute_query(
     let join = GenericJoin::new(extender_refs, num_levels);
     let results = join.join();
 
-    // 4. Project results based on find clause
-    let projection_indices = compile_find(&query.find, &var_index)?;
-
-    let rows: QueryResult = results
-        .into_iter()
-        .map(|tuple| {
-            projection_indices
-                .iter()
-                .map(|&i| bincode::deserialize::<DataType>(&tuple[i]))
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(rows)
+    // 4. Project and aggregate results based on find clause
+    let plan = compile_find_plan(&query.find, &var_index)?;
+    execute_aggregation(results, &plan)
 }
 
 #[cfg(test)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -498,20 +498,29 @@ pub fn execute_aggregation(
         .collect();
 
     for tuple in &results {
-        // Build group key
-        let group_values: Vec<DataType> = plan
-            .group_indices
-            .iter()
-            .map(|&idx| bincode::deserialize::<DataType>(&tuple[idx]))
-            .collect::<Result<Vec<_>, _>>()?;
+        // Build group key from raw bytes (length-prefixed to avoid ambiguity).
+        // This avoids deserializing group columns on every tuple — we only
+        // deserialize once per distinct group when inserting into the map.
+        let mut group_key = Vec::new();
+        for &idx in &plan.group_indices {
+            let bytes = &tuple[idx];
+            group_key.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            group_key.extend_from_slice(bytes);
+        }
 
-        let group_key = bincode::serialize(&group_values)?;
-
-        let (_, accumulators) = groups.entry(group_key).or_insert_with(|| {
-            let accs: Vec<Box<dyn Accumulator>> =
-                agg_funcs.iter().map(|f| make_accumulator(f)).collect();
-            (group_values.clone(), accs)
-        });
+        let (_, accumulators) = match groups.entry(group_key) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                let group_values: Vec<DataType> = plan
+                    .group_indices
+                    .iter()
+                    .map(|&idx| bincode::deserialize::<DataType>(&tuple[idx]))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let accs: Vec<Box<dyn Accumulator>> =
+                    agg_funcs.iter().map(|f| make_accumulator(f)).collect();
+                e.insert((group_values, accs))
+            }
+        };
 
         // Feed values to accumulators
         let mut agg_idx = 0;

--- a/src/query.rs
+++ b/src/query.rs
@@ -448,32 +448,34 @@ fn compile_find_plan(
     })
 }
 
+/// Project join results without aggregation.
+fn project_results(
+    results: Vec<ResultTuple>,
+    plan: &FindPlan,
+) -> Result<QueryResult, Error> {
+    results
+        .into_iter()
+        .map(|tuple| {
+            plan.projections
+                .iter()
+                .map(|proj| match proj {
+                    Projection::GroupVar(group_pos) => {
+                        let join_idx = plan.group_key_indices[*group_pos];
+                        bincode::deserialize::<DataType>(&tuple[join_idx])
+                            .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
+                    }
+                    Projection::Aggregate(_, _) => unreachable!(),
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
 /// Execute aggregation over join results according to the find plan.
 fn execute_aggregation(
     results: Vec<ResultTuple>,
     plan: &FindPlan,
 ) -> Result<QueryResult, Error> {
-    if !plan.has_aggregates {
-        // Simple projection — backward compatible path
-        let rows: QueryResult = results
-            .into_iter()
-            .map(|tuple| {
-                plan.projections
-                    .iter()
-                    .map(|proj| match proj {
-                        Projection::GroupVar(group_pos) => {
-                            let join_idx = plan.group_key_indices[*group_pos];
-                            bincode::deserialize::<DataType>(&tuple[join_idx])
-                                .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
-                        }
-                        Projection::Aggregate(_, _) => unreachable!(),
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        return Ok(rows);
-    }
-
     // Aggregation path: group by non-aggregate columns, accumulate aggregates.
     // Key: serialized group columns; Value: (group_values, accumulators)
     let mut groups: HashMap<Vec<u8>, (Vec<DataType>, Vec<Box<dyn Accumulator>>)> = HashMap::new();
@@ -760,7 +762,11 @@ pub fn execute_query(
 
     // 4. Project and aggregate results based on find clause
     let plan = compile_find_plan(&query.find, &var_index)?;
-    execute_aggregation(results, &plan)
+    if plan.has_aggregates {
+        execute_aggregation(results, &plan)
+    } else {
+        project_results(results, &plan)
+    }
 }
 
 #[cfg(test)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -497,6 +497,15 @@ pub fn execute_aggregation(
         })
         .collect();
 
+    // When there are no group-by variables, all rows collapse into a single
+    // group. Seed it so that empty input still produces one output row
+    // (e.g. (count ?e) on no matches → [[0]]).
+    if plan.group_indices.is_empty() {
+        let accs: Vec<Box<dyn Accumulator>> =
+            agg_funcs.iter().map(|f| make_accumulator(f)).collect();
+        groups.insert(Vec::new(), (Vec::new(), accs));
+    }
+
     for tuple in &results {
         // Build group key from raw bytes (length-prefixed to avoid ambiguity).
         // This avoids deserializing group columns on every tuple — we only
@@ -1100,5 +1109,37 @@ mod tests {
 
         let order = query_variable_order(&where_clauses);
         assert_eq!(order, vec!["?e", "?name", "?age"]);
+    }
+
+    #[test]
+    fn test_execute_aggregation_all_aggs_empty_input() {
+        // [:find (count ?e)] with no results → single row [[0]]
+        use crate::datalog::AggregateFunc;
+        let plan = FindPlan {
+            group_indices: vec![],
+            projections: vec![Projection::Aggregate(AggregateFunc::Count, 0)],
+            has_aggregates: true,
+        };
+        let results: Vec<ResultTuple> = vec![];
+        let output = execute_aggregation(results, &plan).unwrap();
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0], vec![DataType::Long(0)]);
+    }
+
+    #[test]
+    fn test_execute_aggregation_with_group_keys_empty_input() {
+        // [:find ?dept (count ?e)] with no results → empty (no groups formed)
+        use crate::datalog::AggregateFunc;
+        let plan = FindPlan {
+            group_indices: vec![0],
+            projections: vec![
+                Projection::GroupVar(0),
+                Projection::Aggregate(AggregateFunc::Count, 1),
+            ],
+            has_aggregates: true,
+        };
+        let results: Vec<ResultTuple> = vec![];
+        let output = execute_aggregation(results, &plan).unwrap();
+        assert!(output.is_empty());
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -380,18 +380,26 @@ pub fn compile_pattern(
 }
 
 /// How to produce one column of the output row.
+///
+/// Two index spaces are in play:
+/// - **join-order index**: position in the raw result tuple from the join
+/// - **group position**: position in `FindPlan::group_key_indices`
+///
+/// `GroupVar` uses a group position (indirect) so that `group_key_indices` can
+/// be iterated directly in the hot loop without filtering. `Aggregate` uses a
+/// join-order index (direct) since aggregates are only read once per row.
 pub(crate) enum Projection {
-    /// A non-aggregate variable: take from group key at `group_indices[idx]`.
+    /// Index into `group_key_indices`, which itself holds a join-order index.
     GroupVar(usize),
-    /// An aggregate: func + join-order index of the aggregate variable.
+    /// Aggregate function + join-order index of the input variable.
     Aggregate(AggregateFunc, usize),
 }
 
 /// Compiled find plan that describes how to project + aggregate results.
 pub(crate) struct FindPlan {
-    /// Join-order indices of the non-aggregate find variables (group-by keys).
-    pub group_indices: Vec<usize>,
-    /// One projection per find element.
+    /// Join-order indices of the group-by variables, iterated directly to build group keys.
+    pub group_key_indices: Vec<usize>,
+    /// One projection per find element, in find-clause order.
     pub projections: Vec<Projection>,
     /// Whether any aggregation is needed.
     pub has_aggregates: bool,
@@ -406,7 +414,7 @@ fn compile_find_plan(
         FindSpec::FindRel(elements) => elements,
     };
 
-    let mut group_indices = Vec::new();
+    let mut group_key_indices = Vec::new();
     let mut projections = Vec::new();
     let mut has_aggregates = false;
 
@@ -416,8 +424,8 @@ fn compile_find_plan(
                 let idx = *var_index
                     .get(var)
                     .ok_or_else(|| anyhow::anyhow!("Find variable {} not in where clauses", var))?;
-                let group_pos = group_indices.len();
-                group_indices.push(idx);
+                let group_pos = group_key_indices.len();
+                group_key_indices.push(idx);
                 projections.push(Projection::GroupVar(group_pos));
             }
             FindElement::Aggregate(func, var) => {
@@ -434,7 +442,7 @@ fn compile_find_plan(
     }
 
     Ok(FindPlan {
-        group_indices,
+        group_key_indices,
         projections,
         has_aggregates,
     })
@@ -454,7 +462,7 @@ fn execute_aggregation(
                     .iter()
                     .map(|proj| match proj {
                         Projection::GroupVar(group_pos) => {
-                            let join_idx = plan.group_indices[*group_pos];
+                            let join_idx = plan.group_key_indices[*group_pos];
                             bincode::deserialize::<DataType>(&tuple[join_idx])
                                 .map_err(|e| anyhow::anyhow!("deserialization error: {}", e))
                         }
@@ -483,7 +491,7 @@ fn execute_aggregation(
     // When there are no group-by variables (all-aggregate query), all rows
     // collapse into a single group. Seed it so that empty input still
     // produces one output row.
-    if plan.group_indices.is_empty() {
+    if plan.group_key_indices.is_empty() {
         let accs: Vec<Box<dyn Accumulator>> =
             agg_funcs.iter().map(|f| make_accumulator(f)).collect();
         groups.insert(Vec::new(), (Vec::new(), accs));
@@ -493,7 +501,7 @@ fn execute_aggregation(
         // Build group key by concatenating raw serialized bytes of group
         // columns.
         let mut group_key = Vec::new();
-        for &idx in &plan.group_indices {
+        for &idx in &plan.group_key_indices {
             group_key.extend_from_slice(&tuple[idx]);
         }
 
@@ -501,7 +509,7 @@ fn execute_aggregation(
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 let group_values: Vec<DataType> = plan
-                    .group_indices
+                    .group_key_indices
                     .iter()
                     .map(|&idx| bincode::deserialize::<DataType>(&tuple[idx]))
                     .collect::<Result<Vec<_>, _>>()?;
@@ -1074,7 +1082,7 @@ mod tests {
         // [:find (count ?e)] with no results → single row [[0]]
         use crate::datalog::AggregateFunc;
         let plan = FindPlan {
-            group_indices: vec![],
+            group_key_indices: vec![],
             projections: vec![Projection::Aggregate(AggregateFunc::Count, 0)],
             has_aggregates: true,
         };
@@ -1089,7 +1097,7 @@ mod tests {
         // [:find ?dept (count ?e)] with no results → empty (no groups formed)
         use crate::datalog::AggregateFunc;
         let plan = FindPlan {
-            group_indices: vec![0],
+            group_key_indices: vec![0],
             projections: vec![
                 Projection::GroupVar(0),
                 Projection::Aggregate(AggregateFunc::Count, 1),

--- a/src/query.rs
+++ b/src/query.rs
@@ -499,9 +499,7 @@ pub fn execute_aggregation(
 
     // When there are no group-by variables (all-aggregate query), all rows
     // collapse into a single group. Seed it so that empty input still
-    // produces one output row (e.g. (count ?e) on no matches → [[0]]).
-    // This works because the concatenated group key for zero indices is
-    // the empty vec, matching this seeded entry.
+    // produces one output row.
     if plan.group_indices.is_empty() {
         let accs: Vec<Box<dyn Accumulator>> =
             agg_funcs.iter().map(|f| make_accumulator(f)).collect();
@@ -510,9 +508,7 @@ pub fn execute_aggregation(
 
     for tuple in &results {
         // Build group key by concatenating raw serialized bytes of group
-        // columns. Bincode is self-delimiting (enum discriminants + length
-        // prefixes for variable-size data), so concatenation is unambiguous.
-        // Group values are only deserialized once per distinct group.
+        // columns.
         let mut group_key = Vec::new();
         for &idx in &plan.group_indices {
             group_key.extend_from_slice(&tuple[idx]);

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -551,3 +551,29 @@ async fn test_aggregate_empty_result() {
     client.close().await.unwrap();
     token.cancel();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregate_min_incompatible_types() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+
+    // Insert entity with both name (string) and age (long)
+    let mut doc = BTreeMap::new();
+    doc.insert("db/id".to_string(), DataType::Long(100));
+    doc.insert("name".to_string(), DataType::String("Alice".to_string()));
+    doc.insert("age".to_string(), DataType::Long(30));
+    client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+
+    let db = client.db().await.unwrap();
+
+    // OR binds ?v to both string and long values → min should error on incomparable types
+    let result = db
+        .query_edn("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
+        .await;
+    assert!(result.is_err(), "min over incompatible types should error");
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -288,6 +288,24 @@ async fn test_dev_server_connections_are_isolated() {
     token.cancel();
 }
 
+/// Define extra schema attributes beyond the base test_schema_tx.
+async fn define_extra_schema(client: &ClientNode) {
+    let attrs = vec![
+        (54, "last-name", "string"),
+        (55, "sex", "keyword"),
+        (56, "salary", "long"),
+        (57, "city", "string"),
+        (58, "heads", "long"),
+    ];
+    for (id, name, vtype) in attrs {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain(name)));
+        doc.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", vtype)));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+}
+
 /// Mirror of Clojure test-query-using-keywords, exercised through the full
 /// client-server wire protocol via query_edn.
 #[tokio::test(flavor = "multi_thread")]
@@ -295,13 +313,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
-
-    // Add sex attribute (keyword type) at ID 54
-    let mut sex_attr = BTreeMap::new();
-    sex_attr.insert("db/id".to_string(), DataType::Long(54));
-    sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
-    sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
-    client.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
+    define_extra_schema(&client).await;
 
     // Insert 4 people with keyword sex values
     for (id, name, sex) in [(100, "Ivan", "male"), (101, "Petr", "male"),
@@ -324,6 +336,215 @@ async fn test_query_keyword_value_comparison_via_wire() {
     assert_eq!(result.len(), 2, "expected only Ivan and Petr, got {:?}", result);
     assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
     assert!(result.contains(&vec![DataType::String("Petr".to_string())]));
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregates_and_or() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+    define_extra_schema(&client).await;
+
+    // Insert Ada, Alan, Adam
+    for (id, name, last, sex, age) in [
+        (100, "Ada", "Lovelace", "female", 21),
+        (101, "Alan", "Turing", "male", 22),
+        (102, "Adam", "Smith", "male", 23),
+    ] {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("name".to_string(), DataType::String(name.to_string()));
+        doc.insert("last-name".to_string(), DataType::String(last.to_string()));
+        doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
+        doc.insert("age".to_string(), DataType::Long(age));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+
+    let db = client.db().await.unwrap();
+
+    // count with OR: Lovelace AND (name=Ada OR sex=male) → 1 (only Ada)
+    let result = db
+        .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :male])]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Long(1)]]);
+
+    // count with OR: Lovelace AND (name=Ada OR sex=female) → 1
+    let result = db
+        .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :female])]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Long(1)]]);
+
+    // count with top-level OR: Lovelace OR male → 3
+    let result = db
+        .query_edn("{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Long(3)]]);
+
+    // Grouped: gender, count, sum
+    let result = db
+        .query_edn("{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 2, "expected 2 groups, got {:?}", result);
+    assert!(result.contains(&vec![
+        DataType::Keyword(Keyword::plain("male")),
+        DataType::Long(2),
+        DataType::Long(45),
+    ]));
+    assert!(result.contains(&vec![
+        DataType::Keyword(Keyword::plain("female")),
+        DataType::Long(1),
+        DataType::Long(21),
+    ]));
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregate_set_semantics() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+    define_extra_schema(&client).await;
+
+    for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("name".to_string(), DataType::String(name.to_string()));
+        doc.insert("city".to_string(), DataType::String(city.to_string()));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+
+    let db = client.db().await.unwrap();
+
+    // TODO: do we want Datomic (set → 2) or XTDB (bag → 3) semantics here?
+    let result = db
+        .query_edn("{:find [(count ?city)] :where [[?p :city ?city]]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Long(3)]]);
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_datascript_aggregates() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+    define_extra_schema(&client).await;
+
+    // Insert monsters with heads
+    for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("heads".to_string(), DataType::Long(heads));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+
+    let db = client.db().await.unwrap();
+
+    // All aggregate functions at once
+    let result = db
+        .query_edn("{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)] :where [[?monster :heads ?heads]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1, "expected single row, got {:?}", result);
+    let row = &result[0];
+    assert_eq!(row[0], DataType::Long(6), "sum");
+    assert_eq!(row[1], DataType::Long(1), "min");
+    assert_eq!(row[2], DataType::Long(3), "max");
+    assert_eq!(row[3], DataType::Long(4), "count");
+    assert_eq!(row[4], DataType::Long(2), "count-distinct");
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregate_avg() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+
+    for (id, age) in [(100, 21), (101, 22), (102, 23)] {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("age".to_string(), DataType::Long(age));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+
+    let db = client.db().await.unwrap();
+
+    let result = db
+        .query_edn("{:find [(avg ?age)] :where [[?e :age ?age]]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Double(22.0)]]);
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregate_min_max_strings() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+
+    for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(id));
+        doc.insert("name".to_string(), DataType::String(name.to_string()));
+        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    }
+
+    let db = client.db().await.unwrap();
+
+    let result = db
+        .query_edn("{:find [(min ?name) (max ?name)] :where [[?e :name ?name]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0][0], DataType::String("Alice".to_string()));
+    assert_eq!(result[0][1], DataType::String("Charlie".to_string()));
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregate_empty_result() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_test_schema(&client).await;
+
+    // No data inserted — count over empty result should return [[0]]
+    let db = client.db().await.unwrap();
+
+    let result = db
+        .query_edn("{:find [(count ?e)] :where [[?e :name \"nobody\"]]}")
+        .await
+        .unwrap();
+    assert_eq!(result, vec![vec![DataType::Long(0)]]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -12,7 +12,7 @@ use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
 use triplox::TransactionResult;
 
-async fn define_test_schema(client: &ClientNode) {
+async fn define_base_schema(client: &ClientNode) {
     let result = client.execute_tx(test_schema_tx()).await.unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
 }
@@ -48,7 +48,7 @@ async fn test_client_connect_and_close() {
 async fn test_execute_tx_and_query() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     // Insert a document
     let mut doc = BTreeMap::new();
@@ -76,7 +76,7 @@ async fn test_execute_tx_and_query() {
 async fn test_submit_tx() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
@@ -92,7 +92,7 @@ async fn test_submit_tx() {
 async fn test_multiple_transactions_and_query() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     // Insert two documents in separate transactions
     let mut doc1 = BTreeMap::new();
@@ -124,7 +124,7 @@ async fn test_multiple_transactions_and_query() {
 async fn test_open_close_multiple_dbs() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     // Insert data
     let mut doc = BTreeMap::new();
@@ -154,7 +154,7 @@ async fn test_two_connections() {
 
     // Connection 1 inserts data
     let client1 = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client1).await;
+    define_base_schema(&client1).await;
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
@@ -176,7 +176,7 @@ async fn test_two_connections() {
 async fn test_execute_tx_returns_tx_key() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
@@ -198,7 +198,7 @@ async fn test_execute_tx_returns_tx_key() {
 async fn test_db_as_of() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     // First transaction
     let mut doc1 = BTreeMap::new();
@@ -256,7 +256,7 @@ async fn test_dev_server_connections_are_isolated() {
 
     // Connection 1: define schema and insert data
     let client1 = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client1).await;
+    define_base_schema(&client1).await;
 
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
@@ -272,7 +272,7 @@ async fn test_dev_server_connections_are_isolated() {
 
     // Connection 2: gets a fresh node, should see nothing
     let client2 = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client2).await;
+    define_base_schema(&client2).await;
 
     let db2 = client2.db().await.unwrap();
     let result2 = db2
@@ -313,7 +313,7 @@ async fn define_heads_schema(client: &ClientNode) {
 async fn test_query_keyword_value_comparison_via_wire() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
     define_people_schema(&client).await;
 
     // Insert 4 people with keyword sex values
@@ -351,7 +351,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
 async fn test_aggregates_and_or() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
     define_people_schema(&client).await;
 
     // Insert Ada, Alan, Adam
@@ -418,7 +418,7 @@ async fn test_aggregates_and_or() {
 async fn test_aggregate_set_semantics() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
     define_people_schema(&client).await;
 
     for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
@@ -447,7 +447,7 @@ async fn test_aggregate_set_semantics() {
 async fn test_datascript_aggregates() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
     define_heads_schema(&client).await;
 
     // Insert monsters with heads
@@ -482,7 +482,7 @@ async fn test_datascript_aggregates() {
 async fn test_aggregate_avg() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     for (id, age) in [(100, 21), (101, 22), (102, 23)] {
         let mut doc = BTreeMap::new();
@@ -508,7 +508,7 @@ async fn test_aggregate_avg() {
 async fn test_aggregate_min_max_strings() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
         let mut doc = BTreeMap::new();
@@ -536,7 +536,7 @@ async fn test_aggregate_min_max_strings() {
 async fn test_aggregate_empty_result() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
-    define_test_schema(&client).await;
+    define_base_schema(&client).await;
 
     // No data inserted — count over empty result should return [[0]]
     let db = client.db().await.unwrap();

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -288,22 +288,23 @@ async fn test_dev_server_connections_are_isolated() {
     token.cancel();
 }
 
-/// Define extra schema attributes beyond the base test_schema_tx.
-async fn define_extra_schema(client: &ClientNode) {
-    let attrs = vec![
-        (54, "last-name", "string"),
-        (55, "sex", "keyword"),
-        (56, "salary", "long"),
-        (57, "city", "string"),
-        (58, "heads", "long"),
-    ];
-    for (id, name, vtype) in attrs {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain(name)));
-        doc.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", vtype)));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
-    }
+async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &str) {
+    let mut doc = BTreeMap::new();
+    doc.insert("db/id".to_string(), DataType::Long(id));
+    doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain(name)));
+    doc.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", vtype)));
+    client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+}
+
+async fn define_people_schema(client: &ClientNode) {
+    define_schema_attr(client, 54, "last-name", "string").await;
+    define_schema_attr(client, 55, "sex", "keyword").await;
+    define_schema_attr(client, 56, "salary", "long").await;
+    define_schema_attr(client, 57, "city", "string").await;
+}
+
+async fn define_heads_schema(client: &ClientNode) {
+    define_schema_attr(client, 58, "heads", "long").await;
 }
 
 /// Mirror of Clojure test-query-using-keywords, exercised through the full
@@ -313,7 +314,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
-    define_extra_schema(&client).await;
+    define_people_schema(&client).await;
 
     // Insert 4 people with keyword sex values
     for (id, name, sex) in [(100, "Ivan", "male"), (101, "Petr", "male"),
@@ -351,7 +352,7 @@ async fn test_aggregates_and_or() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
-    define_extra_schema(&client).await;
+    define_people_schema(&client).await;
 
     // Insert Ada, Alan, Adam
     for (id, name, last, sex, age) in [
@@ -418,7 +419,7 @@ async fn test_aggregate_set_semantics() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
-    define_extra_schema(&client).await;
+    define_people_schema(&client).await;
 
     for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
         let mut doc = BTreeMap::new();
@@ -447,7 +448,7 @@ async fn test_datascript_aggregates() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_test_schema(&client).await;
-    define_extra_schema(&client).await;
+    define_heads_schema(&client).await;
 
     // Insert monsters with heads
     for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {

--- a/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
@@ -433,3 +433,75 @@
   (is (= #{["Alice" "NYC"]} (q '{:find [?name ?city]
                                  :where [[?p :name ?name]
                                          [?p :city ?city]]}))))
+
+;; ---------------------------------------------------------------------------
+;; Tests — aggregates
+;; ---------------------------------------------------------------------------
+
+(deftest test-aggregates-and-or
+  (tc/transact *conn* [{:db/id 1000 :name "Ada" :last-name "Lovelace" :sex :female :age 21}
+                       {:db/id 1001 :name "Alan" :last-name "Turing" :sex :male :age 22}
+                       {:db/id 1002 :name "Adam" :last-name "Smith" :sex :male :age 23}])
+
+  (is (= #{[1]} (q '{:find [(count ?p)]
+                     :where [[?p :last-name "Lovelace"]
+                             (or [?p :name "Ada"]
+                                 [?p :sex :male])]})))
+
+  (is (= #{[1]} (q '{:find [(count ?p)]
+                     :where [[?p :last-name "Lovelace"]
+                             (or [?p :name "Ada"]
+                                 [?p :sex :female])]})))
+
+  (is (= #{[3]} (q '{:find [(count ?p)]
+                     :where [(or [?p :last-name "Lovelace"]
+                                 [?p :sex :male])]})))
+
+  (is (= #{[:male 2 45] [:female 1 21]}
+         (q '{:find [?gender (count ?p) (sum ?age)]
+              :where [[?p :sex ?gender]
+                      [?p :age ?age]]}))
+      "implicit grouping"))
+
+(deftest test-aggregate-set-semantics
+  (tc/transact *conn* [{:db/id 1000 :name "Alice" :city "NYC"}
+                       {:db/id 1001 :name "Bob" :city "NYC"}
+                       {:db/id 1002 :name "Carol" :city "LA"}])
+
+  ;; TODO: do we want Datomic or XTDB semantics here?
+  (is (= #{[3]} (q '{:find [(count ?city)]
+                     :where [[?p :city ?city]]}))))
+
+(deftest test-datascript-aggregates
+  (tc/transact *conn* [{:db/id 2000 :db/ident :heads
+                        :db/valueType :db.type/long}])
+  (tc/transact *conn* [{:db/id 1000 :heads 3}
+                       {:db/id 1001 :heads 1}
+                       {:db/id 1002 :heads 1}
+                       {:db/id 1003 :heads 1}])
+
+  (testing "Multiple aggregates, correct grouping"
+    (is (= #{[6 1 3 4 2]}
+           (q '{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)]
+                :where [[?monster :heads ?heads]]})))))
+
+(deftest test-aggregate-avg
+  (tc/transact *conn* [{:db/id 1000 :age 21}
+                       {:db/id 1001 :age 22}
+                       {:db/id 1002 :age 23}])
+
+  (is (= #{[22.0]} (q '{:find [(avg ?age)]
+                        :where [[?e :age ?age]]}))))
+
+(deftest test-aggregate-min-max-strings
+  (tc/transact *conn* [{:db/id 1000 :name "Charlie"}
+                       {:db/id 1001 :name "Alice"}
+                       {:db/id 1002 :name "Bob"}])
+
+  (is (= #{["Alice" "Charlie"]}
+         (q '{:find [(min ?name) (max ?name)]
+              :where [[?e :name ?name]]}))))
+
+(deftest test-aggregate-empty-result
+  (is (= #{[0]} (q '{:find [(count ?e)]
+                     :where [[?e :name "nobody"]]}))))


### PR DESCRIPTION
## Summary
- Add `AggregateFunc` enum and typed `FindElement::Aggregate(AggregateFunc, Variable)` AST node, replacing the previous untyped `Aggregate(String, String)`
- Implement post-join hash aggregation with accumulators for `count`, `count-distinct`, `sum`, `avg`, `min`, and `max`
- Integrate aggregation into `execute_query()` via `FindPlan`/`compile_find_plan()`/`execute_aggregation()`, keeping the non-aggregate path backward compatible

## Test plan
- [x] All 292 existing unit tests pass (no regression from AST change)
- [x] 11 new accumulator unit tests covering each aggregate function (Count, CountDistinct, Sum with Long/Double/mixed, Avg, Min, Max, Min on strings, Max on doubles, Sum on non-numeric error)
- [x] 10 integration tests pass
- [ ] Manual: insert entities with numeric attrs, query with `(sum ...)`, `(count ...)`, `(avg ...)`, `(min ...)`, `(max ...)` and verify results
- [ ] Manual: mixed query `[:find ?dept (count ?e) (avg ?salary) :where [?e :dept ?dept] [?e :salary ?salary]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)