### PR TITLE
fix: subscribe to tx completions before appending to log

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -237,7 +237,7 @@ impl Indexer {
     /// let tx_key = log.write().await.append_tx(data).await;
     /// waiter.await_tx(tx_key).await?;
     /// ```
-    pub fn tx_waiter(&self) -> TxWaiter {
+    pub(crate) fn tx_waiter(&self) -> TxWaiter {
         TxWaiter {
             latest_tx: self.latest_indexed_tx,
             rx: self.tx_completion_sender.subscribe(),
@@ -247,10 +247,10 @@ impl Indexer {
     /// Wait until the specified transaction has been indexed.
     ///
     /// Convenience method that subscribes and waits in one call. Only safe when
-    /// the transaction has already been submitted and cannot complete before this
-    /// call (e.g. waiting for a tx that was indexed before this Indexer was created).
-    /// For the general case, prefer `tx_waiter()` + `TxWaiter::await_tx()`.
-    pub fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<(), Error>> + 'static {
+    /// the caller does not need to perform work between subscribing and waiting
+    /// (e.g. the transaction is already submitted). For cases where you need to
+    /// subscribe before triggering the transaction, use `tx_waiter()` + `TxWaiter::await_tx()`.
+    pub(crate) fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<(), Error>> + 'static {
         self.tx_waiter().await_tx(tx_key)
     }
 }
@@ -260,7 +260,7 @@ impl Indexer {
 ///
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
 /// no messages are missed between subscription and the actual wait.
-pub struct TxWaiter {
+pub(crate) struct TxWaiter {
     latest_tx: Option<TxKey>,
     rx: broadcast::Receiver<(TxKey, Result<(), Arc<anyhow::Error>>)>,
 }
@@ -563,13 +563,7 @@ mod tests {
         let tx_ops = vec![TxOp::Put(Document(map))];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        // await_tx should return immediately
-        let start = std::time::Instant::now();
         indexer.await_tx(tx_key).await?;
-        let elapsed = start.elapsed();
-
-        assert!(elapsed < std::time::Duration::from_millis(10),
-                "Should return immediately for already indexed tx");
         Ok(())
     }
 
@@ -582,16 +576,8 @@ mod tests {
 
         let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(200) };
 
-        // Spawn task that calls await_tx - lock is dropped before awaiting
-        let indexer_clone = indexer.clone();
-        let wait_handle = tokio::spawn(async move {
-            let future = indexer_clone.read().await.await_tx(tx_key_1);
-            // Lock is dropped here, before we await
-            future.await
-        });
-
-        // Give wait task time to subscribe
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Subscribe BEFORE transacting to avoid race
+        let waiter = indexer.read().await.tx_waiter();
 
         // Now index the transaction - can acquire write lock
         {
@@ -603,14 +589,8 @@ mod tests {
             guard.transact_tx(tx_key_1, tx_ops).await?;
         }
 
-        // Wait task should complete successfully
-        let result = tokio::time::timeout(
-            std::time::Duration::from_millis(200),
-            wait_handle
-        ).await;
-
-        assert!(result.is_ok(), "Should complete before timeout");
-        assert!(result.unwrap()?.is_ok(), "Should return Ok");
+        // Waiter should complete successfully
+        waiter.await_tx(tx_key_1).await?;
         Ok(())
     }
 
@@ -667,20 +647,13 @@ mod tests {
 
         let tx_key = TxKey { tx_id: 5, system_time: st_from_unix_epoch(500) };
 
-        // Spawn multiple tasks that call await_tx
-        let handles: Vec<_> = (0..5).map(|_| {
-            let indexer_clone = indexer.clone();
-            tokio::spawn(async move {
-                let future = indexer_clone.read().await.await_tx(tx_key);
-                // Lock dropped before awaiting
-                future.await
-            })
-        }).collect();
+        // Subscribe multiple waiters BEFORE transacting
+        let waiters: Vec<_> = {
+            let guard = indexer.read().await;
+            (0..5).map(|_| guard.tx_waiter()).collect()
+        };
 
-        // Give waiters time to subscribe
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        // Index the transaction - can acquire write lock
+        // Index the transaction
         {
             let mut guard = indexer.write().await;
             let mut map = BTreeMap::new();
@@ -691,13 +664,8 @@ mod tests {
         }
 
         // All waiters should complete
-        for handle in handles {
-            let result = tokio::time::timeout(
-                std::time::Duration::from_millis(200),
-                handle
-            ).await;
-            assert!(result.is_ok(), "Task should complete before timeout");
-            assert!(result.unwrap()?.is_ok(), "Task should succeed");
+        for waiter in waiters {
+            waiter.await_tx(tx_key).await?;
         }
 
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -244,15 +244,6 @@ impl Indexer {
         }
     }
 
-    /// Wait until the specified transaction has been indexed.
-    ///
-    /// Convenience method that subscribes and waits in one call. Only safe when
-    /// the caller does not need to perform work between subscribing and waiting
-    /// (e.g. the transaction is already submitted). For cases where you need to
-    /// subscribe before triggering the transaction, use `tx_waiter()` + `TxWaiter::await_tx()`.
-    pub(crate) fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<(), Error>> + 'static {
-        self.tx_waiter().await_tx(tx_key)
-    }
 }
 
 
@@ -563,7 +554,7 @@ mod tests {
         let tx_ops = vec![TxOp::Put(Document(map))];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        indexer.await_tx(tx_key).await?;
+        indexer.tx_waiter().await_tx(tx_key).await?;
         Ok(())
     }
 
@@ -604,7 +595,7 @@ mod tests {
         // Wait for transaction that never arrives
         let result = tokio::time::timeout(
             std::time::Duration::from_millis(100),
-            indexer.await_tx(tx_key)
+            indexer.tx_waiter().await_tx(tx_key)
         ).await;
 
         assert!(result.is_err(), "Should timeout waiting for non-existent tx");
@@ -629,11 +620,11 @@ mod tests {
 
         // Waiting for tx 1 should return immediately
         let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
-        indexer.await_tx(tx_key_1).await?;
+        indexer.tx_waiter().await_tx(tx_key_1).await?;
 
         // Waiting for tx 2 should also return immediately
         let tx_key_2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.await_tx(tx_key_2).await?;
+        indexer.tx_waiter().await_tx(tx_key_2).await?;
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -224,70 +224,84 @@ impl Indexer {
         Ok(tx_key)
     }
 
-    /// Wait until the specified transaction has been indexed.
-    /// Returns immediately if the transaction is already indexed (based on TxKey ordering).
+    /// Subscribe to transaction completion notifications.
     ///
-    /// This method returns a future that does NOT borrow `self`, so it's safe to use
-    /// with RwLock - the lock can be dropped before awaiting the returned future.
-    ///
-    /// # Arguments
-    /// * `tx_key` - The transaction to wait for
-    ///
-    /// # Returns
-    /// * A future that resolves to `Ok(())` when the transaction is indexed
+    /// Returns a `TxWaiter` that can later be used to wait for a specific transaction.
+    /// Call this **before** appending to the log to avoid a race where the indexer
+    /// broadcasts the result before the caller subscribes.
     ///
     /// # Example
     /// ```ignore
-    /// // With RwLock - lock is dropped before waiting
-    /// let future = indexer.read().await.await_tx(tx_key);
-    /// future.await?;
-    ///
-    /// // With timeout
-    /// let future = indexer.read().await.await_tx(tx_key);
-    /// tokio::time::timeout(Duration::from_millis(500), future).await??;
+    /// let waiter = indexer.read().await.tx_waiter();
+    /// // drop the lock, append to log, then wait:
+    /// let tx_key = log.write().await.append_tx(data).await;
+    /// waiter.await_tx(tx_key).await?;
     /// ```
+    pub fn tx_waiter(&self) -> TxWaiter {
+        TxWaiter {
+            latest_tx: self.latest_indexed_tx,
+            rx: self.tx_completion_sender.subscribe(),
+        }
+    }
+
+    /// Wait until the specified transaction has been indexed.
+    ///
+    /// Convenience method that subscribes and waits in one call. Only safe when
+    /// the transaction has already been submitted and cannot complete before this
+    /// call (e.g. waiting for a tx that was indexed before this Indexer was created).
+    /// For the general case, prefer `tx_waiter()` + `TxWaiter::await_tx()`.
     pub fn await_tx(&self, tx_key: TxKey) -> impl std::future::Future<Output = Result<(), Error>> + 'static {
-        // Capture everything we need from self (clone/copy)
-        let latest_tx = self.latest_indexed_tx;
-        let mut rx = self.tx_completion_sender.subscribe();
+        self.tx_waiter().await_tx(tx_key)
+    }
+}
 
-        // Return a future that doesn't borrow self
-        async move {
-            // Fast path: Check if already indexed
-            if let Some(latest_key) = latest_tx {
-                if tx_key <= latest_key {
-                    return Ok(());
-                }
+
+/// A pre-subscribed handle for waiting on transaction completion.
+///
+/// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
+/// no messages are missed between subscription and the actual wait.
+pub struct TxWaiter {
+    latest_tx: Option<TxKey>,
+    rx: broadcast::Receiver<(TxKey, Result<(), Arc<anyhow::Error>>)>,
+}
+
+impl TxWaiter {
+    /// Wait until `tx_key` has been indexed. Returns `Ok(())` on commit,
+    /// `Err` on abort or if the indexer shuts down.
+    pub async fn await_tx(mut self, tx_key: TxKey) -> Result<(), Error> {
+        // Fast path: already indexed at subscription time
+        if let Some(latest_key) = self.latest_tx {
+            if tx_key <= latest_key {
+                return Ok(());
             }
+        }
 
-            // TODO(triplox-j7t): The >= check can return a different tx's result if the
-            // broadcast channel lags. Will be revisited when the log is removed and we
-            // ingest directly into Slate.
-            loop {
-                match rx.recv().await {
-                    Ok((completed_tx_key, result)) => {
-                        if completed_tx_key >= tx_key {
-                            return result.map_err(|e| anyhow::anyhow!("{:#}", e));
-                        }
-                        // Keep waiting for higher tx_id
-                    },
-                    Err(broadcast::error::RecvError::Lagged(_count)) => {
-                        // Channel overflowed. Just continue waiting - we'll eventually
-                        // get the notification or the channel will close.
-                        continue;
-                    },
-                    Err(broadcast::error::RecvError::Closed) => {
-                        return Err(anyhow::anyhow!(
-                            "Indexer shutdown while waiting for tx {}",
-                            tx_key.tx_id
-                        ));
+        // TODO(triplox-j7t): The >= check can return a different tx's result if the
+        // broadcast channel lags. Will be revisited when the log is removed and we
+        // ingest directly into Slate.
+        loop {
+            match self.rx.recv().await {
+                Ok((completed_tx_key, result)) => {
+                    if completed_tx_key >= tx_key {
+                        return result.map_err(|e| anyhow::anyhow!("{:#}", e));
                     }
+                    // Keep waiting for higher tx_id
+                },
+                Err(broadcast::error::RecvError::Lagged(_count)) => {
+                    // Channel overflowed. Just continue waiting - we'll eventually
+                    // get the notification or the channel will close.
+                    continue;
+                },
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(anyhow::anyhow!(
+                        "Indexer shutdown while waiting for tx {}",
+                        tx_key.tx_id
+                    ));
                 }
             }
         }
     }
 }
-
 
 impl Subscriber for Indexer {
     async fn accept(&mut self, record: Record) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -314,7 +314,6 @@ mod tests {
         let doc = Document(map);
         let tx_ops = vec![TxOp::Put(doc)];
 
-        // Subscribe before submitting to avoid race condition
         let waiter = node.indexer.read().await.tx_waiter();
 
         // submit_tx returns immediately with a TxKey

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,8 +125,7 @@ impl Node<FileLog> {
             records.last().map(|r| r.tx_key)
         };
 
-        // Subscribe to completions BEFORE starting the subscriber to avoid
-        // a race where catch-up completes before we start listening.
+        // Create a waiter for catch-up completion
         let waiter = match last_tx_key {
             Some(_) => Some(indexer.read().await.tx_waiter()),
             None => None,
@@ -159,8 +158,6 @@ impl<L: TxLog> SubmitNode for Node<L> {
     async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error> {
         let serialized = bincode::serialize(&ops)?;
 
-        // Subscribe BEFORE appending to the log to avoid a race where the
-        // indexer processes and broadcasts the result before we subscribe.
         let waiter = self.indexer.read().await.tx_waiter();
 
         let tx_key = self.log.write().await.append_tx(serialized).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,12 +125,18 @@ impl Node<FileLog> {
             records.last().map(|r| r.tx_key)
         };
 
+        // Subscribe to completions BEFORE starting the subscriber to avoid
+        // a race where catch-up completes before we start listening.
+        let waiter = match last_tx_key {
+            Some(_) => Some(indexer.read().await.tx_waiter()),
+            None => None,
+        };
+
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
 
         // Wait for catch-up to complete if there are existing transactions
-        if let Some(tx_key) = last_tx_key {
-            let wait = indexer.read().await.await_tx(tx_key);
-            wait.await.unwrap();
+        if let Some((tx_key, waiter)) = last_tx_key.zip(waiter) {
+            waiter.await_tx(tx_key).await.unwrap();
         }
 
         Node { log, indexer, slatedb, subscription }
@@ -153,10 +159,13 @@ impl<L: TxLog> SubmitNode for Node<L> {
     async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error> {
         let serialized = bincode::serialize(&ops)?;
 
+        // Subscribe BEFORE appending to the log to avoid a race where the
+        // indexer processes and broadcasts the result before we subscribe.
+        let waiter = self.indexer.read().await.tx_waiter();
+
         let tx_key = self.log.write().await.append_tx(serialized).await;
 
-        let wait_future = self.indexer.read().await.await_tx(tx_key);
-        match wait_future.await {
+        match waiter.await_tx(tx_key).await {
             Ok(()) => Ok(TransactionResult::TxCommited(tx_key)),
             Err(e) => Ok(TransactionResult::TxAborted(tx_key, e.into())),
         }
@@ -308,6 +317,9 @@ mod tests {
         let doc = Document(map);
         let tx_ops = vec![TxOp::Put(doc)];
 
+        // Subscribe before submitting to avoid race condition
+        let waiter = node.indexer.read().await.tx_waiter();
+
         // submit_tx returns immediately with a TxKey
         // bootstrap goes directly through transact_tx (not log), so:
         // tx_id=0 is test schema, tx_id=1 is first data tx
@@ -315,8 +327,7 @@ mod tests {
         assert_eq!(tx_key.tx_id, 1);
 
         // Wait for indexer to process the transaction
-        let wait_future = node.indexer.read().await.await_tx(tx_key);
-        wait_future.await.expect("Transaction should be indexed");
+        waiter.await_tx(tx_key).await.expect("Transaction should be indexed");
 
         // Verify indices are updated
         let slate = node.slatedb.clone();


### PR DESCRIPTION
## Summary

- Fixes a race condition where fast-failing transactions (e.g. unknown attribute) could broadcast their result before `execute_tx` subscribed to the completion channel, causing a hang
- Split `await_tx` into `tx_waiter()` + `TxWaiter::await_tx()` so callers subscribe before triggering the transaction
- Removed `Indexer::await_tx` convenience method to prevent reintroducing the race
- Made `tx_waiter()` and `TxWaiter` `pub(crate)` — internal API only
- Removed flaky timing assertions and sleep-based race workarounds in tests

Closes #26

## Test plan

- [x] `test_failed_tx_returns_aborted_and_indexer_continues` no longer flaky
- [x] Full test suite passes (293 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)