### PR TITLE
fix: restore indexer latest_indexed_tx on local_node restart

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -87,7 +87,8 @@ fn tx_meta_key(tx_id: i64) -> Vec<u8> {
 /// If the snapshot contains no TX_TO_META entries, returns a sentinel TxKey
 /// (tx_id=0, system_time=epoch).
 ///
-/// TODO: return a real "empty database" TxKey once we have one.
+/// TODO(triplox-8mc): Return Option<TxKey> (None for empty DB) instead of a
+/// sentinel. Needs coordination with the bootstrap transaction (tx_id=0).
 ///
 /// TX_TO_META keys are now big-endian encoded, so byte order matches numeric order.
 /// A reverse iterator could be used for O(1) lookup instead of this full scan.
@@ -111,12 +112,12 @@ pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) ->
 }
 
 impl Indexer {
-    pub fn new(slatedb: Arc<Db>, schema_cache: SchemaCache) -> Self {
+    pub fn new(slatedb: Arc<Db>, schema_cache: SchemaCache, latest_indexed_tx: Option<TxKey>) -> Self {
         let (tx_completion_sender, _) = broadcast::channel(1024);
         Indexer {
             slatedb,
             schema_cache,
-            latest_indexed_tx: None,
+            latest_indexed_tx,
             tx_completion_sender,
         }
     }
@@ -406,7 +407,7 @@ mod tests {
     /// Returns the indexer ready for test data at tx_id=1+.
     async fn bootstrapped_indexer(slate: Arc<Db>) -> Indexer {
         let cache = crate::bootstrap::init_db(slate.clone()).await;
-        let mut indexer = Indexer::new(slate, cache);
+        let mut indexer = Indexer::new(slate, cache, None);
         let tx_key_0 = TxKey { tx_id: 0, system_time: st_from_unix_epoch(1) };
         indexer.transact_tx(tx_key_0, test_schema_tx()).await.unwrap();
         indexer
@@ -599,7 +600,7 @@ mod tests {
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
-        let indexer = Indexer::new(slate.clone(), SchemaCache::new());
+        let indexer = Indexer::new(slate.clone(), SchemaCache::new(), None);
 
         let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(999) };
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -99,7 +99,7 @@ impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slatedb = Arc::new(in_memory_slate().await);
         let cache = crate::bootstrap::init_db(slatedb.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache)));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache, None)));
         let log = Arc::new(RwLock::new(MemoryLog::new(Box::new(clock::SystemClock))));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
@@ -116,19 +116,23 @@ impl Node<FileLog> {
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
         let slatedb = Arc::new(local_slate(db_path_str).await);
         let cache = crate::bootstrap::init_db(slatedb.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache)));
+
+        // Determine the latest already-indexed tx_id so we skip replaying it
+        // and restore the indexer's in-memory state for TxWaiter fast-path.
+        let snapshot = Arc::new(slatedb.snapshot().await?);
+        let latest_indexed = latest_tx_key_from_snapshot(&snapshot).await?;
+        let latest_indexed_tx = if latest_indexed.tx_id > 0 {
+            Some(latest_indexed)
+        } else {
+            None
+        };
+
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache, latest_indexed_tx)));
         let log = Arc::new(RwLock::new(
             FileLog::new(&root_path.join("log"), Box::new(clock::SystemClock))?,
         ));
 
-        // Determine the latest already-indexed tx_id so we skip replaying it
-        let snapshot = Arc::new(slatedb.snapshot().await?);
-        let latest_indexed = latest_tx_key_from_snapshot(&snapshot).await?;
-        let after_tx_id = if latest_indexed.tx_id > 0 {
-            Some(latest_indexed.tx_id)
-        } else {
-            None
-        };
+        let after_tx_id = latest_indexed_tx.map(|k| k.tx_id);
 
         // Read the last tx_key from the log before subscribing (for catch-up awaiting)
         let last_tx_key = {
@@ -823,6 +827,48 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.contains(&vec![DataType::Long(100), DataType::String("alice".to_string())]));
         assert!(results.contains(&vec![DataType::Long(101), DataType::String("bob".to_string())]));
+
+        node.close().await;
+    }
+
+    // The indexer's `latest_indexed_tx` field must be restored on restart so that
+    // a TxWaiter for an already-indexed transaction returns immediately. Without
+    // the fix, `await_tx` falls into the broadcast loop and hangs forever because
+    // no new completions will be broadcast.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_node_restart_tx_waiter_for_already_indexed_tx() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().to_path_buf();
+
+        // First node: bootstrap schema + insert data
+        let node = Node::local_node(&root_path).await.unwrap();
+        define_test_schema(&node).await;
+
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("alice".to_string()));
+
+        let result = node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        let tx_key = match result {
+            TransactionResult::TxCommited(k) => k,
+            _ => panic!("expected commit"),
+        };
+
+        node.close().await;
+
+        // Second node: reopen — no new transactions
+        let node = Node::local_node(&root_path).await.unwrap();
+
+        // A waiter obtained after restart should resolve immediately for the
+        // already-indexed tx_key. Without the fix this hangs forever.
+        let waiter = node.indexer.read().await.tx_waiter();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            waiter.await_tx(tx_key),
+        ).await;
+
+        assert!(result.is_ok(), "tx_waiter should not timeout for an already-indexed tx");
+        result.unwrap().expect("await_tx should succeed");
 
         node.close().await;
     }


### PR DESCRIPTION
## Summary
- `Indexer::new()` always initialized `latest_indexed_tx` to `None`, causing `TxWaiter::await_tx` to hang forever for already-indexed transactions after restart (no broadcast completions to receive when no new transactions arrive)
- Pass the snapshot-derived latest `TxKey` as a parameter to `Indexer::new()` so the `TxWaiter` fast-path works immediately after restart
- Added regression test that verifies `await_tx` resolves immediately for an already-indexed tx after local_node restart

## Test plan
- [x] New test `test_local_node_restart_tx_waiter_for_already_indexed_tx` — confirmed it fails without the fix (2s timeout) and passes with it
- [x] Existing `test_local_node_survives_restart` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)