### PR TITLE
refactor: remove TX_TO_META, use first-class tx entities

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc, TimeZone};
+use chrono::{DateTime, Timelike, Utc, TimeZone};
 
 pub type Instant = DateTime<Utc>;
 
@@ -14,7 +14,12 @@ pub struct SystemClock;
 
 impl SystemTimeSource for SystemClock {
     fn now(&mut self) -> Instant {
-        Utc::now()
+        // Truncate to microsecond precision — all persistent encodings
+        // (encode_timestamp, encode_instant) use microseconds, so sub-µs
+        // nanoseconds would be silently dropped on round-trip.
+        let now = Utc::now();
+        now.with_nanosecond((now.timestamp_subsec_nanos() / 1_000) * 1_000)
+            .expect("truncated nanoseconds should always be valid")
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -37,9 +37,6 @@ pub const AEV: u8 = 2;
 pub const AE: u8 = 3;
 pub const AV: u8 = 4;
 
-/// Prefix for tx_id → TxMeta (system_time) mapping in SlateDB.
-pub const TX_TO_META: u8 = 6;
-
 pub const STATS_INDEX: u8 = 128;
 pub const META_INDEX: u8 = 129;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -89,6 +89,7 @@ pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) ->
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
     let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     let mut latest: Option<(i64, Instant)> = None;
+    // TODO This should scan for the largest entity id and then extract the db/txId attribute
     while let Some(kv) = iter.next().await? {
         let (_entity_id, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
         if attribute != crate::schema::DB_TX_ID {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -8,11 +8,9 @@ use bytes::Bytes;
 use tokio::sync::broadcast;
 use log::{error, trace, warn};
 
-use serde::{Deserialize, Serialize};
-
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, TxOp, tx_ops_to_datoms};
-use crate::partition::{resolve_entity_ids, allocate_counter, make_entity_id, TX_PARTITION};
+use crate::partition::{resolve_entity_ids, allocate_counter, make_entity_id, partition_entity_prefix, TX_PARTITION};
 use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
 use crate::partition::PartitionCounters;
@@ -75,40 +73,36 @@ pub(crate) fn write_index_entries(
     Ok(())
 }
 
-/// Metadata stored per transaction in SlateDB (keyed by tx_id under TX_TO_META prefix).
-#[derive(Serialize, Deserialize)]
-struct TxMeta {
-    system_time: Instant,
-}
-
-fn tx_meta_key(tx_id: i64) -> Vec<u8> {
-    let mut buf = vec![codec::TX_TO_META];
-    encode_i64(tx_id, &mut buf);
-    buf
-}
-
-/// Scan all TX_TO_META keys in a snapshot and return the TxKey for the highest tx_id.
-/// If the snapshot contains no TX_TO_META entries, returns a sentinel TxKey
-/// (tx_id=0, system_time=epoch).
+/// Scan EAV entries for TX_PARTITION entities and return the TxKey for the highest tx_id.
+/// If no transaction entities exist, returns a sentinel TxKey (tx_id=0, system_time=epoch).
+///
+/// Uses the high bits of TX_PARTITION entity IDs to build a targeted EAV prefix,
+/// restricting the scan to TX_PARTITION entities. For each entry with attribute
+/// `db/txId`, the tx_id is extracted from the value and system_time from the key's
+/// timestamp suffix.
 ///
 /// TODO(triplox-8mc): Return Option<TxKey> (None for empty DB) instead of a
 /// sentinel. Needs coordination with the bootstrap transaction (tx_id=0).
 ///
-/// TX_TO_META keys are now big-endian encoded, so byte order matches numeric order.
-/// A reverse iterator could be used for O(1) lookup instead of this full scan.
+/// TODO: Use a reverse iterator for O(1) lookup once SlateDB supports reverse scanning.
 pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
-    let mut iter = snapshot.scan_prefix_with_options(&[codec::TX_TO_META], &DEFAULT_SCAN_OPTIONS).await?;
-    let mut latest: Option<(i64, TxMeta)> = None;
+    let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
+    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+    let mut latest: Option<(i64, Instant)> = None;
     while let Some(kv) = iter.next().await? {
-        let tx_id: i64 = decode_i64(&mut &kv.key[1..])?;
-        let meta: TxMeta = bincode::deserialize(&kv.value)?;
-        if latest.as_ref().map_or(true, |(best_id, _)| tx_id > *best_id) {
-            latest = Some((tx_id, meta));
+        let (_entity_id, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
+        if attribute != crate::schema::DB_TX_ID {
+            continue;
+        }
+        if let DataType::Long(tx_id) = value {
+            if latest.as_ref().map_or(true, |(best_id, _)| tx_id > *best_id) {
+                latest = Some((tx_id, timestamp));
+            }
         }
     }
-    Ok(latest.map(|(tx_id, meta)| TxKey {
+    Ok(latest.map(|(tx_id, system_time)| TxKey {
         tx_id,
-        system_time: meta.system_time,
+        system_time,
     }).unwrap_or_else(|| TxKey {
         tx_id: 0,
         system_time: crate::clock::st_from_unix_epoch(0),
@@ -264,10 +258,6 @@ impl Indexer {
 
         write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
 
-        // Persist tx_id -> system_time mapping
-        let meta = TxMeta { system_time: tx_key.system_time };
-        txn.put(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?)?;
-
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
 
         // Commit succeeded — advance partition counters.
@@ -312,8 +302,6 @@ impl Indexer {
         let datoms = build_tx_entity_datoms(&mut self.counters, tx_key, false, Some(error));
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
         write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
-        let meta = TxMeta { system_time: tx_key.system_time };
-        txn.put(&tx_meta_key(tx_key.tx_id), &bincode::serialize(&meta)?)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
         self.latest_indexed_tx = Some(tx_key);
         Ok(())
@@ -573,7 +561,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tx_meta_written() -> Result<(), Error> {
+    async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
@@ -589,7 +577,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tx_meta_empty_db() -> Result<(), Error> {
+    async fn test_latest_tx_key_empty_db() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let snapshot = Arc::new(slate.snapshot().await?);
         let latest = latest_tx_key_from_snapshot(&snapshot).await?;
@@ -598,7 +586,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tx_meta_latest_wins() -> Result<(), Error> {
+    async fn test_latest_tx_key_highest_wins() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -49,7 +49,7 @@ impl DB {
         Self { snapshot, attribute_map, handle, tx_key }
     }
 
-    /// Construct a DB from a snapshot by scanning TX_TO_META keys to find the latest TxKey.
+    /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
     pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
         let tx_key = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
         Ok(Self { snapshot, attribute_map, handle, tx_key })

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use crate::codec;
+use crate::protocol;
+
 /// Entity ID bit layout (from PARTITIONS.md):
 ///
 /// ```text
@@ -16,6 +19,26 @@ pub const PARTITION_MASK: i64 = ((1i64 << 20) - 1) << 42;
 pub const DB_PARTITION: u32 = 0;
 pub const TX_PARTITION: u32 = 1;
 pub const USER_PARTITION: u32 = 2;
+
+/// Return the encoded byte prefix shared by all entity IDs in the given partition.
+///
+/// The prefix is `TAG_LONG` followed by the high bytes of the order-preserving
+/// encoding of the partition's base entity ID (`make_entity_id(partition, 0)`),
+/// truncated to the 3 bytes that carry the partition bits.
+///
+/// For TX_PARTITION this produces `[7, 0x80, 0x00, 0x04]`.
+///
+/// **Note**: the partition/counter boundary (bit 42) is not byte-aligned, so
+/// byte 2 contains both partition bits (47–42) and counter bits (41–40). The
+/// 3-byte prefix fixes those counter bits to zero, limiting coverage to
+/// counter < 2^40 (~1 trillion) — sufficient for all practical use.
+pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
+    let base = make_entity_id(partition, 0);
+    let encoded = codec::encode_i64_bytes(base);
+    let mut prefix = vec![protocol::TAG_LONG];
+    prefix.extend_from_slice(&encoded[..3]);
+    prefix
+}
 
 /// Construct an entity ID from a partition number and counter value.
 ///


### PR DESCRIPTION
## Summary
- Remove the redundant `TX_TO_META` key system now that first-class transaction entities exist in `TX_PARTITION` (#43)
- Rewrite `latest_tx_key_from_snapshot` to scan EAV restricted to TX_PARTITION entities (via new `partition_entity_prefix` helper) instead of scanning a separate TX_TO_META prefix
- Truncate `SystemClock::now()` to microsecond precision to match all persistent encoding paths (`encode_timestamp`, `encode_instant`)

## Test plan
- [x] `cargo build` succeeds
- [x] All 386 tests pass (`cargo test`)
- [x] Key tests verified: `test_latest_tx_key_*`, `test_committed_tx_entity`, `test_aborted_tx_entity`, `test_local_node_restart_tx_waiter_for_already_indexed_tx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)