### PR TITLE
feat: add kw! macro for concise keyword construction

### DIFF
--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -16,11 +16,82 @@ use std::fmt::{
 
 use namespaceable_name::NamespaceableName;
 
+/// Construct a `Keyword` from a Clojure-like literal syntax.
+///
+/// # Examples
+/// ```
+/// use edn::kw;
+/// // Namespaced keywords
+/// let k = kw!(:db/ident);           // :db/ident
+/// let k = kw!(:db.type/keyword);    // :db.type/keyword
+/// // Plain keywords
+/// let k = kw!(:name);               // :name
+/// // Hyphenated keywords
+/// let k = kw!(:last-name);          // :last-name
+/// ```
 #[macro_export]
-macro_rules! ns_keyword {
-    ($ns: expr, $name: expr) => {{
-        $crate::Keyword::namespaced($ns, $name)
-    }}
+macro_rules! kw {
+    // Dotted ns, dotted name: :ns.sub/name.sub
+    ( : $ns:ident $(. $nss:ident)+ / $nn:ident $(. $nns:ident)+ ) => {
+        $crate::Keyword::namespaced(
+            concat!(stringify!($ns) $(, ".", stringify!($nss))*),
+            concat!(stringify!($nn) $(, ".", stringify!($nns))*),
+        )
+    };
+    // Dotted ns, simple name: :ns.sub/name
+    ( : $ns:ident $(. $nss:ident)+ / $nn:ident ) => {
+        $crate::Keyword::namespaced(
+            concat!(stringify!($ns) $(, ".", stringify!($nss))*),
+            stringify!($nn)
+        )
+    };
+    // Dotted ns, hyphenated name: :ns.sub/name-part
+    ( : $ns:ident $(. $nss:ident)+ / $nn:ident $(- $nnh:ident)+ ) => {
+        $crate::Keyword::namespaced(
+            concat!(stringify!($ns) $(, ".", stringify!($nss))*),
+            concat!(stringify!($nn) $(, "-", stringify!($nnh))*)
+        )
+    };
+    // Simple ns, dotted name: :ns/name.sub
+    ( : $ns:ident / $nn:ident $(. $nns:ident)+ ) => {
+        $crate::Keyword::namespaced(
+            stringify!($ns),
+            concat!(stringify!($nn) $(, ".", stringify!($nns))*),
+        )
+    };
+    // Simple ns, simple name: :ns/name
+    ( : $ns:ident / $nn:ident ) => {
+        $crate::Keyword::namespaced(
+            stringify!($ns),
+            stringify!($nn)
+        )
+    };
+    // Simple ns, hyphenated name: :ns/name-part
+    ( : $ns:ident / $nn:ident $(- $nnh:ident)+ ) => {
+        $crate::Keyword::namespaced(
+            stringify!($ns),
+            concat!(stringify!($nn) $(, "-", stringify!($nnh))*)
+        )
+    };
+    // Hyphenated ns, simple name: :ns-part/name
+    ( : $ns:ident $(- $nsh:ident)+ / $nn:ident ) => {
+        $crate::Keyword::namespaced(
+            concat!(stringify!($ns) $(, "-", stringify!($nsh))*),
+            stringify!($nn)
+        )
+    };
+    // Plain keyword: :name
+    ( : $n:ident ) => {
+        $crate::Keyword::plain(
+            stringify!($n)
+        )
+    };
+    // Plain hyphenated keyword: :name-part
+    ( : $n:ident $(- $nh:ident)+ ) => {
+        $crate::Keyword::plain(
+            concat!(stringify!($n) $(, "-", stringify!($nh))*)
+        )
+    };
 }
 
 /// A simplification of Clojure's Symbol.
@@ -306,9 +377,15 @@ impl Display for Keyword {
 }
 
 #[test]
-fn test_ns_keyword_macro() {
-    assert_eq!(ns_keyword!("test", "name").to_string(),
-               Keyword::namespaced("test", "name").to_string());
-    assert_eq!(ns_keyword!("ns", "_name").to_string(),
-               Keyword::namespaced("ns", "_name").to_string());
+fn test_kw_macro() {
+    // Namespaced
+    assert_eq!(kw!(:test/name), Keyword::namespaced("test", "name"));
+    assert_eq!(kw!(:ns/_name), Keyword::namespaced("ns", "_name"));
+    // Dotted namespace
+    assert_eq!(kw!(:db.type/keyword), Keyword::namespaced("db.type", "keyword"));
+    // Plain
+    assert_eq!(kw!(:name), Keyword::plain("name"));
+    // Hyphenated
+    assert_eq!(kw!(:last-name), Keyword::plain("last-name"));
+    assert_eq!(kw!(:foo/bar-baz), Keyword::namespaced("foo", "bar-baz"));
 }

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -388,4 +388,6 @@ fn test_kw_macro() {
     // Hyphenated
     assert_eq!(kw!(:last-name), Keyword::plain("last-name"));
     assert_eq!(kw!(:foo/bar-baz), Keyword::namespaced("foo", "bar-baz"));
+    // Hyphenated namespace
+    assert_eq!(kw!(:my-ns/attr), Keyword::namespaced("my-ns", "attr"));
 }

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
+use edn::kw;
 use edn::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{QueryNode, SubmitNode, TransactionResult};
@@ -30,7 +31,7 @@ fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
     );
     doc.insert(
         "db/cardinality".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
+        DataType::Keyword(kw!(:db.cardinality/one)),
     );
     TxOp::Put(doc)
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
-use edn::kw;
 use edn::symbols::Keyword;
 use uuid::Uuid;
 
@@ -557,6 +556,7 @@ impl Decode for DataType {
 
 #[cfg(test)]
 mod tests {
+    use edn::kw;
     use super::*;
     use chrono::TimeZone;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use edn::kw;
 use edn::symbols::Keyword;
 use uuid::Uuid;
 
@@ -736,9 +737,9 @@ mod tests {
     #[test]
     fn roundtrip_keyword() {
         let keywords = vec![
-            Keyword::plain("foo"),
-            Keyword::namespaced("db", "ident"),
-            Keyword::namespaced("my.ns", "attr"),
+            kw!(:foo),
+            kw!(:db/ident),
+            kw!(:my.ns/attr),
         ];
         for v in keywords {
             let mut buf = Vec::new();
@@ -762,8 +763,8 @@ mod tests {
             DataType::Double(3.14),
             DataType::Float(2.5),
             DataType::Instant(Utc.timestamp_opt(1_000_000, 0).unwrap()),
-            DataType::Keyword(Keyword::plain("foo")),
-            DataType::Keyword(Keyword::namespaced("db", "ident")),
+            DataType::Keyword(kw!(:foo)),
+            DataType::Keyword(kw!(:db/ident)),
             DataType::Long(42),
             DataType::Long(i64::MIN),
             DataType::String("hello".to_string()),
@@ -936,11 +937,11 @@ mod tests {
     #[test]
     fn order_keyword() {
         let values = vec![
-            Keyword::plain("a"),        // empty ns sorts first
-            Keyword::plain("b"),
-            Keyword::namespaced("a", "a"),
-            Keyword::namespaced("a", "b"),
-            Keyword::namespaced("b", "a"),
+            kw!(:a),        // empty ns sorts first
+            kw!(:b),
+            kw!(:a/a),
+            kw!(:a/b),
+            kw!(:b/a),
         ];
         for window in values.windows(2) {
             let mut a_buf = Vec::new();
@@ -1015,7 +1016,7 @@ mod tests {
             DataType::Double(3.14),
             DataType::Float(2.5),
             DataType::Instant(Utc.timestamp_opt(1_000_000, 0).unwrap()),
-            DataType::Keyword(Keyword::namespaced("db", "id")),
+            DataType::Keyword(kw!(:db/id)),
             DataType::Long(99),
             DataType::String("test".to_string()),
             DataType::Tuple(vec![DataType::Long(1)]),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -8,6 +8,8 @@ use bytes::Bytes;
 use tokio::sync::broadcast;
 use log::{error, trace, warn};
 
+use edn::kw;
+
 use crate::log::{Record, Subscriber};
 use crate::ops::{Datom, DatomOp, TxOp, tx_ops_to_datoms};
 use crate::partition::{resolve_entity_ids, allocate_counter, make_entity_id, partition_entity_prefix, TX_PARTITION};
@@ -155,9 +157,9 @@ fn build_tx_entity_datoms(
 ) -> Vec<Datom> {
     let st = tx_key.system_time;
     let result_kw = if committed {
-        Keyword::namespaced("db.tx", "committed")
+        kw!(:db.tx/committed)
     } else {
-        Keyword::namespaced("db.tx", "aborted")
+        kw!(:db.tx/aborted)
     };
     let mut datoms = vec![
         Datom { entity: tx_eid, attribute: "db/txInstant".into(), value: DataType::Instant(st), tx: tx_eid, op: DatomOp::Assert },

--- a/src/node.rs
+++ b/src/node.rs
@@ -218,13 +218,6 @@ mod tests {
     use edn::Keyword;
     use super::*;
 
-    fn kw(s: &str) -> DataType {
-        DataType::Keyword(match s.rsplit_once('/') {
-            Some((ns, name)) => Keyword::namespaced(ns, name),
-            None => Keyword::plain(s),
-        })
-    }
-
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
     async fn define_test_schema(node: &impl SubmitNode) {
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
@@ -253,7 +246,7 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query(&Query {
             find: find_vars(&["?name"]),
-            where_clauses: vec![triple("?e", "name", "?name")],
+            where_clauses: vec![triple("?e", kw!(:name), "?name")],
         }).await.unwrap();
         assert_eq!(result, vec![vec![DataType::String("bob".to_string())]]);
     }
@@ -315,7 +308,7 @@ mod tests {
             ]),
             where_clauses: vec![WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(kw("name")),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Variable("?name".to_string()),
             })],
         };
@@ -346,7 +339,7 @@ mod tests {
             find: FindSpec::FindRel(vec![FindElement::Variable("?e".to_string())]),
             where_clauses: vec![WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(kw("name")),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Constant(DataType::String("alice".to_string())),
             })],
         };
@@ -380,12 +373,12 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("age")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:age))),
                     value: PatternElement::Variable("?age".to_string()),
                 }),
             ],
@@ -422,12 +415,12 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("follows")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:follows))),
                     value: PatternElement::Variable("?friend".to_string()),
                 }),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?friend".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
             ],
@@ -464,18 +457,18 @@ mod tests {
                 WhereClause::Or(vec![
                     OrBranch::Clause(WhereClause::Triple(TriplePattern {
                         entity: PatternElement::Variable("?e".to_string()),
-                        attribute: PatternElement::Constant(kw("name")),
+                        attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                         value: PatternElement::Constant(DataType::String("alice".to_string())),
                     })),
                     OrBranch::Clause(WhereClause::Triple(TriplePattern {
                         entity: PatternElement::Variable("?e".to_string()),
-                        attribute: PatternElement::Constant(kw("name")),
+                        attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                         value: PatternElement::Constant(DataType::String("bob".to_string())),
                     })),
                 ]),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
             ],
@@ -520,23 +513,23 @@ mod tests {
                 WhereClause::Or(vec![
                     OrBranch::Clause(WhereClause::Triple(TriplePattern {
                         entity: PatternElement::Variable("?e".to_string()),
-                        attribute: PatternElement::Constant(kw("name")),
+                        attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                         value: PatternElement::Constant(DataType::String("alice".to_string())),
                     })),
                     OrBranch::Clause(WhereClause::Triple(TriplePattern {
                         entity: PatternElement::Variable("?e".to_string()),
-                        attribute: PatternElement::Constant(kw("name")),
+                        attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                         value: PatternElement::Constant(DataType::String("bob".to_string())),
                     })),
                 ]),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("age")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:age))),
                     value: PatternElement::Variable("?age".to_string()),
                 }),
             ],
@@ -578,31 +571,31 @@ mod tests {
                     OrBranch::And(vec![
                         WhereClause::Triple(TriplePattern {
                             entity: PatternElement::Variable("?e".to_string()),
-                            attribute: PatternElement::Constant(kw("name")),
+                            attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                             value: PatternElement::Constant(DataType::String("alice".to_string())),
                         }),
                         WhereClause::Triple(TriplePattern {
                             entity: PatternElement::Variable("?e".to_string()),
-                            attribute: PatternElement::Constant(kw("age")),
+                            attribute: PatternElement::Constant(DataType::Keyword(kw!(:age))),
                             value: PatternElement::Constant(DataType::Long(30)),
                         }),
                     ]),
                     OrBranch::And(vec![
                         WhereClause::Triple(TriplePattern {
                             entity: PatternElement::Variable("?e".to_string()),
-                            attribute: PatternElement::Constant(kw("name")),
+                            attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                             value: PatternElement::Constant(DataType::String("charlie".to_string())),
                         }),
                         WhereClause::Triple(TriplePattern {
                             entity: PatternElement::Variable("?e".to_string()),
-                            attribute: PatternElement::Constant(kw("age")),
+                            attribute: PatternElement::Constant(DataType::Keyword(kw!(:age))),
                             value: PatternElement::Constant(DataType::Long(35)),
                         }),
                     ]),
                 ]),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
             ],
@@ -646,7 +639,7 @@ mod tests {
             ]),
             where_clauses: vec![WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(kw("name")),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Variable("?name".to_string()),
             })],
         };
@@ -676,7 +669,7 @@ mod tests {
             ]),
             where_clauses: vec![WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(kw("name")),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Variable("?name".to_string()),
             })],
         };
@@ -790,7 +783,7 @@ mod tests {
             ]),
             where_clauses: vec![WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(kw("name")),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Variable("?name".to_string()),
             })],
         };
@@ -867,10 +860,10 @@ mod tests {
         FindSpec::FindRel(names.iter().map(|n| FindElement::Variable(n.to_string())).collect())
     }
 
-    fn triple(entity: &str, attr: &str, value: &str) -> WhereClause {
+    fn triple(entity: &str, attr: Keyword, value: &str) -> WhereClause {
         WhereClause::Triple(TriplePattern {
             entity: PatternElement::Variable(entity.to_string()),
-            attribute: PatternElement::Constant(kw(attr)),
+            attribute: PatternElement::Constant(DataType::Keyword(attr)),
             value: PatternElement::Variable(value.to_string()),
         })
     }
@@ -884,8 +877,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 predicate(var("?age"), BinaryOp::Lt, lit_long(50)),
             ],
         };
@@ -906,8 +899,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 predicate(var("?age"), BinaryOp::GtEq, lit_long(50)),
             ],
         };
@@ -928,8 +921,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 predicate(lit_long(30), BinaryOp::Eq, var("?age")),
             ],
         };
@@ -949,7 +942,7 @@ mod tests {
         let query = Query {
             find: find_vars(&["?e"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
+                triple("?e", kw!(:name), "?name"),
                 predicate(lit_string("Ivan"), BinaryOp::Eq, var("?name")),
             ],
         };
@@ -968,10 +961,10 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name1", "?name2"]),
             where_clauses: vec![
-                triple("?e1", "name", "?name1"),
-                triple("?e1", "age", "?age1"),
-                triple("?e2", "name", "?name2"),
-                triple("?e2", "age", "?age2"),
+                triple("?e1", kw!(:name), "?name1"),
+                triple("?e1", kw!(:age), "?age1"),
+                triple("?e2", kw!(:name), "?name2"),
+                triple("?e2", kw!(:age), "?age2"),
                 predicate(var("?age1"), BinaryOp::LtEq, var("?age2")),
             ],
         };
@@ -992,8 +985,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name", "?half"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 fn_expr(var("?age"), BinaryOp::Div, lit_long(2), "?half"),
             ],
         };
@@ -1015,8 +1008,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name", "?half"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 fn_expr(var("?age"), BinaryOp::Div, lit_long(2), "?half"),
                 predicate(var("?half"), BinaryOp::Gt, lit_long(20)),
             ],
@@ -1037,8 +1030,8 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name", "?result"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
-                triple("?e", "age", "?age"),
+                triple("?e", kw!(:name), "?name"),
+                triple("?e", kw!(:age), "?age"),
                 fn_expr(var("?age"), BinaryOp::Sub, lit_long(15), "?result"),
             ],
         };
@@ -1060,10 +1053,10 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
+                triple("?e", kw!(:name), "?name"),
                 WhereClause::Not(vec![WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("age")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:age))),
                     value: PatternElement::Constant(DataType::Long(50)),
                 })]),
             ],
@@ -1107,12 +1100,12 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("sex")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:sex))),
                     value: PatternElement::Constant(DataType::Keyword(kw!(:male))),
                 }),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                     value: PatternElement::Variable("?name".to_string()),
                 }),
             ],
@@ -1157,10 +1150,10 @@ mod tests {
         let query = Query {
             find: find_vars(&["?name"]),
             where_clauses: vec![
-                triple("?e", "name", "?name"),
+                triple("?e", kw!(:name), "?name"),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
-                    attribute: PatternElement::Constant(kw("sex")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:sex))),
                     value: PatternElement::Constant(DataType::Keyword(kw!(:male))),
                 }),
             ],
@@ -1206,7 +1199,7 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Constant(DataType::Long(2200)),
-                    attribute: PatternElement::Constant(kw("last-name")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:last-name))),
                     value: PatternElement::Variable("?ln".to_string()),
                 }),
             ],
@@ -1286,7 +1279,7 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Constant(DataType::Long(2000)),
-                    attribute: PatternElement::Constant(kw("tags")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:tags))),
                     value: PatternElement::Variable("?tag".to_string()),
                 }),
             ],
@@ -1327,7 +1320,7 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query(&Query {
             find: find_vars(&["?e", "?name"]),
-            where_clauses: vec![triple("?e", "name", "?name")],
+            where_clauses: vec![triple("?e", kw!(:name), "?name")],
         }).await.unwrap();
 
         assert_eq!(result.len(), 2);
@@ -1364,15 +1357,15 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?tx".to_string()),
-                    attribute: PatternElement::Constant(kw("db/txId")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:db/txId))),
                     value: PatternElement::Constant(DataType::Long(tx_key.tx_id)),
                 }),
-                triple("?tx", "db/txResult", "?result"),
+                triple("?tx", kw!(:db/txResult), "?result"),
             ],
         }).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0][0], kw("db.tx/committed"));
+        assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/committed)));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1396,16 +1389,16 @@ mod tests {
             where_clauses: vec![
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?tx".to_string()),
-                    attribute: PatternElement::Constant(kw("db/txId")),
+                    attribute: PatternElement::Constant(DataType::Keyword(kw!(:db/txId))),
                     value: PatternElement::Constant(DataType::Long(tx_key.tx_id)),
                 }),
-                triple("?tx", "db/txResult", "?result"),
-                triple("?tx", "db.tx/error", "?error"),
+                triple("?tx", kw!(:db/txResult), "?result"),
+                triple("?tx", kw!(:db.tx/error), "?error"),
             ],
         }).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0][0], kw("db.tx/aborted"));
+        assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));
         if let DataType::String(s) = &result[0][1] {
             assert!(s.contains("nonexistent"), "Error should mention the unknown attribute, got: {}", s);
         } else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -214,10 +214,10 @@ mod tests {
     use crate::ops::{Attribute, DataType, EntityId, TxOp};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
+    use edn::kw;
     use edn::Keyword;
     use super::*;
 
-    // TODO: unify with a kw! macro in the edn crate
     fn kw(s: &str) -> DataType {
         DataType::Keyword(match s.rsplit_once('/') {
             Some((ns, name)) => Keyword::namespaced(ns, name),
@@ -1083,9 +1083,9 @@ mod tests {
 
         // Define "sex" attribute with keyword value type
         let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
-        sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
-        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
+        sex_attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:sex)));
+        sex_attr.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/keyword)));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
         node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
 
         let people = vec![
@@ -1108,7 +1108,7 @@ mod tests {
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
                     attribute: PatternElement::Constant(kw("sex")),
-                    value: PatternElement::Constant(DataType::Keyword(Keyword::plain("male"))),
+                    value: PatternElement::Constant(DataType::Keyword(kw!(:male))),
                 }),
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
@@ -1135,9 +1135,9 @@ mod tests {
         define_test_schema(&node).await;
 
         let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("sex")));
-        sex_attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "keyword")));
-        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
+        sex_attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:sex)));
+        sex_attr.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/keyword)));
+        sex_attr.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
         node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
 
         let people = vec![
@@ -1161,7 +1161,7 @@ mod tests {
                 WhereClause::Triple(TriplePattern {
                     entity: PatternElement::Variable("?e".to_string()),
                     attribute: PatternElement::Constant(kw("sex")),
-                    value: PatternElement::Constant(DataType::Keyword(Keyword::plain("male"))),
+                    value: PatternElement::Constant(DataType::Keyword(kw!(:male))),
                 }),
             ],
         };
@@ -1183,9 +1183,9 @@ mod tests {
 
         // Define "last-name" attribute
         let mut attr = BTreeMap::new();
-        attr.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("last-name")));
-        attr.insert("db/valueType".to_string(), DataType::Keyword(Keyword::namespaced("db.type", "string")));
-        attr.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
+        attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:last-name)));
+        attr.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/string)));
+        attr.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
         node.execute_tx(vec![TxOp::Put(attr)]).await.unwrap();
 
         // Insert entity 200 and entity 201 with last-names

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -296,6 +296,7 @@ fn var_to_string(v: &eq::Variable) -> Variable {
 
 #[cfg(test)]
 mod tests {
+    use edn::kw;
     use super::*;
 
     /// Parse both vector and map syntax, assert they produce identical results.
@@ -331,7 +332,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?x".into()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced("foo", "bar"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:foo/bar))),
                 value: PatternElement::Variable("?y".into()),
             })
         );
@@ -363,7 +364,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?x".into()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::plain("active"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:active))),
                 value: PatternElement::Constant(DataType::Boolean(true)),
             })
         );
@@ -379,7 +380,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?x".into()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::plain("name"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:name))),
                 value: PatternElement::Constant(DataType::String("Alice".into())),
             })
         );
@@ -397,7 +398,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?x".into()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::plain("id"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:id))),
                 value: PatternElement::Constant(DataType::Uuid(expected_uuid)),
             })
         );
@@ -528,7 +529,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Constant(DataType::Long(42)),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced("foo", "bar"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:foo/bar))),
                 value: PatternElement::Variable("?v".into()),
             })
         );
@@ -567,7 +568,7 @@ mod tests {
             q.where_clauses[0],
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?x".into()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced("foo", "bar"))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:foo/bar))),
                 value: PatternElement::Constant(DataType::Long(-5)),
             })
         );

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -246,10 +246,10 @@ mod tests {
         let mut counters = PartitionCounters::new();
         let mut doc = BTreeMap::new();
         doc.insert("db/ident".to_string(), DataType::Keyword(
-            edn::symbols::Keyword::plain("my-attr"),
+            edn::kw!(:my-attr),
         ));
         doc.insert("db/valueType".to_string(), DataType::Keyword(
-            edn::symbols::Keyword::namespaced("db.type", "string"),
+            edn::kw!(:db.type/string),
         ));
         let ops = vec![TxOp::Put(doc)];
 
@@ -272,7 +272,7 @@ mod tests {
         let mut counters = PartitionCounters::new();
         let mut doc = BTreeMap::new();
         doc.insert("db/ident".to_string(), DataType::Keyword(
-            edn::symbols::Keyword::namespaced("db.type", "string"),
+            edn::kw!(:db.type/string),
         ));
         let ops = vec![TxOp::Put(doc)];
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1054,6 +1054,7 @@ pub async fn write_backend_message<W: AsyncWrite + Unpin>(
 
 #[cfg(test)]
 mod tests {
+    use edn::kw;
     use super::*;
     use std::collections::BTreeMap;
 
@@ -1139,13 +1140,13 @@ mod tests {
 
     #[test]
     fn test_data_type_keyword_plain() {
-        let dt = DataType::Keyword(Keyword::plain("foo"));
+        let dt = DataType::Keyword(kw!(:foo));
         assert_eq!(roundtrip_data_type(&dt), dt);
     }
 
     #[test]
     fn test_data_type_keyword_namespaced() {
-        let dt = DataType::Keyword(Keyword::namespaced("person", "name"));
+        let dt = DataType::Keyword(kw!(:person/name));
         assert_eq!(roundtrip_data_type(&dt), dt);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use anyhow::{Error, Result};
+use edn::kw;
 use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
@@ -328,35 +329,35 @@ fn bootstrap_schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp
 pub fn bootstrap_schema_tx() -> Vec<TxOp> {
     vec![
         // Schema attribute entities
-        bootstrap_schema_attribute(DB_IDENT, Keyword::namespaced("db", "ident"), "keyword"),
-        bootstrap_schema_attribute(DB_VALUE_TYPE, Keyword::namespaced("db", "valueType"), "keyword"),
-        bootstrap_schema_attribute(DB_CARDINALITY, Keyword::namespaced("db", "cardinality"), "keyword"),
+        bootstrap_schema_attribute(DB_IDENT, kw!(:db/ident), "keyword"),
+        bootstrap_schema_attribute(DB_VALUE_TYPE, kw!(:db/valueType), "keyword"),
+        bootstrap_schema_attribute(DB_CARDINALITY, kw!(:db/cardinality), "keyword"),
         // Value type enum entities
-        bootstrap_put(DB_TYPE_KEYWORD, Keyword::namespaced("db.type", "keyword")),
-        bootstrap_put(DB_TYPE_STRING, Keyword::namespaced("db.type", "string")),
-        bootstrap_put(DB_TYPE_LONG, Keyword::namespaced("db.type", "long")),
-        bootstrap_put(DB_TYPE_REF, Keyword::namespaced("db.type", "ref")),
-        bootstrap_put(DB_TYPE_BOOLEAN, Keyword::namespaced("db.type", "boolean")),
-        bootstrap_put(DB_TYPE_DOUBLE, Keyword::namespaced("db.type", "double")),
-        bootstrap_put(DB_TYPE_FLOAT, Keyword::namespaced("db.type", "float")),
-        bootstrap_put(DB_TYPE_INSTANT, Keyword::namespaced("db.type", "instant")),
-        bootstrap_put(DB_TYPE_UUID, Keyword::namespaced("db.type", "uuid")),
-        bootstrap_put(DB_TYPE_BYTES, Keyword::namespaced("db.type", "bytes")),
-        bootstrap_put(DB_TYPE_BIGINT, Keyword::namespaced("db.type", "bigint")),
-        bootstrap_put(DB_TYPE_TUPLE, Keyword::namespaced("db.type", "tuple")),
-        bootstrap_put(DB_TYPE_VECTOR, Keyword::namespaced("db.type", "vector")),
-        bootstrap_put(DB_TYPE_MAP, Keyword::namespaced("db.type", "map")),
+        bootstrap_put(DB_TYPE_KEYWORD, kw!(:db.type/keyword)),
+        bootstrap_put(DB_TYPE_STRING, kw!(:db.type/string)),
+        bootstrap_put(DB_TYPE_LONG, kw!(:db.type/long)),
+        bootstrap_put(DB_TYPE_REF, kw!(:db.type/ref)),
+        bootstrap_put(DB_TYPE_BOOLEAN, kw!(:db.type/boolean)),
+        bootstrap_put(DB_TYPE_DOUBLE, kw!(:db.type/double)),
+        bootstrap_put(DB_TYPE_FLOAT, kw!(:db.type/float)),
+        bootstrap_put(DB_TYPE_INSTANT, kw!(:db.type/instant)),
+        bootstrap_put(DB_TYPE_UUID, kw!(:db.type/uuid)),
+        bootstrap_put(DB_TYPE_BYTES, kw!(:db.type/bytes)),
+        bootstrap_put(DB_TYPE_BIGINT, kw!(:db.type/bigint)),
+        bootstrap_put(DB_TYPE_TUPLE, kw!(:db.type/tuple)),
+        bootstrap_put(DB_TYPE_VECTOR, kw!(:db.type/vector)),
+        bootstrap_put(DB_TYPE_MAP, kw!(:db.type/map)),
         // Cardinality enum entities
-        bootstrap_put(DB_CARDINALITY_ONE, Keyword::namespaced("db.cardinality", "one")),
-        bootstrap_put(DB_CARDINALITY_MANY, Keyword::namespaced("db.cardinality", "many")),
+        bootstrap_put(DB_CARDINALITY_ONE, kw!(:db.cardinality/one)),
+        bootstrap_put(DB_CARDINALITY_MANY, kw!(:db.cardinality/many)),
         // Transaction schema attributes
-        bootstrap_schema_attribute(DB_TX_INSTANT, Keyword::namespaced("db", "txInstant"), "instant"),
-        bootstrap_schema_attribute(DB_TX_ID, Keyword::namespaced("db", "txId"), "long"),
-        bootstrap_schema_attribute(DB_TX_RESULT, Keyword::namespaced("db", "txResult"), "keyword"),
-        bootstrap_schema_attribute(DB_TX_ERROR, Keyword::namespaced("db.tx", "error"), "string"),
+        bootstrap_schema_attribute(DB_TX_INSTANT, kw!(:db/txInstant), "instant"),
+        bootstrap_schema_attribute(DB_TX_ID, kw!(:db/txId), "long"),
+        bootstrap_schema_attribute(DB_TX_RESULT, kw!(:db/txResult), "keyword"),
+        bootstrap_schema_attribute(DB_TX_ERROR, kw!(:db.tx/error), "string"),
         // Transaction result enum entities
-        bootstrap_put(DB_TX_COMMITTED, Keyword::namespaced("db.tx", "committed")),
-        bootstrap_put(DB_TX_ABORTED, Keyword::namespaced("db.tx", "aborted")),
+        bootstrap_put(DB_TX_COMMITTED, kw!(:db.tx/committed)),
+        bootstrap_put(DB_TX_ABORTED, kw!(:db.tx/aborted)),
     ]
 }
 
@@ -383,25 +384,17 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
         where_clauses: vec![
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced(
-                    "db", "ident",
-                ))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:db/ident))),
                 value: PatternElement::Variable("?ident".to_string()),
             }),
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced(
-                    "db",
-                    "valueType",
-                ))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:db/valueType))),
                 value: PatternElement::Variable("?vt".to_string()),
             }),
             WhereClause::Triple(TriplePattern {
                 entity: PatternElement::Variable("?e".to_string()),
-                attribute: PatternElement::Constant(DataType::Keyword(Keyword::namespaced(
-                    "db",
-                    "cardinality",
-                ))),
+                attribute: PatternElement::Constant(DataType::Keyword(kw!(:db/cardinality))),
                 value: PatternElement::Variable("?card".to_string()),
             }),
         ],
@@ -460,12 +453,12 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
 #[cfg(any(test, feature = "test-helpers"))]
 pub fn test_schema_tx() -> Vec<TxOp> {
     vec![
-        schema_attribute(Keyword::plain("name"), "string"),
-        schema_attribute(Keyword::plain("age"), "long"),
-        schema_attribute(Keyword::plain("email"), "string"),
+        schema_attribute(kw!(:name), "string"),
+        schema_attribute(kw!(:age), "long"),
+        schema_attribute(kw!(:email), "string"),
         // TODO: update this to ref once we support DataType::Ref
-        schema_attribute(Keyword::plain("follows"), "long"),
-        schema_attribute_with_cardinality(Keyword::plain("tags"), "string", "many"),
+        schema_attribute(kw!(:follows), "long"),
+        schema_attribute_with_cardinality(kw!(:tags), "string", "many"),
     ]
 }
 
@@ -498,7 +491,7 @@ mod tests {
 
     fn bootstrapped_cache_with_person_name() -> SchemaCache {
         let mut cache = bootstrapped_cache();
-        let ops = [schema_attribute(Keyword::plain("name"), "string")];
+        let ops = [schema_attribute(kw!(:name), "string")];
         extract_and_process(&mut cache, &to_datoms(&ops));
         cache
     }
@@ -570,7 +563,7 @@ mod tests {
     #[test]
     fn test_validate_tx_schema_defining_tx() {
         let cache = bootstrapped_cache();
-        let ops = [schema_attribute(Keyword::plain("name"), "string")];
+        let ops = [schema_attribute(kw!(:name), "string")];
         assert!(cache.validate_tx(&to_datoms(&ops)).is_ok());
     }
 
@@ -582,9 +575,9 @@ mod tests {
         // Cannot redefine existing schema entity
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(name_id));
-        doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
+        doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "long"));
-        doc.insert("db/cardinality".to_string(), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")));
+        doc.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
         let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
@@ -599,7 +592,7 @@ mod tests {
     #[test]
     fn test_validate_schema_attrs_parses_cardinality_many() {
         let ops = [schema_attribute_with_cardinality(
-            Keyword::plain("tags"), "string", "many",
+            kw!(:tags), "string", "many",
         )];
         let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
         assert_eq!(attrs.len(), 1);
@@ -609,7 +602,7 @@ mod tests {
 
     #[test]
     fn test_validate_schema_attrs_parses_cardinality_one() {
-        let ops = [schema_attribute(Keyword::plain("name"), "string")];
+        let ops = [schema_attribute(kw!(:name), "string")];
         let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
         assert_eq!(attrs.len(), 1);
         assert_eq!(attrs[0].cardinality, Cardinality::One);
@@ -619,7 +612,7 @@ mod tests {
     fn test_validate_schema_attrs_missing_cardinality_errors() {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(100));
-        doc.insert("db/ident".to_string(), DataType::Keyword(Keyword::plain("name")));
+        doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
         doc.insert("db/valueType".to_string(), kw_ns("db.type", "string"));
         // No db/cardinality
         let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -467,10 +467,6 @@ mod tests {
     use super::*;
     use crate::ops::tx_ops_to_datoms;
 
-    fn kw_ns(ns: &str, name: &str) -> DataType {
-        DataType::Keyword(Keyword::namespaced(ns, name))
-    }
-
     fn to_datoms(ops: &[TxOp]) -> Vec<Datom> {
         let mut counters = crate::partition::PartitionCounters::new();
         let resolved = crate::partition::resolve_entity_ids(ops, &mut counters).unwrap();
@@ -576,7 +572,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(name_id));
         doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
-        doc.insert("db/valueType".to_string(), kw_ns("db.type", "long"));
+        doc.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/long)));
         doc.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
         let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
@@ -613,7 +609,7 @@ mod tests {
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
-        doc.insert("db/valueType".to_string(), kw_ns("db.type", "string"));
+        doc.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/string)));
         // No db/cardinality
         let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("db/cardinality is required"));

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -7,6 +7,7 @@ use tokio_util::sync::CancellationToken;
 use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, TxOp};
+use edn::kw;
 use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
@@ -400,12 +401,12 @@ async fn test_aggregates_and_or() {
         .unwrap();
     assert_eq!(result.len(), 2, "expected 2 groups, got {:?}", result);
     assert!(result.contains(&vec![
-        DataType::Keyword(Keyword::plain("male")),
+        DataType::Keyword(kw!(:male)),
         DataType::Long(2),
         DataType::Long(45),
     ]));
     assert!(result.contains(&vec![
-        DataType::Keyword(Keyword::plain("female")),
+        DataType::Keyword(kw!(:female)),
         DataType::Long(1),
         DataType::Long(21),
     ]));


### PR DESCRIPTION
## Summary
- Port the `kw!` macro from Mozilla Mentat to the `edn` crate, replacing the old `ns_keyword!` macro
- Extends Mentat's design with hyphen support (`kw!(:last-name)`, `kw!(:ns/bar-baz)`)
- Replace ~65 verbose `Keyword::namespaced()`/`Keyword::plain()` calls across 10 files

## Test plan
- [x] `cargo test` — all tests pass
- [x] New `test_kw_macro` unit test covers namespaced, dotted, plain, and hyphenated variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)