### PR TITLE
refactor: switch i64/i128 encoding to descending byte order

### DIFF
--- a/design/ENCODING.md
+++ b/design/ENCODING.md
@@ -102,22 +102,22 @@ All encodings guarantee: `memcmp(encode(a), encode(b))` equals `DataType::partia
 
 ### 3.1 Signed Integers: `i64`, `i128`
 
-XOR sign bit, then big-endian bytes.
+XOR all value bits, then big-endian bytes. This produces **descending** byte order (largest values sort first).
 
 ```
-i64:  encoded = (value ^ 0x8000_0000_0000_0000).to_be_bytes()        // 8 bytes
-i128: encoded = (value ^ (1_i128 << 127)).to_be_bytes()              // 16 bytes
+i64:  encoded = (value ^ 0x7FFF_FFFF_FFFF_FFFF).to_be_bytes()       // 8 bytes
+i128: encoded = (value ^ i128::MAX).to_be_bytes()                    // 16 bytes
 ```
 
-XORing the sign bit maps the signed range `[MIN, MAX]` to the unsigned range `[0, UMAX]`, preserving order. Big-endian ensures the most significant byte is compared first.
+XORing with `MAX` flips all bits except the sign bit, mapping the signed range `[MIN, MAX]` to the unsigned range `[UMAX, 0]` — reversing byte order. Big-endian ensures the most significant byte is compared first.
 
 | Value         | Encoded (hex)              |
 |---------------|----------------------------|
-| `i64::MIN`    | `00 00 00 00 00 00 00 00`  |
-| `-1`          | `7F FF FF FF FF FF FF FF`  |
-| `0`           | `80 00 00 00 00 00 00 00`  |
-| `1`           | `80 00 00 00 00 00 00 01`  |
-| `i64::MAX`    | `FF FF FF FF FF FF FF FF`  |
+| `i64::MIN`    | `FF FF FF FF FF FF FF FF`  |
+| `-1`          | `80 00 00 00 00 00 00 00`  |
+| `0`           | `7F FF FF FF FF FF FF FF`  |
+| `1`           | `7F FF FF FF FF FF FF FE`  |
+| `i64::MAX`    | `00 00 00 00 00 00 00 00`  |
 
 **Size**: i64 = 8 bytes. i128 = 16 bytes.
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -29,7 +29,7 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
             .expect("Failed to scan EAV partition prefix");
 
         if let Some(kv) = iter.next().await.expect("Failed to read EAV key") {
-            let mut cursor: &[u8] = &kv.key[1..1 + codec::ENTITY_LENGTH];
+            let mut cursor: &[u8] = &kv.key[codec::CODEC_LENGTH..codec::CODEC_LENGTH + codec::ENTITY_LENGTH];
             let eid = match codec::decode_datatype(&mut cursor).expect("Failed to decode entity ID from EAV key") {
                 crate::ops::DataType::Long(id) => id,
                 other => panic!("Expected Long entity ID in EAV key, got {:?}", other),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -4,7 +4,7 @@ use crate::clock::{self, st_from_unix_epoch};
 use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::ops::tx_ops_to_datoms;
-use crate::partition::{PartitionCounters, extract_counter};
+use crate::partition::{PartitionCounters, extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION};
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
@@ -20,8 +20,6 @@ const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 /// With descending encoding, the first entity per partition has the highest counter.
 /// The DB_PARTITION counter is clamped to at least DB_PARTITION_COUNTER_FLOOR.
 pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
-    use crate::partition::{DB_PARTITION, TX_PARTITION, USER_PARTITION, partition_entity_prefix};
-
     let mut counters = PartitionCounters::new();
     for partition in [DB_PARTITION, TX_PARTITION, USER_PARTITION] {
         let prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(partition)]);

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -4,7 +4,7 @@ use crate::clock::{self, st_from_unix_epoch};
 use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::ops::tx_ops_to_datoms;
-use crate::partition::{PartitionCounters, extract_partition, extract_counter};
+use crate::partition::{PartitionCounters, extract_counter};
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
@@ -16,29 +16,29 @@ const META_KEY_VERSION: &[u8] = b"version";
 /// leaving room below for future bootstrap entities.
 const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 
-/// Scan all EAV keys and return per-partition counters (max counter + 1 for each partition).
+/// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
+/// With descending encoding, the first entity per partition has the highest counter.
 /// The DB_PARTITION counter is clamped to at least DB_PARTITION_COUNTER_FLOOR.
 pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
-    let mut counters = PartitionCounters::new();
-    let mut iter = slatedb
-        .scan_prefix_with_options(&[codec::EAV], &DEFAULT_SCAN_OPTIONS)
-        .await
-        .expect("Failed to scan EAV index");
+    use crate::partition::{DB_PARTITION, TX_PARTITION, USER_PARTITION, partition_entity_prefix};
 
-    while let Some(kv) = iter.next().await.expect("Failed to read EAV key") {
-        // EAV key: [EAV:1] [entity_id:ENTITY_LENGTH] ...
-        let mut cursor: &[u8] = &kv.key[1..1 + codec::ENTITY_LENGTH];
-        let eid = match codec::decode_datatype(&mut cursor).expect("Failed to decode entity ID from EAV key") {
-            crate::ops::DataType::Long(id) => id,
-            other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
-        };
-        let partition = extract_partition(eid);
-        // Descending encoding: first entity per partition has the highest counter.
-        if counters.contains_key(&partition) {
-            continue;
+    let mut counters = PartitionCounters::new();
+    for partition in [DB_PARTITION, TX_PARTITION, USER_PARTITION] {
+        let prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(partition)]);
+        let mut iter = slatedb
+            .scan_prefix_with_options(&prefix, &DEFAULT_SCAN_OPTIONS)
+            .await
+            .expect("Failed to scan EAV partition prefix");
+
+        if let Some(kv) = iter.next().await.expect("Failed to read EAV key") {
+            let mut cursor: &[u8] = &kv.key[1..1 + codec::ENTITY_LENGTH];
+            let eid = match codec::decode_datatype(&mut cursor).expect("Failed to decode entity ID from EAV key") {
+                crate::ops::DataType::Long(id) => id,
+                other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
+            };
+            let counter = extract_counter(eid);
+            counters.insert(partition, counter + 1);
         }
-        let counter = extract_counter(eid);
-        counters.insert(partition, counter + 1);
     }
 
     // Reserve space for future bootstrap entities (only if DB_PARTITION has entries)

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -33,11 +33,12 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
             other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
         };
         let partition = extract_partition(eid);
-        let counter = extract_counter(eid);
-        let entry = counters.entry(partition).or_insert(0);
-        if counter + 1 > *entry {
-            *entry = counter + 1;
+        // Descending encoding: first entity per partition has the highest counter.
+        if counters.contains_key(&partition) {
+            continue;
         }
+        let counter = extract_counter(eid);
+        counters.insert(partition, counter + 1);
     }
 
     // Reserve space for future bootstrap entities (only if DB_PARTITION has entries)

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -110,7 +110,7 @@ pub fn encode_i64(value: i64, buf: &mut Vec<u8>) {
 }
 
 pub fn encode_i64_bytes(value: i64) -> [u8; 8] {
-    (value ^ i64::MIN).to_be_bytes()
+    (value ^ i64::MAX).to_be_bytes()
 }
 
 pub fn decode_i64(cursor: &mut &[u8]) -> Result<i64, DecodeError> {
@@ -119,11 +119,11 @@ pub fn decode_i64(cursor: &mut &[u8]) -> Result<i64, DecodeError> {
     }
     let bytes: [u8; 8] = cursor[..8].try_into().unwrap();
     *cursor = &cursor[8..];
-    Ok(i64::from_be_bytes(bytes) ^ i64::MIN)
+    Ok(i64::from_be_bytes(bytes) ^ i64::MAX)
 }
 
 pub fn encode_i128(value: i128, buf: &mut Vec<u8>) {
-    let encoded = (value ^ i128::MIN).to_be_bytes();
+    let encoded = (value ^ i128::MAX).to_be_bytes();
     buf.extend_from_slice(&encoded);
 }
 
@@ -133,7 +133,7 @@ pub fn decode_i128(cursor: &mut &[u8]) -> Result<i128, DecodeError> {
     }
     let bytes: [u8; 16] = cursor[..16].try_into().unwrap();
     *cursor = &cursor[16..];
-    Ok(i128::from_be_bytes(bytes) ^ i128::MIN)
+    Ok(i128::from_be_bytes(bytes) ^ i128::MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -564,11 +564,11 @@ mod tests {
     #[test]
     fn i64_encoding_table() {
         let cases: Vec<(i64, Vec<u8>)> = vec![
-            (i64::MIN, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-            (-1, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
-            (0, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-            (1, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
-            (i64::MAX, vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (i64::MIN, vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (-1, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            (0, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (1, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE]),
+            (i64::MAX, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         ];
         for (value, expected) in cases {
             let mut buf = Vec::new();
@@ -826,8 +826,8 @@ mod tests {
             encode_i64(window[0], &mut a_buf);
             encode_i64(window[1], &mut b_buf);
             assert!(
-                a_buf < b_buf,
-                "{} should encode before {}",
+                a_buf > b_buf,
+                "{} should encode after {}",
                 window[0],
                 window[1]
             );
@@ -842,7 +842,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_i128(window[0], &mut a_buf);
             encode_i128(window[1], &mut b_buf);
-            assert!(a_buf < b_buf);
+            assert!(a_buf > b_buf);
         }
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -84,24 +84,26 @@ pub(crate) fn write_index_entries(
 /// TODO(triplox-8mc): Return Option<TxKey> (None for empty DB) instead of a
 /// sentinel. Needs coordination with the bootstrap transaction (tx_id=0).
 ///
-/// TODO: Use a reverse iterator for O(1) lookup once SlateDB supports reverse scanning.
+/// With descending entity encoding, the first TX_PARTITION entity is the latest.
 pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
     let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
-    let mut latest: Option<(i64, Instant)> = None;
-    // TODO This should scan for the largest entity id and then extract the db/txId attribute
+    let mut first_entity: Option<DataType> = None;
+    let mut result: Option<(i64, Instant)> = None;
     while let Some(kv) = iter.next().await? {
-        let (_entity_id, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
-        if attribute != crate::schema::DB_TX_ID {
-            continue;
+        let (entity_id, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
+        match &first_entity {
+            None => first_entity = Some(entity_id),
+            Some(eid) if *eid != entity_id => break,
+            _ => {}
         }
-        if let DataType::Long(tx_id) = value {
-            if latest.as_ref().map_or(true, |(best_id, _)| tx_id > *best_id) {
-                latest = Some((tx_id, timestamp));
+        if attribute == crate::schema::DB_TX_ID {
+            if let DataType::Long(tx_id) = value {
+                result = Some((tx_id, timestamp));
             }
         }
     }
-    Ok(latest.map(|(tx_id, system_time)| TxKey {
+    Ok(result.map(|(tx_id, system_time)| TxKey {
         tx_id,
         system_time,
     }).unwrap_or_else(|| TxKey {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use slatedb::Db;
 use slatedb::IsolationLevel;
-use anyhow::{Error, Result};
+use anyhow::{bail, Error, Result};
 use bincode;
 use bytes::Bytes;
 use tokio::sync::broadcast;
@@ -88,13 +88,17 @@ pub(crate) fn write_index_entries(
 pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
     let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
-    let mut first_entity: Option<DataType> = None;
+    let mut first_eid: Option<i64> = None;
     let mut result: Option<(i64, Instant)> = None;
     while let Some(kv) = iter.next().await? {
-        let (entity_id, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
-        match &first_entity {
-            None => first_entity = Some(entity_id),
-            Some(eid) if *eid != entity_id => break,
+        let (entity_dt, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
+        let eid = match entity_dt {
+            DataType::Long(id) => id,
+            other => bail!("Expected Long entity ID in EAV key, got {:?}", other),
+        };
+        match first_eid {
+            None => first_eid = Some(eid),
+            Some(first) if first != eid => break,
             _ => {}
         }
         if attribute == crate::schema::DB_TX_ID {

--- a/src/iterator/generic_predicate_prefix_extender.rs
+++ b/src/iterator/generic_predicate_prefix_extender.rs
@@ -264,11 +264,11 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(
             DataType::decode(&result[0][0]).unwrap(),
-            DataType::Long(10)
+            DataType::Long(20)
         );
         assert_eq!(
             DataType::decode(&result[1][0]).unwrap(),
-            DataType::Long(20)
+            DataType::Long(10)
         );
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -26,7 +26,7 @@ pub const USER_PARTITION: u32 = 2;
 /// encoding of the partition's base entity ID (`make_entity_id(partition, 0)`),
 /// truncated to the 3 bytes that carry the partition bits.
 ///
-/// For TX_PARTITION this produces `[7, 0x80, 0x00, 0x04]`.
+/// For TX_PARTITION this produces `[7, 0x7F, 0xFF, 0xFB]`.
 ///
 /// **Note**: the partition/counter boundary (bit 42) is not byte-aligned, so
 /// byte 2 contains both partition bits (47–42) and counter bits (41–40). The


### PR DESCRIPTION
## Summary
- Switch i64/i128 encoding from `value ^ MIN` (ascending) to `value ^ MAX` (descending) so largest entity IDs sort first in index scans
- Simplify `latest_tx_key_from_snapshot` to O(1) — first TX_PARTITION entity is the latest
- Simplify `scan_partition_counters` — first entity per partition has the highest counter

## Test plan
- [x] All 369 existing tests pass (`cargo test`)
- [x] Updated codec encoding table, i64 order, and i128 order tests
- [x] Fixed predicate extender test for reversed sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)