### PR TITLE
refactor: replace timestamp with tx_eid in index T position

### DIFF
--- a/design/COVERING_INDICES.md
+++ b/design/COVERING_INDICES.md
@@ -1,15 +1,15 @@
 # Covering Indices
 
-Triplox uses Datomic-style covering indices that encode the transaction time in
-every key. Each assertion and retraction produces a distinct key, so the full
-history of every triple is available directly from the indices — no transaction
-log replay is needed for temporal queries.
+Triplox uses Datomic-style covering indices that encode the transaction entity
+ID (tx_eid) in every key. Each assertion and retraction produces a distinct key,
+so the full history of every triple is available directly from the indices — no
+transaction log replay is needed for temporal queries.
 
 ## Index Key Layouts
 
 Five indices are maintained. The three **full indices** (EAVT, AVET, AEVT)
-contain all components of the (E, A, V) triple plus the transaction time T and
-an operation flag. The two **partial indices** (AE, AV) omit one triple
+contain all components of the (E, A, V) triple plus the transaction entity ID T
+and an operation flag. The two **partial indices** (AE, AV) omit one triple
 component and are atemporal — they carry neither T nor op.
 
 | Index | Key components |
@@ -20,8 +20,9 @@ component and are atemporal — they carry neither T nor op.
 | AE    | A, E           |
 | AV    | A, V           |
 
-- **T** is stored in descending order so that **newest transactions sort first**
-  within each logical key group.
+- **T** is the transaction entity ID (tx_eid), stored using descending i64
+  encoding so that **newest transactions sort first** within each logical key
+  group. This uses the same encoding as entity IDs in the E position.
 - **op** is a flag: *added* or *retracted*.
 
 See `ENCODING.md` for byte-level encoding details.
@@ -125,7 +126,7 @@ and `v3` over its lifetime.
 (E2, A1, V1, ...)
 ```
 
-When iterating over these values only one of them will be an assertion on the latest valid timestamp.
+When iterating over these values only one of them will be an assertion at the latest valid transaction.
 The remaining ones will be retractions. So even if we iterate over these values in the joins, in an `as-of`
 query only one value will appear. A similar pattern holds for the other indices (forgetting partial indices AV/AE).
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use slatedb::{Db, IsolationLevel};
-use crate::clock::{self, st_from_unix_epoch};
 use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::ops::tx_ops_to_datoms;
@@ -69,12 +68,12 @@ pub async fn init_db(slatedb: Arc<Db>) -> (SchemaCache, PartitionCounters) {
         None => {
             // Fresh DB — bootstrap schema (ops have explicit db/id values)
             let tx_ops = bootstrap_schema_tx();
-            let datoms = tx_ops_to_datoms(&tx_ops, st_from_unix_epoch(0)).unwrap();
+            let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
             let mut cache = SchemaCache::new();
             cache.process_tx(SchemaCache::validate_schema_attrs(&datoms).unwrap());
 
             let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();
-            write_index_entries(&txn, &datoms, &cache, clock::st_from_unix_epoch(0)).unwrap();
+            write_index_entries(&txn, &datoms, &cache, 0_i64).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&version_key, version.as_bytes()).unwrap();

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -29,7 +29,7 @@ pub const CODEC_LENGTH: usize = 1;
 pub const ENTITY_LENGTH: usize = 9;
 pub const ATTRIBUTE_LENGTH: usize = 8;
 pub const OP_LENGTH: usize = 1;
-pub const TIMESTAMP_LENGTH: usize = 8;
+pub const TX_EID_LENGTH: usize = 8;
 
 pub const EAV: u8 = 0;
 pub const AVE: u8 = 1;
@@ -44,8 +44,8 @@ pub const ADD: u8 = 0;
 pub const DELETE: u8 = 1;
 pub const RETRACT: u8 = 2;
 
-/// Suffix length: timestamp (8 bytes) + op (1 byte), used for end-of-key extraction.
-pub const TIMESTAMP_OP_SUFFIX: usize = TIMESTAMP_LENGTH + OP_LENGTH;
+/// Suffix length: tx_eid (8 bytes) + op (1 byte), used for end-of-key extraction.
+pub const TX_EID_OP_SUFFIX: usize = TX_EID_LENGTH + OP_LENGTH;
 
 // TODO move this to lazy_static
 pub fn index_type_to_prefix(index_type: IndexType) -> Result<u8, Error> {
@@ -1055,23 +1055,3 @@ mod tests {
     }
 }
 
-/// Encode a timestamp as inverted big-endian i64 microseconds for index keys.
-/// Inverted so that newer timestamps sort first in ascending byte order.
-/// Note: this differs from `encode_instant` which uses standard (non-inverted)
-/// order-preserving encoding for DataType::Instant values.
-pub fn encode_timestamp(t: Instant) -> [u8; 8] {
-    let micros = t.timestamp_micros();
-    (!micros).to_be_bytes()
-}
-
-/// Decode an inverted big-endian timestamp back to an Instant.
-pub fn decode_timestamp(bytes: &[u8]) -> Result<Instant, Error> {
-    let arr: [u8; 8] = bytes
-        .try_into()
-        .map_err(|_| anyhow::anyhow!("timestamp must be exactly 8 bytes, got {}", bytes.len()))?;
-    let inverted = i64::from_be_bytes(arr);
-    let micros = !inverted;
-    chrono::TimeZone::timestamp_micros(&chrono::Utc, micros)
-        .single()
-        .ok_or_else(|| anyhow::anyhow!("ambiguous or invalid timestamp: {} micros", micros))
-}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -20,7 +20,6 @@ use crate::transaction::TxKey;
 use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
-use crate::clock::Instant;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
@@ -35,9 +34,9 @@ pub(crate) fn write_index_entries(
     txn: &slatedb::DbTransaction,
     datoms: &[Datom],
     schema_cache: &SchemaCache,
-    system_time: Instant,
+    tx_eid: i64,
 ) -> Result<(), Error> {
-    let timestamp = codec::encode_timestamp(system_time);
+    let tx_eid_bytes = encode_i64_bytes(tx_eid);
 
     for datom in datoms {
         // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
@@ -55,12 +54,12 @@ pub(crate) fn write_index_entries(
             DatomOp::Retract => codec::RETRACT,
         };
 
-        // Temporal indices include timestamp + op
+        // Temporal indices include tx_eid + op
         // TODO(triplox-7fl): concat_bytes allocates intermediate Vecs per component;
         // encoding directly into a single buffer would be faster.
-        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &timestamp, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &timestamp, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &timestamp, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &tx_eid_bytes, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
@@ -73,25 +72,26 @@ pub(crate) fn write_index_entries(
     Ok(())
 }
 
-/// Scan EAV entries for TX_PARTITION entities and return the TxKey for the highest tx_id.
-/// If no transaction entities exist, returns a sentinel TxKey (tx_id=0, system_time=epoch).
+/// Scan EAV entries for TX_PARTITION entities and return (tx_eid, TxKey) for the latest tx.
+/// If no transaction entities exist, returns a sentinel (0, TxKey{tx_id=0, system_time=epoch}).
 ///
 /// Uses the high bits of TX_PARTITION entity IDs to build a targeted EAV prefix,
-/// restricting the scan to TX_PARTITION entities. For each entry with attribute
-/// `db/txId`, the tx_id is extracted from the value and system_time from the key's
-/// timestamp suffix.
+/// restricting the scan to TX_PARTITION entities. With descending entity encoding,
+/// the first TX_PARTITION entity is the latest.
 ///
-/// TODO(triplox-8mc): Return Option<TxKey> (None for empty DB) instead of a
-/// sentinel. Needs coordination with the bootstrap transaction (tx_id=0).
+/// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
+/// system_time from `db/txInstant` value.
 ///
-/// With descending entity encoding, the first TX_PARTITION entity is the latest.
-pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxKey> {
+/// TODO(triplox-8mc): Return Option instead of sentinel. Needs coordination with
+/// the bootstrap transaction (tx_id=0).
+pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<(i64, TxKey)> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
     let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     let mut first_eid: Option<i64> = None;
-    let mut result: Option<(i64, Instant)> = None;
+    let mut tx_id: Option<i64> = None;
+    let mut system_time: Option<crate::clock::Instant> = None;
     while let Some(kv) = iter.next().await? {
-        let (entity_dt, attribute, value, timestamp, _op) = eav_key_to_parts(kv.key)?;
+        let (entity_dt, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
         let eid = match entity_dt {
             DataType::Long(id) => id,
             other => bail!("Expected Long entity ID in EAV key, got {:?}", other),
@@ -102,28 +102,59 @@ pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) ->
             _ => {}
         }
         if attribute == crate::schema::DB_TX_ID {
-            if let DataType::Long(tx_id) = value {
-                result = Some((tx_id, timestamp));
+            if let DataType::Long(id) = value {
+                tx_id = Some(id);
+            }
+        }
+        if attribute == crate::schema::DB_TX_INSTANT {
+            if let DataType::Instant(st) = value {
+                system_time = Some(st);
             }
         }
     }
-    Ok(result.map(|(tx_id, system_time)| TxKey {
-        tx_id,
-        system_time,
-    }).unwrap_or_else(|| TxKey {
-        tx_id: 0,
-        system_time: crate::clock::st_from_unix_epoch(0),
-    }))
+    match (first_eid, tx_id, system_time) {
+        (Some(eid), Some(tid), Some(st)) => Ok((eid, TxKey { tx_id: tid, system_time: st })),
+        _ => Ok((0, TxKey {
+            tx_id: 0,
+            system_time: crate::clock::st_from_unix_epoch(0),
+        })),
+    }
+}
+
+/// Look up the tx_eid for a given TxKey by scanning TX_PARTITION entities
+/// for one with matching `db/txId`.
+pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxKey) -> Result<i64> {
+    let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
+    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+    let mut current_eid: Option<i64> = None;
+    while let Some(kv) = iter.next().await? {
+        let (entity_dt, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
+        let eid = match entity_dt {
+            DataType::Long(id) => id,
+            other => bail!("Expected Long entity ID in EAV key, got {:?}", other),
+        };
+        if current_eid != Some(eid) {
+            current_eid = Some(eid);
+        }
+        if attribute == crate::schema::DB_TX_ID {
+            if let DataType::Long(id) = value {
+                if id == tx_key.tx_id {
+                    return Ok(eid);
+                }
+            }
+        }
+    }
+    bail!("No tx entity found for tx_id={}", tx_key.tx_id)
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.
+/// The `tx_eid` is the pre-allocated entity ID for this transaction.
 fn build_tx_entity_datoms(
-    counters: &mut PartitionCounters,
+    tx_eid: i64,
     tx_key: TxKey,
     committed: bool,
     error: Option<String>,
 ) -> Vec<Datom> {
-    let tx_eid = make_entity_id(TX_PARTITION, allocate_counter(counters, TX_PARTITION));
     let st = tx_key.system_time;
     let result_kw = if committed {
         Keyword::namespaced("db.tx", "committed")
@@ -131,12 +162,12 @@ fn build_tx_entity_datoms(
         Keyword::namespaced("db.tx", "aborted")
     };
     let mut datoms = vec![
-        Datom { entity: tx_eid, attribute: "db/txInstant".into(), value: DataType::Instant(st), tx: st, op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: "db/txId".into(), value: DataType::Long(tx_key.tx_id), tx: st, op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: "db/txResult".into(), value: DataType::Keyword(result_kw), tx: st, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: "db/txInstant".into(), value: DataType::Instant(st), tx: tx_eid, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: "db/txId".into(), value: DataType::Long(tx_key.tx_id), tx: tx_eid, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: "db/txResult".into(), value: DataType::Keyword(result_kw), tx: tx_eid, op: DatomOp::Assert },
     ];
     if let Some(err) = error {
-        datoms.push(Datom { entity: tx_eid, attribute: "db.tx/error".into(), value: DataType::String(err), tx: st, op: DatomOp::Assert });
+        datoms.push(Datom { entity: tx_eid, attribute: "db.tx/error".into(), value: DataType::String(err), tx: tx_eid, op: DatomOp::Assert });
     }
     datoms
 }
@@ -179,10 +210,13 @@ impl Indexer {
         // Use a temporary copy of counters; only persist advances after successful commit.
         let mut pending_counters = self.counters.clone();
         let resolved_ops = resolve_entity_ids(&tx_ops, &mut pending_counters)?;
-        let mut datoms = tx_ops_to_datoms(&resolved_ops, tx_key.system_time)?;
+
+        // Allocate tx_eid early so it can be used in both user datoms and tx entity datoms
+        let tx_eid = make_entity_id(TX_PARTITION, allocate_counter(&mut pending_counters, TX_PARTITION));
+        let mut datoms = tx_ops_to_datoms(&resolved_ops, tx_eid)?;
 
         // Build first-class transaction entity in TX_PARTITION
-        let tx_entity_datoms = build_tx_entity_datoms(&mut pending_counters, tx_key, true, None);
+        let tx_entity_datoms = build_tx_entity_datoms(tx_eid, tx_key, true, None);
         datoms.extend(tx_entity_datoms);
 
         let new_schema_attrs = self.schema_cache.validate_tx(&datoms)?;
@@ -193,7 +227,7 @@ impl Indexer {
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
-        let as_of_encoded = codec::encode_timestamp(tx_key.system_time);
+        let as_of_encoded = encode_i64_bytes(tx_eid);
         let mut resolved_datoms: HashSet<Datom> = HashSet::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
@@ -225,7 +259,7 @@ impl Indexer {
             while let Some(kv) = iter.next().await? {
                 let key = &kv.key;
                 assert!(
-                    key.len() >= codec::TIMESTAMP_OP_SUFFIX,
+                    key.len() >= codec::TX_EID_OP_SUFFIX,
                     "Key too short ({} bytes) to contain timestamp + op suffix",
                     key.len()
                 );
@@ -235,7 +269,7 @@ impl Indexer {
                         break;
                     }
                     Some(_) => {
-                        let value_bytes = &key[eav_prefix.len()..key.len() - codec::TIMESTAMP_OP_SUFFIX];
+                        let value_bytes = &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
                         let mut cursor = value_bytes;
                         let value: DataType = decode_datatype(&mut cursor)?;
                         old_value = Some(value);
@@ -263,7 +297,7 @@ impl Indexer {
         }
         let datoms: Vec<Datom> = resolved_datoms.into_iter().collect();
 
-        write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
+        write_index_entries(&txn, &datoms, &self.schema_cache, tx_eid)?;
 
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
 
@@ -307,9 +341,10 @@ impl Indexer {
     /// Write an aborted transaction entity (no user data) when transact_tx fails.
     async fn write_aborted_tx(&mut self, tx_key: TxKey, error: String) -> Result<(), Error> {
         let mut pending_counters = self.counters.clone();
-        let datoms = build_tx_entity_datoms(&mut pending_counters, tx_key, false, Some(error));
+        let tx_eid = make_entity_id(TX_PARTITION, allocate_counter(&mut pending_counters, TX_PARTITION));
+        let datoms = build_tx_entity_datoms(tx_eid, tx_key, false, Some(error));
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
-        write_index_entries(&txn, &datoms, &self.schema_cache, tx_key.system_time)?;
+        write_index_entries(&txn, &datoms, &self.schema_cache, tx_eid)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
         self.counters = pending_counters;
         self.latest_indexed_tx = Some(tx_key);
@@ -385,18 +420,19 @@ impl Subscriber for Indexer {
     }
 }
 
-/// Strip a temporal index key into (data_bytes, timestamp, op).
-fn strip_temporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<(&'a [u8], Instant, u8), Error> {
+/// Strip a temporal index key into (data_bytes, tx_eid, op).
+fn strip_temporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<(&'a [u8], i64, u8), Error> {
     if key.first() != Some(&expected_prefix) {
         return Err(anyhow::anyhow!("Not a {} key", name));
     }
-    if key.len() < 1 + codec::TIMESTAMP_OP_SUFFIX {
+    if key.len() < 1 + codec::TX_EID_OP_SUFFIX {
         return Err(anyhow::anyhow!("Key too short"));
     }
-    let data = &key[1..key.len() - codec::TIMESTAMP_OP_SUFFIX];
-    let timestamp = codec::decode_timestamp(&key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH])?;
+    let data = &key[1..key.len() - codec::TX_EID_OP_SUFFIX];
+    let mut cursor = &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH];
+    let tx_eid = decode_i64(&mut cursor)?;
     let op = key[key.len() - 1];
-    Ok((data, timestamp, op))
+    Ok((data, tx_eid, op))
 }
 
 /// Strip an atemporal index key, returning data bytes after the prefix.
@@ -410,31 +446,31 @@ fn strip_atemporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Re
     Ok(&key[1..])
 }
 
-pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, Instant, u8), Error> {
-    let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::EAV, "EAV")?;
+pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, i64, u8), Error> {
+    let (data, tx_eid, op) = strip_temporal_key(key.as_ref(), codec::EAV, "EAV")?;
     let mut cursor = data;
     let entity_id = decode_datatype(&mut cursor)?;
     let attribute = decode_i64(&mut cursor)?;
     let value = decode_datatype(&mut cursor)?;
-    Ok((entity_id, attribute, value, timestamp, op))
+    Ok((entity_id, attribute, value, tx_eid, op))
 }
 
-pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
-    let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::AVE, "AVE")?;
+pub fn ave_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, i64, u8), Error> {
+    let (data, tx_eid, op) = strip_temporal_key(key.as_ref(), codec::AVE, "AVE")?;
     let mut cursor = data;
     let attribute = decode_i64(&mut cursor)?;
     let value = decode_datatype(&mut cursor)?;
     let entity_id = decode_datatype(&mut cursor)?;
-    Ok((attribute, value, entity_id, timestamp, op))
+    Ok((attribute, value, entity_id, tx_eid, op))
 }
 
-pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, Instant, u8), Error> {
-    let (data, timestamp, op) = strip_temporal_key(key.as_ref(), codec::AEV, "AEV")?;
+pub fn aev_key_to_parts(key: Bytes) -> Result<(i64, DataType, DataType, i64, u8), Error> {
+    let (data, tx_eid, op) = strip_temporal_key(key.as_ref(), codec::AEV, "AEV")?;
     let mut cursor = data;
     let attribute = decode_i64(&mut cursor)?;
     let entity_id = decode_datatype(&mut cursor)?;
     let value = decode_datatype(&mut cursor)?;
-    Ok((attribute, entity_id, value, timestamp, op))
+    Ok((attribute, entity_id, value, tx_eid, op))
 }
 
 pub fn ae_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
@@ -458,7 +494,7 @@ mod tests {
     use std::collections::BTreeMap;
     use slatedb::{Db, config::ScanOptions};
 
-    use crate::clock::st_from_unix_epoch;
+    use crate::clock::{st_from_unix_epoch, Instant};
     use crate::schema::test_schema_tx;
     use crate::slate::in_memory_slate;
     use super::*;
@@ -579,9 +615,10 @@ mod tests {
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
-        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        let (tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 42);
         assert_eq!(latest.system_time, st_from_unix_epoch(1000));
+        assert!(tx_eid > 0, "tx_eid should be a valid entity ID");
         Ok(())
     }
 
@@ -589,8 +626,9 @@ mod tests {
     async fn test_latest_tx_key_empty_db() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let snapshot = Arc::new(slate.snapshot().await?);
-        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        let (tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 0, "Should return sentinel for empty DB");
+        assert_eq!(tx_eid, 0, "Should return sentinel tx_eid for empty DB");
         Ok(())
     }
 
@@ -609,7 +647,7 @@ mod tests {
         }
 
         let snapshot = Arc::new(slate.snapshot().await?);
-        let latest = latest_tx_key_from_snapshot(&snapshot).await?;
+        let (_tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 3, "Should return highest tx_id");
         assert_eq!(latest.system_time, st_from_unix_epoch(300));
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -121,30 +121,25 @@ pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) ->
     }
 }
 
-/// Look up the tx_eid for a given TxKey by scanning TX_PARTITION entities
-/// for one with matching `db/txId`.
+/// Look up the tx_eid for a given TxKey using the AVE index.
+/// AVE key layout: [AVE][attribute][value][entity_id][tx_eid][op]
+/// We build a prefix for (db/txId, tx_key.tx_id) and extract the entity from the first match.
 pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxKey) -> Result<i64> {
-    let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
-    let mut current_eid: Option<i64> = None;
-    while let Some(kv) = iter.next().await? {
-        let (entity_dt, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
-        let eid = match entity_dt {
-            DataType::Long(id) => id,
-            other => bail!("Expected Long entity ID in EAV key, got {:?}", other),
-        };
-        if current_eid != Some(eid) {
-            current_eid = Some(eid);
-        }
-        if attribute == crate::schema::DB_TX_ID {
-            if let DataType::Long(id) = value {
-                if id == tx_key.tx_id {
-                    return Ok(eid);
-                }
+    let attr_bytes = encode_i64_bytes(crate::schema::DB_TX_ID);
+    let mut value_bytes = Vec::new();
+    codec::encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_bytes);
+    let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
+    let mut iter = snapshot.scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+    match iter.next().await? {
+        Some(kv) => {
+            let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
+            match entity_dt {
+                DataType::Long(eid) => Ok(eid),
+                other => bail!("Expected Long entity ID in AVE key, got {:?}", other),
             }
         }
+        None => bail!("No tx entity found for tx_id={}", tx_key.tx_id),
     }
-    bail!("No tx entity found for tx_id={}", tx_key.tx_id)
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -138,6 +138,9 @@ pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxK
                 other => bail!("Expected Long entity ID in AVE key, got {:?}", other),
             }
         }
+        // TODO: the caller (db_as_of) should wait for the transaction to be
+        // indexed before calling this function, so this case shouldn't happen
+        // in normal operation.
         None => bail!("No tx entity found for tx_id={}", tx_key.tx_id),
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -258,7 +258,7 @@ impl Indexer {
                 let key = &kv.key;
                 assert!(
                     key.len() >= codec::TX_EID_OP_SUFFIX,
-                    "Key too short ({} bytes) to contain timestamp + op suffix",
+                    "Key too short ({} bytes) to contain tx_eid + op suffix",
                     key.len()
                 );
                 match temporal_filter_iterator::resolve_temporal_key(key, &as_of_encoded) {
@@ -648,6 +648,37 @@ mod tests {
         let (_tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 3, "Should return highest tx_id");
         assert_eq!(latest.system_time, st_from_unix_epoch(300));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
+        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
+
+        let tx_ops = vec![TxOp::Put(user_doc(vec![("name", DataType::String("alice".into()))]))];
+        indexer.transact_tx(tx_key, tx_ops).await?;
+
+        let snapshot = Arc::new(slate.snapshot().await?);
+        let tx_eid = tx_eid_for_tx_key(&snapshot, &tx_key).await?;
+        assert!(tx_eid > 0, "tx_eid should be a valid entity ID");
+
+        // Should match what latest_tx_key_from_snapshot returns
+        let (latest_tx_eid, _) = latest_tx_key_from_snapshot(&snapshot).await?;
+        assert_eq!(tx_eid, latest_tx_eid);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
+        let slate = Arc::new(in_memory_slate().await);
+        let snapshot = Arc::new(slate.snapshot().await?);
+        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(1000) };
+
+        let result = tx_eid_for_tx_key(&snapshot, &tx_key).await;
+        assert!(result.is_err(), "Should fail for non-existent tx_id");
+        assert!(result.unwrap_err().to_string().contains("tx_id=999"));
         Ok(())
     }
 

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -5,7 +5,6 @@ use bytes::Bytes;
 use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
-use crate::clock::Instant;
 use crate::codec::{self, index_type_to_prefix};
 use crate::index::IndexType;
 use crate::util::make_extractor;
@@ -22,7 +21,7 @@ pub struct GenericPrefixExtender {
     index_types: Vec<IndexType>,      // e.g., [AV, AVE]
     constant_prefix: Vec<u8>,         // attr_bytes + serialized constant values from the pattern
     participating_levels: Vec<usize>, // Which join levels this participates in
-    as_of: Instant,                   // temporal filter: only see facts at or before this time
+    as_of: i64,                   // temporal filter: only see facts at or before this time
 }
 
 impl GenericPrefixExtender {
@@ -33,7 +32,7 @@ impl GenericPrefixExtender {
         attribute_id: i64,
         constant_prefix: Vec<u8>,
         participating_levels: Vec<usize>,
-        as_of: Instant,
+        as_of: i64,
     ) -> Self {
         let mut full_prefix = Vec::new();
         codec::encode_i64(attribute_id, &mut full_prefix);
@@ -213,7 +212,7 @@ mod tests {
         codec::encode_i64(attribute, &mut key);
         key.extend_from_slice(&value);
         key.extend_from_slice(&DataType::Long(entity).encode());
-        key.extend_from_slice(&crate::codec::encode_timestamp(crate::clock::st_from_unix_epoch(1_000_000)));
+        key.extend_from_slice(&crate::codec::encode_i64_bytes(1000));
         key.push(crate::codec::ADD);
 
         slate.put(&key, b"dummy_value").await?;
@@ -243,7 +242,7 @@ mod tests {
             42,
             vec![],
             vec![0, 1],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         assert!(extender.participates_in_level(0));
@@ -270,7 +269,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         let count = extender.count(&vec![]);
@@ -298,7 +297,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         let values = extender.propose(&vec![]);
@@ -329,7 +328,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0, 1],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         let values = extender.propose(&vec![]);
@@ -360,7 +359,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         let candidates = vec![
@@ -405,7 +404,7 @@ mod tests {
             attr_name,
             value_bytes.to_vec(),
             vec![0],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         let proposed = extender.propose(&vec![]);
@@ -431,7 +430,7 @@ mod tests {
             attr_name,
             vec![],
             vec![0],
-            crate::clock::st_from_unix_epoch(2_000_000),
+            2000_i64,
         );
 
         // Note: estimate_key_count may return non-zero even for empty ranges

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -12,10 +12,10 @@ use super::slate_iterator::{Extractor, Index};
 /// An iterator that wraps a SlateDB prefix scan and resolves temporal versions.
 ///
 /// Keys are expected to have the layout: `[prefix...][data...][T:8][op:1]`
-/// where T is an inverted big-endian timestamp (newest first in sort order).
+/// where T is a descending-encoded tx_eid (newest first in sort order).
 ///
 /// For each distinct logical key (everything except T and op), emits only the
-/// most recent version whose real timestamp <= `as_of`.
+/// most recent version whose tx_eid <= `as_of`.
 ///
 /// TODO(triplox-28q): Add a history mode option that iterates over all history
 /// <= `as_of` including retractions, rather than resolving to current state.
@@ -38,9 +38,9 @@ pub(crate) fn tx_eid_bytes(key: &[u8]) -> &[u8] {
     &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH]
 }
 
-/// Resolve a temporal key against an as-of timestamp.
+/// Resolve a temporal key against an as-of tx_eid.
 ///
-/// Returns `Some(op_byte)` if the key's timestamp <= as_of (i.e. it is the newest
+/// Returns `Some(op_byte)` if the key's tx_eid <= as_of (i.e. it is the newest
 /// valid entry), or `None` if the entry is newer than as_of and should be skipped.
 pub(crate) fn resolve_temporal_key(key: &[u8], as_of_encoded: &[u8; 8]) -> Option<u8> {
     let ts = tx_eid_bytes(key);
@@ -107,7 +107,7 @@ impl TemporalFilterIterator {
                     let key = kv.key;
                     assert!(
                         key.len() >= codec::TX_EID_OP_SUFFIX,
-                        "Key too short ({} bytes) to contain timestamp + op suffix",
+                        "Key too short ({} bytes) to contain tx_eid + op suffix",
                         key.len()
                     );
 

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -3,7 +3,6 @@ use bytes::Bytes;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
-use crate::clock::Instant;
 use crate::codec;
 use crate::slate::DEFAULT_SCAN_OPTIONS;
 use crate::util::next_prefix;
@@ -31,12 +30,12 @@ pub(crate) struct TemporalFilterIterator {
 
 /// Extract the logical key from a full key (everything except timestamp + op suffix).
 pub(crate) fn logical_key(key: &[u8]) -> &[u8] {
-    &key[..key.len() - codec::TIMESTAMP_OP_SUFFIX]
+    &key[..key.len() - codec::TX_EID_OP_SUFFIX]
 }
 
-/// Extract the encoded timestamp bytes from a full key.
-pub(crate) fn timestamp_bytes(key: &[u8]) -> &[u8] {
-    &key[key.len() - codec::TIMESTAMP_OP_SUFFIX..key.len() - codec::OP_LENGTH]
+/// Extract the encoded tx_eid bytes from a full key.
+pub(crate) fn tx_eid_bytes(key: &[u8]) -> &[u8] {
+    &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH]
 }
 
 /// Resolve a temporal key against an as-of timestamp.
@@ -44,8 +43,8 @@ pub(crate) fn timestamp_bytes(key: &[u8]) -> &[u8] {
 /// Returns `Some(op_byte)` if the key's timestamp <= as_of (i.e. it is the newest
 /// valid entry), or `None` if the entry is newer than as_of and should be skipped.
 pub(crate) fn resolve_temporal_key(key: &[u8], as_of_encoded: &[u8; 8]) -> Option<u8> {
-    let ts = timestamp_bytes(key);
-    // Inverted encoding: encoded_T >= as_of_encoded means real_T <= as_of
+    let ts = tx_eid_bytes(key);
+    // Descending encoding: encoded_T >= as_of_encoded means real_T <= as_of
     if ts >= &as_of_encoded[..] {
         Some(key[key.len() - 1])
     } else {
@@ -59,10 +58,10 @@ impl TemporalFilterIterator {
         slate: &slatedb::DbSnapshot,
         handle: Handle,
         extractor: Extractor,
-        as_of: Instant,
+        as_of: i64,
     ) -> Result<Self, Error> {
         let prefix_bytes = Bytes::from(prefix.to_vec());
-        let as_of_encoded = codec::encode_timestamp(as_of);
+        let as_of_encoded = codec::encode_i64_bytes(as_of);
         let iterator =
             handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
 
@@ -107,7 +106,7 @@ impl TemporalFilterIterator {
                 Some(kv) => {
                     let key = kv.key;
                     assert!(
-                        key.len() >= codec::TIMESTAMP_OP_SUFFIX,
+                        key.len() >= codec::TX_EID_OP_SUFFIX,
                         "Key too short ({} bytes) to contain timestamp + op suffix",
                         key.len()
                     );
@@ -195,29 +194,28 @@ impl Index for TemporalFilterIterator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::st_from_unix_epoch;
     use crate::slate::in_memory_slate;
 
     const PFX: &[u8] = b"\x04"; // AV prefix
 
-    fn make_key(prefix: &[u8], data: &[u8], time: Instant, op: u8) -> Vec<u8> {
+    fn make_key(prefix: &[u8], data: &[u8], tx_eid: i64, op: u8) -> Vec<u8> {
         let mut key = prefix.to_vec();
         key.extend_from_slice(data);
-        key.extend_from_slice(&codec::encode_timestamp(time));
+        key.extend_from_slice(&codec::encode_i64_bytes(tx_eid));
         key.push(op);
         key
     }
 
     fn make_test_extractor(prefix_len: usize) -> Extractor {
         Box::new(move |key: Bytes| {
-            key.slice(prefix_len..key.len() - codec::TIMESTAMP_OP_SUFFIX)
+            key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX)
         })
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_single_version() {
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
+        let t1 = 1000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
 
@@ -227,7 +225,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &snapshot, handle, extractor, 2000,
             ).unwrap();
 
             assert!(iter.has_next());
@@ -238,8 +236,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_skips_future() {
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
-        let t2 = st_from_unix_epoch(2_000_000);
+        let t1 = 1000;
+        let t2 = 2000;
 
         // Two versions of "alice" at t1 and t2
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
@@ -263,7 +261,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_before_all() {
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(2_000_000);
+        let t1 = 2000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
 
@@ -274,7 +272,7 @@ mod tests {
             // Query as-of before t1 — should see nothing
             let extractor = make_test_extractor(PFX.len());
             let iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(1_000_000),
+                PFX, &snapshot, handle, extractor, 1000,
             ).unwrap();
 
             assert!(!iter.has_next());
@@ -285,8 +283,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_multiple_logical_keys() {
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
-        let t2 = st_from_unix_epoch(2_000_000);
+        let t1 = 1000;
+        let t2 = 2000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
@@ -298,7 +296,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(3_000_000),
+                PFX, &snapshot, handle, extractor, 3000,
             ).unwrap();
 
             // Should see alice and bob (deduplicated)
@@ -318,10 +316,10 @@ mod tests {
         // as-of T2: alice hidden (retracted)
         // as-of T3: alice visible again (re-added)
         let slate = in_memory_slate().await;
-        let t0 = st_from_unix_epoch(500_000);
-        let t1 = st_from_unix_epoch(1_000_000);
-        let t2 = st_from_unix_epoch(2_000_000);
-        let t3 = st_from_unix_epoch(3_000_000);
+        let t0 = 500;
+        let t1 = 1000;
+        let t2 = 2000;
+        let t3 = 3000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
@@ -383,7 +381,7 @@ mod tests {
         // Three logical keys: alice, bob, charlie at T1.
         // Seek to "bob" should land on bob, then next gives charlie.
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
+        let t1 = 1000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
@@ -395,7 +393,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter = TemporalFilterIterator::new(
-                PFX, &snapshot, handle, extractor, st_from_unix_epoch(2_000_000),
+                PFX, &snapshot, handle, extractor, 2000,
             ).unwrap();
 
             // Initially at alice
@@ -421,8 +419,8 @@ mod tests {
         // As-of T1: see alice and bob.
         // As-of T2: only bob (alice retracted).
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
-        let t2 = st_from_unix_epoch(2_000_000);
+        let t1 = 1000;
+        let t2 = 2000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
@@ -464,9 +462,9 @@ mod tests {
         // "alice" added at T1, retracted at T2, re-added at T3.
         // As-of T2: not visible. As-of T3: visible again.
         let slate = in_memory_slate().await;
-        let t1 = st_from_unix_epoch(1_000_000);
-        let t2 = st_from_unix_epoch(2_000_000);
-        let t3 = st_from_unix_epoch(3_000_000);
+        let t1 = 1000;
+        let t2 = 2000;
+        let t3 = 3000;
 
         slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,18 +41,19 @@ pub struct DB {
     attribute_map: HashMap<String, i64>,
     handle: Handle,
     tx_key: TxKey,
+    tx_eid: i64,
 }
 
 #[allow(unused)]
 impl DB {
-    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey) -> Self {
-        Self { snapshot, attribute_map, handle, tx_key }
+    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
+        Self { snapshot, attribute_map, handle, tx_key, tx_eid }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
     pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
-        let tx_key = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
-        Ok(Self { snapshot, attribute_map, handle, tx_key })
+        let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
+        Ok(Self { snapshot, attribute_map, handle, tx_key, tx_eid })
     }
 
     pub fn tx_key(&self) -> &TxKey {
@@ -74,7 +75,7 @@ impl Database for DB {
         let handle = self.handle.clone();
         let attribute_map = self.attribute_map.clone();
         let query = query.clone();
-        let as_of = self.tx_key.system_time;
+        let as_of = self.tx_eid;
 
         tokio::task::spawn_blocking(move || {
             execute_query(&query, snapshot, handle, &attribute_map, as_of)
@@ -117,7 +118,7 @@ impl Node<FileLog> {
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
         let snapshot = Arc::new(slatedb.snapshot().await?);
-        let latest_indexed = latest_tx_key_from_snapshot(&snapshot).await?;
+        let (_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
         let latest_indexed_tx = if latest_indexed.tx_id > 0 {
             Some(latest_indexed)
         } else {
@@ -195,7 +196,8 @@ impl<L: TxLog> QueryNode for Node<L> {
         let snapshot = self.slatedb.snapshot().await?;
         let attribute_map = self.indexer.read().await.schema_cache().attribute_map();
         let handle = Handle::current();
-        Ok(DB::new(snapshot, attribute_map, handle, tx_key))
+        let tx_eid = crate::indexer::tx_eid_for_tx_key(&snapshot, &tx_key).await?;
+        Ok(DB::new(snapshot, attribute_map, handle, tx_key, tx_eid))
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
 use anyhow::Result;
-use crate::clock::Instant;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct EntityId(pub i64);
@@ -174,7 +173,7 @@ pub struct Datom {
     pub entity: i64,
     pub attribute: String, // TODO(triplox-gaz): avoid cloning, consider Cow or interning
     pub value: DataType,
-    pub tx: Instant,
+    pub tx: i64,
     pub op: DatomOp,
 }
 
@@ -183,7 +182,7 @@ pub struct Datom {
 /// - Add(triple) → 1 Assert datom
 /// - Retract(triple) → 1 Retract datom
 /// - Delete/Erase → panics (not yet implemented)
-pub fn tx_ops_to_datoms(ops: &[TxOp], tx: Instant) -> Result<Vec<Datom>> {
+pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
     let mut datoms = Vec::new();
     for op in ops {
         match op {
@@ -328,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_tx_ops_to_datoms_put() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
@@ -344,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_tx_ops_to_datoms_add() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         let ops = vec![TxOp::Add {
             entity_id: EntityId(200),
             attribute: Attribute("name".to_string()),
@@ -361,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_tx_ops_to_datoms_retract() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         let ops = vec![TxOp::Retract {
             entity_id: EntityId(200),
             attribute: Attribute("name".to_string()),
@@ -376,20 +375,20 @@ mod tests {
     #[test]
     #[should_panic(expected = "Delete/Erase not yet implemented")]
     fn test_tx_ops_to_datoms_delete_panics() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         tx_ops_to_datoms(&[TxOp::Delete(EntityId(100))], tx).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "Delete/Erase not yet implemented")]
     fn test_tx_ops_to_datoms_erase_panics() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         tx_ops_to_datoms(&[TxOp::Erase(EntityId(200))], tx).unwrap();
     }
 
     #[test]
     fn test_tx_ops_to_datoms_put_missing_id() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         let mut doc = BTreeMap::new();
         doc.insert("name".to_string(), DataType::String("alice".to_string()));
         let ops = vec![TxOp::Put(doc)];
@@ -401,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_tx_ops_to_datoms_put_wrong_id_type() {
-        let tx = crate::clock::st_from_unix_epoch(1000);
+        let tx = 1000_i64;
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::String("not-a-long".to_string()));
         doc.insert("name".to_string(), DataType::String("alice".to_string()));

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ use anyhow::Error;
 use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple};
-use crate::clock::Instant;
+
 use crate::aggregate::{make_accumulator, Accumulator};
 use crate::datalog::{
     AggregateFunc, FindElement, FindSpec, FnExpr, OrBranch, PatternClause, PatternElement, Query,
@@ -347,7 +347,7 @@ pub fn compile_pattern(
     attribute_id: i64,
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
-    as_of: Instant,
+    as_of: i64,
 ) -> Result<GenericPrefixExtender, Error> {
     let pattern_clause = PatternClause::from(pattern.clone());
     let pattern_vars = pattern_clause.variables();
@@ -661,7 +661,7 @@ fn compile_or_branch(
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
     attribute_map: &HashMap<String, i64>,
-    as_of: Instant,
+    as_of: i64,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match branch {
         OrBranch::Clause(clause) => {
@@ -685,7 +685,7 @@ fn compile_where_clause(
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
     attribute_map: &HashMap<String, i64>,
-    as_of: Instant,
+    as_of: i64,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match clause {
         WhereClause::Triple(pattern) => {
@@ -733,7 +733,7 @@ pub fn execute_query(
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
     attribute_map: &HashMap<String, i64>,
-    as_of: Instant,
+    as_of: i64,
 ) -> Result<QueryResult, Error> {
     // 1. Extract variable order
     let join_order = query_variable_order(&query.where_clauses);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -410,8 +410,8 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
     validate_query(&query).expect("Schema query validation failed");
 
     let results = tokio::task::spawn_blocking(move || {
-        // TODO: use the latest submitted system_time instead of Utc::now() for consistency
-        execute_query(&query, snapshot, handle, &attribute_map, chrono::Utc::now())
+        // Use i64::MAX to see all facts (no temporal filtering)
+        execute_query(&query, snapshot, handle, &attribute_map, i64::MAX)
     })
     .await
     .expect("Schema query task failed")
@@ -472,7 +472,6 @@ pub fn test_schema_tx() -> Vec<TxOp> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::st_from_unix_epoch;
     use crate::ops::tx_ops_to_datoms;
 
     fn kw_ns(ns: &str, name: &str) -> DataType {
@@ -482,7 +481,7 @@ mod tests {
     fn to_datoms(ops: &[TxOp]) -> Vec<Datom> {
         let mut counters = crate::partition::PartitionCounters::new();
         let resolved = crate::partition::resolve_entity_ids(ops, &mut counters).unwrap();
-        tx_ops_to_datoms(&resolved, st_from_unix_epoch(0)).unwrap()
+        tx_ops_to_datoms(&resolved, 0_i64).unwrap()
     }
 
     fn extract_and_process(cache: &mut SchemaCache, datoms: &[Datom]) {
@@ -492,7 +491,7 @@ mod tests {
     fn bootstrapped_cache() -> SchemaCache {
         let mut cache = SchemaCache::new();
         let tx_ops = bootstrap_schema_tx();
-        let datoms = tx_ops_to_datoms(&tx_ops, st_from_unix_epoch(0)).unwrap();
+        let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
         extract_and_process(&mut cache, &datoms);
         cache
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,7 +109,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 2.. => (
                     codec::CODEC_LENGTH + codec::ENTITY_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length - codec::TX_EID_OP_SUFFIX,
                 ),
             },
             IndexType::AVE => match position {
@@ -119,11 +119,11 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 1 => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                    total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length - codec::ENTITY_LENGTH - codec::TX_EID_OP_SUFFIX,
                 ),
                 2.. => (
-                    total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
-                    total_length - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length - codec::ENTITY_LENGTH - codec::TX_EID_OP_SUFFIX,
+                    total_length - codec::TX_EID_OP_SUFFIX,
                 ),
             },
             IndexType::AEV => match position {
@@ -137,7 +137,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
                 2.. => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH + codec::ENTITY_LENGTH,
-                    total_length - codec::TIMESTAMP_OP_SUFFIX,
+                    total_length - codec::TX_EID_OP_SUFFIX,
                 ),
             },
             // AE/AV are atemporal — no T+op suffix
@@ -188,7 +188,7 @@ pub fn prefix_extractor<T: GetSlice + AsRef<[u8]>>(
             IndexType::AVE => match position {
                 0 => codec::CODEC_LENGTH,
                 1 => codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                2.. => total_length - codec::ENTITY_LENGTH - codec::TIMESTAMP_OP_SUFFIX,
+                2.. => total_length - codec::ENTITY_LENGTH - codec::TX_EID_OP_SUFFIX,
             },
             IndexType::AEV => match position {
                 0 => codec::CODEC_LENGTH,


### PR DESCRIPTION
## Summary

- Replace the inverted wall-clock timestamp in the T position of temporal index keys (EAV, AVE, AEV) with the transaction entity ID (`tx_eid`), providing logical ordering tied to the entity model
- `DB` struct now carries `tx_eid` for `as_of` queries; `latest_tx_key_from_snapshot` returns `(tx_eid, TxKey)`; new `tx_eid_for_tx_key` lookup for `db_as_of`
- Remove `encode_timestamp`/`decode_timestamp` — T position uses `encode_i64_bytes` (descending i64 encoding from PR #50)

## Deferred (separate P1 ticket)

The naming confusion between `TxKey.tx_id` (log-assigned sequential ID) and `tx_eid` (entity ID in TX_PARTITION) — these are different values that don't match. Especially need to sort out the user-facing story: what do clients see, what do they use for `as_of` / `db_as_of`, and how the two IDs are presented in the protocol and API.

## Test plan

- [x] `cargo build` — clean compilation
- [x] `cargo test` — all 386 tests pass
- [ ] Verify `test_db_as_of_time_travel` (node.rs) — temporal queries still work
- [ ] Verify `test_temporal_filter_*` (temporal_filter_iterator.rs) — as-of resolution correct
- [ ] Verify `test_latest_tx_key_after_transact` (indexer.rs) — TxKey reconstruction works
- [ ] Verify `test_execute_tx_and_query` (client_server_test.rs) — end-to-end works

🤖 Generated with [Claude Code](https://claude.com/claude-code)