### PR TITLE
feat: extract datoms from CDC transactions

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -93,8 +93,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
     {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
-            let schema =
-                load_schema_from_indices(slate.db.clone(), slate.range_stats.clone()).await;
+            let schema = load_schema_from_indices(slate).await;
             let pm = scan_partition_counters(&slate.db).await?;
             Ok(Metadata::new(schema, pm))
         }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -93,7 +93,8 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
     {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
-            let schema = load_schema_from_indices(slate).await;
+            let schema =
+                load_schema_from_indices(slate.db.clone(), slate.range_stats.clone()).await;
             let pm = scan_partition_counters(&slate.db).await?;
             Ok(Metadata::new(schema, pm))
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -128,7 +128,7 @@ where
 pub struct Node<L: TxLog> {
     log: Arc<L>,
     indexer: Arc<tokio::sync::RwLock<Indexer>>,
-    slate: SlateComponents,
+    pub(crate) slate: SlateComponents,
     subscription: CancellationToken,
 }
 
@@ -243,22 +243,6 @@ impl Node<FileLog> {
 }
 
 impl<L: TxLog> Node<L> {
-    pub(crate) fn object_store(&self) -> Arc<dyn slatedb::object_store::ObjectStore> {
-        self.slate.object_store.clone()
-    }
-
-    pub(crate) fn slatedb(&self) -> Arc<slatedb::Db> {
-        self.slate.db.clone()
-    }
-
-    pub(crate) fn range_stats(&self) -> Arc<slatedb_estimates::RangeStats> {
-        self.slate.range_stats.clone()
-    }
-
-    pub(crate) fn db_path(&self) -> &str {
-        &self.slate.path
-    }
-
     pub async fn close(self) {
         self.subscription.cancel();
         self.slate.db.close().await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -251,6 +251,10 @@ impl<L: TxLog> Node<L> {
         self.slate.db.clone()
     }
 
+    pub(crate) fn range_stats(&self) -> Arc<slatedb_estimates::RangeStats> {
+        self.slate.range_stats.clone()
+    }
+
     pub(crate) fn db_path(&self) -> &str {
         &self.slate.path
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -243,6 +243,18 @@ impl Node<FileLog> {
 }
 
 impl<L: TxLog> Node<L> {
+    pub(crate) fn object_store(&self) -> Arc<dyn slatedb::object_store::ObjectStore> {
+        self.slate.object_store.clone()
+    }
+
+    pub(crate) fn slatedb(&self) -> Arc<slatedb::Db> {
+        self.slate.db.clone()
+    }
+
+    pub(crate) fn db_path(&self) -> &str {
+        &self.slate.path
+    }
+
     pub async fn close(self) {
         self.subscription.cancel();
         self.slate.db.close().await.unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -457,6 +457,11 @@ impl Schema {
         Some((*eid, attr))
     }
 
+    /// Look up the keyword/ident for a given entity ID.
+    pub fn get_ident(&self, entity_id: Entid) -> Option<&Keyword> {
+        self.entid_map.get(&entity_id)
+    }
+
     /// Check if an entity ID is a schema attribute (has an entry in attribute_map).
     pub fn is_schema_entity(&self, entity_id: Entid) -> bool {
         self.attribute_map.contains_key(&entity_id)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, LazyLock};
 use anyhow::{Error, Result};
 use edn::kw;
 use edn::symbols::Keyword;
-use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
@@ -831,20 +830,15 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// Queries 2 and 3 re-fetch values already retrieved in query 1. This is only run
 /// at startup so the inefficiency is minor, but a single-pass approach would be
 /// cleaner. Could likely be done with an `optional` clause.
-pub async fn load_schema_from_indices<D, M>(
-    sdb: Arc<D>,
-    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-) -> Schema
-where
-    D: DbReadOps + Send + Sync + 'static,
-    M: DbMetadataOps + Send + Sync + 'static,
-{
+pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
     let mut bootstrap_ident_map: IdentMap = HashMap::new();
     bootstrap_ident_map.insert(kw!(:db/ident), DB_IDENT);
     bootstrap_ident_map.insert(kw!(:db/valueType), DB_VALUE_TYPE);
     bootstrap_ident_map.insert(kw!(:db/cardinality), DB_CARDINALITY);
     bootstrap_ident_map.insert(kw!(:db/unique), DB_UNIQUE);
+    let sdb = slate.db.clone();
+    let range_stats = slate.range_stats.clone();
     let handle = Handle::current();
 
     let ident_query: ParsedQuery = "[:find ?e ?ident :where [?e :db/ident ?ident]]"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -830,7 +830,7 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// Queries 2 and 3 re-fetch values already retrieved in query 1. This is only run
 /// at startup so the inefficiency is minor, but a single-pass approach would be
 /// cleaner. Could likely be done with an `optional` clause.
-pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> Schema {
+pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
     let mut bootstrap_ident_map: IdentMap = HashMap::new();
     bootstrap_ident_map.insert(kw!(:db/ident), DB_IDENT);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, LazyLock};
 use anyhow::{Error, Result};
 use edn::kw;
 use edn::symbols::Keyword;
+use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
@@ -830,15 +831,20 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// Queries 2 and 3 re-fetch values already retrieved in query 1. This is only run
 /// at startup so the inefficiency is minor, but a single-pass approach would be
 /// cleaner. Could likely be done with an `optional` clause.
-pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> Schema {
+pub async fn load_schema_from_indices<D, M>(
+    sdb: Arc<D>,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+) -> Schema
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     // Build attribute map from bootstrap constants — sufficient to query schema entities
     let mut bootstrap_ident_map: IdentMap = HashMap::new();
     bootstrap_ident_map.insert(kw!(:db/ident), DB_IDENT);
     bootstrap_ident_map.insert(kw!(:db/valueType), DB_VALUE_TYPE);
     bootstrap_ident_map.insert(kw!(:db/cardinality), DB_CARDINALITY);
     bootstrap_ident_map.insert(kw!(:db/unique), DB_UNIQUE);
-    let sdb = slate.db.clone();
-    let range_stats = slate.range_stats.clone();
     let handle = Handle::current();
 
     let ident_query: ParsedQuery = "[:find ?e ?ident :where [?e :db/ident ?ident]]"

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -747,6 +747,19 @@ mod tests {
         all_tx_datoms
     }
 
+    fn transactions_with_entity(datoms: &[Vec<Datom>], entity: i64) -> Vec<Vec<&Datom>> {
+        datoms
+            .iter()
+            .map(|tx_datoms| {
+                tx_datoms
+                    .iter()
+                    .filter(|datom| datom.entity == entity)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|tx_datoms| !tx_datoms.is_empty())
+            .collect()
+    }
+
     #[tokio::test]
     async fn test_datoms_from_cdc_happy_path() {
         let node = setup_node_with_schema().await;
@@ -760,12 +773,9 @@ mod tests {
 
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
-        // Find the transaction containing our entity 100 datoms.
-        let entity_datoms: Vec<&Datom> = all_tx_datoms
-            .iter()
-            .flatten()
-            .filter(|d| d.entity == 100)
-            .collect();
+        let entity_transactions = transactions_with_entity(&all_tx_datoms, 100);
+        assert_eq!(entity_transactions.len(), 1);
+        let entity_datoms = &entity_transactions[0];
 
         assert_eq!(entity_datoms.len(), 2);
         assert!(entity_datoms.iter().any(|d| d.attribute == kw!(:name)
@@ -796,32 +806,50 @@ mod tests {
 
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
-        // Find all datoms for entity 100, attribute :name.
-        let name_datoms: Vec<&Datom> = all_tx_datoms
-            .iter()
-            .flatten()
-            .filter(|d| d.entity == 100 && d.attribute == kw!(:name))
+        let entity_transactions = transactions_with_entity(&all_tx_datoms, 100);
+        assert_eq!(entity_transactions.len(), 2);
+        let name_transactions: Vec<Vec<&Datom>> = entity_transactions
+            .into_iter()
+            .map(|tx_datoms| {
+                tx_datoms
+                    .into_iter()
+                    .filter(|datom| datom.attribute == kw!(:name))
+                    .collect::<Vec<_>>()
+            })
+            .filter(|tx_datoms| !tx_datoms.is_empty())
             .collect();
 
-        assert!(
-            name_datoms.iter().any(
-                |d| d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Assert
-            ),
-            "Expected assert for alice"
-        );
-        assert!(
-            name_datoms
-                .iter()
-                .any(|d| d.value == DataType::String("alice".to_string())
-                    && d.op == DatomOp::Retract),
-            "Expected retract for alice"
-        );
-        assert!(
-            name_datoms
-                .iter()
-                .any(|d| d.value == DataType::String("bob".to_string()) && d.op == DatomOp::Assert),
-            "Expected assert for bob"
-        );
+        let initial_txs: Vec<&Vec<&Datom>> = name_transactions
+            .iter()
+            .filter(|tx_datoms| {
+                tx_datoms.iter().any(|datom| {
+                    datom.value == DataType::String("alice".to_string())
+                        && datom.op == DatomOp::Assert
+                })
+            })
+            .collect();
+        assert_eq!(initial_txs.len(), 1);
+        assert_eq!(initial_txs[0].len(), 1);
+
+        let update_txs: Vec<&Vec<&Datom>> = name_transactions
+            .iter()
+            .filter(|tx_datoms| {
+                tx_datoms.iter().any(|datom| {
+                    datom.value == DataType::String("alice".to_string())
+                        && datom.op == DatomOp::Retract
+                }) || tx_datoms.iter().any(|datom| {
+                    datom.value == DataType::String("bob".to_string())
+                        && datom.op == DatomOp::Assert
+                })
+            })
+            .collect();
+        assert_eq!(update_txs.len(), 1);
+        assert!(update_txs[0].iter().any(|datom| {
+            datom.value == DataType::String("alice".to_string()) && datom.op == DatomOp::Retract
+        }));
+        assert!(update_txs[0].iter().any(|datom| {
+            datom.value == DataType::String("bob".to_string()) && datom.op == DatomOp::Assert
+        }));
 
         node.close().await;
     }
@@ -843,16 +871,17 @@ mod tests {
 
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
-        let entity_100: Vec<&Datom> = all_tx_datoms
+        let target_transactions: Vec<&Vec<Datom>> = all_tx_datoms
             .iter()
-            .flatten()
-            .filter(|d| d.entity == 100)
+            .filter(|tx_datoms| {
+                tx_datoms.iter().any(|datom| datom.entity == 100)
+                    || tx_datoms.iter().any(|datom| datom.entity == 200)
+            })
             .collect();
-        let entity_200: Vec<&Datom> = all_tx_datoms
-            .iter()
-            .flatten()
-            .filter(|d| d.entity == 200)
-            .collect();
+        assert_eq!(target_transactions.len(), 1);
+        let tx_datoms = target_transactions[0];
+        let entity_100: Vec<&Datom> = tx_datoms.iter().filter(|d| d.entity == 100).collect();
+        let entity_200: Vec<&Datom> = tx_datoms.iter().filter(|d| d.entity == 200).collect();
 
         assert_eq!(entity_100.len(), 1); // name only
         assert_eq!(entity_200.len(), 2); // name + age

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::codec;
 use crate::indexer::eav_key_to_parts;
-use crate::ops::{Datom, DatomOp, DataType};
+use crate::ops::{DataType, Datom, DatomOp};
 use crate::schema::Schema;
 
 /// Tracks position in the WAL stream for resumability.
@@ -181,15 +181,19 @@ pub fn datoms_from_cdc_transaction(
 
         let entity = match entity_dt {
             DataType::Long(id) => id,
-            other => return Err(anyhow::anyhow!(
-                "Expected Long entity in EAV key, got {:?}", other
-            )),
+            other => {
+                return Err(anyhow::anyhow!(
+                    "Expected Long entity in EAV key, got {:?}",
+                    other
+                ))
+            }
         };
 
-        let attribute = schema.get_ident(attribute_id)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Unknown attribute entity_id {} in EAV key", attribute_id
-            ))?
+        let attribute = schema
+            .get_ident(attribute_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Unknown attribute entity_id {} in EAV key", attribute_id)
+            })?
             .clone();
 
         let op = match op_byte {
@@ -198,7 +202,12 @@ pub fn datoms_from_cdc_transaction(
             other => return Err(anyhow::anyhow!("Unknown op byte: {}", other)),
         };
 
-        datoms.push(Datom { entity, attribute, value, op });
+        datoms.push(Datom {
+            entity,
+            attribute,
+            value,
+            op,
+        });
     }
     Ok(datoms)
 }
@@ -691,13 +700,13 @@ mod tests {
 
     // --- datoms_from_cdc_transaction tests (Node-based) ---
 
-    use std::collections::BTreeMap;
     use crate::memory_log::MemoryLog;
     use crate::node::{Node, SubmitNode};
     use crate::ops::TxOp;
     use crate::schema::{load_schema_from_indices, test_schema_tx};
     use crate::transaction::TransactionResult;
     use edn::kw;
+    use std::collections::BTreeMap;
 
     async fn setup_node_with_schema() -> Node<MemoryLog> {
         let node = Node::memory_node().await;
@@ -708,20 +717,25 @@ mod tests {
 
     async fn collect_cdc_datoms(node: &Node<MemoryLog>) -> Vec<Vec<Datom>> {
         // Flush WAL to object store so CdcStream can read it.
-        node.slatedb().flush_with_options(FlushOptions {
-            flush_type: FlushType::Wal,
-        }).await.unwrap();
+        node.slatedb()
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
 
         let wal_reader = WalReader::new(node.db_path(), node.object_store());
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let schema = load_schema_from_indices(node.slatedb()).await;
+        let schema = load_schema_from_indices(node.slatedb(), node.range_stats()).await;
         let mut stream = CdcStream::new(
             wal_reader,
             CdcCursor::default(),
             Duration::from_millis(10),
             cancel,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         let mut all_tx_datoms = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
@@ -747,20 +761,19 @@ mod tests {
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
         // Find the transaction containing our entity 100 datoms.
-        let entity_datoms: Vec<&Datom> = all_tx_datoms.iter()
+        let entity_datoms: Vec<&Datom> = all_tx_datoms
+            .iter()
             .flatten()
             .filter(|d| d.entity == 100)
             .collect();
 
         assert_eq!(entity_datoms.len(), 2);
-        assert!(entity_datoms.iter().any(|d|
-            d.attribute == kw!(:name) && d.value == DataType::String("alice".to_string())
-            && d.op == DatomOp::Assert
-        ));
-        assert!(entity_datoms.iter().any(|d|
-            d.attribute == kw!(:age) && d.value == DataType::Long(30)
-            && d.op == DatomOp::Assert
-        ));
+        assert!(entity_datoms.iter().any(|d| d.attribute == kw!(:name)
+            && d.value == DataType::String("alice".to_string())
+            && d.op == DatomOp::Assert));
+        assert!(entity_datoms.iter().any(|d| d.attribute == kw!(:age)
+            && d.value == DataType::Long(30)
+            && d.op == DatomOp::Assert));
 
         node.close().await;
     }
@@ -784,20 +797,31 @@ mod tests {
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
         // Find all datoms for entity 100, attribute :name.
-        let name_datoms: Vec<&Datom> = all_tx_datoms.iter()
+        let name_datoms: Vec<&Datom> = all_tx_datoms
+            .iter()
             .flatten()
             .filter(|d| d.entity == 100 && d.attribute == kw!(:name))
             .collect();
 
-        assert!(name_datoms.iter().any(|d|
-            d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Assert
-        ), "Expected assert for alice");
-        assert!(name_datoms.iter().any(|d|
-            d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Retract
-        ), "Expected retract for alice");
-        assert!(name_datoms.iter().any(|d|
-            d.value == DataType::String("bob".to_string()) && d.op == DatomOp::Assert
-        ), "Expected assert for bob");
+        assert!(
+            name_datoms.iter().any(
+                |d| d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Assert
+            ),
+            "Expected assert for alice"
+        );
+        assert!(
+            name_datoms
+                .iter()
+                .any(|d| d.value == DataType::String("alice".to_string())
+                    && d.op == DatomOp::Retract),
+            "Expected retract for alice"
+        );
+        assert!(
+            name_datoms
+                .iter()
+                .any(|d| d.value == DataType::String("bob".to_string()) && d.op == DatomOp::Assert),
+            "Expected assert for bob"
+        );
 
         node.close().await;
     }
@@ -813,14 +837,22 @@ mod tests {
         doc2.insert(kw!(:db/id), DataType::Long(200));
         doc2.insert(kw!(:name), DataType::String("bob".to_string()));
         doc2.insert(kw!(:age), DataType::Long(25));
-        node.execute_tx(vec![TxOp::Put(doc1), TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1), TxOp::Put(doc2)])
+            .await
+            .unwrap();
 
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 
-        let entity_100: Vec<&Datom> = all_tx_datoms.iter().flatten()
-            .filter(|d| d.entity == 100).collect();
-        let entity_200: Vec<&Datom> = all_tx_datoms.iter().flatten()
-            .filter(|d| d.entity == 200).collect();
+        let entity_100: Vec<&Datom> = all_tx_datoms
+            .iter()
+            .flatten()
+            .filter(|d| d.entity == 100)
+            .collect();
+        let entity_200: Vec<&Datom> = all_tx_datoms
+            .iter()
+            .flatten()
+            .filter(|d| d.entity == 200)
+            .collect();
 
         assert_eq!(entity_100.len(), 1); // name only
         assert_eq!(entity_200.len(), 2); // name + age

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -717,17 +717,18 @@ mod tests {
 
     async fn collect_cdc_datoms(node: &Node<MemoryLog>) -> Vec<Vec<Datom>> {
         // Flush WAL to object store so CdcStream can read it.
-        node.slatedb()
+        node.slate
+            .db
             .flush_with_options(FlushOptions {
                 flush_type: FlushType::Wal,
             })
             .await
             .unwrap();
 
-        let wal_reader = WalReader::new(node.db_path(), node.object_store());
+        let wal_reader = WalReader::new(node.slate.path.as_str(), node.slate.object_store.clone());
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let schema = load_schema_from_indices(node.slatedb(), node.range_stats()).await;
+        let schema = load_schema_from_indices(&node.slate).await;
         let mut stream = CdcStream::new(
             wal_reader,
             CdcCursor::default(),

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -1,8 +1,13 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
-use slatedb::{RowEntry, WalFile, WalFileIterator, WalReader};
+use slatedb::{RowEntry, ValueDeletable, WalFile, WalFileIterator, WalReader};
 use tokio_util::sync::CancellationToken;
+
+use crate::codec;
+use crate::indexer::eav_key_to_parts;
+use crate::ops::{Datom, DatomOp, DataType};
+use crate::schema::Schema;
 
 /// Tracks position in the WAL stream for resumability.
 #[derive(Debug, Default, Clone)]
@@ -156,6 +161,48 @@ impl CdcStream {
     }
 }
 
+/// Extract Datoms from a CDC transaction by decoding EAV-prefix index keys.
+/// Skips non-EAV keys and tombstone entries.
+pub fn datoms_from_cdc_transaction(
+    tx: &CdcTransaction,
+    schema: &Schema,
+) -> Result<Vec<Datom>, anyhow::Error> {
+    let mut datoms = Vec::new();
+    for entry in &tx.entries {
+        if entry.key.first() != Some(&codec::EAV) {
+            continue;
+        }
+        if matches!(entry.value, ValueDeletable::Tombstone) {
+            continue;
+        }
+
+        let (entity_dt, attribute_id, value, _tx_eid, op_byte) =
+            eav_key_to_parts(entry.key.clone())?;
+
+        let entity = match entity_dt {
+            DataType::Long(id) => id,
+            other => return Err(anyhow::anyhow!(
+                "Expected Long entity in EAV key, got {:?}", other
+            )),
+        };
+
+        let attribute = schema.get_ident(attribute_id)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Unknown attribute entity_id {} in EAV key", attribute_id
+            ))?
+            .clone();
+
+        let op = match op_byte {
+            codec::ADD => DatomOp::Assert,
+            codec::RETRACT => DatomOp::Retract,
+            other => return Err(anyhow::anyhow!("Unknown op byte: {}", other)),
+        };
+
+        datoms.push(Datom { entity, attribute, value, op });
+    }
+    Ok(datoms)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,7 +213,10 @@ mod tests {
 
     async fn setup_db(path: &str) -> (Db, Arc<dyn slatedb::object_store::ObjectStore>) {
         let object_store: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
-        let db = Db::open(path, object_store.clone()).await.unwrap();
+        let db = Db::builder(path, object_store.clone())
+            .build()
+            .await
+            .unwrap();
         (db, object_store)
     }
 
@@ -637,5 +687,144 @@ mod tests {
         })
         .await
         .expect("test_cdc_cursor_reads_existing_and_live_transactions timed out");
+    }
+
+    // --- datoms_from_cdc_transaction tests (Node-based) ---
+
+    use std::collections::BTreeMap;
+    use crate::memory_log::MemoryLog;
+    use crate::node::{Node, SubmitNode};
+    use crate::ops::TxOp;
+    use crate::schema::{load_schema_from_indices, test_schema_tx};
+    use crate::transaction::TransactionResult;
+    use edn::kw;
+
+    async fn setup_node_with_schema() -> Node<MemoryLog> {
+        let node = Node::memory_node().await;
+        let result = node.execute_tx(test_schema_tx()).await.unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        node
+    }
+
+    async fn collect_cdc_datoms(node: &Node<MemoryLog>) -> Vec<Vec<Datom>> {
+        // Flush WAL to object store so CdcStream can read it.
+        node.slatedb().flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        }).await.unwrap();
+
+        let wal_reader = WalReader::new(node.db_path(), node.object_store());
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let schema = load_schema_from_indices(node.slatedb()).await;
+        let mut stream = CdcStream::new(
+            wal_reader,
+            CdcCursor::default(),
+            Duration::from_millis(10),
+            cancel,
+        ).await.unwrap();
+
+        let mut all_tx_datoms = Vec::new();
+        while let Some(tx) = stream.next_transaction().await.unwrap() {
+            let datoms = datoms_from_cdc_transaction(&tx, &schema).unwrap();
+            if !datoms.is_empty() {
+                all_tx_datoms.push(datoms);
+            }
+        }
+        all_tx_datoms
+    }
+
+    #[tokio::test]
+    async fn test_datoms_from_cdc_happy_path() {
+        let node = setup_node_with_schema().await;
+
+        let mut doc = BTreeMap::new();
+        doc.insert(kw!(:db/id), DataType::Long(100));
+        doc.insert(kw!(:name), DataType::String("alice".to_string()));
+        doc.insert(kw!(:age), DataType::Long(30));
+        let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        let all_tx_datoms = collect_cdc_datoms(&node).await;
+
+        // Find the transaction containing our entity 100 datoms.
+        let entity_datoms: Vec<&Datom> = all_tx_datoms.iter()
+            .flatten()
+            .filter(|d| d.entity == 100)
+            .collect();
+
+        assert_eq!(entity_datoms.len(), 2);
+        assert!(entity_datoms.iter().any(|d|
+            d.attribute == kw!(:name) && d.value == DataType::String("alice".to_string())
+            && d.op == DatomOp::Assert
+        ));
+        assert!(entity_datoms.iter().any(|d|
+            d.attribute == kw!(:age) && d.value == DataType::Long(30)
+            && d.op == DatomOp::Assert
+        ));
+
+        node.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_datoms_from_cdc_retract() {
+        let node = setup_node_with_schema().await;
+
+        // First put.
+        let mut doc = BTreeMap::new();
+        doc.insert(kw!(:db/id), DataType::Long(100));
+        doc.insert(kw!(:name), DataType::String("alice".to_string()));
+        node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+
+        // Second put with different name triggers retract of old value.
+        let mut doc2 = BTreeMap::new();
+        doc2.insert(kw!(:db/id), DataType::Long(100));
+        doc2.insert(kw!(:name), DataType::String("bob".to_string()));
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+
+        let all_tx_datoms = collect_cdc_datoms(&node).await;
+
+        // Find all datoms for entity 100, attribute :name.
+        let name_datoms: Vec<&Datom> = all_tx_datoms.iter()
+            .flatten()
+            .filter(|d| d.entity == 100 && d.attribute == kw!(:name))
+            .collect();
+
+        assert!(name_datoms.iter().any(|d|
+            d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Assert
+        ), "Expected assert for alice");
+        assert!(name_datoms.iter().any(|d|
+            d.value == DataType::String("alice".to_string()) && d.op == DatomOp::Retract
+        ), "Expected retract for alice");
+        assert!(name_datoms.iter().any(|d|
+            d.value == DataType::String("bob".to_string()) && d.op == DatomOp::Assert
+        ), "Expected assert for bob");
+
+        node.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_datoms_from_cdc_mixed_entities() {
+        let node = setup_node_with_schema().await;
+
+        let mut doc1 = BTreeMap::new();
+        doc1.insert(kw!(:db/id), DataType::Long(100));
+        doc1.insert(kw!(:name), DataType::String("alice".to_string()));
+        let mut doc2 = BTreeMap::new();
+        doc2.insert(kw!(:db/id), DataType::Long(200));
+        doc2.insert(kw!(:name), DataType::String("bob".to_string()));
+        doc2.insert(kw!(:age), DataType::Long(25));
+        node.execute_tx(vec![TxOp::Put(doc1), TxOp::Put(doc2)]).await.unwrap();
+
+        let all_tx_datoms = collect_cdc_datoms(&node).await;
+
+        let entity_100: Vec<&Datom> = all_tx_datoms.iter().flatten()
+            .filter(|d| d.entity == 100).collect();
+        let entity_200: Vec<&Datom> = all_tx_datoms.iter().flatten()
+            .filter(|d| d.entity == 200).collect();
+
+        assert_eq!(entity_100.len(), 1); // name only
+        assert_eq!(entity_200.len(), 2); // name + age
+
+        node.close().await;
     }
 }


### PR DESCRIPTION
## Summary
- Add `datoms_from_cdc_transaction()` that filters CDC WAL entries to EAV-prefix keys and decodes them back into `Datom` structs using `eav_key_to_parts` and `SchemaCache` for attribute resolution
- Refactor `Node` and slate helpers to retain `object_store` and `db_path`, enabling `WalReader`/`CdcStream` creation from a Node instance
- Add `SchemaCache::get_ident()` for reverse attribute ID → name lookup

## Test plan
- [x] 3 new Node-based tests: happy path, retract, mixed entities
- [x] All 354 lib tests + 17 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)