### PR TITLE
feat: add S2Log remote transaction log via s2-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +127,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -120,7 +144,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -147,7 +171,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -155,6 +179,28 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backon"
@@ -172,6 +218,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -203,6 +255,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,19 +297,29 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cc"
-version = "1.1.28"
+name = "castaway"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -254,6 +330,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -270,10 +357,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmsketch"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7ee2cfacbd29706479902b06d75ad8f1362900836aa32799eabc7e004bfd854"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -283,6 +413,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -299,6 +435,24 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -350,8 +504,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -369,14 +533,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote 1.0.43",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote 1.0.43",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -397,7 +585,7 @@ checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -418,7 +606,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -432,6 +620,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-str"
@@ -468,6 +662,47 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -546,6 +781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +794,16 @@ checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
  "bitflags",
  "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -648,7 +899,7 @@ dependencies = [
  "equivalent",
  "foyer-common",
  "foyer-intrusive-collections",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.5",
  "itertools 0.14.0",
  "madsim-tokio",
  "mixtrics",
@@ -703,6 +954,12 @@ dependencies = [
  "rustix 1.1.3",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -760,7 +1017,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -824,8 +1081,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -870,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -905,12 +1176,11 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -951,19 +1221,21 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1111,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1423,8 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1208,6 +1488,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1311,7 +1597,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote 1.0.43",
  "syn 1.0.109",
@@ -1367,6 +1653,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1630,7 +1926,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1700,7 +1996,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1735,7 +2031,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1792,10 +2088,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.87"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1808,9 +2114,32 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1893,6 +2222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2246,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1950,6 +2296,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xoshiro"
@@ -2139,6 +2491,8 @@ version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2181,6 +2535,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2197,6 +2552,89 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "s2-api"
+version = "0.27.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9677f62b58f739ece5761d898495e919358d3846f8979b0b86d43015adee1a9b"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "compact_str",
+ "enum-ordinalize",
+ "flate2",
+ "futures",
+ "http",
+ "itertools 0.14.0",
+ "mime",
+ "prost",
+ "s2-common",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.12",
+ "time",
+ "tokio-util",
+ "zstd",
+]
+
+[[package]]
+name = "s2-common"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900b6b0a29b5922e4fa40ec268690ce1a8a5dbadbcaa7f448af4f3988a4dfc76"
+dependencies = [
+ "blake3",
+ "bytes",
+ "compact_str",
+ "enum-ordinalize",
+ "enumset",
+ "http",
+ "serde",
+ "strum",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
+name = "s2-sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad841f797a407894ca0c7ca92e5b799115c38cace9a4831f46a7b449af82ab36"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "prost",
+ "rand 0.10.0",
+ "rustls",
+ "s2-api",
+ "s2-common",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "tokio-muxt",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+]
 
 [[package]]
 name = "same-file"
@@ -2221,6 +2659,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2278,7 +2725,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2369,6 +2816,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -2479,7 +2932,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2530,6 +2983,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
@@ -2574,7 +3048,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2630,7 +3104,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2641,7 +3115,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2660,6 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -2710,9 +3185,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2733,7 +3208,17 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-muxt"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79eac432d68f5cc5ca99654adddb6ffc9501618bc267303d18a1f768ea01e7c"
+dependencies = [
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -2748,6 +3233,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,7 +3253,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.5",
  "pin-project-lite",
  "tokio",
 ]
@@ -2861,7 +3357,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2918,6 +3414,7 @@ dependencies = [
  "log",
  "object_store 0.11.1",
  "rand 0.8.5",
+ "s2-sdk",
  "serde",
  "slatedb",
  "tempfile",
@@ -2992,6 +3489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,12 +3531,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.0",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -3075,7 +3585,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3122,7 +3641,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3136,6 +3655,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3687,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3262,7 +3815,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3273,7 +3826,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3542,6 +4095,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.43",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,7 +4213,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3603,7 +4244,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3614,7 +4255,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3634,7 +4275,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3674,7 +4315,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.43",
- "syn 2.0.87",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,6 +3414,7 @@ dependencies = [
  "log",
  "object_store 0.11.1",
  "rand 0.8.5",
+ "rustls",
  "s2-sdk",
  "serde",
  "slatedb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,10 @@ fallible-iterator = "0.3.0"
 [features]
 test-helpers = []
 s2 = ["dep:s2-sdk"]
+s2-integration-test = ["s2"]
 
 [dev-dependencies]
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
 tempfile = "3.14.0"
 triplox = { path = ".", features = ["test-helpers"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,12 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { workspace = true, features = ["serde"] }
+s2-sdk = { version = "0.26", optional = true }
 fallible-iterator = "0.3.0"
 
 [features]
 test-helpers = []
+s2 = ["dep:s2-sdk"]
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -36,7 +36,7 @@ impl FileLog {
 }
 
 impl TxLogReader for FileLog {
-    fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>> {
+    async fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>> {
         let mut file = self.file.get_ref().try_clone().unwrap();
         let mut records = Vec::new();
 
@@ -64,7 +64,7 @@ impl TxLogReader for FileLog {
         Ok(records)
     }
 
-    fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>) {
+    async fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>) {
         let end_of_file = self.file.get_ref()
             .seek(SeekFrom::End(0))
             .unwrap_or(0) as TxId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ mod iterator;
 mod log;
 pub mod logging;
 mod memory_log;
+#[cfg(feature = "s2")]
+pub mod s2_log;
 pub mod ops;
 mod parse;
 mod query;

--- a/src/log.rs
+++ b/src/log.rs
@@ -26,12 +26,12 @@ pub(crate) trait Subscriber: Send + Sync {
 
 pub type TxId = i64;
 
-pub(crate) async fn subscribe<S: Subscriber + 'static>(
-    log: Arc<RwLock<dyn TxLogReader>>,
+pub(crate) async fn subscribe<L: TxLogReader, S: Subscriber + 'static>(
+    log: Arc<RwLock<L>>,
     after_tx_id: Option<TxId>,
     subscriber: Arc<tokio::sync::RwLock<S>>,
 ) -> CancellationToken {
-    let (_next_tx_id, mut tx_receiver) = log.read().await.subscribe_txs();
+    let (_next_tx_id, mut tx_receiver) = log.read().await.subscribe_txs().await;
 
     let token = CancellationToken::new();
     let task_token = token.clone();
@@ -43,7 +43,7 @@ pub(crate) async fn subscribe<S: Subscriber + 'static>(
         // Catch-up phase: read historical transactions after last_tx_id
         loop {
             if task_token.is_cancelled() { break; }
-            let txs = log.read().await.read_txs_after(last_tx_id, 100);
+            let txs = log.read().await.read_txs_after(last_tx_id, 100).await;
             match txs {
                 Ok(txs) if txs.is_empty() => break,
                 Ok(txs) => {
@@ -76,7 +76,7 @@ pub(crate) async fn subscribe<S: Subscriber + 'static>(
                             }
                         },
                         Err(broadcast::error::RecvError::Lagged(missed)) => {
-                            let txs = log.read().await.read_txs_after(last_tx_id, missed.try_into().unwrap());
+                            let txs = log.read().await.read_txs_after(last_tx_id, missed.try_into().unwrap()).await;
                             match txs {
                                 Ok(txs) => {
                                     if !txs.is_empty() {
@@ -111,9 +111,9 @@ pub(crate) async fn subscribe<S: Subscriber + 'static>(
 pub trait TxLogReader: Send + Sync + 'static {
     /// Read up to `limit` records written after `after_tx_id`.
     /// `None` means from the beginning. `Some(id)` means records strictly after `id`.
-    fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>>;
+    fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> impl Future<Output = Result<Vec<Record>>> + Send;
     /// Returns (next_tx_id, receiver). next_tx_id is where the next write will go (0 for empty log).
-    fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>);
+    fn subscribe_txs(&self) -> impl Future<Output = (TxId, broadcast::Receiver<Record>)> + Send;
 }
 
 pub trait TxLogWriter: Send + Sync + 'static {

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -25,7 +25,7 @@ impl MemoryLog {
 }
 
 impl TxLogReader for MemoryLog {
-    fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>> {
+    async fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>> {
         let start = match after_tx_id {
             None => 0,
             Some(id) => id as usize + 1,
@@ -37,7 +37,7 @@ impl TxLogReader for MemoryLog {
         Ok(self.txs[start..end].to_vec())
     }
 
-    fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>) {
+    async fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>) {
         (self.txs.len() as TxId, self.tx_sender.subscribe())
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -137,7 +137,7 @@ impl Node<FileLog> {
         // Read the last tx_key from the log before subscribing (for catch-up awaiting)
         let last_tx_key = {
             let log_reader = log.read().await;
-            let records = log_reader.read_txs_after(after_tx_id, u16::MAX)?;
+            let records = log_reader.read_txs_after(after_tx_id, u16::MAX).await?;
             records.last().map(|r| r.tx_key)
         };
 
@@ -150,6 +150,49 @@ impl Node<FileLog> {
         let subscription = subscribe(log.clone(), after_tx_id, indexer.clone()).await;
 
         // Wait for catch-up to complete if there are existing transactions
+        if let Some((tx_key, waiter)) = last_tx_key.zip(waiter) {
+            waiter.await_tx(tx_key).await?;
+        }
+
+        Ok(Node { log, indexer, slatedb, subscription })
+    }
+}
+
+#[cfg(feature = "s2")]
+impl Node<crate::s2_log::S2Log> {
+    pub async fn remote_node(
+        stream: s2_sdk::S2Stream,
+        db_path: &str,
+    ) -> Result<Self, Error> {
+        let slatedb = Arc::new(local_slate(db_path).await);
+        let cache = crate::bootstrap::init_db(slatedb.clone()).await;
+
+        let snapshot = Arc::new(slatedb.snapshot().await?);
+        let latest_indexed = latest_tx_key_from_snapshot(&snapshot).await?;
+        let latest_indexed_tx = if latest_indexed.tx_id > 0 {
+            Some(latest_indexed)
+        } else {
+            None
+        };
+
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache, latest_indexed_tx)));
+        let log = Arc::new(RwLock::new(crate::s2_log::S2Log::new(stream)));
+
+        let after_tx_id = latest_indexed_tx.map(|k| k.tx_id);
+
+        let last_tx_key = {
+            let log_reader = log.read().await;
+            let records = log_reader.read_txs_after(after_tx_id, u16::MAX).await?;
+            records.last().map(|r| r.tx_key)
+        };
+
+        let waiter = match last_tx_key {
+            Some(_) => Some(indexer.read().await.tx_waiter()),
+            None => None,
+        };
+
+        let subscription = subscribe(log.clone(), after_tx_id, indexer.clone()).await;
+
         if let Some((tx_key, waiter)) = last_tx_key.zip(waiter) {
             waiter.await_tx(tx_key).await?;
         }

--- a/src/s2_log.rs
+++ b/src/s2_log.rs
@@ -1,0 +1,106 @@
+#![allow(unused)]
+
+use anyhow::Result;
+use chrono::{DateTime, TimeZone, Utc};
+use log::warn;
+use tokio::sync::broadcast;
+
+use s2_sdk::types::{
+    AppendInput, AppendRecord, AppendRecordBatch, ReadFrom, ReadInput, ReadLimits, ReadStart,
+    ReadStop, S2Config,
+};
+use s2_sdk::{S2, S2Basin, S2Stream};
+
+use crate::log::{Record, TxId, TxLog, TxLogReader, TxLogWriter};
+use crate::transaction::TxKey;
+
+fn s2_timestamp_to_instant(ts_ms: u64) -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(ts_ms as i64).unwrap_or_else(Utc::now)
+}
+
+pub struct S2Log {
+    stream: S2Stream,
+    tx_sender: broadcast::Sender<Record>,
+}
+
+impl S2Log {
+    pub fn new(stream: S2Stream) -> Self {
+        S2Log {
+            stream,
+            tx_sender: broadcast::channel(1024).0,
+        }
+    }
+}
+
+impl TxLogReader for S2Log {
+    async fn read_txs_after(&self, after_tx_id: Option<TxId>, limit: u16) -> Result<Vec<Record>> {
+        let start_seq = match after_tx_id {
+            None => 0u64,
+            Some(id) => (id + 1) as u64,
+        };
+
+        let read_input = ReadInput::new()
+            .with_start(
+                ReadStart::new()
+                    .with_from(ReadFrom::SeqNum(start_seq))
+                    .with_clamp_to_tail(true),
+            )
+            .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(limit as usize)));
+
+        let batch = self.stream.read(read_input).await?;
+
+        let mut records = Vec::with_capacity(batch.records.len());
+        for sr in batch.records {
+            records.push(Record {
+                tx_key: TxKey {
+                    tx_id: sr.seq_num as i64,
+                    system_time: s2_timestamp_to_instant(sr.timestamp),
+                },
+                record: sr.body.to_vec(),
+            });
+        }
+
+        Ok(records)
+    }
+
+    async fn subscribe_txs(&self) -> (TxId, broadcast::Receiver<Record>) {
+        let tail_seq = self
+            .stream
+            .check_tail()
+            .await
+            .map(|pos| pos.seq_num as TxId)
+            .unwrap_or(0);
+        (tail_seq, self.tx_sender.subscribe())
+    }
+}
+
+impl TxLogWriter for S2Log {
+    async fn append_tx(&mut self, record: Vec<u8>) -> TxKey {
+        let append_record = AppendRecord::new(record.clone()).expect("record should be valid");
+        let batch =
+            AppendRecordBatch::try_from_iter([append_record]).expect("single record batch valid");
+        let ack = self
+            .stream
+            .append(AppendInput::new(batch))
+            .await
+            .expect("S2 append failed");
+
+        let tx_key = TxKey {
+            tx_id: ack.start.seq_num as i64,
+            system_time: s2_timestamp_to_instant(ack.start.timestamp),
+        };
+
+        let log_record = Record {
+            tx_key,
+            record,
+        };
+
+        if let Err(e) = self.tx_sender.send(log_record) {
+            warn!("Failed to send record from S2 log to subscribers: {}", e);
+        }
+
+        tx_key
+    }
+}
+
+impl TxLog for S2Log {}

--- a/src/s2_log.rs
+++ b/src/s2_log.rs
@@ -39,12 +39,14 @@ impl TxLogReader for S2Log {
             Some(id) => (id + 1) as u64,
         };
 
+        // Check tail to avoid reading past the end of the stream
+        let tail = self.stream.check_tail().await?.seq_num;
+        if start_seq >= tail {
+            return Ok(vec![]);
+        }
+
         let read_input = ReadInput::new()
-            .with_start(
-                ReadStart::new()
-                    .with_from(ReadFrom::SeqNum(start_seq))
-                    .with_clamp_to_tail(true),
-            )
+            .with_start(ReadStart::new().with_from(ReadFrom::SeqNum(start_seq)))
             .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(limit as usize)));
 
         let batch = self.stream.read(read_input).await?;
@@ -104,3 +106,172 @@ impl TxLogWriter for S2Log {
 }
 
 impl TxLog for S2Log {}
+
+#[cfg(all(test, feature = "s2-integration-test"))]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+    use tokio::sync::RwLock;
+
+    use s2_sdk::types::{
+        AccountEndpoint, BasinEndpoint, CreateBasinInput, CreateStreamInput, S2Config, S2Endpoints,
+    };
+    use s2_sdk::S2;
+
+    use crate::log::{subscribe, MockSubscriber};
+    use crate::logging::init;
+
+    const S2_LITE_BINARY: &str = "server";
+
+    fn install_crypto_provider() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
+    async fn start_s2_lite() -> Option<(std::process::Child, u16)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let child = Command::new(S2_LITE_BINARY)
+            .args(["--port", &port.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn();
+
+        match child {
+            Ok(child) => {
+                // Poll until server accepts TCP connections
+                for _ in 0..50 {
+                    if TcpListener::bind(("127.0.0.1", port)).await.is_err() {
+                        // Port is in use = server is listening
+                        return Some((child, port));
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                panic!("s2-lite failed to start on port {port}");
+            }
+            Err(_) => {
+                eprintln!("s2-lite binary '{S2_LITE_BINARY}' not found, skipping test");
+                None
+            }
+        }
+    }
+
+    async fn setup_s2_stream(port: u16, stream_name: &str) -> S2Stream {
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let endpoints = S2Endpoints::new(
+            AccountEndpoint::new(&endpoint).unwrap(),
+            BasinEndpoint::new(&endpoint).unwrap(),
+        )
+        .unwrap();
+        let config = S2Config::new("ignored").with_endpoints(endpoints);
+        let s2 = S2::new(config).unwrap();
+
+        let basin_name: s2_sdk::types::BasinName =
+            format!("test-{}", uuid::Uuid::new_v4()).parse().unwrap();
+        s2.create_basin(CreateBasinInput::new(basin_name.clone()))
+            .await
+            .unwrap();
+        let basin = s2.basin(basin_name);
+
+        let stream_name: s2_sdk::types::StreamName = stream_name.parse().unwrap();
+        basin
+            .create_stream(CreateStreamInput::new(stream_name.clone()))
+            .await
+            .unwrap();
+        basin.stream(stream_name)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_s2_log() {
+        init();
+        install_crypto_provider();
+        let Some((mut child, port)) = start_s2_lite().await else {
+            return;
+        };
+
+        let stream = setup_s2_stream(port, "log").await;
+        let subscriber = Arc::new(RwLock::new(MockSubscriber::new()));
+        let log = Arc::new(RwLock::new(S2Log::new(stream)));
+        let token = subscribe(log.clone(), None, subscriber.clone()).await;
+
+        {
+            let mut writer = log.write().await;
+            writer.append_tx(vec![1, 2, 3]).await;
+            writer.append_tx(vec![4, 5, 6]).await;
+            writer.append_tx(vec![7, 8, 9]).await;
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token.cancel();
+
+        let subscriber = subscriber.read().await;
+        assert_eq!(subscriber.records.len(), 3);
+        assert_eq!(subscriber.records[0].record, vec![1, 2, 3]);
+        assert_eq!(subscriber.records[1].record, vec![4, 5, 6]);
+        assert_eq!(subscriber.records[2].record, vec![7, 8, 9]);
+
+        let tx_id_1 = subscriber.records[1].tx_key.tx_id;
+        drop(subscriber);
+
+        // Subscribe after second transaction
+        let subscriber2 = Arc::new(RwLock::new(MockSubscriber::new()));
+        let token2 = subscribe(log.clone(), Some(tx_id_1), subscriber2.clone()).await;
+
+        {
+            let mut writer = log.write().await;
+            writer.append_tx(vec![10, 11, 12]).await;
+            writer.append_tx(vec![13, 14, 15]).await;
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token2.cancel();
+
+        let subscriber2 = subscriber2.read().await;
+        assert_eq!(subscriber2.records.len(), 3);
+        assert_eq!(subscriber2.records[0].record, vec![7, 8, 9]);
+        assert_eq!(subscriber2.records[1].record, vec![10, 11, 12]);
+        assert_eq!(subscriber2.records[2].record, vec![13, 14, 15]);
+
+        child.kill().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_s2_log_infinite_loop_bug() {
+        init();
+        install_crypto_provider();
+        let Some((mut child, port)) = start_s2_lite().await else {
+            return;
+        };
+
+        let stream = setup_s2_stream(port, "log").await;
+        let log = Arc::new(RwLock::new(S2Log::new(stream)));
+
+        // Write one transaction
+        {
+            let mut writer = log.write().await;
+            writer.append_tx(vec![1, 2, 3]).await;
+        }
+
+        // Subscribe from the beginning
+        let subscriber = Arc::new(RwLock::new(MockSubscriber::new()));
+        let token = subscribe(log.clone(), None, subscriber.clone()).await;
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        token.cancel();
+
+        let subscriber = subscriber.read().await;
+        assert_eq!(
+            subscriber.records.len(),
+            1,
+            "Should process transaction exactly once, not in an infinite loop"
+        );
+        assert_eq!(subscriber.records[0].record, vec![1, 2, 3]);
+
+        child.kill().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `S2Log` implementation of `TxLog` backed by S2 streams (s2-lite) for remote/distributed transaction logging
- Make `TxLogReader` trait async (`-> impl Future + Send`) to support network-based log backends
- Add `Node<S2Log>::remote_node()` constructor following the same catch-up and restart pattern as `local_node`
- Gate S2 dependency behind optional `s2` feature flag (`s2-sdk = "0.26"`)

## Test plan
- [x] All 17 existing tests pass (async TxLogReader refactor is backwards-compatible)
- [x] `cargo check --features s2` compiles cleanly
- [ ] Integration test with running s2-lite instance (manual, requires `s2 lite --port 8080`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)