### PR TITLE
feat: support db.cardinality/many in schema and indexer

### DIFF
--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -28,7 +28,10 @@ fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
         "db/valueType".to_string(),
         DataType::Keyword(Keyword::namespaced("db.type", value_type)),
     );
-    doc.insert("db/cardinality".to_string(), DataType::Long(30));
+    doc.insert(
+        "db/cardinality".to_string(),
+        DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
+    );
     TxOp::Put(Document(doc))
 }
 

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -28,6 +28,7 @@ fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
         "db/valueType".to_string(),
         DataType::Keyword(Keyword::namespaced("db.type", value_type)),
     );
+    doc.insert("db/cardinality".to_string(), DataType::Long(30));
     TxOp::Put(Document(doc))
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -806,6 +806,9 @@ mod tests {
         Ok(())
     }
 
+    // NOTE: Currently cardinality-many has bag semantics (duplicate values are stored).
+    // Datomic uses set semantics where asserting the same value twice is a no-op.
+    // We may want to switch to set semantics in the future.
     #[tokio::test]
     async fn test_cardinality_many_same_value() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -784,8 +784,8 @@ mod tests {
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
-        // Scan EAV for entity 100, tags attr (entity_id 54) — expect 2 ADDs, 0 RETRACTs
-        let tags_id: i64 = 54;
+        // Scan EAV for entity 100, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
+        let tags_id: i64 = 1000;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
@@ -833,7 +833,7 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 100, tags attr — expect 2 ADDs (both written)
-        let tags_id: i64 = 54;
+        let tags_id: i64 = 1000;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -145,10 +145,16 @@ impl Indexer {
                 resolved_datoms.insert(datom);
                 continue;
             }
-            let attribute_id = self.schema_cache
+            let attr_schema = self.schema_cache
                 .get(&datom.attribute)
-                .map(|a| a.entity_id)
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+            let attribute_id = attr_schema.entity_id;
+
+            // Cardinality-many attributes accumulate values without retraction.
+            if attr_schema.cardinality == crate::schema::Cardinality::Many {
+                resolved_datoms.insert(datom);
+                continue;
+            }
             let entity_id_bytes = bincode::serialize(&DataType::Long(datom.entity))?;
             let attr_id_bytes = bincode::serialize(&attribute_id)?;
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
@@ -750,6 +756,92 @@ mod tests {
         }
         assert_eq!(add_count, 1, "Expected 1 ADD entry (second tx dropped)");
         assert_eq!(retract_count, 0, "Expected no RETRACT entries");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cardinality_many_no_retract() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+
+        // First tx: assert tags="rust" for entity 100
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx_ops1 = vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("rust".to_string()),
+        }];
+        indexer.transact_tx(tx1, tx_ops1).await?;
+
+        // Second tx: assert tags="database" for same entity — should NOT retract "rust"
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let tx_ops2 = vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("database".to_string()),
+        }];
+        indexer.transact_tx(tx2, tx_ops2).await?;
+
+        // Scan EAV for entity 100, tags attr (entity_id 54) — expect 2 ADDs, 0 RETRACTs
+        let tags_id: i64 = 54;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut add_count = 0;
+        let mut retract_count = 0;
+        while let Some(kv) = iter.next().await? {
+            let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if entity_id != DataType::Long(100) || attribute != tags_id {
+                continue;
+            }
+            match op {
+                codec::ADD => add_count += 1,
+                codec::RETRACT => retract_count += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(add_count, 2, "Expected 2 ADD entries for cardinality-many");
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries for cardinality-many");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cardinality_many_same_value() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+
+        // First tx: assert tags="rust" for entity 100
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx_ops1 = vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("rust".to_string()),
+        }];
+        indexer.transact_tx(tx1, tx_ops1).await?;
+
+        // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let tx_ops2 = vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("rust".to_string()),
+        }];
+        indexer.transact_tx(tx2, tx_ops2).await?;
+
+        // Scan EAV for entity 100, tags attr — expect 2 ADDs (both written)
+        let tags_id: i64 = 54;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut add_count = 0;
+        while let Some(kv) = iter.next().await? {
+            let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if entity_id != DataType::Long(100) || attribute != tags_id {
+                continue;
+            }
+            if op == codec::ADD {
+                add_count += 1;
+            }
+        }
+        assert_eq!(add_count, 2, "Expected 2 ADD entries for same value on cardinality-many");
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -148,13 +148,14 @@ impl Indexer {
             let attr_schema = self.schema_cache
                 .get(&datom.attribute)
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-            let attribute_id = attr_schema.entity_id;
 
             // Cardinality-many attributes accumulate values without retraction.
             if attr_schema.cardinality == crate::schema::Cardinality::Many {
                 resolved_datoms.insert(datom);
                 continue;
             }
+
+            let attribute_id = attr_schema.entity_id;
             let entity_id_bytes = bincode::serialize(&DataType::Long(datom.entity))?;
             let attr_id_bytes = bincode::serialize(&attribute_id)?;
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1136,7 +1136,7 @@ mod tests {
         sex_attr.insert("db/id".to_string(), DataType::Long(55));
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
-        sex_attr.insert("db/cardinality".to_string(), DataType::Long(30));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
         node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
 
         let people = vec![
@@ -1190,7 +1190,7 @@ mod tests {
         sex_attr.insert("db/id".to_string(), DataType::Long(55));
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
-        sex_attr.insert("db/cardinality".to_string(), DataType::Long(30));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
         node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
 
         let people = vec![
@@ -1240,7 +1240,7 @@ mod tests {
         attr.insert("db/id".to_string(), DataType::Long(55));
         attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("last-name")));
         attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "string")));
-        attr.insert("db/cardinality".to_string(), DataType::Long(30));
+        attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
         node.execute_tx(vec![TxOp::Put(Document(attr))]).await.unwrap();
 
         // Insert entity 200 and entity 201 with last-names

--- a/src/node.rs
+++ b/src/node.rs
@@ -1131,11 +1131,12 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        // Define "sex" attribute (ID 54) with keyword value type
+        // Define "sex" attribute (ID 55) with keyword value type
         let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/id".to_string(), DataType::Long(54));
+        sex_attr.insert("db/id".to_string(), DataType::Long(55));
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Long(30));
         node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
 
         let people = vec![
@@ -1186,9 +1187,10 @@ mod tests {
         define_test_schema(&node).await;
 
         let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/id".to_string(), DataType::Long(54));
+        sex_attr.insert("db/id".to_string(), DataType::Long(55));
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Long(30));
         node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
 
         let people = vec![
@@ -1233,11 +1235,12 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        // Define "last-name" attribute (ID 54)
+        // Define "last-name" attribute (ID 55)
         let mut attr = BTreeMap::new();
-        attr.insert("db/id".to_string(), DataType::Long(54));
+        attr.insert("db/id".to_string(), DataType::Long(55));
         attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("last-name")));
         attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "string")));
+        attr.insert("db/cardinality".to_string(), DataType::Long(30));
         node.execute_tx(vec![TxOp::Put(Document(attr))]).await.unwrap();
 
         // Insert entity 200 and entity 201 with last-names
@@ -1311,5 +1314,45 @@ mod tests {
 
         assert!(matches!(result, TransactionResult::TxCommited(_)),
                 "Expected TxCommited for valid tx, got: {:?}", result);
+    }
+
+    /// Cardinality-many attributes accumulate values without retracting old ones.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cardinality_many_attribute() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Insert entity 100 with tags="rust"
+        node.execute_tx(vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("rust".to_string()),
+        }]).await.unwrap();
+
+        // Add another tag to the same entity — should NOT retract "rust"
+        node.execute_tx(vec![TxOp::Add {
+            entity_id: crate::ops::EntityId::new(100),
+            attribute: crate::ops::Attribute("tags".to_string()),
+            value: DataType::String("database".to_string()),
+        }]).await.unwrap();
+
+        // Query: find all tags for entity 100
+        let query = Query {
+            find: find_vars(&["?tag"]),
+            where_clauses: vec![
+                WhereClause::Triple(TriplePattern {
+                    entity: PatternElement::Constant(DataType::Long(100)),
+                    attribute: PatternElement::Constant(kw("tags")),
+                    value: PatternElement::Variable("?tag".to_string()),
+                }),
+            ],
+        };
+
+        let db = node.db().await.unwrap();
+        let result = db.query(&query).await.unwrap();
+
+        assert_eq!(result.len(), 2, "Expected both tags, got {:?}", result);
+        assert!(result.contains(&vec![DataType::String("rust".to_string())]));
+        assert!(result.contains(&vec![DataType::String("database".to_string())]));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -431,7 +431,7 @@ pub fn test_schema_tx() -> Vec<TxOp> {
         schema_attribute(52, Keyword::plain("email"), "string"),
         // TODO: update this to ref once we support DataType::Ref
         schema_attribute(53, Keyword::plain("follows"), "long"),
-        schema_attribute_with_cardinality(54, Keyword::plain("tags"), "string", "many"),
+        schema_attribute_with_cardinality(1000, Keyword::plain("tags"), "string", "many"),
     ]
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,9 @@ pub const DB_TYPE_VECTOR: i64 = 22;
 pub const DB_TYPE_MAP: i64 = 23;
 
 // Cardinality enum entities
+#[allow(dead_code)]
 pub const DB_CARDINALITY_ONE: i64 = 30;
+#[allow(dead_code)]
 pub const DB_CARDINALITY_MANY: i64 = 31;
 
 // --- Schema types ---
@@ -128,15 +130,6 @@ impl std::fmt::Display for Cardinality {
 }
 
 impl Cardinality {
-    /// Map a cardinality enum entity ID to a Cardinality.
-    pub fn from_entity_id(id: i64) -> Result<Self> {
-        match id {
-            DB_CARDINALITY_ONE => Ok(Cardinality::One),
-            DB_CARDINALITY_MANY => Ok(Cardinality::Many),
-            _ => Err(anyhow::anyhow!("Unknown cardinality entity ID: {}", id)),
-        }
-    }
-
     /// Map a cardinality keyword (e.g. :db.cardinality/one) to a Cardinality.
     pub fn from_keyword(kw: &Keyword) -> Result<Self> {
         let s = kw.to_string();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -136,6 +136,17 @@ impl Cardinality {
             _ => Err(anyhow::anyhow!("Unknown cardinality entity ID: {}", id)),
         }
     }
+
+    /// Map a cardinality keyword (e.g. :db.cardinality/one) to a Cardinality.
+    pub fn from_keyword(kw: &Keyword) -> Result<Self> {
+        let s = kw.to_string();
+        let s = s.strip_prefix(':').unwrap_or(&s);
+        match s {
+            "db.cardinality/one" => Ok(Cardinality::One),
+            "db.cardinality/many" => Ok(Cardinality::Many),
+            _ => Err(anyhow::anyhow!("Unknown cardinality keyword: {}", kw)),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -209,8 +220,8 @@ impl SchemaCache {
                 None => continue, // enum entity
             };
             let cardinality = match f.get("db/cardinality") {
-                Some(DataType::Long(id)) => Cardinality::from_entity_id(*id)?,
-                Some(_) => return Err(anyhow::anyhow!("db/cardinality must be a Long")),
+                Some(DataType::Keyword(kw)) => Cardinality::from_keyword(kw)?,
+                Some(_) => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
                 None => return Err(anyhow::anyhow!(
                     "db/cardinality is required for schema attribute '{}'", ident
                 )),
@@ -264,7 +275,7 @@ impl SchemaCache {
 
 // --- Bootstrap transaction builders ---
 
-fn schema_attribute_with_cardinality(id: i64, ident: Keyword, value_type: &str, cardinality: i64) -> TxOp {
+fn schema_attribute_with_cardinality(id: i64, ident: Keyword, value_type: &str, cardinality: &str) -> TxOp {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(id));
     doc.insert("db/ident".to_string(), DataType::Keyword(ident));
@@ -272,12 +283,15 @@ fn schema_attribute_with_cardinality(id: i64, ident: Keyword, value_type: &str, 
         "db/valueType".to_string(),
         DataType::Keyword(Keyword::namespaced("db.type", value_type)),
     );
-    doc.insert("db/cardinality".to_string(), DataType::Long(cardinality));
+    doc.insert(
+        "db/cardinality".to_string(),
+        DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)),
+    );
     TxOp::Put(Document(doc))
 }
 
 fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
-    schema_attribute_with_cardinality(id, ident, value_type, DB_CARDINALITY_ONE)
+    schema_attribute_with_cardinality(id, ident, value_type, "one")
 }
 
 /// Build a Put operation for an enum entity (value type or cardinality).
@@ -297,9 +311,7 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
         // Schema attribute entities (IDs 1-3)
         schema_attribute(DB_IDENT, Keyword::namespaced("db", "ident"), "keyword"),
         schema_attribute(DB_VALUE_TYPE, Keyword::namespaced("db", "valueType"), "keyword"),
-        // TODO: db/cardinality still uses Long (entity ref) values. Consider switching to
-        // keywords (like db/valueType) for consistency.
-        schema_attribute(DB_CARDINALITY, Keyword::namespaced("db", "cardinality"), "long"),
+        schema_attribute(DB_CARDINALITY, Keyword::namespaced("db", "cardinality"), "keyword"),
         // Value type enum entities (IDs 10-23)
         enum_entity(DB_TYPE_KEYWORD, "db.type", "keyword"),
         enum_entity(DB_TYPE_STRING, "db.type", "string"),
@@ -400,9 +412,9 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
             other => panic!("Expected Keyword for valueType, got {:?}", other),
         };
         let cardinality = match &row[3] {
-            DataType::Long(id) => Cardinality::from_entity_id(*id)
+            DataType::Keyword(kw) => Cardinality::from_keyword(kw)
                 .unwrap_or_else(|e| panic!("Invalid cardinality: {}", e)),
-            other => panic!("Expected Long for cardinality, got {:?}", other),
+            other => panic!("Expected Keyword for cardinality, got {:?}", other),
         };
 
         cache.insert(SchemaAttribute {
@@ -426,7 +438,7 @@ pub fn test_schema_tx() -> Vec<TxOp> {
         schema_attribute(52, Keyword::plain("email"), "string"),
         // TODO: update this to ref once we support DataType::Ref
         schema_attribute(53, Keyword::plain("follows"), "long"),
-        schema_attribute_with_cardinality(54, Keyword::plain("tags"), "string", DB_CARDINALITY_MANY),
+        schema_attribute_with_cardinality(54, Keyword::plain("tags"), "string", "many"),
     ]
 }
 
@@ -498,7 +510,7 @@ mod tests {
 
         let db_card = cache.get("db/cardinality").unwrap();
         assert_eq!(db_card.entity_id, DB_CARDINALITY);
-        assert_eq!(db_card.value_type, ValueType::Long);
+        assert_eq!(db_card.value_type, ValueType::Keyword);
     }
 
     #[test]
@@ -564,7 +576,7 @@ mod tests {
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "long"));
-        doc.insert("db/cardinality".to_string(), DataType::Long(DB_CARDINALITY_ONE));
+        doc.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
         let err = cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
@@ -579,7 +591,7 @@ mod tests {
     #[test]
     fn test_validate_schema_attrs_parses_cardinality_many() {
         let ops = [schema_attribute_with_cardinality(
-            100, Keyword::plain("tags"), "string", DB_CARDINALITY_MANY,
+            100, Keyword::plain("tags"), "string", "many",
         )];
         let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
         assert_eq!(attrs.len(), 1);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -179,14 +179,14 @@ impl SchemaCache {
     /// Entities with only db/ident (enum entities) are skipped.
     pub fn validate_schema_attrs(datoms: &[Datom]) -> Result<Vec<SchemaAttribute>> {
         if !datoms.iter().any(|d| d.op == DatomOp::Assert
-            && matches!(d.attribute.as_str(), "db/ident" | "db/valueType"))
+            && matches!(d.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality"))
         {
             return Ok(Vec::new());
         }
 
         let mut facts: HashMap<i64, HashMap<&str, &DataType>> = HashMap::new();
         for d in datoms.iter().filter(|d| d.op == DatomOp::Assert) {
-            if matches!(d.attribute.as_str(), "db/ident" | "db/valueType") {
+            if matches!(d.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality") {
                 facts.entry(d.entity).or_default().insert(&d.attribute, &d.value);
             }
         }
@@ -208,8 +208,15 @@ impl SchemaCache {
                 Some(_) => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
                 None => continue, // enum entity
             };
+            let cardinality = match f.get("db/cardinality") {
+                Some(DataType::Long(id)) => Cardinality::from_entity_id(*id)?,
+                Some(_) => return Err(anyhow::anyhow!("db/cardinality must be a Long")),
+                None => return Err(anyhow::anyhow!(
+                    "db/cardinality is required for schema attribute '{}'", ident
+                )),
+            };
             attrs.push(SchemaAttribute {
-                ident, value_type, cardinality: Cardinality::One, entity_id: *entity_id,
+                ident, value_type, cardinality, entity_id: *entity_id,
             });
         }
         Ok(attrs)
@@ -257,7 +264,7 @@ impl SchemaCache {
 
 // --- Bootstrap transaction builders ---
 
-fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
+fn schema_attribute_with_cardinality(id: i64, ident: Keyword, value_type: &str, cardinality: i64) -> TxOp {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(id));
     doc.insert("db/ident".to_string(), DataType::Keyword(ident));
@@ -265,8 +272,12 @@ fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
         "db/valueType".to_string(),
         DataType::Keyword(Keyword::namespaced("db.type", value_type)),
     );
-    doc.insert("db/cardinality".to_string(), DataType::Long(DB_CARDINALITY_ONE));
+    doc.insert("db/cardinality".to_string(), DataType::Long(cardinality));
     TxOp::Put(Document(doc))
+}
+
+fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
+    schema_attribute_with_cardinality(id, ident, value_type, DB_CARDINALITY_ONE)
 }
 
 /// Build a Put operation for an enum entity (value type or cardinality).
@@ -415,6 +426,7 @@ pub fn test_schema_tx() -> Vec<TxOp> {
         schema_attribute(52, Keyword::plain("email"), "string"),
         // TODO: update this to ref once we support DataType::Ref
         schema_attribute(53, Keyword::plain("follows"), "long"),
+        schema_attribute_with_cardinality(54, Keyword::plain("tags"), "string", DB_CARDINALITY_MANY),
     ]
 }
 
@@ -552,6 +564,7 @@ mod tests {
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "long"));
+        doc.insert("db/cardinality".to_string(), DataType::Long(DB_CARDINALITY_ONE));
         let err = cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
@@ -561,5 +574,35 @@ mod tests {
         assert!(ValueType::String.matches(&DataType::String("hello".to_string())));
         assert!(ValueType::Long.matches(&DataType::Long(42)));
         assert!(!ValueType::String.matches(&DataType::Long(42)));
+    }
+
+    #[test]
+    fn test_validate_schema_attrs_parses_cardinality_many() {
+        let ops = [schema_attribute_with_cardinality(
+            100, Keyword::plain("tags"), "string", DB_CARDINALITY_MANY,
+        )];
+        let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].ident, "tags");
+        assert_eq!(attrs[0].cardinality, Cardinality::Many);
+    }
+
+    #[test]
+    fn test_validate_schema_attrs_parses_cardinality_one() {
+        let ops = [schema_attribute(100, Keyword::plain("name"), "string")];
+        let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].cardinality, Cardinality::One);
+    }
+
+    #[test]
+    fn test_validate_schema_attrs_missing_cardinality_errors() {
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
+        doc.insert("db/valueType".to_string(), kw_ns("db.type", "string"));
+        // No db/cardinality
+        let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
+        assert!(err.to_string().contains("db/cardinality is required"));
     }
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -293,6 +293,7 @@ async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &st
     doc.insert("db/id".to_string(), DataType::Long(id));
     doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain(name)));
     doc.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", vtype)));
+    doc.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
     client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
 }
 

--- a/triplox-jvm/dev/dev.clj
+++ b/triplox-jvm/dev/dev.clj
@@ -5,8 +5,8 @@
 (comment
   (def conn (t/connect "localhost" 5490))
 
-  (t/transact conn [{:db/id 50 :db/ident :person/name :db/valueType :db.type/string}
-                    {:db/id 51 :db/ident :person/age :db/valueType :db.type/long}])
+  (t/transact conn [{:db/id 50 :db/ident :person/name :db/valueType :db.type/string :db/cardinality 30}
+                    {:db/id 51 :db/ident :person/age :db/valueType :db.type/long :db/cardinality 30}])
 
   ;; Transact some data
   (t/transact conn [{:db/id 1001 :person/name "alice" :person/age 30}

--- a/triplox-jvm/dev/dev.clj
+++ b/triplox-jvm/dev/dev.clj
@@ -5,8 +5,8 @@
 (comment
   (def conn (t/connect "localhost" 5490))
 
-  (t/transact conn [{:db/id 50 :db/ident :person/name :db/valueType :db.type/string :db/cardinality 30}
-                    {:db/id 51 :db/ident :person/age :db/valueType :db.type/long :db/cardinality 30}])
+  (t/transact conn [{:db/id 50 :db/ident :person/name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+                    {:db/id 51 :db/ident :person/age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}])
 
   ;; Transact some data
   (t/transact conn [{:db/id 1001 :person/name "alice" :person/age 30}

--- a/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
@@ -10,12 +10,12 @@
 (def ^:dynamic *conn* nil)
 
 (def people-schema
-  [{:db/id 200 :db/ident :name :db/valueType :db.type/string :db/cardinality 30}
-   {:db/id 201 :db/ident :last-name :db/valueType :db.type/string :db/cardinality 30}
-   {:db/id 202 :db/ident :sex :db/valueType :db.type/keyword :db/cardinality 30}
-   {:db/id 203 :db/ident :age :db/valueType :db.type/long :db/cardinality 30}
-   {:db/id 204 :db/ident :salary :db/valueType :db.type/long :db/cardinality 30}
-   {:db/id 205 :db/ident :city :db/valueType :db.type/string :db/cardinality 30}])
+  [{:db/id 200 :db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+   {:db/id 201 :db/ident :last-name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+   {:db/id 202 :db/ident :sex :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/id 203 :db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/id 204 :db/ident :salary :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/id 205 :db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
 
 (defn connect []
   (let [host (System/getProperty "triplox.host" "localhost")

--- a/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
@@ -10,12 +10,12 @@
 (def ^:dynamic *conn* nil)
 
 (def people-schema
-  [{:db/id 200 :db/ident :name :db/valueType :db.type/string}
-   {:db/id 201 :db/ident :last-name :db/valueType :db.type/string}
-   {:db/id 202 :db/ident :sex :db/valueType :db.type/keyword}
-   {:db/id 203 :db/ident :age :db/valueType :db.type/long}
-   {:db/id 204 :db/ident :salary :db/valueType :db.type/long}
-   {:db/id 205 :db/ident :city :db/valueType :db.type/string}])
+  [{:db/id 200 :db/ident :name :db/valueType :db.type/string :db/cardinality 30}
+   {:db/id 201 :db/ident :last-name :db/valueType :db.type/string :db/cardinality 30}
+   {:db/id 202 :db/ident :sex :db/valueType :db.type/keyword :db/cardinality 30}
+   {:db/id 203 :db/ident :age :db/valueType :db.type/long :db/cardinality 30}
+   {:db/id 204 :db/ident :salary :db/valueType :db.type/long :db/cardinality 30}
+   {:db/id 205 :db/ident :city :db/valueType :db.type/string :db/cardinality 30}])
 
 (defn connect []
   (let [host (System/getProperty "triplox.host" "localhost")

--- a/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/integration/query_test.clj
@@ -474,7 +474,8 @@
 
 (deftest test-datascript-aggregates
   (tc/transact *conn* [{:db/id 2000 :db/ident :heads
-                        :db/valueType :db.type/long}])
+                        :db/valueType :db.type/long
+                        :db/cardinality :db.cardinality/one}])
   (tc/transact *conn* [{:db/id 1000 :heads 3}
                        {:db/id 1001 :heads 1}
                        {:db/id 1002 :heads 1}

--- a/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
@@ -26,7 +26,8 @@ class TriploxNodeTest {
             node.executeTx(List.of(new TxOp.Put(Map.of(
                     "db/id", 200L,
                     "db/ident", Keyword.intern("name"),
-                    "db/valueType", Keyword.intern("db.type", "string")))));
+                    "db/valueType", Keyword.intern("db.type", "string"),
+                    "db/cardinality", 30L))));
 
             // Data
             var txResult = node.executeTx(List.of(new TxOp.Put(

--- a/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
@@ -27,7 +27,7 @@ class TriploxNodeTest {
                     "db/id", 200L,
                     "db/ident", Keyword.intern("name"),
                     "db/valueType", Keyword.intern("db.type", "string"),
-                    "db/cardinality", 30L))));
+                    "db/cardinality", Keyword.intern("db.cardinality", "one")))));
 
             // Data
             var txResult = node.executeTx(List.of(new TxOp.Put(


### PR DESCRIPTION
## Summary
- Parse `db/cardinality` from transaction datoms in `validate_schema_attrs()` instead of hardcoding `Cardinality::One`; `db/cardinality` is now a **required** field for schema attributes
- Switch `db/cardinality` from Long (entity ref) to **Keyword** type (`:db.cardinality/one` / `:db.cardinality/many`), matching how `db/valueType` works
- Skip auto-retraction in the indexer for `Cardinality::Many` attributes — they accumulate values without retracting old ones
- Add `tags` (cardinality-many, string) test attribute to `test_schema_tx()` and update all inline schema definitions across Rust, Clojure, and Java test/example code to include `db/cardinality`

**Note:** Cardinality-many currently has bag semantics (duplicate values are stored). Datomic uses set semantics. We may switch to set semantics in the future.

## Test plan
- [x] New schema tests: parses cardinality-many, parses cardinality-one, errors on missing cardinality
- [x] New indexer tests: `test_cardinality_many_no_retract`, `test_cardinality_many_same_value`
- [x] New end-to-end test in `node.rs`: `test_cardinality_many_attribute`
- [x] All 289 unit tests + 10 integration tests pass (`cargo test`)
- [ ] JVM integration tests (require running server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)