### PR TITLE
docs: refine partition and schema specs

### DIFF
--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -68,14 +68,14 @@ Each transaction is reified as an entity in this partition. The transaction enti
 
 | Attribute      | Value Type | Description                                                    |
 |----------------|------------|----------------------------------------------------------------|
-| `db/txInstant` | instant    | Wall-clock time of the transaction                             |
-| `db/txResult`  | keyword    | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)      |
-| `db/txId`      | long       | The sequential tx_id assigned by the log                       |
-| `db.tx/error`  | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
+| `db.tx/instant` | instant    | Wall-clock time of the transaction                             |
+| `db.tx/result`  | keyword    | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)      |
+| `db.tx/id`      | long       | The sequential tx_id assigned by the log                       |
+| `db.tx/error`   | string     | Error message (present only when `db.tx/result` is `:db.tx/aborted`) |
 
 A transaction with counter value `t` has entity ID `(1 << 42) | t`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
 
-Note: the relationship between `db/txId` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
+Note: the relationship between `db.tx/id` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
 
 ### 2.3 :db.part/user (partition 2)
 
@@ -129,7 +129,7 @@ Because entity IDs encode the partition in their upper bits, and because entity 
 
 _This section covers a future phase. The details of partition creation and assignment are TBD._
 
-The 20-bit partition field supports up to 1,048,575 partitions beyond the three built-in ones. In the the future we will allow users to create named partitions and assign entities to them. This enables domain-specific locality. It allows for grouping all entities related to a particular tenant or dataset so they cluster together in the E-leading indices.
+The 20-bit partition field supports up to 1,048,575 partitions beyond the three built-in ones. In the future we will allow users to create named partitions and assign entities to them. This enables domain-specific locality. It allows for grouping all entities related to a particular tenant or dataset so they cluster together in the E-leading indices.
 
 Topics to be addressed:
 

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -41,8 +41,9 @@ Because partition 0 places no bits above the counter, entities in `:db.part/db` 
 
 ### 1.1 Tempids
 
-A negative entity ID (sign bit = 1) is a **tempid** — a client-side placeholder that is never stored persistently. Within a single transaction, two operations referencing the same negative value refer to the same entity. The system resolves each unique tempid to a fresh permanent ID before writing to the indices. Although Triplox should support negative tempids in transactions at some point, we should
-push people to use string identifiers, as this seems to be the common convention.
+A negative entity ID (sign bit = 1) is a **tempid** — a client-side placeholder that is never stored persistently. Within a single transaction, two operations referencing the same negative value refer to the same entity. The system resolves each unique tempid to a fresh permanent ID before writing to the indices.
+
+**Design note:** The primary tempid mechanism will be string identifiers (e.g. `"my-new-entity"`), following the common convention in Datomic-style systems. Negative integer tempids may be supported as an alternative in a later phase.
 
 ---
 

--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -100,7 +100,7 @@ The bootstrap transaction installs two enum entities representing transaction ou
 
 ### 2.2 Enums and References
 
-Several bootstrap attributes (e.g. `db/cardinality`, `db/valueType`, `db.tx/result`) reference enum entities by keyword. Currently these are stored as keyword values, not as entity references (`db.type/ref`). In the future we intend to support first-class enum entities and ref-typed attributes, at which point these attributes would become `ref`-typed and their values would be entity IDs rather than keywords. The enum entities (IDs 10–23, 30–31, 40–41) are already installed with `db/ident` in anticipation of this transition.
+Several bootstrap attributes (e.g. `db/cardinality`, `db/valueType`, `db.tx/result`) reference enum entities by keyword. Currently these are stored as keyword values, not as entity references (`db.type/ref`). In the future we intend to support first-class enum entities and ref-typed attributes, at which point these attributes would become `ref`-typed and their values would be entity IDs rather than keywords.
 
 ---
 

--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -70,8 +70,12 @@ A fresh database is initialized with a bootstrap transaction (tx_id=0) that inst
 | 1         | `db/ident`         | keyword    | one         |
 | 2         | `db/valueType`     | keyword    | one         |
 | 3         | `db/cardinality`   | long       | one         |
+| 32        | `db.tx/instant`    | instant    | one         |
+| 33        | `db.tx/result`     | keyword    | one         |
+| 34        | `db.tx/id`         | long       | one         |
+| 35        | `db.tx/error`      | string     | one         |
 
-These three attributes are self-referential: they describe themselves. They are the minimal set needed to define any further schema attributes.
+The first three attributes are self-referential: they describe themselves. They are the minimal set needed to define any further schema attributes. Attributes 32–35 are used on transaction entities (see `PARTITIONS.md`).
 
 The bootstrap transaction also installs enum entities for value types (IDs 10–23) and cardinalities (IDs 30–31). These are regular entities with `db/ident` but no `db/valueType` — they are **not** schema attributes.
 
@@ -79,19 +83,24 @@ Reserved entity ID ranges:
 
 | Range | Purpose                      |
 |-------|------------------------------|
-| 1–3   | Bootstrap schema attributes  |
+| 1–3   | Core schema attributes (db/) |
+| 32–35 | Transaction schema attributes (db.tx/) |
 | 10–23 | Value type enum entities     |
 | 30–31 | Cardinality enum entities    |
 | 40–41 | Transaction result enum entities |
 
 ### 2.1 Transaction Result Enums
 
-The bootstrap transaction installs two enum entities representing transaction outcomes. These are used as values for the `db/txResult` attribute on transaction entities (see `PARTITIONS.md`):
+The bootstrap transaction installs two enum entities representing transaction outcomes. These are used as values for the `db.tx/result` attribute on transaction entities (see `PARTITIONS.md`):
 
 | Entity ID | Ident               |
 |-----------|---------------------|
 | 40        | `:db.tx/committed`  |
 | 41        | `:db.tx/aborted`    |
+
+### 2.2 Enums and References
+
+Several bootstrap attributes (e.g. `db/cardinality`, `db/valueType`, `db.tx/result`) reference enum entities by keyword. Currently these are stored as keyword values, not as entity references (`db.type/ref`). In the future we intend to support first-class enum entities and ref-typed attributes, at which point these attributes would become `ref`-typed and their values would be entity IDs rather than keywords. The enum entities (IDs 10–23, 30–31, 40–41) are already installed with `db/ident` in anticipation of this transition.
 
 ---
 
@@ -108,7 +117,7 @@ The bootstrap transaction installs two enum entities representing transaction ou
 
 1. **Fresh database**: `SchemaCache` is populated by processing the bootstrap transaction through `process_tx()`.
 2. **Existing database**: `SchemaCache` is rebuilt from stored data by running a query against the indices.
-3. **During operation**: Each transaction may define new schema attributes. After the triples have been written to the indices. The `SchemaCache` updates if the new data contains schema attributes.
+3. **During operation**: Each transaction may define new schema attributes. After the triples have been written to the indices, the `SchemaCache` updates if the new data contains schema attributes.
 
 ### 3.2 Validation Flow
 


### PR DESCRIPTION
## Summary
- Rename tx entity attributes to `db.tx/` namespace (`db.tx/instant`, `db.tx/result`, `db.tx/id`, `db.tx/error`)
- Reserve entity IDs 32–35 for tx schema attributes in bootstrap schema
- Add Section 2.2 (Enums and References) noting the planned transition from keyword to ref-typed enum attributes
- Separate tempid section into factual spec and labelled design note
- Fix typos and sentence fragment

## Test plan
- [x] Review rendered markdown for correct table formatting
- [x] Verify cross-references between PARTITIONS.md and SCHEMA.md are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)