### PR TITLE
refactor: use Keyword for attribute identifiers

### DIFF
--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -426,10 +426,10 @@ impl FromStr for Keyword {
     }
 }
 
-impl<'a> TryFrom<&'a str> for Keyword {
+impl TryFrom<&str> for Keyword {
     type Error = KeywordParseError;
 
-    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
         Keyword::from_str(s)
     }
 }

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -13,8 +13,38 @@ use std::fmt::{
     Formatter,
     Write,
 };
+use std::str::FromStr;
 
 use crate::namespaceable_name::NamespaceableName;
+
+/// Error returned when a string cannot be parsed as a `Keyword`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeywordParseError {
+    /// Input did not start with `:`.
+    MissingColonPrefix,
+    /// The namespace part (before `/`) was empty.
+    EmptyNamespace,
+    /// The name part was empty.
+    EmptyName,
+}
+
+impl Display for KeywordParseError {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        match self {
+            KeywordParseError::MissingColonPrefix => {
+                write!(f, "keyword must start with ':'")
+            }
+            KeywordParseError::EmptyNamespace => {
+                write!(f, "keyword namespace cannot be empty")
+            }
+            KeywordParseError::EmptyName => {
+                write!(f, "keyword name cannot be empty")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KeywordParseError {}
 
 /// Construct a `Keyword` from a Clojure-like literal syntax.
 ///
@@ -355,6 +385,52 @@ impl Display for NamespacedSymbol {
     /// ```
     fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl FromStr for Keyword {
+    type Err = KeywordParseError;
+
+    /// Parse a keyword from its EDN Display form, e.g. `:foo/bar` or `:baz`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::str::FromStr;
+    /// # use edn::symbols::Keyword;
+    /// assert_eq!(Keyword::from_str(":foo/bar").unwrap(), Keyword::namespaced("foo", "bar"));
+    /// assert_eq!(Keyword::from_str(":baz").unwrap(), Keyword::plain("baz"));
+    /// assert!(Keyword::from_str("foo/bar").is_err());
+    /// assert!(Keyword::from_str(":/bar").is_err());
+    /// assert!(Keyword::from_str(":foo/").is_err());
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix(':').ok_or(KeywordParseError::MissingColonPrefix)?;
+        match s.split_once('/') {
+            Some((ns, name)) => {
+                if ns.is_empty() {
+                    return Err(KeywordParseError::EmptyNamespace);
+                }
+                if name.is_empty() {
+                    return Err(KeywordParseError::EmptyName);
+                }
+                Ok(Keyword::namespaced(ns, name))
+            }
+            None => {
+                if s.is_empty() {
+                    return Err(KeywordParseError::EmptyName);
+                }
+                Ok(Keyword::plain(s))
+            }
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Keyword {
+    type Error = KeywordParseError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Keyword::from_str(s)
     }
 }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -93,6 +93,7 @@ mod tests {
     use super::*;
     use crate::partition::DB_PARTITION;
     use crate::slate::in_memory_slate;
+    use edn::kw;
 
     #[tokio::test]
     async fn test_init_db_fresh() {
@@ -100,18 +101,18 @@ mod tests {
         let metadata = init_db(slatedb).await;
         // Bootstrap defines 7 schema attributes (3 core + 4 tx)
         assert_eq!(metadata.schema.len(), 7);
-        assert!(metadata.schema.get_attribute("db/ident").is_some());
-        assert!(metadata.schema.get_attribute("db/valueType").is_some());
-        assert!(metadata.schema.get_attribute("db/cardinality").is_some());
-        assert!(metadata.schema.get_attribute("db/txInstant").is_some());
-        assert!(metadata.schema.get_attribute("db/txId").is_some());
-        assert!(metadata.schema.get_attribute("db/txResult").is_some());
-        assert!(metadata.schema.get_attribute("db.tx/error").is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/ident)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/valueType)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/cardinality)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/txInstant)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/txId)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/txResult)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db.tx/error)).is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
         assert_eq!(metadata.partition_map[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
         // Enum entities are in ident_map but not attribute_map
-        assert!(metadata.schema.ident_map.contains_key("db.type/string"));
-        assert!(metadata.schema.get_attribute("db.type/string").is_none());
+        assert!(metadata.schema.ident_map.contains_key(&kw!(:db.type/string)));
+        assert!(metadata.schema.get_attribute(&kw!(:db.type/string)).is_none());
     }
 
     #[tokio::test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -161,12 +161,12 @@ fn build_tx_entity_datoms(
         kw!(:db.tx/aborted)
     };
     let mut datoms = vec![
-        Datom { entity: tx_eid, attribute: "db/txInstant".into(), value: DataType::Instant(st), tx: tx_eid, op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: "db/txId".into(), value: DataType::Long(tx_key.tx_id), tx: tx_eid, op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: "db/txResult".into(), value: DataType::Keyword(result_kw), tx: tx_eid, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: kw!(:db/txInstant), value: DataType::Instant(st), tx: tx_eid, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: kw!(:db/txId), value: DataType::Long(tx_key.tx_id), tx: tx_eid, op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: kw!(:db/txResult), value: DataType::Keyword(result_kw), tx: tx_eid, op: DatomOp::Assert },
     ];
     if let Some(err) = error {
-        datoms.push(Datom { entity: tx_eid, attribute: "db.tx/error".into(), value: DataType::String(err), tx: tx_eid, op: DatomOp::Assert });
+        datoms.push(Datom { entity: tx_eid, attribute: kw!(:db.tx/error), value: DataType::String(err), tx: tx_eid, op: DatomOp::Assert });
     }
     datoms
 }
@@ -512,7 +512,7 @@ mod tests {
     async fn test_indexer() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
         let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
         let mut doc = BTreeMap::new();
         doc.insert("name".to_string(), DataType::String("alan".to_string()));
@@ -793,7 +793,7 @@ mod tests {
     async fn test_retract_on_overwrite() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
@@ -855,7 +855,7 @@ mod tests {
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute("name").unwrap().0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
@@ -911,7 +911,7 @@ mod tests {
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("rust".to_string()),
         }];
         indexer.transact_tx(tx1, tx_ops1).await?;
@@ -920,13 +920,13 @@ mod tests {
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("database".to_string()),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
-        let tags_id = indexer.metadata().schema.get_attribute("tags").unwrap().0;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
@@ -960,7 +960,7 @@ mod tests {
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("rust".to_string()),
         }];
         indexer.transact_tx(tx1, tx_ops1).await?;
@@ -969,13 +969,13 @@ mod tests {
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("rust".to_string()),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr — expect 2 ADDs (both written)
-        let tags_id = indexer.metadata().schema.get_attribute("tags").unwrap().0;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {

--- a/src/node.rs
+++ b/src/node.rs
@@ -210,7 +210,7 @@ mod tests {
     use crate::codec;
     use crate::parse::parse_query;
     use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
-    use crate::ops::{Attribute, DataType, TxOp};
+    use crate::ops::{DataType, TxOp};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
@@ -257,7 +257,7 @@ mod tests {
         // Use entity ID 1000 to avoid reserved bootstrap range (1-31)
         let tx_ops = vec![TxOp::Add {
             entity_id: 2000,
-            attribute: Attribute("email".to_string()),
+            attribute: kw!(:email),
             value: DataType::String("test@example.com".to_string()),
         }];
 
@@ -265,7 +265,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let slate = node.slatedb.clone();
-        let email_id = node.indexer.read().await.metadata().schema.get_attribute("email").unwrap().0;
+        let email_id = node.indexer.read().await.metadata().schema.get_attribute(&kw!(:email)).unwrap().0;
 
         // Check EAV index — find entry for entity 2000
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
@@ -955,14 +955,14 @@ mod tests {
         // Insert entity 2000 with tags="rust"
         node.execute_tx(vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("rust".to_string()),
         }]).await.unwrap();
 
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
             entity_id: 2000,
-            attribute: crate::ops::Attribute("tags".to_string()),
+            attribute: kw!(:tags),
             value: DataType::String("database".to_string()),
         }]).await.unwrap();
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,18 +1,17 @@
 #[allow(unused_imports)]
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
+use edn::symbols::Keyword;
 #[allow(unused_imports)]
-use edn::symbols::{Keyword, NamespacedSymbol};
+use edn::symbols::NamespacedSymbol;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
 use uuid::Uuid;
 use anyhow::Result;
 
 pub type Entid = i64;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Attribute(pub String);
 
 // TODO: Ref commented out for now — entity refs are stored as DataType::Long.
 // Revisit when schema is added (ref-typed attributes should use entity encoding).
@@ -159,8 +158,8 @@ impl_from_for_enum!(
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(BTreeMap<String, DataType>),
-    Add { entity_id: Entid, attribute: Attribute, value: DataType },
-    Retract { entity_id: Entid, attribute: Attribute, value: DataType },
+    Add { entity_id: Entid, attribute: Keyword, value: DataType },
+    Retract { entity_id: Entid, attribute: Keyword, value: DataType },
     Delete(Entid),
     Erase(Entid),
 }
@@ -172,11 +171,11 @@ pub enum DatomOp {
 }
 
 /// A normalized fact: (entity, attribute, value, tx, op).
-/// The attribute is an unresolved string name.
+/// The attribute is an unresolved keyword ident.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Datom {
     pub entity: i64,
-    pub attribute: String, // TODO(triplox-gaz): avoid cloning, consider Cow or interning
+    pub attribute: Keyword,
     pub value: DataType,
     pub tx: i64,
     pub op: DatomOp,
@@ -198,9 +197,11 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
                     None => return Err(anyhow::anyhow!("Document must have a db/id")),
                 };
                 for (attr, value) in doc.iter().filter(|(k, _)| *k != "db/id") {
+                    let kw = Keyword::from_str(&format!(":{}", attr))
+                        .map_err(|e| anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, e))?;
                     datoms.push(Datom {
                         entity,
-                        attribute: attr.clone(),
+                        attribute: kw,
                         value: value.clone(),
                         tx,
                         op: DatomOp::Assert,
@@ -210,7 +211,7 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
             TxOp::Add { entity_id, attribute, value } => {
                 datoms.push(Datom {
                     entity: *entity_id,
-                    attribute: attribute.0.clone(),
+                    attribute: attribute.clone(),
                     value: value.clone(),
                     tx,
                     op: DatomOp::Assert,
@@ -219,7 +220,7 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
             TxOp::Retract { entity_id, attribute, value } => {
                 datoms.push(Datom {
                     entity: *entity_id,
-                    attribute: attribute.0.clone(),
+                    attribute: attribute.clone(),
                     value: value.clone(),
                     tx,
                     op: DatomOp::Retract,
@@ -237,6 +238,7 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
 mod tests {
     use super::*;
     use bincode;
+    use edn::kw;
 
     #[test]
     fn test_partial_compare_same_type() {
@@ -312,7 +314,7 @@ mod tests {
     fn test_op_add() {
         let op = TxOp::Add {
             entity_id: 1,
-            attribute: Attribute("string".to_string()),
+            attribute: kw!(:string),
             value: DataType::String("string_value".to_string()),
         };
         let serialized = bincode::serialize(&op).unwrap();
@@ -324,7 +326,7 @@ mod tests {
     fn test_op_retract() {
         let op = TxOp::Retract {
             entity_id: 1,
-            attribute: Attribute("string".to_string()),
+            attribute: kw!(:string),
             value: DataType::String("string_value".to_string()),
         };
         let serialized = bincode::serialize(&op).unwrap();
@@ -369,14 +371,14 @@ mod tests {
         let tx = 1000_i64;
         let ops = vec![TxOp::Add {
             entity_id: 200,
-            attribute: Attribute("name".to_string()),
+            attribute: kw!(:name),
             value: DataType::String("bob".to_string()),
         }];
 
         let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
         assert_eq!(datoms.len(), 1);
         assert_eq!(datoms[0].entity, 200);
-        assert_eq!(datoms[0].attribute, "name");
+        assert_eq!(datoms[0].attribute, kw!(:name));
         assert_eq!(datoms[0].value, DataType::String("bob".to_string()));
         assert_eq!(datoms[0].op, DatomOp::Assert);
     }
@@ -386,7 +388,7 @@ mod tests {
         let tx = 1000_i64;
         let ops = vec![TxOp::Retract {
             entity_id: 200,
-            attribute: Attribute("name".to_string()),
+            attribute: kw!(:name),
             value: DataType::String("bob".to_string()),
         }];
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -175,7 +175,6 @@ pub enum DatomOp {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Datom {
     pub entity: i64,
-    // TODO(perf, triplox-gaz): Keyword::clone() still allocates (wraps String); revisit with interning.
     pub attribute: Keyword,
     pub value: DataType,
     pub tx: i64,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -7,6 +7,7 @@ use edn::symbols::NamespacedSymbol;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
 use uuid::Uuid;
 use anyhow::Result;
 
@@ -180,32 +181,6 @@ pub struct Datom {
     pub op: DatomOp,
 }
 
-/// Parse a Put document key (e.g. `"name"`, `"db/ident"`) into a `Keyword`.
-///
-/// Put doc keys are stored without the leading `:` that `Keyword::from_str`
-/// expects, so we split on `/` directly and avoid the `format!(":{}", …)`
-/// allocation on the transaction hot path.
-fn parse_put_key(attr: &str) -> Result<Keyword> {
-    let bad = |reason: &str| anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, reason);
-    match attr.split_once('/') {
-        Some((ns, name)) => {
-            if ns.is_empty() {
-                return Err(bad("namespace cannot be empty"));
-            }
-            if name.is_empty() {
-                return Err(bad("name cannot be empty"));
-            }
-            Ok(Keyword::namespaced(ns, name))
-        }
-        None => {
-            if attr.is_empty() {
-                return Err(bad("name cannot be empty"));
-            }
-            Ok(Keyword::plain(attr))
-        }
-    }
-}
-
 /// Expand TxOps into a flat vec of Datoms.
 /// - Put(doc) → N Assert datoms (one per non-db/id field)
 /// - Add(triple) → 1 Assert datom
@@ -222,7 +197,12 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
                     None => return Err(anyhow::anyhow!("Document must have a db/id")),
                 };
                 for (attr, value) in doc.iter().filter(|(k, _)| *k != "db/id") {
-                    let kw = parse_put_key(attr)?;
+                    // TODO(perf): allocates a fresh `:<attr>` String per attribute on the Put
+                    // hot path just to feed it to `Keyword::from_str`, which strips the `:`
+                    // and splits again. Could be replaced with a direct split-and-construct
+                    // once the Put doc key type is revisited (see client-side Keyword TODO).
+                    let kw = Keyword::from_str(&format!(":{}", attr))
+                        .map_err(|e| anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, e))?;
                     datoms.push(Datom {
                         entity,
                         attribute: kw,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -175,6 +175,7 @@ pub enum DatomOp {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Datom {
     pub entity: i64,
+    // TODO(perf, triplox-gaz): Keyword::clone() still allocates (wraps String); revisit with interning.
     pub attribute: Keyword,
     pub value: DataType,
     pub tx: i64,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -7,7 +7,6 @@ use edn::symbols::NamespacedSymbol;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, BTreeSet};
-use std::str::FromStr;
 use uuid::Uuid;
 use anyhow::Result;
 
@@ -181,6 +180,32 @@ pub struct Datom {
     pub op: DatomOp,
 }
 
+/// Parse a Put document key (e.g. `"name"`, `"db/ident"`) into a `Keyword`.
+///
+/// Put doc keys are stored without the leading `:` that `Keyword::from_str`
+/// expects, so we split on `/` directly and avoid the `format!(":{}", …)`
+/// allocation on the transaction hot path.
+fn parse_put_key(attr: &str) -> Result<Keyword> {
+    let bad = |reason: &str| anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, reason);
+    match attr.split_once('/') {
+        Some((ns, name)) => {
+            if ns.is_empty() {
+                return Err(bad("namespace cannot be empty"));
+            }
+            if name.is_empty() {
+                return Err(bad("name cannot be empty"));
+            }
+            Ok(Keyword::namespaced(ns, name))
+        }
+        None => {
+            if attr.is_empty() {
+                return Err(bad("name cannot be empty"));
+            }
+            Ok(Keyword::plain(attr))
+        }
+    }
+}
+
 /// Expand TxOps into a flat vec of Datoms.
 /// - Put(doc) → N Assert datoms (one per non-db/id field)
 /// - Add(triple) → 1 Assert datom
@@ -197,8 +222,7 @@ pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
                     None => return Err(anyhow::anyhow!("Document must have a db/id")),
                 };
                 for (attr, value) in doc.iter().filter(|(k, _)| *k != "db/id") {
-                    let kw = Keyword::from_str(&format!(":{}", attr))
-                        .map_err(|e| anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, e))?;
+                    let kw = parse_put_key(attr)?;
                     datoms.push(Datom {
                         entity,
                         attribute: kw,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -190,7 +190,8 @@ mod tests {
     // --- resolve_entity_ids tests ---
 
     use std::collections::BTreeMap;
-    use crate::ops::{TxOp, DataType, Attribute};
+    use crate::ops::{TxOp, DataType};
+    use edn::kw;
 
     #[test]
     fn test_resolve_entity_ids_explicit_id_passthrough() {
@@ -283,12 +284,12 @@ mod tests {
         let ops = vec![
             TxOp::Add {
                 entity_id: 100,
-                attribute: Attribute("name".into()),
+                attribute: kw!(:name),
                 value: DataType::String("alice".into()),
             },
             TxOp::Retract {
                 entity_id: 100,
-                attribute: Attribute("name".into()),
+                attribute: kw!(:name),
                 value: DataType::String("alice".into()),
             },
         ];

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -11,7 +11,9 @@ use edn::symbols::Keyword;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use uuid::Uuid;
 
-use crate::ops::{Attribute, DataType, TxOp};
+use std::str::FromStr;
+
+use crate::ops::{DataType, TxOp};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -406,9 +408,9 @@ fn encode_data_type_map(buf: &mut Vec<u8>, map: &BTreeMap<String, DataType>) {
 // Wire Encoding: TxOp
 // ---------------------------------------------------------------------------
 
-fn encode_eav(buf: &mut Vec<u8>, entity_id: &i64, attribute: &Attribute, value: &DataType) {
+fn encode_eav(buf: &mut Vec<u8>, entity_id: &i64, attribute: &Keyword, value: &DataType) {
     encode_i64(buf, *entity_id);
-    encode_string(buf, &attribute.0);
+    encode_string(buf, &attribute.to_string());
     encode_data_type(buf, value);
 }
 
@@ -581,15 +583,6 @@ impl<'a> Cursor<'a> {
 // Wire Decoding: DataType
 // ---------------------------------------------------------------------------
 
-/// Parse a keyword string like ":foo/bar" or ":baz" into a Keyword.
-fn parse_keyword_string(s: &str) -> Result<Keyword> {
-    let s = s.strip_prefix(':').ok_or_else(|| anyhow!("Keyword must start with ':'"))?;
-    match s.split_once('/') {
-        Some((ns, name)) => Ok(Keyword::namespaced(ns, name)),
-        None => Ok(Keyword::plain(s)),
-    }
-}
-
 fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
     let tag = cursor.read_u8()?;
     match tag {
@@ -614,7 +607,7 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
         TAG_MAP => Ok(DataType::Map(decode_data_type_map(cursor)?)),
         TAG_KEYWORD => {
             let s = cursor.read_string()?;
-            Ok(DataType::Keyword(parse_keyword_string(&s)?))
+            Ok(DataType::Keyword(Keyword::from_str(&s).map_err(|e| anyhow!("{}", e))?))
         }
         _ => bail!("Unknown DataType tag: {}", tag),
     }
@@ -650,9 +643,10 @@ fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType
 // Wire Decoding: TxOp
 // ---------------------------------------------------------------------------
 
-fn decode_eav(cursor: &mut Cursor) -> Result<(i64, Attribute, DataType)> {
+fn decode_eav(cursor: &mut Cursor) -> Result<(i64, Keyword, DataType)> {
     let entity_id = cursor.read_i64()?;
-    let attribute = Attribute(cursor.read_string()?);
+    let attribute_str = cursor.read_string()?;
+    let attribute = Keyword::from_str(&attribute_str).map_err(|e| anyhow!("{}", e))?;
     let value = decode_data_type(cursor)?;
     Ok((entity_id, attribute, value))
 }
@@ -1226,7 +1220,7 @@ mod tests {
     fn test_tx_op_add() {
         let op = TxOp::Add {
             entity_id: 42,
-            attribute: Attribute("email".to_string()),
+            attribute: kw!(:email),
             value: DataType::String("test@example.com".to_string()),
         };
         assert_eq!(roundtrip_tx_op(&op), op);
@@ -1236,7 +1230,7 @@ mod tests {
     fn test_tx_op_retract() {
         let op = TxOp::Retract {
             entity_id: 42,
-            attribute: Attribute("email".to_string()),
+            attribute: kw!(:email),
             value: DataType::String("old@example.com".to_string()),
         };
         assert_eq!(roundtrip_tx_op(&op), op);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -607,7 +607,7 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
         TAG_MAP => Ok(DataType::Map(decode_data_type_map(cursor)?)),
         TAG_KEYWORD => {
             let s = cursor.read_string()?;
-            Ok(DataType::Keyword(Keyword::from_str(&s).map_err(|e| anyhow!("{}", e))?))
+            Ok(DataType::Keyword(Keyword::from_str(&s)?))
         }
         _ => bail!("Unknown DataType tag: {}", tag),
     }
@@ -645,8 +645,7 @@ fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType
 
 fn decode_eav(cursor: &mut Cursor) -> Result<(i64, Keyword, DataType)> {
     let entity_id = cursor.read_i64()?;
-    let attribute_str = cursor.read_string()?;
-    let attribute = Keyword::from_str(&attribute_str).map_err(|e| anyhow!("{}", e))?;
+    let attribute = Keyword::from_str(&cursor.read_string()?)?;
     let value = decode_data_type(cursor)?;
     Ok((entity_id, attribute, value))
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -115,16 +115,10 @@ fn resolve_attribute_from_pattern(
     ident_map: &IdentMap,
 ) -> Result<i64, Error> {
     match attr {
-        PatternNonValuePlace::Ident(ref kw) => {
-            let name = match kw.namespace() {
-                Some(ns) => format!("{}/{}", ns, kw.name()),
-                None => kw.name().to_string(),
-            };
-            ident_map
-                .get(&name)
-                .copied()
-                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", name))
-        }
+        PatternNonValuePlace::Ident(ref kw) => ident_map
+            .get(kw.as_ref())
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", kw)),
         PatternNonValuePlace::Entid(id) => Ok(*id),
         _ => Err(anyhow::anyhow!("Attribute must be a keyword or entid")),
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -155,9 +155,9 @@ impl Cardinality {
 }
 
 /// ident → entity_id (ALL named entities: enums + schema attrs)
-pub type IdentMap = HashMap<String, i64>;
+pub type IdentMap = HashMap<Keyword, i64>;
 /// entity_id → ident (ALL named entities: enums + schema attrs)
-pub type EntidMap = HashMap<i64, String>;
+pub type EntidMap = HashMap<i64, Keyword>;
 /// entity_id → Attribute (only schema attributes with db/valueType)
 pub type AttributeMap = HashMap<i64, Attribute>;
 
@@ -202,7 +202,7 @@ impl AttributeBuilder {
 /// Pre-validated schema changes, ready to apply after commit.
 #[derive(Debug)]
 pub struct SchemaUpdate {
-    pub(crate) idents: Vec<(i64, String)>,
+    pub(crate) idents: Vec<(i64, Keyword)>,
     pub(crate) attributes: Vec<(i64, Attribute)>,
 }
 
@@ -222,7 +222,7 @@ pub struct Schema {
 
 impl Schema {
     /// Two-step lookup: ident → entity_id via ident_map, then entity_id → Attribute via attribute_map.
-    pub fn get_attribute(&self, ident: &str) -> Option<(i64, &Attribute)> {
+    pub fn get_attribute(&self, ident: &Keyword) -> Option<(i64, &Attribute)> {
         let eid = self.ident_map.get(ident)?;
         let attr = self.attribute_map.get(eid)?;
         Some((*eid, attr))
@@ -241,8 +241,12 @@ impl Schema {
     ///    - Ident stream: db/ident → pending (i64, String) pairs
     ///    - Attribute stream: db/valueType, db/cardinality → AttributeBuilder per entity
     pub fn validate_and_prepare(&self, datoms: &[Datom]) -> Result<SchemaUpdate> {
-        let mut ident_updates: Vec<(i64, String)> = Vec::new();
+        let mut ident_updates: Vec<(i64, Keyword)> = Vec::new();
         let mut builders: HashMap<i64, AttributeBuilder> = HashMap::new();
+
+        let db_ident = kw!(:db/ident);
+        let db_value_type = kw!(:db/valueType);
+        let db_cardinality = kw!(:db/cardinality);
 
         for datom in datoms {
             if datom.op != DatomOp::Assert {
@@ -268,7 +272,10 @@ impl Schema {
                         datom.attribute, attr.value_type, datom.value
                     ));
                 }
-            } else if !matches!(datom.attribute.as_str(), "db/ident" | "db/valueType" | "db/cardinality") {
+            } else if datom.attribute != db_ident
+                && datom.attribute != db_value_type
+                && datom.attribute != db_cardinality
+            {
                 return Err(anyhow::anyhow!("Unknown attribute: {}", datom.attribute));
             }
 
@@ -277,38 +284,29 @@ impl Schema {
             // db/valueType + db/cardinality) also has a db/ident. Bootstrap entities
             // always include one, but user-defined attributes could be installed without
             // a name. Not an issue for correctness, but maybe worth enforcing.
-            match datom.attribute.as_str() {
-                "db/ident" => {
-                    // TODO: should match against a namespaced Keyword and use its
-                    // namespace/name directly instead of string-stripping the colon prefix.
-                    match &datom.value {
-                        DataType::Keyword(kw) => {
-                            let s = kw.to_string();
-                            let ident = s.strip_prefix(':').unwrap_or(&s).to_string();
-                            ident_updates.push((datom.entity, ident));
-                        }
-                        _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
+            if datom.attribute == db_ident {
+                match &datom.value {
+                    DataType::Keyword(kw) => {
+                        ident_updates.push((datom.entity, kw.clone()));
                     }
+                    _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
                 }
-                "db/valueType" => {
-                    match &datom.value {
-                        DataType::Keyword(kw) => {
-                            let vt = ValueType::from_keyword(kw)?;
-                            builders.entry(datom.entity).or_default().value_type = Some(vt);
-                        }
-                        _ => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
+            } else if datom.attribute == db_value_type {
+                match &datom.value {
+                    DataType::Keyword(kw) => {
+                        let vt = ValueType::from_keyword(kw)?;
+                        builders.entry(datom.entity).or_default().value_type = Some(vt);
                     }
+                    _ => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
                 }
-                "db/cardinality" => {
-                    match &datom.value {
-                        DataType::Keyword(kw) => {
-                            let card = Cardinality::from_keyword(kw)?;
-                            builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
-                        }
-                        _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
+            } else if datom.attribute == db_cardinality {
+                match &datom.value {
+                    DataType::Keyword(kw) => {
+                        let card = Cardinality::from_keyword(kw)?;
+                        builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
                     }
+                    _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
                 }
-                _ => {}
             }
         }
 
@@ -322,8 +320,8 @@ impl Schema {
                 // Find the ident for better error messages
                 let ident = ident_updates.iter()
                     .find(|(eid, _)| *eid == entity_id)
-                    .map(|(_, name)| name.as_str())
-                    .unwrap_or("<unknown>");
+                    .map(|(_, kw)| kw.to_string())
+                    .unwrap_or_else(|| "<unknown>".to_string());
                 anyhow::anyhow!("{} for '{}'", e, ident)
             })?;
             attribute_updates.push((entity_id, builder.build()));
@@ -449,10 +447,10 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// so the inefficiency is minor, but a single-pass approach would be cleaner.
 pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     // Build attribute map from bootstrap constants — sufficient to query schema entities
-    let mut bootstrap_ident_map = HashMap::new();
-    bootstrap_ident_map.insert("db/ident".to_string(), DB_IDENT);
-    bootstrap_ident_map.insert("db/valueType".to_string(), DB_VALUE_TYPE);
-    bootstrap_ident_map.insert("db/cardinality".to_string(), DB_CARDINALITY);
+    let mut bootstrap_ident_map: IdentMap = HashMap::new();
+    bootstrap_ident_map.insert(kw!(:db/ident), DB_IDENT);
+    bootstrap_ident_map.insert(kw!(:db/valueType), DB_VALUE_TYPE);
+    bootstrap_ident_map.insert(kw!(:db/cardinality), DB_CARDINALITY);
     let snapshot = slatedb.snapshot().await.expect("Failed to create snapshot");
     let handle = Handle::current();
 
@@ -492,11 +490,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
             other => panic!("Expected Long for entity_id, got {:?}", other),
         };
         let ident = match &row[1] {
-            DataType::Keyword(kw) => {
-                let s = kw.to_string();
-                // TODO: this destructing is brittle. Let's address it when we move to only use the EDN crate.
-                s.strip_prefix(':').unwrap_or(&s).to_string()
-            }
+            DataType::Keyword(kw) => kw.clone(),
             other => panic!("Expected Keyword for ident, got {:?}", other),
         };
         schema.ident_map.insert(ident.clone(), entity_id);
@@ -579,21 +573,21 @@ mod tests {
         // 7 schema attrs (3 core + 4 tx); enum entities go into ident_map but not attribute_map
         assert_eq!(schema.len(), 7);
 
-        let (eid, attr) = schema.get_attribute("db/ident").unwrap();
+        let (eid, attr) = schema.get_attribute(&kw!(:db/ident)).unwrap();
         assert_eq!(eid, DB_IDENT);
         assert_eq!(attr.value_type, ValueType::Keyword);
 
-        let (eid, attr) = schema.get_attribute("db/valueType").unwrap();
+        let (eid, attr) = schema.get_attribute(&kw!(:db/valueType)).unwrap();
         assert_eq!(eid, DB_VALUE_TYPE);
         assert_eq!(attr.value_type, ValueType::Keyword);
 
-        let (eid, attr) = schema.get_attribute("db/cardinality").unwrap();
+        let (eid, attr) = schema.get_attribute(&kw!(:db/cardinality)).unwrap();
         assert_eq!(eid, DB_CARDINALITY);
         assert_eq!(attr.value_type, ValueType::Keyword);
 
         // Enum entities are in ident_map but not attribute_map
-        assert!(schema.ident_map.contains_key("db.type/string"));
-        assert_eq!(schema.ident_map["db.type/string"], DB_TYPE_STRING);
+        assert!(schema.ident_map.contains_key(&kw!(:db.type/string)));
+        assert_eq!(schema.ident_map[&kw!(:db.type/string)], DB_TYPE_STRING);
     }
 
     #[test]
@@ -601,7 +595,7 @@ mod tests {
         let schema = bootstrapped_schema_with_person_name();
         assert_eq!(schema.len(), 8);
 
-        let (_eid, attr) = schema.get_attribute("name").unwrap();
+        let (_eid, attr) = schema.get_attribute(&kw!(:name)).unwrap();
         assert_eq!(attr.value_type, ValueType::String);
     }
 
@@ -609,9 +603,9 @@ mod tests {
     fn test_enum_entity_not_in_attribute_map() {
         let schema = bootstrapped_schema();
         // enum entities have db/ident but no db/valueType → not in attribute_map
-        assert!(schema.get_attribute("db.type/string").is_none());
+        assert!(schema.get_attribute(&kw!(:db.type/string)).is_none());
         // but they are in ident_map
-        assert!(schema.ident_map.contains_key("db.type/string"));
+        assert!(schema.ident_map.contains_key(&kw!(:db.type/string)));
     }
 
     #[test]
@@ -630,7 +624,7 @@ mod tests {
         doc.insert("db/id".to_string(), DataType::Long(200));
         doc.insert("person/age".to_string(), DataType::Long(30));
         let err = schema.validate_and_prepare(&to_datoms(&[TxOp::Put(doc)])).unwrap_err();
-        assert!(err.to_string().contains("Unknown attribute: person/age"));
+        assert!(err.to_string().contains("Unknown attribute: :person/age"));
     }
 
     #[test]
@@ -653,7 +647,7 @@ mod tests {
     #[test]
     fn test_schema_immutability() {
         let schema = bootstrapped_schema_with_person_name();
-        let (name_id, _) = schema.get_attribute("name").unwrap();
+        let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
 
         // Cannot redefine existing schema entity
         let mut doc = BTreeMap::new();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -244,6 +244,7 @@ impl Schema {
         let mut ident_updates: Vec<(i64, Keyword)> = Vec::new();
         let mut builders: HashMap<i64, AttributeBuilder> = HashMap::new();
 
+        // TODO(perf): these three kw!(...) allocate fresh Keywords on every call; lift to LazyLock statics.
         let db_ident = kw!(:db/ident);
         let db_value_type = kw!(:db/valueType);
         let db_cardinality = kw!(:db/cardinality);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -244,11 +244,6 @@ impl Schema {
         let mut ident_updates: Vec<(i64, Keyword)> = Vec::new();
         let mut builders: HashMap<i64, AttributeBuilder> = HashMap::new();
 
-        // TODO(perf): these three kw!(...) allocate fresh Keywords on every call; lift to LazyLock statics.
-        let db_ident = kw!(:db/ident);
-        let db_value_type = kw!(:db/valueType);
-        let db_cardinality = kw!(:db/cardinality);
-
         for datom in datoms {
             if datom.op != DatomOp::Assert {
                 continue;
@@ -273,10 +268,10 @@ impl Schema {
                         datom.attribute, attr.value_type, datom.value
                     ));
                 }
-            } else if datom.attribute != db_ident
-                && datom.attribute != db_value_type
-                && datom.attribute != db_cardinality
-            {
+            } else if !matches!(
+                datom.attribute.components(),
+                ("db", "ident" | "valueType" | "cardinality")
+            ) {
                 return Err(anyhow::anyhow!("Unknown attribute: {}", datom.attribute));
             }
 
@@ -285,29 +280,26 @@ impl Schema {
             // db/valueType + db/cardinality) also has a db/ident. Bootstrap entities
             // always include one, but user-defined attributes could be installed without
             // a name. Not an issue for correctness, but maybe worth enforcing.
-            if datom.attribute == db_ident {
-                match &datom.value {
-                    DataType::Keyword(kw) => {
-                        ident_updates.push((datom.entity, kw.clone()));
-                    }
+            match datom.attribute.components() {
+                ("db", "ident") => match &datom.value {
+                    DataType::Keyword(kw) => ident_updates.push((datom.entity, kw.clone())),
                     _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
-                }
-            } else if datom.attribute == db_value_type {
-                match &datom.value {
+                },
+                ("db", "valueType") => match &datom.value {
                     DataType::Keyword(kw) => {
                         let vt = ValueType::from_keyword(kw)?;
                         builders.entry(datom.entity).or_default().value_type = Some(vt);
                     }
                     _ => return Err(anyhow::anyhow!("db/valueType must be a Keyword")),
-                }
-            } else if datom.attribute == db_cardinality {
-                match &datom.value {
+                },
+                ("db", "cardinality") => match &datom.value {
                     DataType::Keyword(kw) => {
                         let card = Cardinality::from_keyword(kw)?;
                         builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
                     }
                     _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
-                }
+                },
+                _ => {}
             }
         }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -238,7 +238,7 @@ impl Schema {
     /// For each datom:
     /// 1. Type-check value against attribute's value_type, error on unknown attributes
     /// 2. Witness schema-related datoms into two streams:
-    ///    - Ident stream: db/ident → pending (i64, String) pairs
+    ///    - Ident stream: db/ident → pending (i64, Keyword) pairs
     ///    - Attribute stream: db/valueType, db/cardinality → AttributeBuilder per entity
     pub fn validate_and_prepare(&self, datoms: &[Datom]) -> Result<SchemaUpdate> {
         let mut ident_updates: Vec<(i64, Keyword)> = Vec::new();


### PR DESCRIPTION
## Summary
- Delete `ops::Attribute(String)` and propagate `edn::Keyword` as the single internal representation for attribute identifiers across `TxOp`, `Datom`, and `Schema`.
- Add `impl FromStr for Keyword` (+ `TryFrom<&str>`) with a dedicated `KeywordParseError` in the edn crate. No `From<&str>` — malformed input must fail explicitly rather than panic inside an `.into()`.
- `Schema::IdentMap` / `EntidMap` switch to `Keyword` keys; `get_attribute(&Keyword)`; `validate_and_prepare` compares keywords directly instead of string-matching `"db/ident"` etc.
- `query::resolve_attribute_from_pattern` looks up the keyword directly, dropping the `format!("{}/{}")` bridge.
- `protocol.rs` encodes/decodes EAV via `Keyword::to_string()` + `Keyword::from_str`, and the local `parse_keyword_string` helper is deleted.

`TxOp::Put`'s `BTreeMap<String, DataType>` key type is intentionally left as-is — client-side `Keyword` representation will be decided separately. Put doc keys are parsed into keywords at the `tx_ops_to_datoms` boundary via `Keyword::from_str`.

## Test plan
- [x] `cargo check --tests --examples` clean
- [x] `cargo test` — 362 unit + 18 integration tests pass
- [x] `cargo test -p edn` — all pass (includes new `FromStr` doctests)
- [x] `grep "Attribute(" src/` returns no matches (only `schema::Attribute`, the `{value_type, multival}` metadata struct, remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)