### PR TITLE
refactor: change partition bits from 20 to 18

### DIFF
--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -24,18 +24,18 @@ Partitions serve two purposes:
 An entity ID is a 64-bit signed integer with three fields:
 
 ```
- 63  62   61                    42  41                              0
-+----+----+---------------------+---+-------------------------------+
-| S  | 0  | partition (20 bits) |          counter (42 bits)        |
-+----+----+---------------------+---+-------------------------------+
+ 63  62   61                  44  43                                0
++----+----+-------------------+---+---------------------------------+
+| S  | 0  | partition (18 b)  |          counter (44 bits)          |
++----+----+-------------------+---+---------------------------------+
 ```
 
-| Field     | Bits  | Width | Range                      |
-|-----------|-------|-------|----------------------------|
-| Sign      | 63    | 1     | 0 (permanent), 1 (tempid)  |
-| Reserved  | 62    | 1     | Always 0                   |
-| Partition | 61–42 | 20    | 0 to 1,048,575             |
-| Counter   | 41–0  | 42    | 0 to 4,398,046,511,103     |
+| Field     | Bits  | Width | Range                        |
+|-----------|-------|-------|------------------------------|
+| Sign      | 63    | 1     | 0 (permanent), 1 (tempid)    |
+| Reserved  | 62    | 1     | Always 0                     |
+| Partition | 61–44 | 18    | 0 to 262,143                 |
+| Counter   | 43–0  | 44    | 0 to 17,592,186,044,415      |
 
 Because partition 0 places no bits above the counter, entities in `:db.part/db` have small, readable entity IDs (the raw counter value).
 
@@ -54,8 +54,8 @@ Three partitions are installed at bootstrap:
 | Partition | Number | Keyword           | Entity ID base    | Purpose                          |
 |-----------|--------|-------------------|-------------------|----------------------------------|
 | db        | 0      | `:db.part/db`     | `0`               | Schema, enums, system entities   |
-| tx        | 1      | `:db.part/tx`     | `1 << 42`         | Transaction entities             |
-| user      | 2      | `:db.part/user`   | `2 << 42`         | Default for application data     |
+| tx        | 1      | `:db.part/tx`     | `1 << 44`         | Transaction entities             |
+| user      | 2      | `:db.part/user`   | `2 << 44`         | Default for application data     |
 
 ### 2.1 :db.part/db (partition 0)
 
@@ -74,7 +74,7 @@ Each transaction is reified as an entity in this partition. The transaction enti
 | `db.tx/id`      | long       | The sequential tx_id assigned by the log                       |
 | `db.tx/error`   | string     | Error message (present only when `db.tx/result` is `:db.tx/aborted`) |
 
-A transaction with counter value `t` has entity ID `(1 << 42) | t`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
+A transaction with counter value `t` has entity ID `(1 << 44) | t`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
 
 Note: the relationship between `db.tx/id` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
 
@@ -88,7 +88,7 @@ The default partition for application data. When a tempid does not specify a par
 
 Entity IDs are allocated from a single, monotonically increasing counter called **T**. Every allocation — whether for a schema entity in `:db.part/db`, a transaction entity in `:db.part/tx`, or a user entity in `:db.part/user` — advances the same counter.
 
-When an entity is allocated in partition P, its entity ID is `(P << 42) | T`, and T advances to `T + 1`.
+When an entity is allocated in partition P, its entity ID is `(P << 44) | T`, and T advances to `T + 1`.
 
 ### 3.1 Counter Semantics
 
@@ -130,7 +130,7 @@ Because entity IDs encode the partition in their upper bits, and because entity 
 
 _This section covers a future phase. The details of partition creation and assignment are TBD._
 
-The 20-bit partition field supports up to 1,048,575 partitions beyond the three built-in ones. In the future we will allow users to create named partitions and assign entities to them. This enables domain-specific locality. It allows for grouping all entities related to a particular tenant or dataset so they cluster together in the E-leading indices.
+The 18-bit partition field supports up to 262,143 partitions beyond the three built-in ones. In the future we will allow users to create named partitions and assign entities to them. This enables domain-specific locality. It allows for grouping all entities related to a particular tenant or dataset so they cluster together in the E-leading indices.
 
 Topics to be addressed:
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -489,7 +489,7 @@ mod tests {
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // The entity was auto-assigned an ID in USER_PARTITION
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let user_base = crate::partition::make_entity_id(crate::partition::USER_PARTITION, 0);
 
         // Find the EAV entry for the user entity (skip bootstrap/schema entries)
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
@@ -530,7 +530,7 @@ mod tests {
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Verify an EAV entry in USER_PARTITION exists
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let user_base = crate::partition::make_entity_id(crate::partition::USER_PARTITION, 0);
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
@@ -558,7 +558,7 @@ mod tests {
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Count EAV entries in USER_PARTITION (should be 2: name + age)
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let user_base = crate::partition::make_entity_id(crate::partition::USER_PARTITION, 0);
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut eav_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -737,7 +737,7 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find the auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let user_base = crate::partition::make_entity_id(crate::partition::USER_PARTITION, 0);
         let mut entity_id: i64 = 0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
@@ -799,7 +799,7 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let user_base = crate::partition::make_entity_id(crate::partition::USER_PARTITION, 0);
         let mut entity_id: i64 = 0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 /// Entity ID bit layout (from PARTITIONS.md):
 ///
 /// ```text
-///  63  62   61                    42  41                              0
-/// +----+----+---------------------+---+-------------------------------+
-/// | S  | 0  | partition (20 bits) |          counter (42 bits)        |
-/// +----+----+---------------------+---+-------------------------------+
+///  63  62   61                  44  43                                0
+/// +----+----+-------------------+---+---------------------------------+
+/// | S  | 0  | partition (18 b)  |          counter (44 bits)          |
+/// +----+----+-------------------+---+---------------------------------+
 /// ```
 
-pub const COUNTER_BITS: u32 = 42;
-pub const COUNTER_MASK: i64 = (1i64 << 42) - 1;
-pub const PARTITION_MASK: i64 = ((1i64 << 20) - 1) << 42;
+pub const COUNTER_BITS: u32 = 44;
+pub const COUNTER_MASK: i64 = (1i64 << 44) - 1;
+pub const PARTITION_MASK: i64 = ((1i64 << 18) - 1) << 44;
 
 pub const DB_PARTITION: u32 = 0;
 pub const TX_PARTITION: u32 = 1;
@@ -21,17 +21,17 @@ pub const USER_PARTITION: u32 = 2;
 ///
 /// For partition 0, the result equals the counter (small, readable IDs).
 pub fn make_entity_id(partition: u32, counter: i64) -> i64 {
-    assert!(partition < (1 << 20), "partition must fit in 20 bits");
-    assert!(counter >= 0 && counter <= COUNTER_MASK, "counter must fit in 42 bits");
+    assert!(partition < (1 << 18), "partition must fit in 18 bits");
+    assert!(counter >= 0 && counter <= COUNTER_MASK, "counter must fit in 44 bits");
     ((partition as i64) << COUNTER_BITS) | counter
 }
 
-/// Extract the partition number (bits 61–42) from an entity ID.
+/// Extract the partition number (bits 61–44) from an entity ID.
 pub fn extract_partition(eid: i64) -> u32 {
     ((eid & PARTITION_MASK) >> COUNTER_BITS) as u32
 }
 
-/// Extract the counter value (bits 41–0) from an entity ID.
+/// Extract the counter value (bits 43–0) from an entity ID.
 pub fn extract_counter(eid: i64) -> i64 {
     eid & COUNTER_MASK
 }
@@ -127,7 +127,7 @@ mod tests {
         let eid = make_entity_id(TX_PARTITION, 100);
         assert_eq!(extract_partition(eid), TX_PARTITION);
         assert_eq!(extract_counter(eid), 100);
-        assert_eq!(eid, (1i64 << 42) | 100);
+        assert_eq!(eid, (1i64 << 44) | 100);
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod tests {
         let eid = make_entity_id(USER_PARTITION, 500);
         assert_eq!(extract_partition(eid), USER_PARTITION);
         assert_eq!(extract_counter(eid), 500);
-        assert_eq!(eid, (2i64 << 42) | 500);
+        assert_eq!(eid, (2i64 << 44) | 500);
     }
 
     #[test]
@@ -149,19 +149,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "partition must fit in 20 bits")]
+    #[should_panic(expected = "partition must fit in 18 bits")]
     fn test_partition_overflow() {
-        make_entity_id(1 << 20, 0);
+        make_entity_id(1 << 18, 0);
     }
 
     #[test]
-    #[should_panic(expected = "counter must fit in 42 bits")]
+    #[should_panic(expected = "counter must fit in 44 bits")]
     fn test_counter_overflow() {
         make_entity_id(0, COUNTER_MASK + 1);
     }
 
     #[test]
-    #[should_panic(expected = "counter must fit in 42 bits")]
+    #[should_panic(expected = "counter must fit in 44 bits")]
     fn test_counter_negative() {
         make_entity_id(0, -1);
     }


### PR DESCRIPTION
## Summary
- Shrink partition field from 20 to 18 bits, expand counter from 42 to 44 bits
- Sign(1) + reserved(1) + partition(18) = 20-bit prefix, giving clean 5-byte alignment in encoded entity IDs
- Updated design doc, `partition.rs` constants/tests, and hardcoded `<< 42` values in `indexer.rs` tests

## Test plan
- [x] All 386 tests pass (`cargo test`)
- [x] Partition round-trip, overflow, and non-overlapping tests updated and passing
- [x] Indexer tests use `make_entity_id()` instead of hardcoded shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)