### PR TITLE
Add Float cross-numeric promotion and error on incomparable types

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -156,9 +156,7 @@ impl Accumulator for MinAccumulator {
                 self.current = Some(value.clone());
             }
             Some(current) => {
-                let ord = current
-                    .partial_compare(value)
-                    .ok_or_else(|| anyhow!("min: incomparable types"))?;
+                let ord = current.partial_compare(value)?;
                 if ord == std::cmp::Ordering::Greater {
                     self.current = Some(value.clone());
                 }
@@ -185,9 +183,7 @@ impl Accumulator for MaxAccumulator {
                 self.current = Some(value.clone());
             }
             Some(current) => {
-                let ord = current
-                    .partial_compare(value)
-                    .ok_or_else(|| anyhow!("max: incomparable types"))?;
+                let ord = current.partial_compare(value)?;
                 if ord == std::cmp::Ordering::Less {
                     self.current = Some(value.clone());
                 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -135,17 +135,17 @@ pub fn evaluate_as_bool(expr: &Expr, ctx: &EvalContext) -> bool {
 fn eval_binary_op(left: &DataType, op: &BinaryOp, right: &DataType) -> Option<DataType> {
     match op {
         BinaryOp::Lt => {
-            Some(DataType::Boolean(left.partial_compare(right)? == Ordering::Less))
+            Some(DataType::Boolean(left.partial_compare(right).ok()? == Ordering::Less))
         }
         BinaryOp::LtEq => {
-            let ord = left.partial_compare(right)?;
+            let ord = left.partial_compare(right).ok()?;
             Some(DataType::Boolean(ord == Ordering::Less || ord == Ordering::Equal))
         }
         BinaryOp::Gt => {
-            Some(DataType::Boolean(left.partial_compare(right)? == Ordering::Greater))
+            Some(DataType::Boolean(left.partial_compare(right).ok()? == Ordering::Greater))
         }
         BinaryOp::GtEq => {
-            let ord = left.partial_compare(right)?;
+            let ord = left.partial_compare(right).ok()?;
             Some(DataType::Boolean(ord == Ordering::Greater || ord == Ordering::Equal))
         }
         BinaryOp::Eq => Some(DataType::Boolean(left == right)),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -92,24 +92,46 @@ impl DataType {
         }
     }
 
-    /// Compare two DataType values. Returns None if the types are incompatible
+    /// Compare two DataType values. Returns an error if the types are incompatible
     /// or if floats are NaN.
-    pub fn partial_compare(&self, other: &DataType) -> Option<std::cmp::Ordering> {
+    pub fn partial_compare(&self, other: &DataType) -> Result<std::cmp::Ordering> {
         use DataType::*;
         match (self, other) {
-            (Long(a), Long(b)) => Some(a.cmp(b)),
-            (BigInt(a), BigInt(b)) => Some(a.cmp(b)),
-            (Double(a), Double(b)) => a.partial_cmp(b),
-            (Float(a), Float(b)) => a.partial_cmp(b),
-            (String(a), String(b)) => Some(a.cmp(b)),
-            (Boolean(a), Boolean(b)) => Some(a.cmp(b)),
-            (Instant(a), Instant(b)) => Some(a.cmp(b)),
+            (Long(a), Long(b)) => Ok(a.cmp(b)),
+            (BigInt(a), BigInt(b)) => Ok(a.cmp(b)),
+            (Double(a), Double(b)) => a.partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Float(a), Float(b)) => a.partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (String(a), String(b)) => Ok(a.cmp(b)),
+            (Boolean(a), Boolean(b)) => Ok(a.cmp(b)),
+            (Instant(a), Instant(b)) => Ok(a.cmp(b)),
             // Cross-numeric promotion
-            (Long(a), BigInt(b)) => Some((*a as i128).cmp(b)),
-            (BigInt(a), Long(b)) => Some(a.cmp(&(*b as i128))),
-            (Long(a), Double(b)) => (*a as f64).partial_cmp(b),
-            (Double(a), Long(b)) => a.partial_cmp(&(*b as f64)),
-            _ => None,
+            (Long(a), BigInt(b)) => Ok((*a as i128).cmp(b)),
+            (BigInt(a), Long(b)) => Ok(a.cmp(&(*b as i128))),
+            (Long(a), Double(b)) => (*a as f64).partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Double(a), Long(b)) => a.partial_cmp(&(*b as f64))
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Long(a), Float(b)) => (*a as f32).partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Float(a), Long(b)) => a.partial_cmp(&(*b as f32))
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (BigInt(a), Float(b)) => (*a as f32).partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Float(a), BigInt(b)) => a.partial_cmp(&(*b as f32))
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (BigInt(a), Double(b)) => (*a as f64).partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Double(a), BigInt(b)) => a.partial_cmp(&(*b as f64))
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Float(a), Double(b)) => (*a as f64).partial_cmp(b)
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Double(a), Float(b)) => a.partial_cmp(&(*b as f64))
+                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            _ => Err(anyhow::anyhow!(
+                "cannot compare {:?} with {:?}", self.value_type(), other.value_type()
+            )),
         }
     }
 }
@@ -229,42 +251,53 @@ mod tests {
     #[test]
     fn test_partial_compare_same_type() {
         use std::cmp::Ordering;
-        assert_eq!(DataType::Long(1).partial_compare(&DataType::Long(2)), Some(Ordering::Less));
-        assert_eq!(DataType::Long(2).partial_compare(&DataType::Long(2)), Some(Ordering::Equal));
-        assert_eq!(DataType::Long(3).partial_compare(&DataType::Long(2)), Some(Ordering::Greater));
+        assert_eq!(DataType::Long(1).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Long(2).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Long(3).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Greater);
 
         assert_eq!(
-            DataType::String("a".into()).partial_compare(&DataType::String("b".into())),
-            Some(Ordering::Less),
+            DataType::String("a".into()).partial_compare(&DataType::String("b".into())).unwrap(),
+            Ordering::Less,
         );
         assert_eq!(
-            DataType::Boolean(false).partial_compare(&DataType::Boolean(true)),
-            Some(Ordering::Less),
+            DataType::Boolean(false).partial_compare(&DataType::Boolean(true)).unwrap(),
+            Ordering::Less,
         );
         assert_eq!(
-            DataType::Double(1.5).partial_compare(&DataType::Double(2.5)),
-            Some(Ordering::Less),
+            DataType::Double(1.5).partial_compare(&DataType::Double(2.5)).unwrap(),
+            Ordering::Less,
         );
     }
 
     #[test]
     fn test_partial_compare_cross_numeric() {
         use std::cmp::Ordering;
-        assert_eq!(DataType::Long(10).partial_compare(&DataType::BigInt(20)), Some(Ordering::Less));
-        assert_eq!(DataType::BigInt(20).partial_compare(&DataType::Long(10)), Some(Ordering::Greater));
-        assert_eq!(DataType::Long(5).partial_compare(&DataType::Double(5.0)), Some(Ordering::Equal));
-        assert_eq!(DataType::Double(3.0).partial_compare(&DataType::Long(4)), Some(Ordering::Less));
+        assert_eq!(DataType::Long(10).partial_compare(&DataType::BigInt(20)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::BigInt(20).partial_compare(&DataType::Long(10)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Long(5).partial_compare(&DataType::Double(5.0)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Double(3.0).partial_compare(&DataType::Long(4)).unwrap(), Ordering::Less);
+
+        // Float cross-numeric
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Long(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Double(1.0)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::BigInt(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::BigInt(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::BigInt(1).partial_compare(&DataType::Double(2.0)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::BigInt(1)).unwrap(), Ordering::Greater);
     }
 
     #[test]
     fn test_partial_compare_incompatible() {
-        assert_eq!(DataType::Long(1).partial_compare(&DataType::String("a".into())), None);
-        assert_eq!(DataType::Boolean(true).partial_compare(&DataType::Long(1)), None);
+        assert!(DataType::Long(1).partial_compare(&DataType::String("a".into())).is_err());
+        assert!(DataType::Boolean(true).partial_compare(&DataType::Long(1)).is_err());
     }
 
     #[test]
     fn test_partial_compare_nan() {
-        assert_eq!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)), None);
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Float(1.0)).is_err());
     }
 
     #[test]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -96,39 +96,29 @@ impl DataType {
     /// or if floats are NaN.
     pub fn partial_compare(&self, other: &DataType) -> Result<std::cmp::Ordering> {
         use DataType::*;
+        let nan_err = || anyhow::anyhow!("cannot compare NaN values");
         match (self, other) {
             (Long(a), Long(b)) => Ok(a.cmp(b)),
             (BigInt(a), BigInt(b)) => Ok(a.cmp(b)),
-            (Double(a), Double(b)) => a.partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Float(a), Float(b)) => a.partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Double(a), Double(b)) => a.partial_cmp(b).ok_or_else(nan_err),
+            (Float(a), Float(b)) => a.partial_cmp(b).ok_or_else(nan_err),
             (String(a), String(b)) => Ok(a.cmp(b)),
             (Boolean(a), Boolean(b)) => Ok(a.cmp(b)),
             (Instant(a), Instant(b)) => Ok(a.cmp(b)),
             // Cross-numeric promotion
+            // NOTE: casting BigInt(i128) to f32/f64 may lose precision for large values.
             (Long(a), BigInt(b)) => Ok((*a as i128).cmp(b)),
             (BigInt(a), Long(b)) => Ok(a.cmp(&(*b as i128))),
-            (Long(a), Double(b)) => (*a as f64).partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Double(a), Long(b)) => a.partial_cmp(&(*b as f64))
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Long(a), Float(b)) => (*a as f32).partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Float(a), Long(b)) => a.partial_cmp(&(*b as f32))
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (BigInt(a), Float(b)) => (*a as f32).partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Float(a), BigInt(b)) => a.partial_cmp(&(*b as f32))
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (BigInt(a), Double(b)) => (*a as f64).partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Double(a), BigInt(b)) => a.partial_cmp(&(*b as f64))
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Float(a), Double(b)) => (*a as f64).partial_cmp(b)
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
-            (Double(a), Float(b)) => a.partial_cmp(&(*b as f64))
-                .ok_or_else(|| anyhow::anyhow!("cannot compare NaN values")),
+            (Long(a), Double(b)) => (*a as f64).partial_cmp(b).ok_or_else(nan_err),
+            (Double(a), Long(b)) => a.partial_cmp(&(*b as f64)).ok_or_else(nan_err),
+            (Long(a), Float(b)) => (*a as f32).partial_cmp(b).ok_or_else(nan_err),
+            (Float(a), Long(b)) => a.partial_cmp(&(*b as f32)).ok_or_else(nan_err),
+            (BigInt(a), Float(b)) => (*a as f32).partial_cmp(b).ok_or_else(nan_err),
+            (Float(a), BigInt(b)) => a.partial_cmp(&(*b as f32)).ok_or_else(nan_err),
+            (BigInt(a), Double(b)) => (*a as f64).partial_cmp(b).ok_or_else(nan_err),
+            (Double(a), BigInt(b)) => a.partial_cmp(&(*b as f64)).ok_or_else(nan_err),
+            (Float(a), Double(b)) => (*a as f64).partial_cmp(b).ok_or_else(nan_err),
+            (Double(a), Float(b)) => a.partial_cmp(&(*b as f64)).ok_or_else(nan_err),
             _ => Err(anyhow::anyhow!(
                 "cannot compare {:?} with {:?}", self.value_type(), other.value_type()
             )),
@@ -296,8 +286,15 @@ mod tests {
 
     #[test]
     fn test_partial_compare_nan() {
+        // Same-type NaN
         assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)).is_err());
         assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Float(1.0)).is_err());
+        // Cross-type NaN
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::BigInt(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::BigInt(1)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `partial_compare` now returns `Result<Ordering>` instead of `Option<Ordering>`, erroring on incompatible types (e.g., Long vs String) and NaN comparisons
- Adds Float cross-numeric promotion for all numeric pairs: Float↔Long, Float↔BigInt, Float↔Double, BigInt↔Double
- Updates callers in `expr.rs` (`.ok()?`) and `aggregate.rs` (direct `?` propagation)

## Test plan
- [x] Existing `partial_compare` tests updated to use `Result`
- [x] New test cases for Float↔Long, Float↔BigInt, Float↔Double, BigInt↔Double
- [x] Incompatible type tests assert `is_err()`
- [x] NaN tests for both `f32` and `f64`
- [x] Full `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)