### PR TITLE
refactor: change ORDER BY syntax to [[?var :asc] [?var :desc]]

### DIFF
--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -341,9 +341,9 @@ limit -> query::Limit
     }
 
 order -> query::Order
-    = __ "(" __ "asc" v:variable ")" __ { query::Order(query::Direction::Ascending, v) }
-    / __ "(" __ "desc" v:variable ")" __ { query::Order(query::Direction::Descending, v) }
-    / v:variable { query::Order(query::Direction::Ascending, v) }
+    = __ "[" v:variable __ ":desc" __ "]" __ { query::Order(query::Direction::Descending, v) }
+    / __ "[" v:variable __ ":asc" __ "]" __ { query::Order(query::Direction::Ascending, v) }
+    / __ "[" v:variable __ "]" __ { query::Order(query::Direction::Ascending, v) }
 
 
 pattern_value_place -> query::PatternValuePlace
@@ -479,6 +479,8 @@ query_part -> query::QueryPart
 map_query_part -> query::QueryPart
     = __ ":find" __ "[" fs:find_spec "]" __ { query::QueryPart::FindSpec(fs) }
     / __ ":where" __ "[" ws:where_clause+ "]" __ { query::QueryPart::WhereClauses(ws) }
+    / __ ":order" __ "[" os:order+ "]" __ { query::QueryPart::Order(os) }
+    / __ ":limit" l:limit { query::QueryPart::Limit(l) }
 
 pub parse_query -> query::ParsedQuery
     = __ "[" qps:query_part+ "]" __ {? query::ParsedQuery::from_parts(qps) }

--- a/edn/src/query.rs
+++ b/edn/src/query.rs
@@ -1479,8 +1479,8 @@ impl std::fmt::Display for FindSpec {
 impl std::fmt::Display for Order {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.0 {
-            Direction::Ascending => write!(f, "(asc {})", self.1),
-            Direction::Descending => write!(f, "(desc {})", self.1),
+            Direction::Ascending => write!(f, "[{} :asc]", self.1),
+            Direction::Descending => write!(f, "[{} :desc]", self.1),
         }
     }
 }

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -219,19 +219,19 @@ fn can_parse_order_by() {
     assert!(parse_query(invalid).is_err());
 
     // Defaults to ascending.
-    let default = "[:find ?x :where [?x :foo/baz ?y] :order ?y]";
+    let default = "[:find ?x :where [?x :foo/baz ?y] :order [?y]]";
     assert_eq!(parse_query(default).unwrap().order,
                Some(vec![Order(Direction::Ascending, "?y".to_var())]));
 
-    let ascending = "[:find ?x :where [?x :foo/baz ?y] :order (asc ?y)]";
+    let ascending = "[:find ?x :where [?x :foo/baz ?y] :order [?y :asc]]";
     assert_eq!(parse_query(ascending).unwrap().order,
                Some(vec![Order(Direction::Ascending, "?y".to_var())]));
 
-    let descending = "[:find ?x :where [?x :foo/baz ?y] :order (desc ?y)]";
+    let descending = "[:find ?x :where [?x :foo/baz ?y] :order [?y :desc]]";
     assert_eq!(parse_query(descending).unwrap().order,
                Some(vec![Order(Direction::Descending, "?y".to_var())]));
 
-    let mixed = "[:find ?x :where [?x :foo/baz ?y] :order (desc ?y) (asc ?x)]";
+    let mixed = "[:find ?x :where [?x :foo/baz ?y] :order [?y :desc] [?x :asc]]";
     assert_eq!(parse_query(mixed).unwrap().order,
                Some(vec![Order(Direction::Descending, "?y".to_var()),
                          Order(Direction::Ascending, "?x".to_var())]));


### PR DESCRIPTION
## Summary

- Changes `:order` clause syntax from `(asc ?var)` / `(desc ?var)` to `[?var :asc]` / `[?var :desc]` (bare `[?var]` defaults to ascending)
- Adds `:order` and `:limit` support to the map-style `{...}` parser (previously only vector-style `[...]` supported them)
- Updates `Order` Display impl and parser tests

## Test plan

- [x] `can_parse_order_by` parser test updated and passing
- [x] Full `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)