### PR TITLE
feat: Schema, Attribute, Metadata, and PartitionMap

### DIFF
--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -1,0 +1,41 @@
+# Triplox Transaction Pipeline
+
+Version 0.1
+
+## Overview
+
+The `transact_tx_inner` pipeline processes a set of transaction operations into committed datoms. A cloned `PartitionMap` isolates counter mutations so they are only applied on successful commit.
+
+---
+
+## Pipeline Stages
+
+```
+1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
+   Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
+                                ↓
+2. Resolve entity IDs           resolve_entity_ids(ops, &mut pending_pm)
+   - Missing db/id → allocate from USER_PARTITION (or DB_PARTITION if db/ident present)
+   - Explicit db/id → pass through (TODO: validate via contains_entid once tempid pipeline exists)
+                                ↓
+3. Expand to datoms             tx_ops_to_datoms(resolved_ops, tx_eid)
+   Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
+                                ↓
+4. Validate + prepare           schema.validate_and_prepare(datoms) → Result<SchemaUpdate>
+   - Type checking: value type matches attribute's value_type
+   - Unknown attribute errors
+   - Witness pattern: split schema datoms, validate via AttributeBuilder
+   - Produces SchemaUpdate (pending delta) — errors abort before commit
+                                ↓
+5. Cardinality resolution       (existing EAV scan for card-one auto-retract)
+   // TODO: should likely merge into step 4 by using Attribute.multival
+   // to detect card-one conflicts during validate_and_prepare, but
+   // not in this change — keep the existing EAV scan logic for now.
+                                ↓
+6. Write indices + commit       write_index_entries(), txn.commit()
+                                ↓
+7. Apply on success only:
+   - self.metadata.partition_map = pending_pm    (counter reservation committed)
+   - self.metadata.schema.apply_schema_update(schema_update)  (infallible)
+   - self.metadata.advance_generation()
+```

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 use slatedb::{Db, IsolationLevel};
 use crate::codec;
 use crate::indexer::write_index_entries;
+use crate::metadata::{Metadata, PartitionMap};
 use crate::ops::tx_ops_to_datoms;
-use crate::partition::{PartitionCounters, extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION};
-use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, SchemaCache};
+use crate::partition::{extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION};
+use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, Schema};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
 
@@ -18,8 +19,8 @@ const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 /// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
 /// With descending encoding, the first entity per partition has the highest counter.
 /// The DB_PARTITION counter is clamped to at least DB_PARTITION_COUNTER_FLOOR.
-pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
-    let mut counters = PartitionCounters::new();
+pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
+    let mut pm = PartitionMap::new();
     for partition in [DB_PARTITION, TX_PARTITION, USER_PARTITION] {
         let prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(partition)]);
         let mut iter = slatedb
@@ -34,55 +35,54 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionCounters {
                 other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
             };
             let counter = extract_counter(eid);
-            counters.insert(partition, counter + 1);
+            pm.insert(partition, counter + 1);
         }
     }
 
     // Reserve space for future bootstrap entities (only if DB_PARTITION has entries)
-    if let Some(db_counter) = counters.get_mut(&crate::partition::DB_PARTITION) {
+    if let Some(db_counter) = pm.get_mut(&crate::partition::DB_PARTITION) {
         if *db_counter < DB_PARTITION_COUNTER_FLOOR {
             *db_counter = DB_PARTITION_COUNTER_FLOOR;
         }
     }
 
-    counters
+    pm
 }
 
-/// Initialize the database and return a ready `SchemaCache` and per-partition counters.
+/// Initialize the database and return ready `Metadata`.
 ///
 /// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries
-///   directly to SlateDB, writes the version, and returns the populated cache.
+///   directly to SlateDB, writes the version, and returns populated metadata.
 /// - **Existing DB**: loads the schema from indices via the Datalog query engine,
 ///   derives counters by scanning the EAV index.
-pub async fn init_db(slatedb: Arc<Db>) -> (SchemaCache, PartitionCounters) {
+pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
     let version_key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);
 
     match slatedb.get(&version_key).await.expect("Failed to read version from META_INDEX") {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
-            let cache = load_schema_from_indices(slatedb.clone()).await;
-            let counters = scan_partition_counters(&slatedb).await;
-
-            (cache, counters)
+            let schema = load_schema_from_indices(slatedb.clone()).await;
+            let pm = scan_partition_counters(&slatedb).await;
+            Metadata::new(schema, pm)
         }
         None => {
             // Fresh DB — bootstrap schema (ops have explicit db/id values)
             let tx_ops = bootstrap_schema_tx();
             let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
-            let mut cache = SchemaCache::new();
-            cache.process_tx(SchemaCache::validate_schema_attrs(&datoms).unwrap());
+            let mut schema = Schema::default();
+            let update = schema.validate_and_prepare(&datoms).unwrap();
+            schema.apply_schema_update(update);
 
             let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();
-            write_index_entries(&txn, &datoms, &cache, 0_i64).unwrap();
+            write_index_entries(&txn, &datoms, &schema, 0_i64).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&version_key, version.as_bytes()).unwrap();
             txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await.unwrap();
 
             // Derive counters from the just-written index
-            let counters = scan_partition_counters(&slatedb).await;
-
-            (cache, counters)
+            let pm = scan_partition_counters(&slatedb).await;
+            Metadata::new(schema, pm)
         }
     }
 }
@@ -96,29 +96,32 @@ mod tests {
     #[tokio::test]
     async fn test_init_db_fresh() {
         let slatedb = Arc::new(in_memory_slate().await);
-        let (cache, counters) = init_db(slatedb).await;
+        let metadata = init_db(slatedb).await;
         // Bootstrap defines 7 schema attributes (3 core + 4 tx)
-        assert_eq!(cache.len(), 7);
-        assert!(cache.get("db/ident").is_some());
-        assert!(cache.get("db/valueType").is_some());
-        assert!(cache.get("db/cardinality").is_some());
-        assert!(cache.get("db/txInstant").is_some());
-        assert!(cache.get("db/txId").is_some());
-        assert!(cache.get("db/txResult").is_some());
-        assert!(cache.get("db.tx/error").is_some());
+        assert_eq!(metadata.schema.len(), 7);
+        assert!(metadata.schema.get_attribute("db/ident").is_some());
+        assert!(metadata.schema.get_attribute("db/valueType").is_some());
+        assert!(metadata.schema.get_attribute("db/cardinality").is_some());
+        assert!(metadata.schema.get_attribute("db/txInstant").is_some());
+        assert!(metadata.schema.get_attribute("db/txId").is_some());
+        assert!(metadata.schema.get_attribute("db/txResult").is_some());
+        assert!(metadata.schema.get_attribute("db.tx/error").is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
-        assert_eq!(counters[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
+        assert_eq!(metadata.partition_map[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
+        // Enum entities are in ident_map but not attribute_map
+        assert!(metadata.schema.ident_map.contains_key("db.type/string"));
+        assert!(metadata.schema.get_attribute("db.type/string").is_none());
     }
 
     #[tokio::test]
     async fn test_init_db_existing() {
         let slatedb = Arc::new(in_memory_slate().await);
-        let (cache1, counters1) = init_db(slatedb.clone()).await;
+        let metadata1 = init_db(slatedb.clone()).await;
         // Second call takes the existing-DB path (scan EAV for counters)
-        let (cache2, counters2) = init_db(slatedb).await;
-        assert_eq!(cache1.len(), cache2.len());
-        assert_eq!(cache1.len(), 7);
-        assert_eq!(counters1[&DB_PARTITION], counters2[&DB_PARTITION]);
+        let metadata2 = init_db(slatedb).await;
+        assert_eq!(metadata1.schema.len(), metadata2.schema.len());
+        assert_eq!(metadata1.schema.len(), 7);
+        assert_eq!(metadata1.partition_map[&DB_PARTITION], metadata2.partition_map[&DB_PARTITION]);
     }
 
     #[tokio::test]
@@ -130,10 +133,10 @@ mod tests {
         slatedb.put(&key, b"0.0.1").await.unwrap();
 
         // init_db takes the existing-DB path — loads from indices (empty, since no bootstrap ran)
-        let (cache, counters) = init_db(slatedb).await;
-        assert_eq!(cache.len(), 0);
+        let metadata = init_db(slatedb).await;
+        assert_eq!(metadata.schema.len(), 0);
         // No EAV entries → empty counters
-        assert!(counters.is_empty());
+        assert!(metadata.partition_map.is_empty());
     }
 
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -71,6 +71,7 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
             let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
             let mut schema = Schema::default();
             let update = schema.validate_and_prepare(&datoms).unwrap();
+            // TODO: We should bootstrap the schema properly and do the validation in the same manner as the indexer
             schema.apply_schema_update(update);
 
             let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -11,13 +11,13 @@ use log::{error, trace, warn};
 use edn::kw;
 
 use crate::log::{Record, Subscriber};
+use crate::metadata::Metadata;
 use crate::ops::{Datom, DatomOp, TxOp, tx_ops_to_datoms};
-use crate::partition::{resolve_entity_ids, allocate_counter, make_entity_id, partition_entity_prefix, TX_PARTITION};
+use crate::partition::{resolve_entity_ids, partition_entity_prefix, TX_PARTITION};
 use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
 use crate::iterator::temporal_filter_iterator;
-use crate::partition::PartitionCounters;
 use edn::symbols::Keyword;
-use crate::schema::SchemaCache;
+use crate::schema::Schema;
 use crate::transaction::TxKey;
 use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
@@ -25,8 +25,7 @@ use crate::util::concat_bytes;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
-    schema_cache: SchemaCache,
-    counters: PartitionCounters,
+    metadata: Metadata,
     latest_indexed_tx: Option<TxKey>,
     tx_completion_sender: broadcast::Sender<(TxKey, Result<(), Arc<anyhow::Error>>)>,
 }
@@ -35,7 +34,7 @@ pub struct Indexer {
 pub(crate) fn write_index_entries(
     txn: &slatedb::DbTransaction,
     datoms: &[Datom],
-    schema_cache: &SchemaCache,
+    schema: &Schema,
     tx_eid: i64,
 ) -> Result<(), Error> {
     let tx_eid_bytes = encode_i64_bytes(tx_eid);
@@ -44,9 +43,9 @@ pub(crate) fn write_index_entries(
         // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
         // Revisit with schema/custom encoding.
         let entity_id = DataType::Long(datom.entity).encode();
-        let attribute_id = schema_cache
-            .get(&datom.attribute)
-            .map(|a| a.entity_id)
+        let attribute_id = schema
+            .get_attribute(&datom.attribute)
+            .map(|(eid, _)| eid)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
         let attribute = encode_i64_bytes(attribute_id);
         let mut value = Vec::new();
@@ -173,19 +172,18 @@ fn build_tx_entity_datoms(
 }
 
 impl Indexer {
-    pub fn new(slatedb: Arc<Db>, schema_cache: SchemaCache, counters: PartitionCounters, latest_indexed_tx: Option<TxKey>) -> Self {
+    pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: Option<TxKey>) -> Self {
         let (tx_completion_sender, _) = broadcast::channel(1024);
         Indexer {
             slatedb,
-            schema_cache,
-            counters,
+            metadata,
             latest_indexed_tx,
             tx_completion_sender,
         }
     }
 
-    pub fn schema_cache(&self) -> &SchemaCache {
-        &self.schema_cache
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
     }
 
     /// Transact a set of operations, automatically retracting old values for
@@ -206,21 +204,21 @@ impl Indexer {
     }
 
     async fn transact_tx_inner(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
-        // TODO: resolve_entity_ids + tx_ops_to_datoms should be unified into a single pass
-        // Use a temporary copy of counters; only persist advances after successful commit.
-        let mut pending_counters = self.counters.clone();
-        let resolved_ops = resolve_entity_ids(&tx_ops, &mut pending_counters)?;
+        // 1. Clone PartitionMap + allocate tx entity
+        let mut pending_pm = self.metadata.partition_map.clone();
+        let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
 
-        // Allocate tx_eid early so it can be used in both user datoms and tx entity datoms
-        let tx_eid = make_entity_id(TX_PARTITION, allocate_counter(&mut pending_counters, TX_PARTITION));
+        // 2. Resolve entity IDs
+        let resolved_ops = resolve_entity_ids(&tx_ops, &mut pending_pm)?;
+
+        // 3. Expand to datoms + build tx entity datoms
         let mut datoms = tx_ops_to_datoms(&resolved_ops, tx_eid)?;
+        datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
-        // Build first-class transaction entity in TX_PARTITION
-        let tx_entity_datoms = build_tx_entity_datoms(tx_eid, tx_key, true, None);
-        datoms.extend(tx_entity_datoms);
+        // 4. Validate + prepare schema update (single pass, pre-commit, fallible)
+        let schema_update = self.metadata.schema.validate_and_prepare(&datoms)?;
 
-        let new_schema_attrs = self.schema_cache.validate_tx(&datoms)?;
-
+        // 5. Cardinality resolution (existing EAV scan for card-one auto-retract)
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
 
         // For each Assert datom, scan EAV for the current value of (entity, attribute).
@@ -234,17 +232,16 @@ impl Indexer {
                 resolved_datoms.insert(datom);
                 continue;
             }
-            let attr_schema = self.schema_cache
-                .get(&datom.attribute)
+            let (attribute_id, attr) = self.metadata.schema
+                .get_attribute(&datom.attribute)
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
 
             // Cardinality-many attributes accumulate values without retraction.
-            if attr_schema.cardinality == crate::schema::Cardinality::Many {
+            if attr.multival {
                 resolved_datoms.insert(datom);
                 continue;
             }
 
-            let attribute_id = attr_schema.entity_id;
             let entity_id_bytes = DataType::Long(datom.entity).encode();
             let attr_id_bytes = encode_i64_bytes(attribute_id);
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
@@ -297,16 +294,14 @@ impl Indexer {
         }
         let datoms: Vec<Datom> = resolved_datoms.into_iter().collect();
 
-        write_index_entries(&txn, &datoms, &self.schema_cache, tx_eid)?;
-
+        // 6. Write indices + commit
+        write_index_entries(&txn, &datoms, &self.metadata.schema, tx_eid)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
 
-        // Commit succeeded — advance partition counters.
-        self.counters = pending_counters;
-
-        // Update schema cache after commit so new attributes are only visible
-        // in subsequent transactions.
-        self.schema_cache.process_tx(new_schema_attrs);
+        // 7. Apply on success only (infallible — validation already passed)
+        self.metadata.partition_map = pending_pm;
+        self.metadata.schema.apply_schema_update(schema_update);
+        self.metadata.advance_generation();
 
         // Update latest indexed tx and broadcast completion
         self.latest_indexed_tx = Some(tx_key);
@@ -340,13 +335,13 @@ impl Indexer {
 
     /// Write an aborted transaction entity (no user data) when transact_tx fails.
     async fn write_aborted_tx(&mut self, tx_key: TxKey, error: String) -> Result<(), Error> {
-        let mut pending_counters = self.counters.clone();
-        let tx_eid = make_entity_id(TX_PARTITION, allocate_counter(&mut pending_counters, TX_PARTITION));
+        let mut pending_pm = self.metadata.partition_map.clone();
+        let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
         let datoms = build_tx_entity_datoms(tx_eid, tx_key, false, Some(error));
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
-        write_index_entries(&txn, &datoms, &self.schema_cache, tx_eid)?;
+        write_index_entries(&txn, &datoms, &self.metadata.schema, tx_eid)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
-        self.counters = pending_counters;
+        self.metadata.partition_map = pending_pm;
         self.latest_indexed_tx = Some(tx_key);
         Ok(())
     }
@@ -503,8 +498,8 @@ mod tests {
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
     /// Returns the indexer ready for test data at tx_id=1+.
     async fn bootstrapped_indexer(slate: Arc<Db>) -> Indexer {
-        let (cache, counters) = crate::bootstrap::init_db(slate.clone()).await;
-        let mut indexer = Indexer::new(slate, cache, counters, None);
+        let metadata = crate::bootstrap::init_db(slate.clone()).await;
+        let mut indexer = Indexer::new(slate, metadata, None);
         let tx_key_0 = TxKey { tx_id: 0, system_time: st_from_unix_epoch(1) };
         indexer.transact_tx(tx_key_0, test_schema_tx()).await.unwrap();
         indexer
@@ -514,7 +509,7 @@ mod tests {
     async fn test_indexer() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.schema_cache().get("name").unwrap().entity_id;
+        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
         let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
         let mut doc = BTreeMap::new();
         doc.insert("name".to_string(), DataType::String("alan".to_string()));
@@ -724,7 +719,7 @@ mod tests {
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
-        let indexer = Indexer::new(slate.clone(), SchemaCache::new(), PartitionCounters::new(), None);
+        let indexer = Indexer::new(slate.clone(), Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()), None);
 
         let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(999) };
 
@@ -795,7 +790,7 @@ mod tests {
     async fn test_retract_on_overwrite() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.schema_cache().get("name").unwrap().entity_id;
+        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
@@ -857,7 +852,7 @@ mod tests {
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.schema_cache().get("name").unwrap().entity_id;
+        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
 
         // First tx: assert name="alice" for a new entity
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
@@ -928,7 +923,7 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
-        let tags_id = indexer.schema_cache().get("tags").unwrap().entity_id;
+        let tags_id = indexer.metadata().schema.get_attribute("tags").unwrap().0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
@@ -977,7 +972,7 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr — expect 2 ADDs (both written)
-        let tags_id = indexer.schema_cache().get("tags").unwrap().entity_id;
+        let tags_id = indexer.metadata().schema.get_attribute("tags").unwrap().0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -341,6 +341,7 @@ impl Indexer {
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
         write_index_entries(&txn, &datoms, &self.metadata.schema, tx_eid)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
+        // No need to advance generation for aborted transactions
         self.metadata.partition_map = pending_pm;
         self.latest_indexed_tx = Some(tx_key);
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -300,8 +300,10 @@ impl Indexer {
 
         // 7. Apply on success only (infallible — validation already passed)
         self.metadata.partition_map = pending_pm;
-        self.metadata.schema.apply_schema_update(schema_update);
-        self.metadata.advance_generation();
+        if !schema_update.is_empty() {
+            self.metadata.schema.apply_schema_update(schema_update);
+            self.metadata.advance_generation();
+        }
 
         // Update latest indexed tx and broadcast completion
         self.latest_indexed_tx = Some(tx_key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod iterator;
 mod log;
 pub mod logging;
 mod memory_log;
+pub(crate) mod metadata;
 pub mod ops;
 pub mod partition;
 mod parse;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+
+use crate::partition::{extract_counter, extract_partition, make_entity_id};
+use crate::schema::Schema;
+
+/// Newtype wrapping partition counters. Deref/DerefMut to inner HashMap
+/// so standard map methods work transparently.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PartitionMap(HashMap<u32, i64>);
+
+impl PartitionMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate the next counter value for the given partition.
+    /// Returns the current counter and increments it.
+    pub fn allocate_counter(&mut self, partition: u32) -> i64 {
+        let counter = self.0.entry(partition).or_insert(0);
+        let value = *counter;
+        *counter += 1;
+        value
+    }
+
+    /// Allocate a new entity ID in the given partition.
+    pub fn allocate_entid(&mut self, partition: u32) -> i64 {
+        let counter = self.allocate_counter(partition);
+        make_entity_id(partition, counter)
+    }
+
+    /// Check if an entity ID has been allocated (counter < next_counter for its partition).
+    /// Used to validate explicit db/id values in transactions.
+    pub fn contains_entid(&self, eid: i64) -> bool {
+        let partition = extract_partition(eid);
+        let counter = extract_counter(eid);
+        match self.0.get(&partition) {
+            Some(&next) => counter < next,
+            None => false,
+        }
+    }
+}
+
+impl Deref for PartitionMap {
+    type Target = HashMap<u32, i64>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PartitionMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+impl<const N: usize> From<[(u32, i64); N]> for PartitionMap {
+    fn from(arr: [(u32, i64); N]) -> Self {
+        PartitionMap(HashMap::from(arr))
+    }
+}
+
+/// Groups all mutable metadata that evolves with each transaction.
+#[derive(Debug)]
+pub struct Metadata {
+    pub generation: u64,
+    pub partition_map: PartitionMap,
+    pub schema: Schema,
+}
+
+impl Metadata {
+    pub fn new(schema: Schema, partition_map: PartitionMap) -> Self {
+        Self {
+            generation: 0,
+            partition_map,
+            schema,
+        }
+    }
+
+    pub fn advance_generation(&mut self) {
+        self.generation += 1;
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,7 +38,7 @@ pub trait QueryNode {
 
 pub struct DB {
     snapshot: Arc<slatedb::DbSnapshot>,
-    attribute_map: HashMap<String, i64>,
+    ident_map: HashMap<String, i64>,
     handle: Handle,
     tx_key: TxKey,
     tx_eid: i64,
@@ -46,14 +46,14 @@ pub struct DB {
 
 #[allow(unused)]
 impl DB {
-    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
-        Self { snapshot, attribute_map, handle, tx_key, tx_eid }
+    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, ident_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
+        Self { snapshot, ident_map, handle, tx_key, tx_eid }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
-    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, attribute_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
+    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, ident_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
         let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
-        Ok(Self { snapshot, attribute_map, handle, tx_key, tx_eid })
+        Ok(Self { snapshot, ident_map, handle, tx_key, tx_eid })
     }
 
     pub fn tx_key(&self) -> &TxKey {
@@ -73,12 +73,12 @@ impl Database for DB {
 
         let snapshot = self.snapshot.clone();
         let handle = self.handle.clone();
-        let attribute_map = self.attribute_map.clone();
+        let ident_map = self.ident_map.clone();
         let query = query.clone();
         let as_of = self.tx_eid;
 
         tokio::task::spawn_blocking(move || {
-            execute_query(&query, snapshot, handle, &attribute_map, as_of)
+            execute_query(&query, snapshot, handle, &ident_map, as_of)
         })
         .await
         .map_err(|e| anyhow::anyhow!("Query task failed: {}", e))?
@@ -96,8 +96,8 @@ pub struct Node<L: TxLog> {
 impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slatedb = Arc::new(in_memory_slate().await);
-        let (cache, counters) = crate::bootstrap::init_db(slatedb.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache, counters, None)));
+        let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, None)));
         let log = Arc::new(RwLock::new(MemoryLog::new(Box::new(clock::SystemClock))));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
@@ -113,7 +113,7 @@ impl Node<FileLog> {
         let db_path_str = db_path.to_str()
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
         let slatedb = Arc::new(local_slate(db_path_str).await);
-        let (cache, counters) = crate::bootstrap::init_db(slatedb.clone()).await;
+        let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
 
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
@@ -125,7 +125,7 @@ impl Node<FileLog> {
             None
         };
 
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), cache, counters, latest_indexed_tx)));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, latest_indexed_tx)));
         let log = Arc::new(RwLock::new(
             FileLog::new(&root_path.join("log"), Box::new(clock::SystemClock))?,
         ));
@@ -187,17 +187,17 @@ impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
     async fn db(&self) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let attribute_map = self.indexer.read().await.schema_cache().attribute_map();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
-        DB::from_latest_snapshot(snapshot, attribute_map, handle).await
+        DB::from_latest_snapshot(snapshot, ident_map, handle).await
     }
     // TODO we are currently not checking that snapshot contains TxKey
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let attribute_map = self.indexer.read().await.schema_cache().attribute_map();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
         let tx_eid = crate::indexer::tx_eid_for_tx_key(&snapshot, &tx_key).await?;
-        Ok(DB::new(snapshot, attribute_map, handle, tx_key, tx_eid))
+        Ok(DB::new(snapshot, ident_map, handle, tx_key, tx_eid))
     }
 }
 
@@ -265,7 +265,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let slate = node.slatedb.clone();
-        let email_id = node.indexer.read().await.schema_cache().get("email").unwrap().entity_id;
+        let email_id = node.indexer.read().await.metadata().schema.get_attribute("email").unwrap().0;
 
         // Check EAV index — find entry for entity 2000
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -14,6 +13,7 @@ use tokio::sync::RwLock;
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, TxOp};
 use crate::query::{execute_query, validate_query, QueryResult};
+use crate::schema::IdentMap;
 use crate::slate::{in_memory_slate, local_slate};
 pub use crate::transaction::{TransactionResult, TxKey};
 use tokio_util::sync::CancellationToken;
@@ -38,7 +38,7 @@ pub trait QueryNode {
 
 pub struct DB {
     snapshot: Arc<slatedb::DbSnapshot>,
-    ident_map: HashMap<String, i64>,
+    ident_map: IdentMap,
     handle: Handle,
     tx_key: TxKey,
     tx_eid: i64,
@@ -46,12 +46,12 @@ pub struct DB {
 
 #[allow(unused)]
 impl DB {
-    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, ident_map: HashMap<String, i64>, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
+    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
         Self { snapshot, ident_map, handle, tx_key, tx_eid }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
-    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, ident_map: HashMap<String, i64>, handle: Handle) -> Result<Self, Error> {
+    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle) -> Result<Self, Error> {
         let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
         Ok(Self { snapshot, ident_map, handle, tx_key, tx_eid })
     }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use crate::codec;
+use crate::metadata::PartitionMap;
 use crate::protocol;
 
 /// Entity ID bit layout (from PARTITIONS.md):
@@ -59,18 +58,6 @@ pub fn extract_counter(eid: i64) -> i64 {
     eid & COUNTER_MASK
 }
 
-/// Per-partition counter map: partition number → next counter value to allocate.
-pub type PartitionCounters = HashMap<u32, i64>;
-
-/// Allocate the next counter value for a partition, returning the current value
-/// and incrementing it. Initializes to 0 if the partition has no entry yet.
-pub fn allocate_counter(counters: &mut PartitionCounters, partition: u32) -> i64 {
-    let counter = counters.entry(partition).or_insert(0);
-    let value = *counter;
-    *counter = value + 1;
-    value
-}
-
 /// Returns true if the entity ID is a tempid (sign bit set, i.e. negative).
 pub fn is_tempid(eid: i64) -> bool {
     eid < 0
@@ -79,11 +66,12 @@ pub fn is_tempid(eid: i64) -> bool {
 /// Resolve entity IDs for Put documents that lack a `db/id` field.
 ///
 /// - If `db/id` is `DataType::Long` → keep as-is (explicit ID).
-/// - If `db/id` is missing → allocate from per-partition counters:
+///   TODO: validate via `PartitionMap::contains_entid` once tempid resolution is implemented.
+/// - If `db/id` is missing → allocate from partition map:
 ///   - Documents with `db/ident` → `DB_PARTITION` (schema/enum entities).
 ///   - All other documents → `USER_PARTITION`.
 /// - Add/Retract/Delete/Erase → pass through unchanged (require explicit IDs).
-pub fn resolve_entity_ids(ops: &[crate::ops::TxOp], counters: &mut PartitionCounters) -> anyhow::Result<Vec<crate::ops::TxOp>> {
+pub fn resolve_entity_ids(ops: &[crate::ops::TxOp], partition_map: &mut PartitionMap) -> anyhow::Result<Vec<crate::ops::TxOp>> {
     use crate::ops::{TxOp, DataType};
 
     let mut resolved = Vec::with_capacity(ops.len());
@@ -100,7 +88,7 @@ pub fn resolve_entity_ids(ops: &[crate::ops::TxOp], counters: &mut PartitionCoun
                         } else {
                             USER_PARTITION
                         };
-                        let eid = make_entity_id(partition, allocate_counter(counters, partition));
+                        let eid = partition_map.allocate_entid(partition);
                         let mut new_doc = doc.clone();
                         new_doc.insert("db/id".to_string(), DataType::Long(eid));
                         resolved.push(TxOp::Put(new_doc));
@@ -206,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_explicit_id_passthrough() {
-        let mut counters = PartitionCounters::new();
+        let mut counters = PartitionMap::new();
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(42));
         doc.insert("name".to_string(), DataType::String("alice".into()));
@@ -222,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_user_partition() {
-        let mut counters = PartitionCounters::new();
+        let mut counters = PartitionMap::new();
         let mut doc = BTreeMap::new();
         doc.insert("name".to_string(), DataType::String("alice".into()));
         let ops = vec![TxOp::Put(doc)];
@@ -243,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_db_partition_for_schema() {
-        let mut counters = PartitionCounters::new();
+        let mut counters = PartitionMap::new();
         let mut doc = BTreeMap::new();
         doc.insert("db/ident".to_string(), DataType::Keyword(
             edn::kw!(:my-attr),
@@ -269,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_db_partition_for_enum() {
-        let mut counters = PartitionCounters::new();
+        let mut counters = PartitionMap::new();
         let mut doc = BTreeMap::new();
         doc.insert("db/ident".to_string(), DataType::Keyword(
             edn::kw!(:db.type/string),
@@ -291,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_add_retract_passthrough() {
-        let mut counters = PartitionCounters::new();
+        let mut counters = PartitionMap::new();
         let ops = vec![
             TxOp::Add {
                 entity_id: 100,
@@ -312,7 +300,7 @@ mod tests {
 
     #[test]
     fn test_resolve_entity_ids_multiple_docs() {
-        let mut counters = PartitionCounters::from([(USER_PARTITION, 5i64)]);
+        let mut counters = PartitionMap::from([(USER_PARTITION, 5i64)]);
         let ops = vec![
             TxOp::Put({
                 let mut m = BTreeMap::new();

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use anyhow::Error;
 use tokio::runtime::Handle;
 
+use crate::schema::IdentMap;
+
 use edn::query::{
     Direction, Element, FindSpec, Limit, NonIntegerConstant, NotJoin, Order, OrJoin,
     OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace, PatternValuePlace,
@@ -110,7 +112,7 @@ fn pattern_variables(pattern: &Pattern) -> Vec<Variable> {
 /// Resolve attribute from a PatternNonValuePlace to an attribute ID.
 fn resolve_attribute_from_pattern(
     attr: &PatternNonValuePlace,
-    attribute_map: &HashMap<String, i64>,
+    ident_map: &IdentMap,
 ) -> Result<i64, Error> {
     match attr {
         PatternNonValuePlace::Ident(ref kw) => {
@@ -118,7 +120,7 @@ fn resolve_attribute_from_pattern(
                 Some(ns) => format!("{}/{}", ns, kw.name()),
                 None => kw.name().to_string(),
             };
-            attribute_map
+            ident_map
                 .get(&name)
                 .copied()
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", name))
@@ -1062,12 +1064,12 @@ fn compile_or_branch(
     var_index: &HashMap<&Variable, usize>,
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
-    attribute_map: &HashMap<String, i64>,
+    ident_map: &IdentMap,
     as_of: i64,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match branch {
         OrWhereClause::Clause(clause) => {
-            compile_where_clause(clause, join_order, var_index, slate, handle, attribute_map, as_of)
+            compile_where_clause(clause, join_order, var_index, slate, handle, ident_map, as_of)
         }
         OrWhereClause::And(children) => {
             let extenders: Vec<Box<dyn PrefixExtender>> = children
@@ -1079,7 +1081,7 @@ fn compile_or_branch(
                         var_index,
                         slate,
                         handle,
-                        attribute_map,
+                        ident_map,
                         as_of,
                     )
                 })
@@ -1096,12 +1098,12 @@ fn compile_where_clause(
     var_index: &HashMap<&Variable, usize>,
     slate: &Arc<slatedb::DbSnapshot>,
     handle: &Handle,
-    attribute_map: &HashMap<String, i64>,
+    ident_map: &IdentMap,
     as_of: i64,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match clause {
         WhereClause::Pattern(pattern) => {
-            let attr_id = resolve_attribute_from_pattern(&pattern.attribute, attribute_map)?;
+            let attr_id = resolve_attribute_from_pattern(&pattern.attribute, ident_map)?;
             let extender = compile_pattern(
                 pattern,
                 join_order,
@@ -1124,7 +1126,7 @@ fn compile_where_clause(
                         var_index,
                         slate,
                         handle,
-                        attribute_map,
+                        ident_map,
                         as_of,
                     )
                 })
@@ -1142,7 +1144,7 @@ fn compile_where_clause(
                         var_index,
                         slate,
                         handle,
-                        attribute_map,
+                        ident_map,
                         as_of,
                     )
                 })
@@ -1172,7 +1174,7 @@ pub fn execute_query(
     query: &ParsedQuery,
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
-    attribute_map: &HashMap<String, i64>,
+    ident_map: &IdentMap,
     as_of: i64,
 ) -> Result<QueryResult, Error> {
     // 1. Extract variable order
@@ -1190,7 +1192,7 @@ pub fn execute_query(
             &var_index,
             &slate,
             &handle,
-            attribute_map,
+            ident_map,
             as_of,
         )?);
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -154,8 +154,6 @@ impl Cardinality {
     }
 }
 
-// --- Mentat-aligned type aliases ---
-
 /// ident → entity_id (ALL named entities: enums + schema attrs)
 pub type IdentMap = HashMap<String, i64>;
 /// entity_id → ident (ALL named entities: enums + schema attrs)
@@ -258,7 +256,11 @@ impl Schema {
                 ));
             }
 
-            // Type-check against known attributes (skip schema-defining attrs for new entities)
+            // Type-check against known attributes. The `else if` fallback exists only for
+            // the bootstrap transaction: db/ident, db/valueType, and db/cardinality are
+            // installed BY the bootstrap tx itself, so they aren't in attribute_map yet when
+            // we validate it.
+            // TODO: Make the bootstrap process resemble more what Mentat does and remove the else if fallback
             if let Some((_eid, attr)) = self.get_attribute(&datom.attribute) {
                 if !attr.value_type.matches(&datom.value) {
                     return Err(anyhow::anyhow!(
@@ -270,7 +272,11 @@ impl Schema {
                 return Err(anyhow::anyhow!("Unknown attribute: {}", datom.attribute));
             }
 
-            // Witness schema-related datoms
+            // Witness schema-related datoms.
+            // NOTE: we do not currently require that an attribute entity (one with
+            // db/valueType + db/cardinality) also has a db/ident. Bootstrap entities
+            // always include one, but user-defined attributes could be installed without
+            // a name. Not an issue for correctness, but maybe worth enforcing.
             match datom.attribute.as_str() {
                 "db/ident" => {
                     // TODO: should match against a namespaced Keyword and use its

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -443,10 +443,10 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// so the inefficiency is minor, but a single-pass approach would be cleaner.
 pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
-    let mut bootstrap_attr_map = HashMap::new();
-    bootstrap_attr_map.insert("db/ident".to_string(), DB_IDENT);
-    bootstrap_attr_map.insert("db/valueType".to_string(), DB_VALUE_TYPE);
-    bootstrap_attr_map.insert("db/cardinality".to_string(), DB_CARDINALITY);
+    let mut bootstrap_ident_map = HashMap::new();
+    bootstrap_ident_map.insert("db/ident".to_string(), DB_IDENT);
+    bootstrap_ident_map.insert("db/valueType".to_string(), DB_VALUE_TYPE);
+    bootstrap_ident_map.insert("db/cardinality".to_string(), DB_CARDINALITY);
     let snapshot = slatedb.snapshot().await.expect("Failed to create snapshot");
     let handle = Handle::current();
 
@@ -457,9 +457,9 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
 
     let snap_clone = snapshot.clone();
     let handle_clone = handle.clone();
-    let attr_map_clone = bootstrap_attr_map.clone();
+    let ident_map_clone = bootstrap_ident_map.clone();
     let ident_results = tokio::task::spawn_blocking(move || {
-        execute_query(&ident_query, snap_clone, handle_clone, &attr_map_clone, i64::MAX)
+        execute_query(&ident_query, snap_clone, handle_clone, &ident_map_clone, i64::MAX)
     })
     .await
     .expect("Ident query task failed")
@@ -471,7 +471,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     ).expect("Attribute query parse failed");
 
     let attr_results = tokio::task::spawn_blocking(move || {
-        execute_query(&attr_query, snapshot, handle, &bootstrap_attr_map, i64::MAX)
+        execute_query(&attr_query, snapshot, handle, &bootstrap_ident_map, i64::MAX)
     })
     .await
     .expect("Attribute query task failed")

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -204,8 +204,8 @@ impl AttributeBuilder {
 /// Pre-validated schema changes, ready to apply after commit.
 #[derive(Debug)]
 pub struct SchemaUpdate {
-    pub idents: Vec<(i64, String)>,
-    pub attributes: Vec<(i64, Attribute)>,
+    pub(crate) idents: Vec<(i64, String)>,
+    pub(crate) attributes: Vec<(i64, Attribute)>,
 }
 
 impl SchemaUpdate {
@@ -252,9 +252,9 @@ impl Schema {
             }
 
             // Reject modifications to existing schema entities
-            if self.is_schema_entity(datom.entity) {
+            if let Some(ident) = self.entid_map.get(&datom.entity) {
                 return Err(anyhow::anyhow!(
-                    "Cannot modify schema entity {}", datom.entity
+                    "Cannot modify schema entity {} ({})", datom.entity, ident
                 ));
             }
 
@@ -436,6 +436,11 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// Runs two queries:
 /// 1. All entities with db/ident → populates ident_map/entid_map
 /// 2. Entities with db/ident + db/valueType + db/cardinality → populates attribute_map
+///
+/// TODO: These two queries could be merged into a single query that fetches all
+/// db/ident entities with optional db/valueType + db/cardinality. Query 2 re-fetches
+/// ?e and ?ident that were already retrieved in query 1. This is only run at startup
+/// so the inefficiency is minor, but a single-pass approach would be cleaner.
 pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
     let mut bootstrap_attr_map = HashMap::new();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,9 +6,9 @@ use edn::kw;
 use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
-use crate::ops::{Attribute, DataType, Datom, DatomOp, Entid, TxOp};
+use crate::ops::{DataType, Datom, DatomOp, TxOp};
 use crate::parse::parse_query;
-use crate::query::{execute_query, validate_query};
+use crate::query::execute_query;
 
 // --- Reserved entity IDs ---
 // Used as explicit db/id values in bootstrap_schema_tx().
@@ -154,127 +154,198 @@ impl Cardinality {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SchemaAttribute {
-    pub entity_id: i64,
-    pub ident: String,
+// --- Mentat-aligned type aliases ---
+
+/// ident → entity_id (ALL named entities: enums + schema attrs)
+pub type IdentMap = HashMap<String, i64>;
+/// entity_id → ident (ALL named entities: enums + schema attrs)
+pub type EntidMap = HashMap<i64, String>;
+/// entity_id → Attribute (only schema attributes with db/valueType)
+pub type AttributeMap = HashMap<i64, Attribute>;
+
+/// A schema attribute's properties.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attribute {
     pub value_type: ValueType,
-    pub cardinality: Cardinality,
+    pub multival: bool,
 }
 
+/// Builder for accumulating attribute properties from (e, a, v) assertions.
+/// Each schema-related datom (db/valueType, db/cardinality) for the same entity
+/// is witnessed onto the same builder. After all datoms are processed, build()
+/// produces a validated Attribute.
 #[derive(Debug, Default)]
-pub struct SchemaCache {
-    by_ident: HashMap<String, SchemaAttribute>,
-    by_entity_id: HashMap<i64, String>,
+pub struct AttributeBuilder {
+    pub value_type: Option<ValueType>,
+    pub multival: Option<bool>,
 }
 
-impl SchemaCache {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn get(&self, ident: &str) -> Option<&SchemaAttribute> {
-        self.by_ident.get(ident)
-    }
-
-    pub fn is_schema_entity(&self, entity_id: i64) -> bool {
-        self.by_entity_id.contains_key(&entity_id)
-    }
-
-    fn insert(&mut self, attr: SchemaAttribute) {
-        self.by_entity_id.insert(attr.entity_id, attr.ident.clone());
-        self.by_ident.insert(attr.ident.clone(), attr);
-    }
-
-    pub fn attribute_map(&self) -> HashMap<String, i64> {
-        self.by_entity_id.iter().map(|(id, ident)| (ident.clone(), *id)).collect()
-    }
-
-    /// Extract schema attributes defined by assert datoms.
-    /// Entities with both db/ident and db/valueType become SchemaAttributes.
-    /// Entities with only db/ident (enum entities) are skipped.
-    pub fn validate_schema_attrs(datoms: &[Datom]) -> Result<Vec<SchemaAttribute>> {
-        if !datoms.iter().any(|d| d.op == DatomOp::Assert
-            && matches!(d.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality"))
-        {
-            return Ok(Vec::new());
+impl AttributeBuilder {
+    /// Validate that all required fields are present for a new attribute.
+    pub fn validate_install_attribute(&self) -> Result<()> {
+        if self.value_type.is_none() {
+            return Err(anyhow::anyhow!("db/valueType is required for schema attribute"));
         }
-
-        let mut facts: HashMap<i64, HashMap<&str, &DataType>> = HashMap::new();
-        for d in datoms.iter().filter(|d| d.op == DatomOp::Assert) {
-            if matches!(d.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality") {
-                facts.entry(d.entity).or_default().insert(&d.attribute, &d.value);
-            }
+        if self.multival.is_none() {
+            return Err(anyhow::anyhow!("db/cardinality is required for schema attribute"));
         }
-
-        let mut attrs = Vec::new();
-        for (entity_id, f) in &facts {
-            // TODO: should match against a namespaced Keyword and use its
-            // namespace/name directly instead of string-stripping the colon prefix.
-            let ident = match f.get("db/ident") {
-                Some(DataType::Keyword(kw)) => {
-                    let s = kw.to_string();
-                    s.strip_prefix(':').unwrap_or(&s).to_string()
-                }
-                Some(_) => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
-                None => continue,
-            };
-            let value_type = match f.get("db/valueType") {
-                Some(DataType::Keyword(kw)) => ValueType::from_keyword(kw)?,
-                Some(_) => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
-                None => continue, // enum entity
-            };
-            let cardinality = match f.get("db/cardinality") {
-                Some(DataType::Keyword(kw)) => Cardinality::from_keyword(kw)?,
-                Some(_) => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
-                None => return Err(anyhow::anyhow!(
-                    "db/cardinality is required for schema attribute '{}'", ident
-                )),
-            };
-            attrs.push(SchemaAttribute {
-                ident, value_type, cardinality, entity_id: *entity_id,
-            });
-        }
-        Ok(attrs)
+        Ok(())
     }
 
-    pub fn process_tx(&mut self, new_attrs: Vec<SchemaAttribute>) {
-        for attr in new_attrs {
-            self.insert(attr);
+    /// Build a validated Attribute from accumulated fields.
+    pub fn build(self) -> Attribute {
+        Attribute {
+            value_type: self.value_type.expect("value_type must be set"),
+            multival: self.multival.expect("multival must be set"),
         }
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.by_ident.len()
-    }
+/// Pre-validated schema changes, ready to apply after commit.
+#[derive(Debug)]
+pub struct SchemaUpdate {
+    pub idents: Vec<(i64, String)>,
+    pub attributes: Vec<(i64, Attribute)>,
+}
 
+impl SchemaUpdate {
     pub fn is_empty(&self) -> bool {
-        self.by_ident.is_empty()
+        self.idents.is_empty() && self.attributes.is_empty()
+    }
+}
+
+/// The schema: bidirectional ident/entid maps + attribute definitions.
+#[derive(Debug, Default)]
+pub struct Schema {
+    pub entid_map: EntidMap,
+    pub ident_map: IdentMap,
+    pub attribute_map: AttributeMap,
+}
+
+impl Schema {
+    /// Two-step lookup: ident → entity_id via ident_map, then entity_id → Attribute via attribute_map.
+    pub fn get_attribute(&self, ident: &str) -> Option<(i64, &Attribute)> {
+        let eid = self.ident_map.get(ident)?;
+        let attr = self.attribute_map.get(eid)?;
+        Some((*eid, attr))
     }
 
-    /// Validate datoms against the schema and return any new schema attributes
-    /// defined by this transaction.
-    pub fn validate_tx(&self, datoms: &[Datom]) -> Result<Vec<SchemaAttribute>> {
+    /// Check if an entity ID is a schema attribute (has an entry in attribute_map).
+    pub fn is_schema_entity(&self, entity_id: i64) -> bool {
+        self.attribute_map.contains_key(&entity_id)
+    }
+
+    /// Single-pass validation and schema change extraction (pre-commit, fallible).
+    ///
+    /// For each datom:
+    /// 1. Type-check value against attribute's value_type, error on unknown attributes
+    /// 2. Witness schema-related datoms into two streams:
+    ///    - Ident stream: db/ident → pending (i64, String) pairs
+    ///    - Attribute stream: db/valueType, db/cardinality → AttributeBuilder per entity
+    pub fn validate_and_prepare(&self, datoms: &[Datom]) -> Result<SchemaUpdate> {
+        let mut ident_updates: Vec<(i64, String)> = Vec::new();
+        let mut builders: HashMap<i64, AttributeBuilder> = HashMap::new();
+
         for datom in datoms {
+            if datom.op != DatomOp::Assert {
+                continue;
+            }
+
+            // Reject modifications to existing schema entities
             if self.is_schema_entity(datom.entity) {
                 return Err(anyhow::anyhow!(
                     "Cannot modify schema entity {}", datom.entity
                 ));
             }
 
-            let schema_attr = self.by_ident.get(&datom.attribute)
-                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-            if !schema_attr.value_type.matches(&datom.value) {
-                return Err(anyhow::anyhow!(
-                    "Type mismatch for attribute {}: expected {}, got {:?}",
-                    datom.attribute, schema_attr.value_type, datom.value
-                ));
+            // Type-check against known attributes (skip schema-defining attrs for new entities)
+            if let Some((_eid, attr)) = self.get_attribute(&datom.attribute) {
+                if !attr.value_type.matches(&datom.value) {
+                    return Err(anyhow::anyhow!(
+                        "Type mismatch for attribute {}: expected {}, got {:?}",
+                        datom.attribute, attr.value_type, datom.value
+                    ));
+                }
+            } else if !matches!(datom.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality") {
+                return Err(anyhow::anyhow!("Unknown attribute: {}", datom.attribute));
+            }
+
+            // Witness schema-related datoms
+            match datom.attribute.as_str() {
+                "db/ident" => {
+                    // TODO: should match against a namespaced Keyword and use its
+                    // namespace/name directly instead of string-stripping the colon prefix.
+                    match &datom.value {
+                        DataType::Keyword(kw) => {
+                            let s = kw.to_string();
+                            let ident = s.strip_prefix(':').unwrap_or(&s).to_string();
+                            ident_updates.push((datom.entity, ident));
+                        }
+                        _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
+                    }
+                }
+                "db/valueType" => {
+                    match &datom.value {
+                        DataType::Keyword(kw) => {
+                            let vt = ValueType::from_keyword(kw)?;
+                            builders.entry(datom.entity).or_default().value_type = Some(vt);
+                        }
+                        _ => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
+                    }
+                }
+                "db/cardinality" => {
+                    match &datom.value {
+                        DataType::Keyword(kw) => {
+                            let card = Cardinality::from_keyword(kw)?;
+                            builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
+                        }
+                        _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
+                    }
+                }
+                _ => {}
             }
         }
 
-        // Also validates schema definitions
-        // (e.g. db/ident must be a Keyword, db/valueType must map to a valid ValueType).
-        Self::validate_schema_attrs(datoms)
+        // Validate and build attributes from builders
+        let mut attribute_updates: Vec<(i64, Attribute)> = Vec::new();
+        for (entity_id, builder) in builders {
+            // Only require full validation if the entity has db/valueType (is a real attribute).
+            // Entities with only db/cardinality but no db/valueType would fail validation,
+            // but that's the correct behavior.
+            builder.validate_install_attribute().map_err(|e| {
+                // Find the ident for better error messages
+                let ident = ident_updates.iter()
+                    .find(|(eid, _)| *eid == entity_id)
+                    .map(|(_, name)| name.as_str())
+                    .unwrap_or("<unknown>");
+                anyhow::anyhow!("{} for '{}'", e, ident)
+            })?;
+            attribute_updates.push((entity_id, builder.build()));
+        }
+
+        Ok(SchemaUpdate {
+            idents: ident_updates,
+            attributes: attribute_updates,
+        })
+    }
+
+    /// Apply pre-validated schema changes (post-commit, infallible).
+    pub fn apply_schema_update(&mut self, update: SchemaUpdate) {
+        for (eid, ident) in update.idents {
+            self.ident_map.insert(ident.clone(), eid);
+            self.entid_map.insert(eid, ident);
+        }
+        for (eid, attr) in update.attributes {
+            self.attribute_map.insert(eid, attr);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.attribute_map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.attribute_map.is_empty()
     }
 }
 
@@ -361,36 +432,50 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
     ]
 }
 
-/// Load the SchemaCache from indices by querying with the Datalog engine.
-/// Finds all entities with db/ident + db/valueType + db/cardinality (inner join).
-/// Uses bootstrap attribute constants (DB_IDENT, DB_VALUE_TYPE, DB_CARDINALITY) to
-/// bootstrap the query — these are the only attributes needed to query schema entities.
-pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache {
+/// Load the Schema from indices by querying with the Datalog engine.
+/// Runs two queries:
+/// 1. All entities with db/ident → populates ident_map/entid_map
+/// 2. Entities with db/ident + db/valueType + db/cardinality → populates attribute_map
+pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
-    let mut attribute_map = HashMap::new();
-    attribute_map.insert("db/ident".to_string(), DB_IDENT);
-    attribute_map.insert("db/valueType".to_string(), DB_VALUE_TYPE);
-    attribute_map.insert("db/cardinality".to_string(), DB_CARDINALITY);
+    let mut bootstrap_attr_map = HashMap::new();
+    bootstrap_attr_map.insert("db/ident".to_string(), DB_IDENT);
+    bootstrap_attr_map.insert("db/valueType".to_string(), DB_VALUE_TYPE);
+    bootstrap_attr_map.insert("db/cardinality".to_string(), DB_CARDINALITY);
     let snapshot = slatedb.snapshot().await.expect("Failed to create snapshot");
     let handle = Handle::current();
 
-    let query = parse_query(
-        "[:find ?e ?ident ?vt ?card :where [?e :db/ident ?ident] [?e :db/valueType ?vt] [?e :db/cardinality ?card]]"
-    ).expect("Schema query parse failed");
+    // Query 1: all entities with db/ident (populates ident_map/entid_map)
+    let ident_query = parse_query(
+        "[:find ?e ?ident :where [?e :db/ident ?ident]]"
+    ).expect("Ident query parse failed");
 
-    validate_query(&query).expect("Schema query validation failed");
-
-    let results = tokio::task::spawn_blocking(move || {
-        // Use i64::MAX to see all facts (no temporal filtering)
-        execute_query(&query, snapshot, handle, &attribute_map, i64::MAX)
+    let snap_clone = snapshot.clone();
+    let handle_clone = handle.clone();
+    let attr_map_clone = bootstrap_attr_map.clone();
+    let ident_results = tokio::task::spawn_blocking(move || {
+        execute_query(&ident_query, snap_clone, handle_clone, &attr_map_clone, i64::MAX)
     })
     .await
-    .expect("Schema query task failed")
-    .expect("Schema query execution failed");
+    .expect("Ident query task failed")
+    .expect("Ident query execution failed");
 
-    let mut cache = SchemaCache::new();
+    // Query 2: entities with db/ident + db/valueType + db/cardinality (populates attribute_map)
+    let attr_query = parse_query(
+        "[:find ?e ?ident ?vt ?card :where [?e :db/ident ?ident] [?e :db/valueType ?vt] [?e :db/cardinality ?card]]"
+    ).expect("Attribute query parse failed");
 
-    for row in results {
+    let attr_results = tokio::task::spawn_blocking(move || {
+        execute_query(&attr_query, snapshot, handle, &bootstrap_attr_map, i64::MAX)
+    })
+    .await
+    .expect("Attribute query task failed")
+    .expect("Attribute query execution failed");
+
+    let mut schema = Schema::default();
+
+    // Populate ident_map/entid_map from all entities with db/ident
+    for row in ident_results {
         let entity_id = match &row[0] {
             DataType::Long(id) => *id,
             other => panic!("Expected Long for entity_id, got {:?}", other),
@@ -402,6 +487,16 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
                 s.strip_prefix(':').unwrap_or(&s).to_string()
             }
             other => panic!("Expected Keyword for ident, got {:?}", other),
+        };
+        schema.ident_map.insert(ident.clone(), entity_id);
+        schema.entid_map.insert(entity_id, ident);
+    }
+
+    // Populate attribute_map from entities with all three schema properties
+    for row in attr_results {
+        let entity_id = match &row[0] {
+            DataType::Long(id) => *id,
+            other => panic!("Expected Long for entity_id, got {:?}", other),
         };
         let value_type = match &row[2] {
             DataType::Keyword(kw) => {
@@ -415,15 +510,13 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> SchemaCache 
             other => panic!("Expected Keyword for cardinality, got {:?}", other),
         };
 
-        cache.insert(SchemaAttribute {
-            ident,
+        schema.attribute_map.insert(entity_id, Attribute {
             value_type,
-            cardinality,
-            entity_id,
+            multival: cardinality == Cardinality::Many,
         });
     }
 
-    cache
+    schema
 }
 
 /// Build a transaction that defines common test attributes.
@@ -443,108 +536,113 @@ pub fn test_schema_tx() -> Vec<TxOp> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metadata::PartitionMap;
     use crate::ops::tx_ops_to_datoms;
 
     fn to_datoms(ops: &[TxOp]) -> Vec<Datom> {
-        let mut counters = crate::partition::PartitionCounters::new();
-        let resolved = crate::partition::resolve_entity_ids(ops, &mut counters).unwrap();
+        let mut pm = PartitionMap::new();
+        let resolved = crate::partition::resolve_entity_ids(ops, &mut pm).unwrap();
         tx_ops_to_datoms(&resolved, 0_i64).unwrap()
     }
 
-    fn extract_and_process(cache: &mut SchemaCache, datoms: &[Datom]) {
-        cache.process_tx(SchemaCache::validate_schema_attrs(datoms).unwrap());
-    }
-
-    fn bootstrapped_cache() -> SchemaCache {
-        let mut cache = SchemaCache::new();
+    fn bootstrapped_schema() -> Schema {
+        let mut schema = Schema::default();
         let tx_ops = bootstrap_schema_tx();
         let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
-        extract_and_process(&mut cache, &datoms);
-        cache
+        let update = schema.validate_and_prepare(&datoms).unwrap();
+        schema.apply_schema_update(update);
+        schema
     }
 
-    fn bootstrapped_cache_with_person_name() -> SchemaCache {
-        let mut cache = bootstrapped_cache();
+    fn bootstrapped_schema_with_person_name() -> Schema {
+        let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        extract_and_process(&mut cache, &to_datoms(&ops));
-        cache
+        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        schema.apply_schema_update(update);
+        schema
     }
 
     #[test]
-    fn test_schema_cache_from_bootstrap() {
-        let cache = bootstrapped_cache();
-        // 7 schema attrs (3 core + 4 tx); enum entities (db/ident only, no db/valueType) are skipped
-        assert_eq!(cache.len(), 7);
+    fn test_schema_from_bootstrap() {
+        let schema = bootstrapped_schema();
+        // 7 schema attrs (3 core + 4 tx); enum entities go into ident_map but not attribute_map
+        assert_eq!(schema.len(), 7);
 
-        let db_ident = cache.get("db/ident").unwrap();
-        assert_eq!(db_ident.entity_id, DB_IDENT);
-        assert_eq!(db_ident.value_type, ValueType::Keyword);
+        let (eid, attr) = schema.get_attribute("db/ident").unwrap();
+        assert_eq!(eid, DB_IDENT);
+        assert_eq!(attr.value_type, ValueType::Keyword);
 
-        let db_vt = cache.get("db/valueType").unwrap();
-        assert_eq!(db_vt.entity_id, DB_VALUE_TYPE);
-        assert_eq!(db_vt.value_type, ValueType::Keyword);
+        let (eid, attr) = schema.get_attribute("db/valueType").unwrap();
+        assert_eq!(eid, DB_VALUE_TYPE);
+        assert_eq!(attr.value_type, ValueType::Keyword);
 
-        let db_card = cache.get("db/cardinality").unwrap();
-        assert_eq!(db_card.entity_id, DB_CARDINALITY);
-        assert_eq!(db_card.value_type, ValueType::Keyword);
+        let (eid, attr) = schema.get_attribute("db/cardinality").unwrap();
+        assert_eq!(eid, DB_CARDINALITY);
+        assert_eq!(attr.value_type, ValueType::Keyword);
+
+        // Enum entities are in ident_map but not attribute_map
+        assert!(schema.ident_map.contains_key("db.type/string"));
+        assert_eq!(schema.ident_map["db.type/string"], DB_TYPE_STRING);
     }
 
     #[test]
-    fn test_process_tx_user_attribute() {
-        let cache = bootstrapped_cache_with_person_name();
-        assert_eq!(cache.len(), 8);
+    fn test_apply_schema_update_user_attribute() {
+        let schema = bootstrapped_schema_with_person_name();
+        assert_eq!(schema.len(), 8);
 
-        let attr = cache.get("name").unwrap();
+        let (_eid, attr) = schema.get_attribute("name").unwrap();
         assert_eq!(attr.value_type, ValueType::String);
     }
 
     #[test]
-    fn test_enum_entity_not_added_to_cache() {
-        let cache = bootstrapped_cache();
-        // enum entities have db/ident but no db/valueType → not schema attributes
-        assert!(cache.get("db.type/string").is_none());
+    fn test_enum_entity_not_in_attribute_map() {
+        let schema = bootstrapped_schema();
+        // enum entities have db/ident but no db/valueType → not in attribute_map
+        assert!(schema.get_attribute("db.type/string").is_none());
+        // but they are in ident_map
+        assert!(schema.ident_map.contains_key("db.type/string"));
     }
 
     #[test]
-    fn test_validate_tx_valid() {
-        let cache = bootstrapped_cache_with_person_name();
+    fn test_validate_and_prepare_valid() {
+        let schema = bootstrapped_schema_with_person_name();
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("name".to_string(), DataType::String("Alice".to_string()));
-        assert!(cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).is_ok());
+        assert!(schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).is_ok());
     }
 
     #[test]
-    fn test_validate_tx_unknown_attribute() {
-        let cache = bootstrapped_cache_with_person_name();
+    fn test_validate_and_prepare_unknown_attribute() {
+        let schema = bootstrapped_schema_with_person_name();
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("person/age".to_string(), DataType::Long(30));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
+        let err = schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Unknown attribute: person/age"));
     }
 
     #[test]
-    fn test_validate_tx_type_mismatch() {
-        let cache = bootstrapped_cache_with_person_name();
+    fn test_validate_and_prepare_type_mismatch() {
+        let schema = bootstrapped_schema_with_person_name();
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("name".to_string(), DataType::Long(42));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
+        let err = schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Type mismatch"));
     }
 
     #[test]
-    fn test_validate_tx_schema_defining_tx() {
-        let cache = bootstrapped_cache();
+    fn test_validate_and_prepare_schema_defining_tx() {
+        let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        assert!(cache.validate_tx(&to_datoms(&ops)).is_ok());
+        assert!(schema.validate_and_prepare(&to_datoms(&ops)).is_ok());
     }
 
     #[test]
     fn test_schema_immutability() {
-        let cache = bootstrapped_cache_with_person_name();
-        let name_id = cache.get("name").unwrap().entity_id;
+        let schema = bootstrapped_schema_with_person_name();
+        let (name_id, _) = schema.get_attribute("name").unwrap();
 
         // Cannot redefine existing schema entity
         let mut doc = BTreeMap::new();
@@ -552,7 +650,7 @@ mod tests {
         doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
         doc.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/long)));
         doc.insert("db/cardinality".to_string(), DataType::Keyword(kw!(:db.cardinality/one)));
-        let err = cache.validate_tx(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
+        let err = schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
 
@@ -564,32 +662,32 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_schema_attrs_parses_cardinality_many() {
-        let ops = [schema_attribute_with_cardinality(
-            kw!(:tags), "string", "many",
-        )];
-        let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
-        assert_eq!(attrs.len(), 1);
-        assert_eq!(attrs[0].ident, "tags");
-        assert_eq!(attrs[0].cardinality, Cardinality::Many);
+    fn test_validate_and_prepare_parses_cardinality_many() {
+        let schema = bootstrapped_schema();
+        let ops = [schema_attribute_with_cardinality(kw!(:tags), "string", "many")];
+        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        assert_eq!(update.attributes.len(), 1);
+        assert!(update.attributes[0].1.multival);
     }
 
     #[test]
-    fn test_validate_schema_attrs_parses_cardinality_one() {
+    fn test_validate_and_prepare_parses_cardinality_one() {
+        let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        let attrs = SchemaCache::validate_schema_attrs(&to_datoms(&ops)).unwrap();
-        assert_eq!(attrs.len(), 1);
-        assert_eq!(attrs[0].cardinality, Cardinality::One);
+        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        assert_eq!(update.attributes.len(), 1);
+        assert!(!update.attributes[0].1.multival);
     }
 
     #[test]
-    fn test_validate_schema_attrs_missing_cardinality_errors() {
+    fn test_validate_and_prepare_missing_cardinality_errors() {
+        let schema = bootstrapped_schema();
         let mut doc = BTreeMap::new();
         doc.insert("db/id".to_string(), DataType::Long(100));
         doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
         doc.insert("db/valueType".to_string(), DataType::Keyword(kw!(:db.type/string)));
         // No db/cardinality
-        let err = SchemaCache::validate_schema_attrs(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
+        let err = schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
         assert!(err.to_string().contains("db/cardinality is required"));
     }
 }


### PR DESCRIPTION
## Summary

- Replace `SchemaCache`/`SchemaAttribute` with three-map `Schema` (`ident_map`, `entid_map`, `attribute_map`), `Attribute`/`AttributeBuilder`, and two-phase schema update (`validate_and_prepare` + `apply_schema_update`)
- Replace `PartitionCounters` type alias with `PartitionMap` newtype (wraps `HashMap<u32, i64>` with `Deref`/`DerefMut` and methods `allocate_counter`, `allocate_entid`, `contains_entid`)
- Group `Schema` + `PartitionMap` + `generation` into `Metadata` struct owned by `Indexer`
- Update `transact_tx_inner` to the 7-stage pipeline (clone PM → allocate tx → resolve IDs → expand datoms → validate+prepare → cardinality resolution → write+commit → apply)
- Rename `attribute_map` parameter to `ident_map` (with new `IdentMap` type alias) throughout the query pipeline and `DB` struct — the map is ident → entid, not entid → attribute
- Only advance `Metadata::generation` and call `apply_schema_update` when the transaction actually contains schema changes
- Add `design/TRANSACTION_PIPELINE.md` design doc

## Test plan

- [x] `cargo build` compiles cleanly
- [x] All 371 unit tests pass
- [x] All 17 integration tests pass
- [x] Schema, partition, indexer, bootstrap, and node tests all updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)