### PR TITLE
refactor: remove Document newtype wrapper

### DIFF
--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use edn::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{QueryNode, SubmitNode, TransactionResult};
-use triplox::ops::{DataType, Document, TxOp};
+use triplox::ops::{DataType, TxOp};
 
 /// Build a schema attribute definition as a Put document.
 /// This mirrors the internal `plain_schema_attribute` helper.
@@ -32,7 +32,7 @@ fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
         "db/cardinality".to_string(),
         DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
     );
-    TxOp::Put(Document(doc))
+    TxOp::Put(doc)
 }
 
 #[tokio::main]
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     bob.insert("name".to_string(), DataType::String("bob".to_string()));
     bob.insert("age".to_string(), DataType::Long(25));
 
-    let data_ops = vec![TxOp::Put(Document(alice)), TxOp::Put(Document(bob))];
+    let data_ops = vec![TxOp::Put(alice), TxOp::Put(bob)];
     let result = node.execute_tx(data_ops).await?;
     match &result {
         TransactionResult::TxCommited(tx_key) => {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -418,10 +418,9 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("alan".to_string()));
-        let doc = map;
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("alan".to_string()));
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -452,10 +451,9 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("alan".to_string()));
-        let doc = map;
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("alan".to_string()));
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -480,11 +478,10 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("alan".to_string()));
-        map.insert("age".to_string(), DataType::Long(30));
-        let doc = map;
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("alan".to_string()));
+        doc.insert("age".to_string(), DataType::Long(30));
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -11,7 +11,7 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 
 use crate::log::{Record, Subscriber};
-use crate::ops::{Datom, DatomOp, Document, TxOp, tx_ops_to_datoms};
+use crate::ops::{Datom, DatomOp, TxOp, tx_ops_to_datoms};
 use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
 use crate::schema::SchemaCache;
@@ -421,7 +421,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alan".to_string()));
-        let doc = Document(map);
+        let doc = map;
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -455,7 +455,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alan".to_string()));
-        let doc = Document(map);
+        let doc = map;
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -484,7 +484,7 @@ mod tests {
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alan".to_string()));
         map.insert("age".to_string(), DataType::Long(30));
-        let doc = Document(map);
+        let doc = map;
         let tx_ops = vec![TxOp::Put(doc)];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -511,7 +511,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let tx_ops = vec![TxOp::Put(Document(map))];
+        let tx_ops = vec![TxOp::Put(map)];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
@@ -542,7 +542,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert("db/id".to_string(), DataType::Long(100 + i));
             map.insert("name".to_string(), DataType::String(format!("user{}", i)));
-            let tx_ops = vec![TxOp::Put(Document(map))];
+            let tx_ops = vec![TxOp::Put(map)];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -563,7 +563,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let tx_ops = vec![TxOp::Put(Document(map))];
+        let tx_ops = vec![TxOp::Put(map)];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         indexer.tx_waiter().await_tx(tx_key).await?;
@@ -588,7 +588,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert("db/id".to_string(), DataType::Long(100));
             map.insert("name".to_string(), DataType::String("bob".to_string()));
-            let tx_ops = vec![TxOp::Put(Document(map))];
+            let tx_ops = vec![TxOp::Put(map)];
             guard.transact_tx(tx_key_1, tx_ops).await?;
         }
 
@@ -626,7 +626,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert("db/id".to_string(), DataType::Long(100 + i));
             map.insert("name".to_string(), DataType::String(format!("user{}", i)));
-            let tx_ops = vec![TxOp::Put(Document(map))];
+            let tx_ops = vec![TxOp::Put(map)];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -662,7 +662,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert("db/id".to_string(), DataType::Long(100));
             map.insert("name".to_string(), DataType::String("shared".to_string()));
-            let tx_ops = vec![TxOp::Put(Document(map))];
+            let tx_ops = vec![TxOp::Put(map)];
             guard.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -684,14 +684,14 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
+        indexer.transact_tx(tx1, vec![TxOp::Put(map)]).await?;
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("bob".to_string()));
-        indexer.transact_tx(tx2, vec![TxOp::Put(Document(map))]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::Put(map)]).await?;
 
         // Scan EAV for entity 100 — expect: alice ADD, alice RETRACT, bob ADD
         let name_id: i64 = 50;
@@ -735,14 +735,14 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        indexer.transact_tx(tx1, vec![TxOp::Put(Document(map))]).await?;
+        indexer.transact_tx(tx1, vec![TxOp::Put(map)]).await?;
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        indexer.transact_tx(tx2, vec![TxOp::Put(Document(map))]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::Put(map)]).await?;
 
         // Count EAV entries for entity 100, name attr — should be 1 ADD, 0 RETRACTs
         let name_id: i64 = 50;

--- a/src/node.rs
+++ b/src/node.rs
@@ -212,7 +212,7 @@ mod tests {
     use crate::datalog::{FindElement, FindSpec, FnExpr, OrBranch, PatternElement, Query, TriplePattern, WhereClause};
     use crate::expr::{BinaryExpr, BinaryOp, Expr};
     use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
-    use crate::ops::{Attribute, DataType, Document, EntityId, TxOp};
+    use crate::ops::{Attribute, DataType, EntityId, TxOp};
     use crate::schema::test_schema_tx;
     // "name" has entity_id 50, "age" 51, "email" 52, "follows" 53 from test_schema_tx
     use crate::transaction::TransactionResult;
@@ -238,7 +238,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let doc = Document(map);
+        let doc = map;
         let tx_ops = vec![TxOp::Put(doc)];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
@@ -327,7 +327,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(100));
         map.insert("name".to_string(), DataType::String("bob".to_string()));
-        let doc = Document(map);
+        let doc = map;
         let tx_ops = vec![TxOp::Put(doc)];
 
         let waiter = node.indexer.read().await.tx_waiter();
@@ -410,8 +410,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![
@@ -446,8 +446,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![FindElement::Variable("?e".to_string())]),
@@ -479,8 +479,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![
@@ -522,8 +522,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
         // ?friend is in value position of :follows and entity position of :name
         let query = Query {
@@ -566,9 +566,9 @@ mod tests {
         doc3.insert("db/id".to_string(), DataType::Long(102));
         doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc3))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![FindElement::Variable("?e".to_string())]),
@@ -615,9 +615,9 @@ mod tests {
         doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
         doc3.insert("age".to_string(), DataType::Long(35));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc3))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![
@@ -673,9 +673,9 @@ mod tests {
         doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
         doc3.insert("age".to_string(), DataType::Long(35));
 
-        node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(Document(doc3))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
 
         let query = Query {
             find: FindSpec::FindRel(vec![FindElement::Variable("?e".to_string())]),
@@ -727,7 +727,7 @@ mod tests {
         doc1.insert("db/id".to_string(), DataType::Long(100));
         doc1.insert("name".to_string(), DataType::String("alice".to_string()));
 
-        let tx_key1 = match node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap() {
+        let tx_key1 = match node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap() {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx1 should commit"),
         };
@@ -736,7 +736,7 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        let tx_key2 = match node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap() {
+        let tx_key2 = match node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap() {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx2 should commit"),
         };
@@ -797,7 +797,7 @@ mod tests {
         doc1.insert("db/id".to_string(), DataType::Long(100));
         doc1.insert("name".to_string(), DataType::String("alice".to_string()));
 
-        let result = node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -819,7 +819,7 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(101));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
 
-        let result = node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -848,7 +848,7 @@ mod tests {
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
 
-        let result = node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("expected commit"),
@@ -882,7 +882,7 @@ mod tests {
         let mut doc1 = BTreeMap::new();
         doc1.insert("db/id".to_string(), DataType::Long(100));
         doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        let result1 = node.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
+        let result1 = node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
         let tx_key1 = match result1 {
             TransactionResult::TxCommited(tk) => tk,
             _ => panic!("Expected TxCommited"),
@@ -892,7 +892,7 @@ mod tests {
         let mut doc2 = BTreeMap::new();
         doc2.insert("db/id".to_string(), DataType::Long(200));
         doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-        node.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
@@ -942,7 +942,7 @@ mod tests {
             doc.insert("db/id".to_string(), DataType::Long(id));
             doc.insert("name".to_string(), DataType::String(name.to_string()));
             doc.insert("age".to_string(), DataType::Long(age));
-            node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
         }
     }
 
@@ -1200,7 +1200,7 @@ mod tests {
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
         sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
-        node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
 
         let people = vec![
             (100, "Ivan", "male"),
@@ -1213,7 +1213,7 @@ mod tests {
             doc.insert("db/id".to_string(), DataType::Long(id));
             doc.insert("name".to_string(), DataType::String(name.to_string()));
             doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-            node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
         }
 
         // find ?name where [?e :sex :male] [?e :name ?name]
@@ -1254,7 +1254,7 @@ mod tests {
         sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
         sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
         sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
-        node.execute_tx(vec![TxOp::Put(Document(sex_attr))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
 
         let people = vec![
             (100, "Ivan", "male"),
@@ -1267,7 +1267,7 @@ mod tests {
             doc.insert("db/id".to_string(), DataType::Long(id));
             doc.insert("name".to_string(), DataType::String(name.to_string()));
             doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-            node.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
         }
 
         // Same clause order as Clojure: name first (binds ?e), sex filter second
@@ -1304,7 +1304,7 @@ mod tests {
         attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("last-name")));
         attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "string")));
         attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
-        node.execute_tx(vec![TxOp::Put(Document(attr))]).await.unwrap();
+        node.execute_tx(vec![TxOp::Put(attr)]).await.unwrap();
 
         // Insert entity 200 and entity 201 with last-names
         let mut doc1 = BTreeMap::new();
@@ -1314,8 +1314,8 @@ mod tests {
         doc2.insert("db/id".to_string(), DataType::Long(201));
         doc2.insert("last-name".to_string(), DataType::String("Bobnev".to_string()));
         node.execute_tx(vec![
-            TxOp::Put(Document(doc1)),
-            TxOp::Put(Document(doc2)),
+            TxOp::Put(doc1),
+            TxOp::Put(doc2),
         ]).await.unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
@@ -1350,7 +1350,7 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Put(Document(bad_doc))]),
+            node.execute_tx(vec![TxOp::Put(bad_doc)]),
         ).await.expect("Should not hang").expect("execute_tx should not return Err");
 
         match &result {
@@ -1372,7 +1372,7 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Put(Document(good_doc))]),
+            node.execute_tx(vec![TxOp::Put(good_doc)]),
         ).await.expect("Should not hang").expect("execute_tx should not return Err");
 
         assert!(matches!(result, TransactionResult::TxCommited(_)),

--- a/src/node.rs
+++ b/src/node.rs
@@ -235,10 +235,9 @@ mod tests {
         define_test_schema(&node).await;
 
         // Use entity ID 100 to avoid reserved bootstrap range (1-31)
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let doc = map;
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("alice".to_string()));
         let tx_ops = vec![TxOp::Put(doc)];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
@@ -324,10 +323,9 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(100));
-        map.insert("name".to_string(), DataType::String("bob".to_string()));
-        let doc = map;
+        let mut doc = BTreeMap::new();
+        doc.insert("db/id".to_string(), DataType::Long(100));
+        doc.insert("name".to_string(), DataType::String("bob".to_string()));
         let tx_ops = vec![TxOp::Put(doc)];
 
         let waiter = node.indexer.read().await.tx_waiter();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -153,11 +153,8 @@ impl_from_for_enum!(
 );
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Document(pub BTreeMap<String, DataType>);
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
-    Put(Document),
+    Put(BTreeMap<String, DataType>),
     Add { entity_id: EntityId, attribute: Attribute, value: DataType },
     Retract { entity_id: EntityId, attribute: Attribute, value: DataType },
     Delete(EntityId),
@@ -190,7 +187,7 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: Instant) -> Result<Vec<Datom>> {
     let mut datoms = Vec::new();
     for op in ops {
         match op {
-            TxOp::Put(Document(doc)) => {
+            TxOp::Put(doc) => {
                 let entity = match doc.get("db/id") {
                     Some(DataType::Long(id)) => *id,
                     Some(_) => return Err(anyhow::anyhow!("Document db/id must be a Long")),
@@ -283,7 +280,7 @@ mod tests {
         let mut document: BTreeMap<String, DataType> = BTreeMap::new();
         document.insert("string".to_string(), "string_value".to_string().into());
         document.insert("int".to_string(), 1i64.into());
-        let op = TxOp::Put(Document(document));
+        let op = TxOp::Put(document);
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
@@ -336,7 +333,7 @@ mod tests {
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
         doc.insert("age".to_string(), DataType::Long(30));
-        let ops = vec![TxOp::Put(Document(doc))];
+        let ops = vec![TxOp::Put(doc)];
 
         let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
         assert_eq!(datoms.len(), 2);
@@ -395,7 +392,7 @@ mod tests {
         let tx = crate::clock::st_from_unix_epoch(1000);
         let mut doc = BTreeMap::new();
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        let ops = vec![TxOp::Put(Document(doc))];
+        let ops = vec![TxOp::Put(doc)];
 
         let result = tx_ops_to_datoms(&ops, tx);
         assert!(result.is_err());
@@ -408,7 +405,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::String("not-a-long".to_string()));
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        let ops = vec![TxOp::Put(Document(doc))];
+        let ops = vec![TxOp::Put(doc)];
 
         let result = tx_ops_to_datoms(&ops, tx);
         assert!(result.is_err());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -11,7 +11,7 @@ use edn::symbols::Keyword;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use uuid::Uuid;
 
-use crate::ops::{Attribute, DataType, Document, EntityId, TxOp};
+use crate::ops::{Attribute, DataType, EntityId, TxOp};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -416,7 +416,7 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
     match op {
         TxOp::Put(doc) => {
             encode_u8(buf, TXOP_PUT);
-            encode_data_type_map(buf, &doc.0);
+            encode_data_type_map(buf, doc);
         }
         TxOp::Add { entity_id, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
@@ -662,7 +662,7 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
     match tag {
         TXOP_PUT => {
             let map = decode_data_type_map(cursor)?;
-            Ok(TxOp::Put(Document(map)))
+            Ok(TxOp::Put(map))
         }
         TXOP_ADD => {
             let (entity_id, attribute, value) = decode_eav(cursor)?;
@@ -1217,7 +1217,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("db/id".to_string(), DataType::Long(1));
         map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let op = TxOp::Put(Document(map));
+        let op = TxOp::Put(map);
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
@@ -1304,7 +1304,7 @@ mod tests {
         map.insert("name".to_string(), DataType::String("alice".to_string()));
         let msg = FrontendMessage::Execute {
             ops: vec![
-                TxOp::Put(Document(map)),
+                TxOp::Put(map),
                 TxOp::Delete(EntityId(99)),
             ],
             await_indexing: true,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,7 @@ use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
 use crate::datalog::{FindElement, FindSpec, PatternElement, Query, TriplePattern, WhereClause};
-use crate::ops::{Attribute, DataType, Datom, DatomOp, Document, EntityId, TxOp};
+use crate::ops::{Attribute, DataType, Datom, DatomOp, EntityId, TxOp};
 use crate::query::{execute_query, validate_query};
 
 // --- Reserved entity IDs ---
@@ -280,7 +280,7 @@ fn schema_attribute_with_cardinality(id: i64, ident: Keyword, value_type: &str, 
         "db/cardinality".to_string(),
         DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)),
     );
-    TxOp::Put(Document(doc))
+    TxOp::Put(doc)
 }
 
 fn schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
@@ -471,7 +471,7 @@ mod tests {
         assert_eq!(tx.len(), 19); // 3 attrs + 14 type enums + 2 cardinality enums
 
         let mut ids: Vec<i64> = tx.iter().map(|op| match op {
-            TxOp::Put(Document(doc)) => match doc.get("db/id") {
+            TxOp::Put(doc) => match doc.get("db/id") {
                 Some(DataType::Long(id)) => *id,
                 _ => panic!("Expected db/id Long"),
             },
@@ -530,7 +530,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("name".to_string(), DataType::String("Alice".to_string()));
-        assert!(cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).is_ok());
+        assert!(cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).is_ok());
     }
 
     #[test]
@@ -539,7 +539,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("person/age".to_string(), DataType::Long(30));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
+        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Unknown attribute: person/age"));
     }
 
@@ -549,7 +549,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("name".to_string(), DataType::Long(42));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
+        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Type mismatch"));
     }
 
@@ -570,7 +570,7 @@ mod tests {
         doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "long"));
         doc.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
+        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
 
@@ -607,7 +607,7 @@ mod tests {
         doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "string"));
         // No db/cardinality
-        let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(Document(doc))])).unwrap_err();
+        let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("db/cardinality is required"));
     }
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
-use triplox::ops::{DataType, Document, TxOp};
+use triplox::ops::{DataType, TxOp};
 use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
@@ -54,7 +54,7 @@ async fn test_execute_tx_and_query() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result = client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    let result = client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
 
     // Open a DB and query
@@ -81,7 +81,7 @@ async fn test_submit_tx() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("bob".to_string()));
-    let tx_key = client.submit_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    let tx_key = client.submit_tx(vec![TxOp::Put(doc)]).await.unwrap();
     assert!(tx_key.tx_id >= 0);
 
     client.close().await.unwrap();
@@ -98,12 +98,12 @@ async fn test_multiple_transactions_and_query() {
     let mut doc1 = BTreeMap::new();
     doc1.insert("db/id".to_string(), DataType::Long(100));
     doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-    client.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
 
     let mut doc2 = BTreeMap::new();
     doc2.insert("db/id".to_string(), DataType::Long(200));
     doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-    client.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
     let db = client.db().await.unwrap();
     let result = db
@@ -130,7 +130,7 @@ async fn test_open_close_multiple_dbs() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 
     // Open two DB handles
     let db1 = client.db().await.unwrap();
@@ -158,7 +158,7 @@ async fn test_two_connections() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client1.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    client1.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 
     // Connection 2 can see the data
     let client2 = ClientNode::connect(&addr).await.unwrap();
@@ -181,7 +181,7 @@ async fn test_execute_tx_returns_tx_key() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result = client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    let result = client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 
     match result {
         TransactionResult::TxCommited(tx_key) => {
@@ -204,7 +204,7 @@ async fn test_db_as_of() {
     let mut doc1 = BTreeMap::new();
     doc1.insert("db/id".to_string(), DataType::Long(100));
     doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result1 = client.execute_tx(vec![TxOp::Put(Document(doc1))]).await.unwrap();
+    let result1 = client.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
     let tx_key1 = match result1 {
         TransactionResult::TxCommited(tk) => tk,
         _ => panic!("Expected TxCommited"),
@@ -214,7 +214,7 @@ async fn test_db_as_of() {
     let mut doc2 = BTreeMap::new();
     doc2.insert("db/id".to_string(), DataType::Long(200));
     doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-    client.execute_tx(vec![TxOp::Put(Document(doc2))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
 
     // Open DB pinned to tx_key after first tx — should only see alice
     let db = client.db_as_of(tx_key1).await.unwrap();
@@ -261,7 +261,7 @@ async fn test_dev_server_connections_are_isolated() {
     let mut doc = BTreeMap::new();
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client1.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    client1.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 
     let db1 = client1.db().await.unwrap();
     let result1 = db1
@@ -294,7 +294,7 @@ async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &st
     doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain(name)));
     doc.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", vtype)));
     doc.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
-    client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 }
 
 async fn define_people_schema(client: &ClientNode) {
@@ -324,7 +324,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
         doc.insert("db/id".to_string(), DataType::Long(id));
         doc.insert("name".to_string(), DataType::String(name.to_string()));
         doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -367,7 +367,7 @@ async fn test_aggregates_and_or() {
         doc.insert("last-name".to_string(), DataType::String(last.to_string()));
         doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
         doc.insert("age".to_string(), DataType::Long(age));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -427,7 +427,7 @@ async fn test_aggregate_set_semantics() {
         doc.insert("db/id".to_string(), DataType::Long(id));
         doc.insert("name".to_string(), DataType::String(name.to_string()));
         doc.insert("city".to_string(), DataType::String(city.to_string()));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -456,7 +456,7 @@ async fn test_datascript_aggregates() {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(id));
         doc.insert("heads".to_string(), DataType::Long(heads));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -489,7 +489,7 @@ async fn test_aggregate_avg() {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(id));
         doc.insert("age".to_string(), DataType::Long(age));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -515,7 +515,7 @@ async fn test_aggregate_min_max_strings() {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(id));
         doc.insert("name".to_string(), DataType::String(name.to_string()));
-        client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -564,7 +564,7 @@ async fn test_aggregate_min_incompatible_types() {
     doc.insert("db/id".to_string(), DataType::Long(100));
     doc.insert("name".to_string(), DataType::String("Alice".to_string()));
     doc.insert("age".to_string(), DataType::Long(30));
-    client.execute_tx(vec![TxOp::Put(Document(doc))]).await.unwrap();
+    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
 
     let db = client.db().await.unwrap();
 


### PR DESCRIPTION
## Summary
- Remove the `Document` newtype (`pub struct Document(pub BTreeMap<String, DataType>)`) which was a zero-behavior wrapper since day one
- `TxOp::Put` now holds `BTreeMap<String, DataType>` directly
- All call sites updated to remove the `Document(...)` wrapping/destructuring

## Test plan
- [x] `cargo test` — all 17 integration tests + all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)