### PR TITLE
feat: EntityRef, TxValue, and tempid support in transaction API

### DIFF
--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -14,22 +14,22 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
    Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
                                 ↓
-2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) → Vec<DatomWithTempids>
-   - TxOp::Put → N DatomWithTempids (one per attr)
-   - TxOp::Add/Retract → 1 DatomWithTempids
-   - Resolves EntityRef::Ident → entid via schema.ident_map
-   - EntityRef::Id → IdOrTempId::Id (passthrough)
-   - EntityRef::TempId → IdOrTempId::TempId (deferred)
-   - EntityRef::LookupRef → error (not yet supported)
-   - Put without :db/id key → generates internal tempid (__auto_N)
+2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) -> Vec<DatomWithTempids>
+   - TxOp::Put -> N DatomWithTempids (one per attr)
+   - TxOp::Add/Retract -> 1 DatomWithTempids
+   - Resolves EntityRef::Ident -> entid via schema.ident_map
+   - EntityRef::Id -> IdOrTempId::Id (passthrough)
+   - EntityRef::TempId -> IdOrTempId::TempId (deferred)
+   - EntityRef::LookupRef -> error (not yet supported)
+   - Put without :db/id key -> generates internal tempid (__auto_N)
                                 ↓
 3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm)
-   - Pre-scan: tempids with :db/ident → DB_PARTITION, others → USER_PARTITION
-   - Allocate entids from PartitionMap (same tempid string → same entid)
-   - Map DatomWithTempids → Datom (IdOrTempId→i64, ValueWithTempIds→DataType)
+   - Pre-scan: tempids with :db/ident -> DB_PARTITION, others -> USER_PARTITION
+   - Allocate entids from PartitionMap (same tempid string -> same entid)
+   - Map DatomWithTempids -> Datom (IdOrTempId->i64, ValueWithTempIds->DataType)
    Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
                                 ↓
-4. Validate + prepare           schema.validate_and_prepare(datoms) → Result<SchemaUpdate>
+4. Validate + prepare           schema.validate_and_prepare(datoms) -> Result<SchemaUpdate>
    - Type checking: value type matches attribute's value_type
    - Unknown attribute errors
    - Witness pattern: split schema datoms, validate via AttributeBuilder

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -1,6 +1,6 @@
 # Triplox Transaction Pipeline
 
-Version 0.2
+Version 0.1
 
 ## Overview
 
@@ -21,7 +21,7 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - EntityRef::Id → IdOrTempId::Id (passthrough)
    - EntityRef::TempId → IdOrTempId::TempId (deferred)
    - EntityRef::LookupRef → error (not yet supported)
-   - Put with id: None → generates internal tempid (__auto_N)
+   - Put without :db/id key → generates internal tempid (__auto_N)
                                 ↓
 3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm, &schema)
    - Pre-scan: tempids with :db/ident → DB_PARTITION, others → USER_PARTITION

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -1,6 +1,6 @@
 # Triplox Transaction Pipeline
 
-Version 0.1
+Version 0.2
 
 ## Overview
 
@@ -14,11 +14,19 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
    Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
                                 ↓
-2. Resolve entity IDs           resolve_entity_ids(ops, &mut pending_pm)
-   - Missing db/id → allocate from USER_PARTITION (or DB_PARTITION if db/ident present)
-   - Explicit db/id → pass through (TODO: validate via contains_entid once tempid pipeline exists)
+2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) → Vec<DatomWithTempids>
+   - TxOp::Put → N DatomWithTempids (one per attr)
+   - TxOp::Add/Retract → 1 DatomWithTempids
+   - Resolves EntityRef::Ident → entid via schema.ident_map
+   - EntityRef::Id → IdOrTempId::Id (passthrough)
+   - EntityRef::TempId → IdOrTempId::TempId (deferred)
+   - EntityRef::LookupRef → error (not yet supported)
+   - Put with id: None → generates internal tempid (__auto_N)
                                 ↓
-3. Expand to datoms             tx_ops_to_datoms(resolved_ops, tx_eid)
+3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm, &schema)
+   - Pre-scan: tempids with :db/ident → DB_PARTITION, others → USER_PARTITION
+   - Allocate entids from PartitionMap (same tempid string → same entid)
+   - Map DatomWithTempids → Datom (IdOrTempId→i64, ValueWithTempIds→DataType)
    Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
                                 ↓
 4. Validate + prepare           schema.validate_and_prepare(datoms) → Result<SchemaUpdate>
@@ -28,9 +36,6 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - Produces SchemaUpdate (pending delta) — errors abort before commit
                                 ↓
 5. Cardinality resolution       (existing EAV scan for card-one auto-retract)
-   // TODO: should likely merge into step 4 by using Attribute.multival
-   // to detect card-one conflicts during validate_and_prepare, but
-   // not in this change — keep the existing EAV scan logic for now.
                                 ↓
 6. Write indices + commit       write_index_entries(), txn.commit()
                                 ↓
@@ -39,3 +44,22 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - self.metadata.schema.apply_schema_update(schema_update)  (infallible)
    - self.metadata.advance_generation()
 ```
+
+## Key Types
+
+### User-facing (src/ops.rs)
+
+- `EntityRef` — how to identify an entity: `Id(i64)`, `TempId(String)`, `Ident(Keyword)`, `LookupRef(Keyword, DataType)`
+- `TxValue` — a value: `Data(DataType)` or `Ref(EntityRef)`
+- `TxOp` — transaction operation: `Put`, `Add`, `Retract`, `Delete`, `Erase`
+
+### Intermediate (src/tx.rs)
+
+- `IdOrTempId` — entity after ident resolution: `Id(i64)` or `TempId(String)`
+- `ValueWithTempIds` — value after ident resolution: `Data(DataType)` or `TempRef(String)`
+- `DatomWithTempids` — datom-shaped tuple before tempid allocation
+
+### Resolved (src/ops.rs)
+
+- `Datom` — fully resolved fact: `entity: i64`, `attribute: Keyword`, `value: DataType`, `op: DatomOp`
+- Note: `tx_eid` is not stored on Datom — passed separately to `write_index_entries`

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -23,7 +23,7 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - EntityRef::LookupRef → error (not yet supported)
    - Put without :db/id key → generates internal tempid (__auto_N)
                                 ↓
-3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm, &schema)
+3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm)
    - Pre-scan: tempids with :db/ident → DB_PARTITION, others → USER_PARTITION
    - Allocate entids from PartitionMap (same tempid string → same entid)
    - Map DatomWithTempids → Datom (IdOrTempId→i64, ValueWithTempIds→DataType)

--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -656,27 +656,41 @@ A `DataType` value is encoded as a 1-byte type tag (from [Section 10](#10-data-t
 | 13  | Map     | `Map<String, DataType>` (u32 count + entries)    |
 | 14  | Keyword | `String` (u32 length + UTF-8 bytes)              |
 
-### 11.8 TxOp Encoding
+### 11.8 EntityRef Encoding
+
+An `EntityRef` value is encoded as a 1-byte variant tag followed by the variant payload:
+
+| Tag    | Name      | Payload                                  |
+|--------|-----------|------------------------------------------|
+| 0x90   | Id        | `i64`                                    |
+| 0x91   | TempId    | `String`                                 |
+| 0x92   | Ident     | `String` (keyword as string)             |
+| 0x93   | LookupRef | `String` (keyword) + `DataType`          |
+
+### 11.9 TxValue Encoding
+
+A `TxValue` value is encoded as a 1-byte variant tag followed by the variant payload:
+
+| Tag    | Name | Payload                                     |
+|--------|------|---------------------------------------------|
+| 0x94   | Data | `DataType`                                  |
+| 0x95   | Ref  | `EntityRef`                                 |
+
+### 11.10 TxOp Encoding
 
 A `TxOp` value is encoded as a 1-byte variant tag followed by the variant payload:
 
-| Tag | Name     | Payload                                    |
-|-----|----------|--------------------------------------------|
-| 0   | Put      | `Document` (encoded as `Map<String, DataType>`) |
-| 1   | Add      | `Triple` (see below)                       |
-| 2   | Retract  | `Triple` (see below)                       |
-| 3   | Delete   | `Entid` (`i64`)                            |
-| 4   | Erase    | `Entid` (`i64`)                            |
+| Tag | Name     | Payload                                           |
+|-----|----------|---------------------------------------------------|
+| 0   | Put      | `Map<Keyword, TxValue>` (`:db/id` key holds entity ref) |
+| 1   | Add      | `EntityRef` + `String` (keyword) + `TxValue`       |
+| 2   | Retract  | `EntityRef` + `String` (keyword) + `TxValue`       |
+| 3   | Delete   | `EntityRef`                                        |
+| 4   | Erase    | `EntityRef`                                        |
 
-**Triple encoding**:
+**Put encoding**: a map of `Keyword` keys (encoded as `String`) to `TxValue` values (u32 count + entries). The `:db/id` key holds `TxValue::Ref(EntityRef)` for the entity identity; if absent, an internal tempid is auto-allocated during expansion.
 
-```
-+-------------------+---------------------+------------------+
-| entity: i64       | attribute: String    | value: DataType  |
-+-------------------+---------------------+------------------+
-```
-
-### 11.9 Message Payloads
+### 11.11 Message Payloads
 
 Each message payload is the concatenation of its fields in declaration order, encoded using the types above.
 

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -12,12 +12,13 @@ use edn::kw;
 use edn::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{QueryNode, SubmitNode, TransactionResult};
-use triplox::ops::{DataType, TxOp};
+use triplox::ops::{DataType, TxOp, TxValue};
 
 /// Build a schema attribute definition as a Put document.
 /// This mirrors the internal `plain_schema_attribute` helper.
 fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
-    TxOp::put_with_id(id, vec![
+    TxOp::put(vec![
+        (kw!(:db/id), TxValue::Ref(id.into())),
         (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
         (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type)).into()),
         (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
@@ -48,11 +49,13 @@ async fn main() -> Result<()> {
 
     // 2. Insert some data
     let data_ops = vec![
-        TxOp::put_with_id(100_i64, vec![
+        TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ]),
-        TxOp::put_with_id(101_i64, vec![
+        TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(101_i64.into())),
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
         ]),

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -7,8 +7,6 @@
 //! Then run this example:
 //!   cargo run --bin simple-example  (from examples/)
 
-use std::collections::BTreeMap;
-
 use anyhow::Result;
 use edn::kw;
 use edn::Keyword;
@@ -19,21 +17,11 @@ use triplox::ops::{DataType, TxOp};
 /// Build a schema attribute definition as a Put document.
 /// This mirrors the internal `plain_schema_attribute` helper.
 fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(id));
-    doc.insert(
-        "db/ident".to_string(),
-        DataType::Keyword(Keyword::plain(name)),
-    );
-    doc.insert(
-        "db/valueType".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.type", value_type)),
-    );
-    doc.insert(
-        "db/cardinality".to_string(),
-        DataType::Keyword(kw!(:db.cardinality/one)),
-    );
-    TxOp::Put(doc)
+    TxOp::put_with_id(id, vec![
+        (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
+        (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type)).into()),
+        (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
+    ])
 }
 
 #[tokio::main]
@@ -59,17 +47,16 @@ async fn main() -> Result<()> {
     }
 
     // 2. Insert some data
-    let mut alice = BTreeMap::new();
-    alice.insert("db/id".to_string(), DataType::Long(100));
-    alice.insert("name".to_string(), DataType::String("alice".to_string()));
-    alice.insert("age".to_string(), DataType::Long(30));
-
-    let mut bob = BTreeMap::new();
-    bob.insert("db/id".to_string(), DataType::Long(101));
-    bob.insert("name".to_string(), DataType::String("bob".to_string()));
-    bob.insert("age".to_string(), DataType::Long(25));
-
-    let data_ops = vec![TxOp::Put(alice), TxOp::Put(bob)];
+    let data_ops = vec![
+        TxOp::put_with_id(100_i64, vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ]),
+        TxOp::put_with_id(101_i64, vec![
+            (kw!(:name), "bob".into()),
+            (kw!(:age), 25_i64.into()),
+        ]),
+    ];
     let result = node.execute_tx(data_ops).await?;
     match &result {
         TransactionResult::TxCommited(tx_key) => {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,15 +1,13 @@
+use std::sync::Arc;
+use slatedb::{Db, IsolationLevel};
 use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::metadata::{Metadata, PartitionMap};
-use crate::ops::tx_ops_to_datoms;
-use crate::partition::{
-    extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION,
-};
+use crate::partition::{extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION};
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, Schema};
+use crate::tx;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::util::concat_bytes;
-use slatedb::{Db, IsolationLevel};
-use std::sync::Arc;
 
 const META_KEY_VERSION: &[u8] = b"version";
 
@@ -31,11 +29,8 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
             .expect("Failed to scan EAV partition prefix");
 
         if let Some(kv) = iter.next().await.expect("Failed to read EAV key") {
-            let mut cursor: &[u8] =
-                &kv.key[codec::CODEC_LENGTH..codec::CODEC_LENGTH + codec::ENTITY_LENGTH];
-            let eid = match codec::decode_datatype(&mut cursor)
-                .expect("Failed to decode entity ID from EAV key")
-            {
+            let mut cursor: &[u8] = &kv.key[codec::CODEC_LENGTH..codec::CODEC_LENGTH + codec::ENTITY_LENGTH];
+            let eid = match codec::decode_datatype(&mut cursor).expect("Failed to decode entity ID from EAV key") {
                 crate::ops::DataType::Long(id) => id,
                 other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
             };
@@ -63,11 +58,7 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
 pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
     let version_key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);
 
-    match slatedb
-        .get(&version_key)
-        .await
-        .expect("Failed to read version from META_INDEX")
-    {
+    match slatedb.get(&version_key).await.expect("Failed to read version from META_INDEX") {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
             let schema = load_schema_from_indices(slatedb.clone()).await;
@@ -77,7 +68,10 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
         None => {
             // Fresh DB — bootstrap schema (ops have explicit db/id values)
             let tx_ops = bootstrap_schema_tx();
-            let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
+            let schema = Schema::default();
+            let expanded = tx::expand_tx_ops(&tx_ops, &schema).unwrap();
+            let mut boot_pm = PartitionMap::new();
+            let datoms = tx::resolve_tempids(&expanded, &mut boot_pm, &schema).unwrap();
             let mut schema = Schema::default();
             let update = schema.validate_and_prepare(&datoms).unwrap();
             // TODO: We should bootstrap the schema properly and do the validation in the same manner as the indexer
@@ -88,9 +82,7 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&version_key, version.as_bytes()).unwrap();
-            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS)
-                .await
-                .unwrap();
+            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await.unwrap();
 
             // Derive counters from the just-written index
             let pm = scan_partition_counters(&slatedb).await;
@@ -114,28 +106,16 @@ mod tests {
         assert_eq!(metadata.schema.len(), 7);
         assert!(metadata.schema.get_attribute(&kw!(:db/ident)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/valueType)).is_some());
-        assert!(metadata
-            .schema
-            .get_attribute(&kw!(:db/cardinality))
-            .is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/cardinality)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txInstant)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txId)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txResult)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db.tx/error)).is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
-        assert_eq!(
-            metadata.partition_map[&DB_PARTITION],
-            DB_PARTITION_COUNTER_FLOOR
-        );
+        assert_eq!(metadata.partition_map[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
         // Enum entities are in ident_map but not attribute_map
-        assert!(metadata
-            .schema
-            .ident_map
-            .contains_key(&kw!(:db.type/string)));
-        assert!(metadata
-            .schema
-            .get_attribute(&kw!(:db.type/string))
-            .is_none());
+        assert!(metadata.schema.ident_map.contains_key(&kw!(:db.type/string)));
+        assert!(metadata.schema.get_attribute(&kw!(:db.type/string)).is_none());
     }
 
     #[tokio::test]
@@ -146,10 +126,7 @@ mod tests {
         let metadata2 = init_db(slatedb).await;
         assert_eq!(metadata1.schema.len(), metadata2.schema.len());
         assert_eq!(metadata1.schema.len(), 7);
-        assert_eq!(
-            metadata1.partition_map[&DB_PARTITION],
-            metadata2.partition_map[&DB_PARTITION]
-        );
+        assert_eq!(metadata1.partition_map[&DB_PARTITION], metadata2.partition_map[&DB_PARTITION]);
     }
 
     #[tokio::test]
@@ -166,4 +143,5 @@ mod tests {
         // No EAV entries → empty counters
         assert!(metadata.partition_map.is_empty());
     }
+
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,13 +1,15 @@
-use std::sync::Arc;
-use slatedb::{Db, IsolationLevel};
 use crate::codec;
 use crate::indexer::write_index_entries;
 use crate::metadata::{Metadata, PartitionMap};
-use crate::partition::{extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION};
+use crate::partition::{
+    extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION,
+};
 use crate::schema::{bootstrap_schema_tx, load_schema_from_indices, Schema};
-use crate::tx;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
+use crate::tx;
 use crate::util::concat_bytes;
+use slatedb::{Db, IsolationLevel};
+use std::sync::Arc;
 
 const META_KEY_VERSION: &[u8] = b"version";
 
@@ -29,8 +31,11 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
             .expect("Failed to scan EAV partition prefix");
 
         if let Some(kv) = iter.next().await.expect("Failed to read EAV key") {
-            let mut cursor: &[u8] = &kv.key[codec::CODEC_LENGTH..codec::CODEC_LENGTH + codec::ENTITY_LENGTH];
-            let eid = match codec::decode_datatype(&mut cursor).expect("Failed to decode entity ID from EAV key") {
+            let mut cursor: &[u8] =
+                &kv.key[codec::CODEC_LENGTH..codec::CODEC_LENGTH + codec::ENTITY_LENGTH];
+            let eid = match codec::decode_datatype(&mut cursor)
+                .expect("Failed to decode entity ID from EAV key")
+            {
                 crate::ops::DataType::Long(id) => id,
                 other => panic!("Expected Long entity ID in EAV key, got {:?}", other),
             };
@@ -58,7 +63,11 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
 pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
     let version_key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);
 
-    match slatedb.get(&version_key).await.expect("Failed to read version from META_INDEX") {
+    match slatedb
+        .get(&version_key)
+        .await
+        .expect("Failed to read version from META_INDEX")
+    {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
             let schema = load_schema_from_indices(slatedb.clone()).await;
@@ -82,7 +91,9 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&version_key, version.as_bytes()).unwrap();
-            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await.unwrap();
+            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS)
+                .await
+                .unwrap();
 
             // Derive counters from the just-written index
             let pm = scan_partition_counters(&slatedb).await;
@@ -106,16 +117,28 @@ mod tests {
         assert_eq!(metadata.schema.len(), 7);
         assert!(metadata.schema.get_attribute(&kw!(:db/ident)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/valueType)).is_some());
-        assert!(metadata.schema.get_attribute(&kw!(:db/cardinality)).is_some());
+        assert!(metadata
+            .schema
+            .get_attribute(&kw!(:db/cardinality))
+            .is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txInstant)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txId)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txResult)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db.tx/error)).is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
-        assert_eq!(metadata.partition_map[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
+        assert_eq!(
+            metadata.partition_map[&DB_PARTITION],
+            DB_PARTITION_COUNTER_FLOOR
+        );
         // Enum entities are in ident_map but not attribute_map
-        assert!(metadata.schema.ident_map.contains_key(&kw!(:db.type/string)));
-        assert!(metadata.schema.get_attribute(&kw!(:db.type/string)).is_none());
+        assert!(metadata
+            .schema
+            .ident_map
+            .contains_key(&kw!(:db.type/string)));
+        assert!(metadata
+            .schema
+            .get_attribute(&kw!(:db.type/string))
+            .is_none());
     }
 
     #[tokio::test]
@@ -126,7 +149,10 @@ mod tests {
         let metadata2 = init_db(slatedb).await;
         assert_eq!(metadata1.schema.len(), metadata2.schema.len());
         assert_eq!(metadata1.schema.len(), 7);
-        assert_eq!(metadata1.partition_map[&DB_PARTITION], metadata2.partition_map[&DB_PARTITION]);
+        assert_eq!(
+            metadata1.partition_map[&DB_PARTITION],
+            metadata2.partition_map[&DB_PARTITION]
+        );
     }
 
     #[tokio::test]
@@ -143,5 +169,4 @@ mod tests {
         // No EAV entries → empty counters
         assert!(metadata.partition_map.is_empty());
     }
-
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -68,10 +68,10 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
         None => {
             // Fresh DB — bootstrap schema (ops have explicit db/id values)
             let tx_ops = bootstrap_schema_tx();
-            let schema = Schema::default();
-            let expanded = tx::expand_tx_ops(&tx_ops, &schema).unwrap();
+            let empty_schema = Schema::default();
+            let expanded = tx::expand_tx_ops(&tx_ops, &empty_schema).unwrap();
             let mut boot_pm = PartitionMap::new();
-            let datoms = tx::resolve_tempids(&expanded, &mut boot_pm, &schema).unwrap();
+            let datoms = tx::resolve_tempids(&expanded, &mut boot_pm).unwrap();
             let mut schema = Schema::default();
             let update = schema.validate_and_prepare(&datoms).unwrap();
             // TODO: We should bootstrap the schema properly and do the validation in the same manner as the indexer

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,28 +1,29 @@
-use std::collections::HashSet;
-use std::sync::Arc;
+use anyhow::{bail, Error, Result};
+use bytes::Bytes;
+use log::{error, trace, warn};
 use slatedb::Db;
 use slatedb::IsolationLevel;
-use anyhow::{bail, Error, Result};
-use bincode;
-use bytes::Bytes;
+use std::collections::HashSet;
+use std::sync::Arc;
 use tokio::sync::broadcast;
-use log::{error, trace, warn};
 
 use edn::kw;
 
+use crate::codec::{
+    self, decode_datatype, decode_i64, encode_datatype, encode_i64, encode_i64_bytes, Encode,
+};
+use crate::iterator::temporal_filter_iterator;
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
+use crate::ops::DataType;
 use crate::ops::{Datom, DatomOp, TxOp};
 use crate::partition::{partition_entity_prefix, TX_PARTITION};
-use crate::tx;
-use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
-use crate::iterator::temporal_filter_iterator;
-use edn::symbols::Keyword;
 use crate::schema::Schema;
-use crate::transaction::TxKey;
-use crate::ops::DataType;
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
+use crate::transaction::TxKey;
+use crate::tx;
 use crate::util::concat_bytes;
+use edn::symbols::Keyword;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
@@ -59,15 +60,45 @@ pub(crate) fn write_index_entries(
         // Temporal indices include tx_eid + op
         // TODO(triplox-7fl): concat_bytes allocates intermediate Vecs per component;
         // encoding directly into a single buffer would be faster.
-        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &tx_eid_bytes, &[op_byte]]), &[])?;
-        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
+        txn.put(
+            concat_bytes(&[
+                &[codec::EAV],
+                &entity_id,
+                &attribute,
+                &value,
+                &tx_eid_bytes,
+                &[op_byte],
+            ]),
+            [],
+        )?;
+        txn.put(
+            concat_bytes(&[
+                &[codec::AVE],
+                &attribute,
+                &value,
+                &entity_id,
+                &tx_eid_bytes,
+                &[op_byte],
+            ]),
+            [],
+        )?;
+        txn.put(
+            concat_bytes(&[
+                &[codec::AEV],
+                &attribute,
+                &entity_id,
+                &value,
+                &tx_eid_bytes,
+                &[op_byte],
+            ]),
+            [],
+        )?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[])?;
-            txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
+            txn.put(concat_bytes(&[&[codec::AE], &attribute, &entity_id]), [])?;
+            txn.put(concat_bytes(&[&[codec::AV], &attribute, &value]), [])?;
         }
     }
 
@@ -86,9 +117,13 @@ pub(crate) fn write_index_entries(
 ///
 /// TODO(triplox-8mc): Return Option instead of sentinel. Needs coordination with
 /// the bootstrap transaction (tx_id=0).
-pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<(i64, TxKey)> {
+pub async fn latest_tx_key_from_snapshot(
+    snapshot: &Arc<slatedb::DbSnapshot>,
+) -> Result<(i64, TxKey)> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+    let mut iter = snapshot
+        .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
     let mut first_eid: Option<i64> = None;
     let mut tx_id: Option<i64> = None;
     let mut system_time: Option<crate::clock::Instant> = None;
@@ -115,11 +150,20 @@ pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) ->
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok((eid, TxKey { tx_id: tid, system_time: st })),
-        _ => Ok((0, TxKey {
-            tx_id: 0,
-            system_time: crate::clock::st_from_unix_epoch(0),
-        })),
+        (Some(eid), Some(tid), Some(st)) => Ok((
+            eid,
+            TxKey {
+                tx_id: tid,
+                system_time: st,
+            },
+        )),
+        _ => Ok((
+            0,
+            TxKey {
+                tx_id: 0,
+                system_time: crate::clock::st_from_unix_epoch(0),
+            },
+        )),
     }
 }
 
@@ -131,7 +175,9 @@ pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxK
     let mut value_bytes = Vec::new();
     codec::encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_bytes);
     let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
-    let mut iter = snapshot.scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+    let mut iter = snapshot
+        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
     match iter.next().await? {
         Some(kv) => {
             let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
@@ -162,12 +208,32 @@ fn build_tx_entity_datoms(
         kw!(:db.tx/aborted)
     };
     let mut datoms = vec![
-        Datom { entity: tx_eid, attribute: kw!(:db/txInstant), value: DataType::Instant(st), op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: kw!(:db/txId), value: DataType::Long(tx_key.tx_id), op: DatomOp::Assert },
-        Datom { entity: tx_eid, attribute: kw!(:db/txResult), value: DataType::Keyword(result_kw), op: DatomOp::Assert },
+        Datom {
+            entity: tx_eid,
+            attribute: kw!(:db/txInstant),
+            value: DataType::Instant(st),
+            op: DatomOp::Assert,
+        },
+        Datom {
+            entity: tx_eid,
+            attribute: kw!(:db/txId),
+            value: DataType::Long(tx_key.tx_id),
+            op: DatomOp::Assert,
+        },
+        Datom {
+            entity: tx_eid,
+            attribute: kw!(:db/txResult),
+            value: DataType::Keyword(result_kw),
+            op: DatomOp::Assert,
+        },
     ];
     if let Some(err) = error {
-        datoms.push(Datom { entity: tx_eid, attribute: kw!(:db.tx/error), value: DataType::String(err), op: DatomOp::Assert });
+        datoms.push(Datom {
+            entity: tx_eid,
+            attribute: kw!(:db.tx/error),
+            value: DataType::String(err),
+            op: DatomOp::Assert,
+        });
     }
     datoms
 }
@@ -197,14 +263,21 @@ impl Indexer {
             Ok(tx_key) => Ok(tx_key),
             Err(e) => {
                 if let Err(abort_err) = self.write_aborted_tx(tx_key, e.to_string()).await {
-                    error!("Failed to write aborted tx entity for {}: {}", tx_key.tx_id, abort_err);
+                    error!(
+                        "Failed to write aborted tx entity for {}: {}",
+                        tx_key.tx_id, abort_err
+                    );
                 }
                 Err(e)
             }
         }
     }
 
-    async fn transact_tx_inner(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
+    async fn transact_tx_inner(
+        &mut self,
+        tx_key: TxKey,
+        tx_ops: Vec<TxOp>,
+    ) -> Result<TxKey, Error> {
         // 1. Clone PartitionMap + allocate tx entity
         let mut pending_pm = self.metadata.partition_map.clone();
         let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
@@ -233,7 +306,9 @@ impl Indexer {
                 resolved_datoms.insert(datom);
                 continue;
             }
-            let (attribute_id, attr) = self.metadata.schema
+            let (attribute_id, attr) = self
+                .metadata
+                .schema
                 .get_attribute(&datom.attribute)
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
 
@@ -252,7 +327,9 @@ impl Indexer {
             // This duplicates the temporal resolution logic from advance_to_next_valid().
             // TODO(triplox-vbc): unify with TemporalFilterIterator once the iterator
             // layer becomes fully async, eliminating this duplication.
-            let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
+            let mut iter = txn
+                .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
+                .await?;
             let mut old_value: Option<DataType> = None;
             while let Some(kv) = iter.next().await? {
                 let key = &kv.key;
@@ -267,7 +344,8 @@ impl Indexer {
                         break;
                     }
                     Some(_) => {
-                        let value_bytes = &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
+                        let value_bytes =
+                            &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
                         let mut cursor = value_bytes;
                         let value: DataType = decode_datatype(&mut cursor)?;
                         old_value = Some(value);
@@ -309,7 +387,11 @@ impl Indexer {
         self.latest_indexed_tx = Some(tx_key);
 
         if let Err(e) = self.tx_completion_sender.send((tx_key, Ok(()))) {
-            trace!("No receivers for indexed transaction {}: {}", tx_key.tx_id, e);
+            trace!(
+                "No receivers for indexed transaction {}: {}",
+                tx_key.tx_id,
+                e
+            );
         }
 
         Ok(tx_key)
@@ -350,7 +432,6 @@ impl Indexer {
     }
 }
 
-
 /// A pre-subscribed handle for waiting on transaction completion.
 ///
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
@@ -381,12 +462,12 @@ impl TxWaiter {
                         return result.map_err(|e| anyhow::anyhow!("{:#}", e));
                     }
                     // Keep waiting for higher tx_id
-                },
+                }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
                     // Channel overflowed. Just continue waiting - we'll eventually
                     // get the notification or the channel will close.
                     continue;
-                },
+                }
                 Err(broadcast::error::RecvError::Closed) => {
                     return Err(anyhow::anyhow!(
                         "Indexer shutdown while waiting for tx {}",
@@ -404,8 +485,13 @@ impl Subscriber for Indexer {
             Ok(ops) => ops,
             Err(e) => {
                 let err = anyhow::anyhow!("Failed to deserialize TxOps: {}", e);
-                warn!("Transaction {} deserialization failed: {}", record.tx_key.tx_id, err);
-                let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(err))));
+                warn!(
+                    "Transaction {} deserialization failed: {}",
+                    record.tx_key.tx_id, err
+                );
+                let _ = self
+                    .tx_completion_sender
+                    .send((record.tx_key, Err(Arc::new(err))));
                 return;
             }
         };
@@ -413,13 +499,19 @@ impl Subscriber for Indexer {
         // the subscriber should propagate the error notification via tx_completion_sender.
         if let Err(e) = self.transact_tx(record.tx_key, tx_ops).await {
             warn!("Transaction {} failed: {}", record.tx_key.tx_id, e);
-            let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(e))));
+            let _ = self
+                .tx_completion_sender
+                .send((record.tx_key, Err(Arc::new(e))));
         }
     }
 }
 
 /// Strip a temporal index key into (data_bytes, tx_eid, op).
-fn strip_temporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<(&'a [u8], i64, u8), Error> {
+fn strip_temporal_key<'a>(
+    key: &'a [u8],
+    expected_prefix: u8,
+    name: &str,
+) -> Result<(&'a [u8], i64, u8), Error> {
     if key.first() != Some(&expected_prefix) {
         return Err(anyhow::anyhow!("Not a {} key", name));
     }
@@ -434,7 +526,11 @@ fn strip_temporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Res
 }
 
 /// Strip an atemporal index key, returning data bytes after the prefix.
-fn strip_atemporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<&'a [u8], Error> {
+fn strip_atemporal_key<'a>(
+    key: &'a [u8],
+    expected_prefix: u8,
+    name: &str,
+) -> Result<&'a [u8], Error> {
     if key.first() != Some(&expected_prefix) {
         return Err(anyhow::anyhow!("Not a {} key", name));
     }
@@ -489,13 +585,13 @@ pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
 
 #[cfg(test)]
 mod tests {
-    use slatedb::{Db, config::ScanOptions};
+    use slatedb::{config::ScanOptions, Db};
 
+    use super::*;
     use crate::clock::{st_from_unix_epoch, Instant};
     use crate::ops::{EntityRef, TxValue};
     use crate::schema::test_schema_tx;
     use crate::slate::in_memory_slate;
-    use super::*;
 
     /// Create an indexer with bootstrap schema and test attributes already transacted.
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
@@ -503,8 +599,14 @@ mod tests {
     async fn bootstrapped_indexer(slate: Arc<Db>) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate.clone()).await;
         let mut indexer = Indexer::new(slate, metadata, None);
-        let tx_key_0 = TxKey { tx_id: 0, system_time: st_from_unix_epoch(1) };
-        indexer.transact_tx(tx_key_0, test_schema_tx()).await.unwrap();
+        let tx_key_0 = TxKey {
+            tx_id: 0,
+            system_time: st_from_unix_epoch(1),
+        };
+        indexer
+            .transact_tx(tx_key_0, test_schema_tx())
+            .await
+            .unwrap();
         indexer
     }
 
@@ -512,8 +614,16 @@ mod tests {
     async fn test_indexer() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
-        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
@@ -521,10 +631,14 @@ mod tests {
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
 
         // Find the EAV entry for the user entity (skip bootstrap/schema entries)
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await
+            .unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) =
+                eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = &entity_id {
                 if *eid >= user_base {
                     assert_eq!(attribute, name_id);
@@ -544,19 +658,28 @@ mod tests {
     async fn test_indexer_write_persisted() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
 
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Verify an EAV entry in USER_PARTITION exists
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await
+            .unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = entity_id {
-                if eid >= user_base { found = true; break; }
+                if eid >= user_base {
+                    found = true;
+                    break;
+                }
             }
         }
         assert!(found, "Expected EAV entry to be written to the database");
@@ -568,7 +691,10 @@ mod tests {
     async fn test_indexer_multi_attribute_document() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
 
         let tx_ops = vec![TxOp::put(vec![
             (kw!(:name), "alan".into()),
@@ -579,12 +705,17 @@ mod tests {
 
         // Count EAV entries in USER_PARTITION (should be 2: name + age)
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await
+            .unwrap();
         let mut eav_count = 0;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = entity_id {
-                if eid >= user_base { eav_count += 1; }
+                if eid >= user_base {
+                    eav_count += 1;
+                }
             }
         }
         assert_eq!(eav_count, 2, "Expected 2 EAV entries for user entity");
@@ -596,7 +727,10 @@ mod tests {
     async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
+        let tx_key = TxKey {
+            tx_id: 42,
+            system_time: st_from_unix_epoch(1000),
+        };
 
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
@@ -626,10 +760,11 @@ mod tests {
 
         for i in 0..3 {
             let tx_id = i + 1;
-            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
-            let tx_ops = vec![TxOp::put(vec![
-                (kw!(:name), format!("user{}", i).into()),
-            ])];
+            let tx_key = TxKey {
+                tx_id,
+                system_time: st_from_unix_epoch(tx_id as u64 * 100),
+            };
+            let tx_ops = vec![TxOp::put(vec![(kw!(:name), format!("user{}", i).into())])];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -644,7 +779,10 @@ mod tests {
     async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
+        let tx_key = TxKey {
+            tx_id: 42,
+            system_time: st_from_unix_epoch(1000),
+        };
 
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
@@ -663,7 +801,10 @@ mod tests {
     async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let snapshot = Arc::new(slate.snapshot().await?);
-        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(1000) };
+        let tx_key = TxKey {
+            tx_id: 999,
+            system_time: st_from_unix_epoch(1000),
+        };
 
         let result = tx_eid_for_tx_key(&snapshot, &tx_key).await;
         assert!(result.is_err(), "Should fail for non-existent tx_id");
@@ -676,7 +817,10 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
-        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
@@ -691,7 +835,10 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(200) };
+        let tx_key_1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(200),
+        };
 
         // Subscribe BEFORE transacting to avoid race
         let waiter = indexer.read().await.tx_waiter();
@@ -711,16 +858,27 @@ mod tests {
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
-        let indexer = Indexer::new(slate.clone(), Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()), None);
+        let indexer = Indexer::new(
+            slate.clone(),
+            Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
+            None,
+        );
 
-        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(999) };
+        let tx_key = TxKey {
+            tx_id: 999,
+            system_time: st_from_unix_epoch(999),
+        };
 
         let result = tokio::time::timeout(
             std::time::Duration::from_millis(100),
-            indexer.tx_waiter().await_tx(tx_key)
-        ).await;
+            indexer.tx_waiter().await_tx(tx_key),
+        )
+        .await;
 
-        assert!(result.is_err(), "Should timeout waiting for non-existent tx");
+        assert!(
+            result.is_err(),
+            "Should timeout waiting for non-existent tx"
+        );
         Ok(())
     }
 
@@ -731,16 +889,23 @@ mod tests {
 
         for i in 0..2 {
             let tx_id = i + 1;
-            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
-            let tx_ops = vec![TxOp::put(vec![
-                (kw!(:name), format!("user{}", i).into()),
-            ])];
+            let tx_key = TxKey {
+                tx_id,
+                system_time: st_from_unix_epoch(tx_id as u64 * 100),
+            };
+            let tx_ops = vec![TxOp::put(vec![(kw!(:name), format!("user{}", i).into())])];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx_key_1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
         indexer.tx_waiter().await_tx(tx_key_1).await?;
-        let tx_key_2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let tx_key_2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
         indexer.tx_waiter().await_tx(tx_key_2).await?;
 
         Ok(())
@@ -753,7 +918,10 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key = TxKey { tx_id: 5, system_time: st_from_unix_epoch(500) };
+        let tx_key = TxKey {
+            tx_id: 5,
+            system_time: st_from_unix_epoch(500),
+        };
 
         // Subscribe multiple waiters BEFORE transacting
         let waiters: Vec<_> = {
@@ -782,34 +950,57 @@ mod tests {
     async fn test_retract_on_overwrite() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
-        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find the auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
-                if id >= user_base { entity_id = id; break; }
+                if id >= user_base {
+                    entity_id = id;
+                    break;
+                }
             }
         }
         assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
-        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put(vec![
-            (kw!(:db/id), TxValue::Ref(entity_id.into())),
-            (kw!(:name), "bob".into()),
-        ])]).await?;
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        indexer
+            .transact_tx(
+                tx2,
+                vec![TxOp::put(vec![
+                    (kw!(:db/id), TxValue::Ref(entity_id.into())),
+                    (kw!(:name), "bob".into()),
+                ])],
+            )
+            .await?;
 
         // Scan EAV for entity — expect: alice ADD, alice RETRACT, bob ADD
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         let mut alice_add = false;
         let mut alice_retract = false;
         let mut bob_add = false;
@@ -844,33 +1035,56 @@ mod tests {
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
 
         // First tx: assert name="alice" for a new entity
-        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
         let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
-                if id >= user_base { entity_id = id; break; }
+                if id >= user_base {
+                    entity_id = id;
+                    break;
+                }
             }
         }
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
-        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put(vec![
-            (kw!(:db/id), TxValue::Ref(entity_id.into())),
-            (kw!(:name), "alice".into()),
-        ])]).await?;
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        indexer
+            .transact_tx(
+                tx2,
+                vec![TxOp::put(vec![
+                    (kw!(:db/id), TxValue::Ref(entity_id.into())),
+                    (kw!(:name), "alice".into()),
+                ])],
+            )
+            .await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -897,7 +1111,10 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for entity 2000
-        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
         let tx_ops1 = vec![TxOp::Add {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
@@ -906,7 +1123,10 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
-        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
         let tx_ops2 = vec![TxOp::Add {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
@@ -915,8 +1135,15 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
-        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let tags_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:tags))
+            .unwrap()
+            .0;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -931,7 +1158,10 @@ mod tests {
             }
         }
         assert_eq!(add_count, 2, "Expected 2 ADD entries for cardinality-many");
-        assert_eq!(retract_count, 0, "Expected no RETRACT entries for cardinality-many");
+        assert_eq!(
+            retract_count, 0,
+            "Expected no RETRACT entries for cardinality-many"
+        );
 
         Ok(())
     }
@@ -946,7 +1176,10 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for entity 2000
-        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
         let tx_ops1 = vec![TxOp::Add {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
@@ -955,7 +1188,10 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
-        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
         let tx_ops2 = vec![TxOp::Add {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
@@ -964,8 +1200,15 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr — expect 2 ADDs (both written)
-        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
+        let tags_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:tags))
+            .unwrap()
+            .0;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {
             let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
@@ -976,9 +1219,11 @@ mod tests {
                 add_count += 1;
             }
         }
-        assert_eq!(add_count, 2, "Expected 2 ADD entries for same value on cardinality-many");
+        assert_eq!(
+            add_count, 2,
+            "Expected 2 ADD entries for same value on cardinality-many"
+        );
 
         Ok(())
     }
-
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -893,7 +893,7 @@ mod tests {
         // First tx: assert tags="rust" for entity 2000
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];
@@ -902,7 +902,7 @@ mod tests {
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "database".into(),
         }];
@@ -942,7 +942,7 @@ mod tests {
         // First tx: assert tags="rust" for entity 2000
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];
@@ -951,7 +951,7 @@ mod tests {
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -803,7 +803,10 @@ mod tests {
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(entity_id.into())), (kw!(:name), "bob".into())])]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(entity_id.into())),
+            (kw!(:name), "bob".into()),
+        ])]).await?;
 
         // Scan EAV for entity — expect: alice ADD, alice RETRACT, bob ADD
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
@@ -861,7 +864,10 @@ mod tests {
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(entity_id.into())), (kw!(:name), "alice".into())])]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(entity_id.into())),
+            (kw!(:name), "alice".into()),
+        ])]).await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -213,7 +213,7 @@ impl Indexer {
         let expanded = tx::expand_tx_ops(&tx_ops, &self.metadata.schema)?;
 
         // 3. Resolve tempids + build tx entity datoms
-        let mut datoms = tx::resolve_tempids(&expanded, &mut pending_pm, &self.metadata.schema)?;
+        let mut datoms = tx::resolve_tempids(&expanded, &mut pending_pm)?;
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
         // 4. Validate + prepare schema update (single pass, pre-commit, fallible)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -893,7 +893,7 @@ mod tests {
         // First tx: assert tags="rust" for entity 2000
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];
@@ -902,7 +902,7 @@ mod tests {
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "database".into(),
         }];
@@ -942,7 +942,7 @@ mod tests {
         // First tx: assert tags="rust" for entity 2000
         let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];
@@ -951,7 +951,7 @@ mod tests {
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,28 +1,28 @@
-use anyhow::{bail, Error, Result};
-use bytes::Bytes;
-use log::{error, trace, warn};
-use slatedb::Db;
-use slatedb::IsolationLevel;
 use std::collections::HashSet;
 use std::sync::Arc;
+use slatedb::Db;
+use slatedb::IsolationLevel;
+use anyhow::{bail, Error, Result};
+use bincode;
+use bytes::Bytes;
 use tokio::sync::broadcast;
+use log::{error, trace, warn};
 
 use edn::kw;
 
-use crate::codec::{
-    self, decode_datatype, decode_i64, encode_datatype, encode_i64, encode_i64_bytes, Encode,
-};
-use crate::iterator::temporal_filter_iterator;
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
-use crate::ops::DataType;
-use crate::ops::{tx_ops_to_datoms, Datom, DatomOp, TxOp};
-use crate::partition::{partition_entity_prefix, resolve_entity_ids, TX_PARTITION};
-use crate::schema::Schema;
-use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
-use crate::transaction::TxKey;
-use crate::util::concat_bytes;
+use crate::ops::{Datom, DatomOp, TxOp};
+use crate::partition::{partition_entity_prefix, TX_PARTITION};
+use crate::tx;
+use crate::codec::{self, Encode, encode_i64, encode_i64_bytes, encode_datatype, decode_i64, decode_datatype};
+use crate::iterator::temporal_filter_iterator;
 use edn::symbols::Keyword;
+use crate::schema::Schema;
+use crate::transaction::TxKey;
+use crate::ops::DataType;
+use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
+use crate::util::concat_bytes;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
@@ -59,45 +59,15 @@ pub(crate) fn write_index_entries(
         // Temporal indices include tx_eid + op
         // TODO(triplox-7fl): concat_bytes allocates intermediate Vecs per component;
         // encoding directly into a single buffer would be faster.
-        txn.put(
-            concat_bytes(&[
-                &[codec::EAV],
-                &entity_id,
-                &attribute,
-                &value,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
-        txn.put(
-            concat_bytes(&[
-                &[codec::AVE],
-                &attribute,
-                &value,
-                &entity_id,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
-        txn.put(
-            concat_bytes(&[
-                &[codec::AEV],
-                &attribute,
-                &entity_id,
-                &value,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
+        txn.put(&concat_bytes(&[&[codec::EAV], &entity_id, &attribute, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AVE], &attribute, &value, &entity_id, &tx_eid_bytes, &[op_byte]]), &[])?;
+        txn.put(&concat_bytes(&[&[codec::AEV], &attribute, &entity_id, &value, &tx_eid_bytes, &[op_byte]]), &[])?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            txn.put(concat_bytes(&[&[codec::AE], &attribute, &entity_id]), [])?;
-            txn.put(concat_bytes(&[&[codec::AV], &attribute, &value]), [])?;
+            txn.put(&concat_bytes(&[&[codec::AE], &attribute, &entity_id]), &[])?;
+            txn.put(&concat_bytes(&[&[codec::AV], &attribute, &value]), &[])?;
         }
     }
 
@@ -116,13 +86,9 @@ pub(crate) fn write_index_entries(
 ///
 /// TODO(triplox-8mc): Return Option instead of sentinel. Needs coordination with
 /// the bootstrap transaction (tx_id=0).
-pub async fn latest_tx_key_from_snapshot(
-    snapshot: &Arc<slatedb::DbSnapshot>,
-) -> Result<(i64, TxKey)> {
+pub async fn latest_tx_key_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<(i64, TxKey)> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = snapshot
-        .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
+    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     let mut first_eid: Option<i64> = None;
     let mut tx_id: Option<i64> = None;
     let mut system_time: Option<crate::clock::Instant> = None;
@@ -149,20 +115,11 @@ pub async fn latest_tx_key_from_snapshot(
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok((
-            eid,
-            TxKey {
-                tx_id: tid,
-                system_time: st,
-            },
-        )),
-        _ => Ok((
-            0,
-            TxKey {
-                tx_id: 0,
-                system_time: crate::clock::st_from_unix_epoch(0),
-            },
-        )),
+        (Some(eid), Some(tid), Some(st)) => Ok((eid, TxKey { tx_id: tid, system_time: st })),
+        _ => Ok((0, TxKey {
+            tx_id: 0,
+            system_time: crate::clock::st_from_unix_epoch(0),
+        })),
     }
 }
 
@@ -174,9 +131,7 @@ pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxK
     let mut value_bytes = Vec::new();
     codec::encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_bytes);
     let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
-    let mut iter = snapshot
-        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
+    let mut iter = snapshot.scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     match iter.next().await? {
         Some(kv) => {
             let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
@@ -207,36 +162,12 @@ fn build_tx_entity_datoms(
         kw!(:db.tx/aborted)
     };
     let mut datoms = vec![
-        Datom {
-            entity: tx_eid,
-            attribute: kw!(:db/txInstant),
-            value: DataType::Instant(st),
-            tx: tx_eid,
-            op: DatomOp::Assert,
-        },
-        Datom {
-            entity: tx_eid,
-            attribute: kw!(:db/txId),
-            value: DataType::Long(tx_key.tx_id),
-            tx: tx_eid,
-            op: DatomOp::Assert,
-        },
-        Datom {
-            entity: tx_eid,
-            attribute: kw!(:db/txResult),
-            value: DataType::Keyword(result_kw),
-            tx: tx_eid,
-            op: DatomOp::Assert,
-        },
+        Datom { entity: tx_eid, attribute: kw!(:db/txInstant), value: DataType::Instant(st), op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: kw!(:db/txId), value: DataType::Long(tx_key.tx_id), op: DatomOp::Assert },
+        Datom { entity: tx_eid, attribute: kw!(:db/txResult), value: DataType::Keyword(result_kw), op: DatomOp::Assert },
     ];
     if let Some(err) = error {
-        datoms.push(Datom {
-            entity: tx_eid,
-            attribute: kw!(:db.tx/error),
-            value: DataType::String(err),
-            tx: tx_eid,
-            op: DatomOp::Assert,
-        });
+        datoms.push(Datom { entity: tx_eid, attribute: kw!(:db.tx/error), value: DataType::String(err), op: DatomOp::Assert });
     }
     datoms
 }
@@ -266,30 +197,23 @@ impl Indexer {
             Ok(tx_key) => Ok(tx_key),
             Err(e) => {
                 if let Err(abort_err) = self.write_aborted_tx(tx_key, e.to_string()).await {
-                    error!(
-                        "Failed to write aborted tx entity for {}: {}",
-                        tx_key.tx_id, abort_err
-                    );
+                    error!("Failed to write aborted tx entity for {}: {}", tx_key.tx_id, abort_err);
                 }
                 Err(e)
             }
         }
     }
 
-    async fn transact_tx_inner(
-        &mut self,
-        tx_key: TxKey,
-        tx_ops: Vec<TxOp>,
-    ) -> Result<TxKey, Error> {
+    async fn transact_tx_inner(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
         // 1. Clone PartitionMap + allocate tx entity
         let mut pending_pm = self.metadata.partition_map.clone();
         let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
 
-        // 2. Resolve entity IDs
-        let resolved_ops = resolve_entity_ids(&tx_ops, &mut pending_pm)?;
+        // 2. Expand TxOps to DatomWithTempids (resolves idents via schema)
+        let expanded = tx::expand_tx_ops(&tx_ops, &self.metadata.schema)?;
 
-        // 3. Expand to datoms + build tx entity datoms
-        let mut datoms = tx_ops_to_datoms(&resolved_ops, tx_eid)?;
+        // 3. Resolve tempids + build tx entity datoms
+        let mut datoms = tx::resolve_tempids(&expanded, &mut pending_pm, &self.metadata.schema)?;
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
         // 4. Validate + prepare schema update (single pass, pre-commit, fallible)
@@ -309,9 +233,7 @@ impl Indexer {
                 resolved_datoms.insert(datom);
                 continue;
             }
-            let (attribute_id, attr) = self
-                .metadata
-                .schema
+            let (attribute_id, attr) = self.metadata.schema
                 .get_attribute(&datom.attribute)
                 .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
 
@@ -330,9 +252,7 @@ impl Indexer {
             // This duplicates the temporal resolution logic from advance_to_next_valid().
             // TODO(triplox-vbc): unify with TemporalFilterIterator once the iterator
             // layer becomes fully async, eliminating this duplication.
-            let mut iter = txn
-                .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
-                .await?;
+            let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
             let mut old_value: Option<DataType> = None;
             while let Some(kv) = iter.next().await? {
                 let key = &kv.key;
@@ -347,8 +267,7 @@ impl Indexer {
                         break;
                     }
                     Some(_) => {
-                        let value_bytes =
-                            &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
+                        let value_bytes = &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
                         let mut cursor = value_bytes;
                         let value: DataType = decode_datatype(&mut cursor)?;
                         old_value = Some(value);
@@ -368,7 +287,6 @@ impl Indexer {
                     entity: datom.entity,
                     attribute: datom.attribute.clone(),
                     value: old_value,
-                    tx: datom.tx,
                     op: DatomOp::Retract,
                 });
             }
@@ -391,11 +309,7 @@ impl Indexer {
         self.latest_indexed_tx = Some(tx_key);
 
         if let Err(e) = self.tx_completion_sender.send((tx_key, Ok(()))) {
-            trace!(
-                "No receivers for indexed transaction {}: {}",
-                tx_key.tx_id,
-                e
-            );
+            trace!("No receivers for indexed transaction {}: {}", tx_key.tx_id, e);
         }
 
         Ok(tx_key)
@@ -436,6 +350,7 @@ impl Indexer {
     }
 }
 
+
 /// A pre-subscribed handle for waiting on transaction completion.
 ///
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
@@ -466,12 +381,12 @@ impl TxWaiter {
                         return result.map_err(|e| anyhow::anyhow!("{:#}", e));
                     }
                     // Keep waiting for higher tx_id
-                }
+                },
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
                     // Channel overflowed. Just continue waiting - we'll eventually
                     // get the notification or the channel will close.
                     continue;
-                }
+                },
                 Err(broadcast::error::RecvError::Closed) => {
                     return Err(anyhow::anyhow!(
                         "Indexer shutdown while waiting for tx {}",
@@ -489,13 +404,8 @@ impl Subscriber for Indexer {
             Ok(ops) => ops,
             Err(e) => {
                 let err = anyhow::anyhow!("Failed to deserialize TxOps: {}", e);
-                warn!(
-                    "Transaction {} deserialization failed: {}",
-                    record.tx_key.tx_id, err
-                );
-                let _ = self
-                    .tx_completion_sender
-                    .send((record.tx_key, Err(Arc::new(err))));
+                warn!("Transaction {} deserialization failed: {}", record.tx_key.tx_id, err);
+                let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(err))));
                 return;
             }
         };
@@ -503,19 +413,13 @@ impl Subscriber for Indexer {
         // the subscriber should propagate the error notification via tx_completion_sender.
         if let Err(e) = self.transact_tx(record.tx_key, tx_ops).await {
             warn!("Transaction {} failed: {}", record.tx_key.tx_id, e);
-            let _ = self
-                .tx_completion_sender
-                .send((record.tx_key, Err(Arc::new(e))));
+            let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(e))));
         }
     }
 }
 
 /// Strip a temporal index key into (data_bytes, tx_eid, op).
-fn strip_temporal_key<'a>(
-    key: &'a [u8],
-    expected_prefix: u8,
-    name: &str,
-) -> Result<(&'a [u8], i64, u8), Error> {
+fn strip_temporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<(&'a [u8], i64, u8), Error> {
     if key.first() != Some(&expected_prefix) {
         return Err(anyhow::anyhow!("Not a {} key", name));
     }
@@ -530,11 +434,7 @@ fn strip_temporal_key<'a>(
 }
 
 /// Strip an atemporal index key, returning data bytes after the prefix.
-fn strip_atemporal_key<'a>(
-    key: &'a [u8],
-    expected_prefix: u8,
-    name: &str,
-) -> Result<&'a [u8], Error> {
+fn strip_atemporal_key<'a>(key: &'a [u8], expected_prefix: u8, name: &str) -> Result<&'a [u8], Error> {
     if key.first() != Some(&expected_prefix) {
         return Err(anyhow::anyhow!("Not a {} key", name));
     }
@@ -589,13 +489,13 @@ pub fn av_key_to_parts(key: Bytes) -> Result<(i64, DataType), Error> {
 
 #[cfg(test)]
 mod tests {
-    use slatedb::{config::ScanOptions, Db};
-    use std::collections::BTreeMap;
+    use slatedb::{Db, config::ScanOptions};
 
-    use super::*;
     use crate::clock::{st_from_unix_epoch, Instant};
+    use crate::ops::EntityRef;
     use crate::schema::test_schema_tx;
     use crate::slate::in_memory_slate;
+    use super::*;
 
     /// Create an indexer with bootstrap schema and test attributes already transacted.
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
@@ -603,14 +503,8 @@ mod tests {
     async fn bootstrapped_indexer(slate: Arc<Db>) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate.clone()).await;
         let mut indexer = Indexer::new(slate, metadata, None);
-        let tx_key_0 = TxKey {
-            tx_id: 0,
-            system_time: st_from_unix_epoch(1),
-        };
-        indexer
-            .transact_tx(tx_key_0, test_schema_tx())
-            .await
-            .unwrap();
+        let tx_key_0 = TxKey { tx_id: 0, system_time: st_from_unix_epoch(1) };
+        indexer.transact_tx(tx_key_0, test_schema_tx()).await.unwrap();
         indexer
     }
 
@@ -618,33 +512,19 @@ mod tests {
     async fn test_indexer() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
-        let mut doc = BTreeMap::new();
-        doc.insert("name".to_string(), DataType::String("alan".to_string()));
-        let tx_ops = vec![TxOp::Put(doc)];
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // The entity was auto-assigned an ID in USER_PARTITION
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
 
         // Find the EAV entry for the user entity (skip bootstrap/schema entries)
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, attribute, value, _timestamp, suffix) =
-                eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = &entity_id {
                 if *eid >= user_base {
                     assert_eq!(attribute, name_id);
@@ -660,44 +540,23 @@ mod tests {
         Ok(())
     }
 
-    fn user_doc(attrs: Vec<(&str, DataType)>) -> BTreeMap<String, DataType> {
-        let mut map = BTreeMap::new();
-        for (k, v) in attrs {
-            map.insert(k.to_string(), v);
-        }
-        map
-    }
-
     #[tokio::test]
     async fn test_indexer_write_persisted() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alan".into()),
-        )]))];
-
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Verify an EAV entry in USER_PARTITION exists
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = entity_id {
-                if eid >= user_base {
-                    found = true;
-                    break;
-                }
+                if eid >= user_base { found = true; break; }
             }
         }
         assert!(found, "Expected EAV entry to be written to the database");
@@ -709,31 +568,23 @@ mod tests {
     async fn test_indexer_multi_attribute_document() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let tx_ops = vec![TxOp::Put(user_doc(vec![
-            ("name", DataType::String("alan".into())),
-            ("age", DataType::Long(30)),
-        ]))];
+        let tx_ops = vec![TxOp::put(vec![
+            (kw!(:name), "alan".into()),
+            (kw!(:age), 30_i64.into()),
+        ])];
 
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Count EAV entries in USER_PARTITION (should be 2: name + age)
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut eav_count = 0;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
             if let DataType::Long(eid) = entity_id {
-                if eid >= user_base {
-                    eav_count += 1;
-                }
+                if eid >= user_base { eav_count += 1; }
             }
         }
         assert_eq!(eav_count, 2, "Expected 2 EAV entries for user entity");
@@ -745,15 +596,9 @@ mod tests {
     async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 42,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
 
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alice".into()),
-        )]))];
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
@@ -781,14 +626,10 @@ mod tests {
 
         for i in 0..3 {
             let tx_id = i + 1;
-            let tx_key = TxKey {
-                tx_id,
-                system_time: st_from_unix_epoch(tx_id as u64 * 100),
-            };
-            let tx_ops = vec![TxOp::Put(user_doc(vec![(
-                "name",
-                DataType::String(format!("user{}", i)),
-            )]))];
+            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
+            let tx_ops = vec![TxOp::put(vec![
+                (kw!(:name), format!("user{}", i).into()),
+            ])];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -803,15 +644,9 @@ mod tests {
     async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 42,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
 
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alice".into()),
-        )]))];
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
@@ -828,10 +663,7 @@ mod tests {
     async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let snapshot = Arc::new(slate.snapshot().await?);
-        let tx_key = TxKey {
-            tx_id: 999,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(1000) };
 
         let result = tx_eid_for_tx_key(&snapshot, &tx_key).await;
         assert!(result.is_err(), "Should fail for non-existent tx_id");
@@ -844,14 +676,8 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alice".into()),
-        )]))];
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         indexer.tx_waiter().await_tx(tx_key).await?;
@@ -865,20 +691,14 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key_1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(200) };
 
         // Subscribe BEFORE transacting to avoid race
         let waiter = indexer.read().await.tx_waiter();
 
         {
             let mut guard = indexer.write().await;
-            let tx_ops = vec![TxOp::Put(user_doc(vec![(
-                "name",
-                DataType::String("bob".into()),
-            )]))];
+            let tx_ops = vec![TxOp::put(vec![(kw!(:name), "bob".into())])];
 
             guard.transact_tx(tx_key_1, tx_ops).await?;
         }
@@ -891,27 +711,16 @@ mod tests {
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
-        let indexer = Indexer::new(
-            slate.clone(),
-            Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
-            None,
-        );
+        let indexer = Indexer::new(slate.clone(), Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()), None);
 
-        let tx_key = TxKey {
-            tx_id: 999,
-            system_time: st_from_unix_epoch(999),
-        };
+        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(999) };
 
         let result = tokio::time::timeout(
             std::time::Duration::from_millis(100),
-            indexer.tx_waiter().await_tx(tx_key),
-        )
-        .await;
+            indexer.tx_waiter().await_tx(tx_key)
+        ).await;
 
-        assert!(
-            result.is_err(),
-            "Should timeout waiting for non-existent tx"
-        );
+        assert!(result.is_err(), "Should timeout waiting for non-existent tx");
         Ok(())
     }
 
@@ -922,26 +731,16 @@ mod tests {
 
         for i in 0..2 {
             let tx_id = i + 1;
-            let tx_key = TxKey {
-                tx_id,
-                system_time: st_from_unix_epoch(tx_id as u64 * 100),
-            };
-            let tx_ops = vec![TxOp::Put(user_doc(vec![(
-                "name",
-                DataType::String(format!("user{}", i)),
-            )]))];
+            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
+            let tx_ops = vec![TxOp::put(vec![
+                (kw!(:name), format!("user{}", i).into()),
+            ])];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let tx_key_1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         indexer.tx_waiter().await_tx(tx_key_1).await?;
-        let tx_key_2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx_key_2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         indexer.tx_waiter().await_tx(tx_key_2).await?;
 
         Ok(())
@@ -954,10 +753,7 @@ mod tests {
         let slate = Arc::new(in_memory_slate().await);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key = TxKey {
-            tx_id: 5,
-            system_time: st_from_unix_epoch(500),
-        };
+        let tx_key = TxKey { tx_id: 5, system_time: st_from_unix_epoch(500) };
 
         // Subscribe multiple waiters BEFORE transacting
         let waiters: Vec<_> = {
@@ -968,10 +764,7 @@ mod tests {
         // Index the transaction
         {
             let mut guard = indexer.write().await;
-            let tx_ops = vec![TxOp::Put(user_doc(vec![(
-                "name",
-                DataType::String("shared".into()),
-            )]))];
+            let tx_ops = vec![TxOp::put(vec![(kw!(:name), "shared".into())])];
 
             guard.transact_tx(tx_key, tx_ops).await?;
         }
@@ -989,55 +782,31 @@ mod tests {
     async fn test_retract_on_overwrite() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alice".into()),
-        )]))];
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find the auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
+                if id >= user_base { entity_id = id; break; }
             }
         }
         assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(entity_id));
-        map.insert("name".to_string(), DataType::String("bob".to_string()));
-        indexer.transact_tx(tx2, vec![TxOp::Put(map)]).await?;
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        indexer.transact_tx(tx2, vec![TxOp::put_with_id(entity_id, vec![(kw!(:name), "bob".into())])]).await?;
 
         // Scan EAV for entity — expect: alice ADD, alice RETRACT, bob ADD
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut alice_add = false;
         let mut alice_retract = false;
         let mut bob_add = false;
@@ -1072,54 +841,30 @@ mod tests {
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
-        let tx_ops = vec![TxOp::Put(user_doc(vec![(
-            "name",
-            DataType::String("alice".into()),
-        )]))];
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
+                if id >= user_base { entity_id = id; break; }
             }
         }
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(entity_id));
-        map.insert("name".to_string(), DataType::String("alice".to_string()));
-        indexer.transact_tx(tx2, vec![TxOp::Put(map)]).await?;
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
+        indexer.transact_tx(tx2, vec![TxOp::put_with_id(entity_id, vec![(kw!(:name), "alice".into())])]).await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -1146,39 +891,26 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for entity 2000
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("rust".to_string()),
+            value: "rust".into(),
         }];
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("database".to_string()),
+            value: "database".into(),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -1193,10 +925,7 @@ mod tests {
             }
         }
         assert_eq!(add_count, 2, "Expected 2 ADD entries for cardinality-many");
-        assert_eq!(
-            retract_count, 0,
-            "Expected no RETRACT entries for cardinality-many"
-        );
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries for cardinality-many");
 
         Ok(())
     }
@@ -1211,39 +940,26 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for entity 2000
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("rust".to_string()),
+            value: "rust".into(),
         }];
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("rust".to_string()),
+            value: "rust".into(),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity 2000, tags attr — expect 2 ADDs (both written)
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {
             let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
@@ -1254,11 +970,9 @@ mod tests {
                 add_count += 1;
             }
         }
-        assert_eq!(
-            add_count, 2,
-            "Expected 2 ADD entries for same value on cardinality-many"
-        );
+        assert_eq!(add_count, 2, "Expected 2 ADD entries for same value on cardinality-many");
 
         Ok(())
     }
+
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -492,7 +492,7 @@ mod tests {
     use slatedb::{Db, config::ScanOptions};
 
     use crate::clock::{st_from_unix_epoch, Instant};
-    use crate::ops::EntityRef;
+    use crate::ops::{EntityRef, TxValue};
     use crate::schema::test_schema_tx;
     use crate::slate::in_memory_slate;
     use super::*;
@@ -803,7 +803,7 @@ mod tests {
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put_with_id(entity_id, vec![(kw!(:name), "bob".into())])]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(entity_id.into())), (kw!(:name), "bob".into())])]).await?;
 
         // Scan EAV for entity — expect: alice ADD, alice RETRACT, bob ADD
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
@@ -861,7 +861,7 @@ mod tests {
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
-        indexer.transact_tx(tx2, vec![TxOp::put_with_id(entity_id, vec![(kw!(:name), "alice".into())])]).await?;
+        indexer.transact_tx(tx2, vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(entity_id.into())), (kw!(:name), "alice".into())])]).await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
         let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod schema;
 mod schema;
 mod slate;
 mod transaction;
+pub mod tx;
 mod util;
 
 pub mod client;

--- a/src/node.rs
+++ b/src/node.rs
@@ -252,7 +252,7 @@ mod tests {
 
         // Use entity ID 1000 to avoid reserved bootstrap range (1-31)
         let tx_ops = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:email),
             value: "test@example.com".into(),
         }];
@@ -864,14 +864,14 @@ mod tests {
 
         // Insert entity 2000 with tags="rust"
         node.execute_tx(vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }]).await.unwrap();
 
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity_id: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "database".into(),
         }]).await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -320,7 +320,10 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])]).await.unwrap();
         node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
 
         let query = parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
@@ -383,9 +386,18 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into()), (kw!(:age), 25_i64.into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into()), (kw!(:age), 35_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "bob".into()),
+            (kw!(:age), 25_i64.into()),
+        ])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "charlie".into()),
+            (kw!(:age), 35_i64.into()),
+        ])]).await.unwrap();
 
         let query = parse_query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).unwrap();
 
@@ -402,9 +414,18 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into()), (kw!(:age), 25_i64.into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into()), (kw!(:age), 35_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "bob".into()),
+            (kw!(:age), 25_i64.into()),
+        ])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "charlie".into()),
+            (kw!(:age), 35_i64.into()),
+        ])]).await.unwrap();
 
         let query = parse_query(r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#).unwrap();
 
@@ -504,7 +525,10 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])]).await.unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("expected commit"),
@@ -807,8 +831,14 @@ mod tests {
 
         // Insert entity 200 and entity 201 with last-names
         node.execute_tx(vec![
-            TxOp::put(vec![(kw!(:db/id), TxValue::Ref(2200_i64.into())), (kw!(:last-name), "Ivannotov".into())]),
-            TxOp::put(vec![(kw!(:db/id), TxValue::Ref(1201_i64.into())), (kw!(:last-name), "Bobnev".into())]),
+            TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(2200_i64.into())),
+                (kw!(:last-name), "Ivannotov".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(1201_i64.into())),
+                (kw!(:last-name), "Bobnev".into()),
+            ]),
         ]).await.unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position

--- a/src/node.rs
+++ b/src/node.rs
@@ -208,7 +208,7 @@ mod tests {
     use crate::codec;
     use crate::parse::parse_query;
     use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
-    use crate::ops::{DataType, EntityRef, TxOp};
+    use crate::ops::{DataType, EntityRef, TxOp, TxValue};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
@@ -338,11 +338,13 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put_with_id(2000_i64, vec![
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(2000_i64.into())),
             (kw!(:name), "alice".into()),
             (kw!(:follows), 2001_i64.into()),
         ])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put_with_id(2001_i64, vec![
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(2001_i64.into())),
             (kw!(:name), "bob".into()),
         ])]).await.unwrap();
 
@@ -502,7 +504,7 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let result = node.execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])]).await.unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("expected commit"),
@@ -805,8 +807,8 @@ mod tests {
 
         // Insert entity 200 and entity 201 with last-names
         node.execute_tx(vec![
-            TxOp::put_with_id(2200_i64, vec![(kw!(:last-name), "Ivannotov".into())]),
-            TxOp::put_with_id(1201_i64, vec![(kw!(:last-name), "Bobnev".into())]),
+            TxOp::put(vec![(kw!(:db/id), TxValue::Ref(2200_i64.into())), (kw!(:last-name), "Ivannotov".into())]),
+            TxOp::put(vec![(kw!(:db/id), TxValue::Ref(1201_i64.into())), (kw!(:last-name), "Bobnev".into())]),
         ]).await.unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position

--- a/src/node.rs
+++ b/src/node.rs
@@ -252,7 +252,7 @@ mod tests {
 
         // Use entity ID 1000 to avoid reserved bootstrap range (1-31)
         let tx_ops = vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:email),
             value: "test@example.com".into(),
         }];
@@ -864,14 +864,14 @@ mod tests {
 
         // Insert entity 2000 with tags="rust"
         node.execute_tx(vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
         }]).await.unwrap();
 
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
-            entity_id: EntityRef::Id(2000),
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "database".into(),
         }]).await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,17 +5,17 @@ use anyhow::Error;
 use tokio::runtime::Handle;
 
 use crate::clock;
-use edn::query::ParsedQuery;
 use crate::file_log::FileLog;
-use crate::indexer::{Indexer, latest_tx_key_from_snapshot};
+use crate::indexer::{latest_tx_key_from_snapshot, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader};
-use tokio::sync::RwLock;
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, TxOp};
 use crate::query::{execute_query, validate_query, QueryResult};
 use crate::schema::IdentMap;
 use crate::slate::{in_memory_slate, local_slate};
 pub use crate::transaction::{TransactionResult, TxKey};
+use edn::query::ParsedQuery;
+use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 #[allow(async_fn_in_trait)]
@@ -46,14 +46,36 @@ pub struct DB {
 
 #[allow(unused)]
 impl DB {
-    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
-        Self { snapshot, ident_map, handle, tx_key, tx_eid }
+    pub fn new(
+        snapshot: Arc<slatedb::DbSnapshot>,
+        ident_map: IdentMap,
+        handle: Handle,
+        tx_key: TxKey,
+        tx_eid: i64,
+    ) -> Self {
+        Self {
+            snapshot,
+            ident_map,
+            handle,
+            tx_key,
+            tx_eid,
+        }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
-    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle) -> Result<Self, Error> {
+    pub async fn from_latest_snapshot(
+        snapshot: Arc<slatedb::DbSnapshot>,
+        ident_map: IdentMap,
+        handle: Handle,
+    ) -> Result<Self, Error> {
         let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
-        Ok(Self { snapshot, ident_map, handle, tx_key, tx_eid })
+        Ok(Self {
+            snapshot,
+            ident_map,
+            handle,
+            tx_key,
+            tx_eid,
+        })
     }
 
     pub fn tx_key(&self) -> &TxKey {
@@ -97,12 +119,21 @@ impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slatedb = Arc::new(in_memory_slate().await);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, None)));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
+            slatedb.clone(),
+            metadata,
+            None,
+        )));
         let log = Arc::new(RwLock::new(MemoryLog::new(Box::new(clock::SystemClock))));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
 
-        Node { log, indexer, slatedb, subscription }
+        Node {
+            log,
+            indexer,
+            slatedb,
+            subscription,
+        }
     }
 }
 
@@ -110,7 +141,8 @@ impl Node<FileLog> {
     pub async fn local_node(root_path: &Path) -> Result<Self, Error> {
         std::fs::create_dir_all(root_path.join("db"))?;
         let db_path = root_path.join("db");
-        let db_path_str = db_path.to_str()
+        let db_path_str = db_path
+            .to_str()
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
         let slatedb = Arc::new(local_slate(db_path_str).await);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
@@ -125,10 +157,15 @@ impl Node<FileLog> {
             None
         };
 
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, latest_indexed_tx)));
-        let log = Arc::new(RwLock::new(
-            FileLog::new(&root_path.join("log"), Box::new(clock::SystemClock))?,
-        ));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
+            slatedb.clone(),
+            metadata,
+            latest_indexed_tx,
+        )));
+        let log = Arc::new(RwLock::new(FileLog::new(
+            &root_path.join("log"),
+            Box::new(clock::SystemClock),
+        )?));
 
         let after_tx_id = latest_indexed_tx.map(|k| k.tx_id);
 
@@ -152,7 +189,12 @@ impl Node<FileLog> {
             waiter.await_tx(tx_key).await?;
         }
 
-        Ok(Node { log, indexer, slatedb, subscription })
+        Ok(Node {
+            log,
+            indexer,
+            slatedb,
+            subscription,
+        })
     }
 }
 
@@ -187,14 +229,28 @@ impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
     async fn db(&self) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
+        let ident_map = self
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .ident_map
+            .clone();
         let handle = Handle::current();
         DB::from_latest_snapshot(snapshot, ident_map, handle).await
     }
     // TODO we are currently not checking that snapshot contains TxKey
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
+        let ident_map = self
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .ident_map
+            .clone();
         let handle = Handle::current();
         let tx_eid = crate::indexer::tx_eid_for_tx_key(&snapshot, &tx_key).await?;
         Ok(DB::new(snapshot, ident_map, handle, tx_key, tx_eid))
@@ -205,15 +261,17 @@ impl<L: TxLog> QueryNode for Node<L> {
 mod tests {
     use slatedb::config::ScanOptions;
 
+    use super::*;
     use crate::codec;
-    use crate::parse::parse_query;
-    use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
+    use crate::indexer::{
+        ae_key_to_parts, aev_key_to_parts, av_key_to_parts, ave_key_to_parts, eav_key_to_parts,
+    };
     use crate::ops::{DataType, EntityRef, TxOp, TxValue};
+    use crate::parse::parse_query;
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
     use edn::Keyword;
-    use super::*;
 
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
     async fn define_test_schema(node: &impl SubmitNode) {
@@ -235,7 +293,10 @@ mod tests {
         assert_eq!(tx_key.tx_id, 1);
 
         // Wait for indexer to process the transaction
-        waiter.await_tx(tx_key).await.expect("Transaction should be indexed");
+        waiter
+            .await_tx(tx_key)
+            .await
+            .expect("Transaction should be indexed");
 
         // Verify data is queryable after async indexing
         let db = node.db().await.unwrap();
@@ -261,13 +322,25 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let slate = node.slatedb.clone();
-        let email_id = node.indexer.read().await.metadata().schema.get_attribute(&kw!(:email)).unwrap().0;
+        let email_id = node
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:email))
+            .unwrap()
+            .0;
 
         // Check EAV index — find entry for entity 2000
-        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await
+            .unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) =
+                eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(2000) {
                 assert_eq!(attribute, email_id);
                 assert_eq!(value, DataType::String("test@example.com".to_string()));
@@ -286,8 +359,12 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
 
         let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
 
@@ -304,8 +381,12 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
 
         let query = parse_query(r#"[:find ?e :where [?e :name "alice"]]"#).unwrap();
 
@@ -323,16 +404,24 @@ mod tests {
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
-        ])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
 
-        let query = parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
+        let query =
+            parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], vec![DataType::String("alice".to_string()), DataType::Long(30)]);
+        assert_eq!(
+            result[0],
+            vec![DataType::String("alice".to_string()), DataType::Long(30)]
+        );
     }
 
     // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
@@ -345,14 +434,19 @@ mod tests {
             (kw!(:db/id), TxValue::Ref(2000_i64.into())),
             (kw!(:name), "alice".into()),
             (kw!(:follows), 2001_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(2001_i64.into())),
             (kw!(:name), "bob".into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
 
         // ?friend is in value position of :follows and entity position of :name
-        let query = parse_query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]").unwrap();
+        let query = parse_query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]")
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -366,11 +460,20 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into())])])
+            .await
+            .unwrap();
 
-        let query = parse_query(r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#).unwrap();
+        let query = parse_query(
+            r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#,
+        )
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -389,15 +492,21 @@ mod tests {
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "charlie".into()),
             (kw!(:age), 35_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
 
         let query = parse_query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).unwrap();
 
@@ -405,8 +514,14 @@ mod tests {
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&vec![DataType::String("alice".to_string()), DataType::Long(30)]));
-        assert!(result.contains(&vec![DataType::String("bob".to_string()), DataType::Long(25)]));
+        assert!(result.contains(&vec![
+            DataType::String("alice".to_string()),
+            DataType::Long(30)
+        ]));
+        assert!(result.contains(&vec![
+            DataType::String("bob".to_string()),
+            DataType::Long(25)
+        ]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -417,15 +532,21 @@ mod tests {
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:name), "charlie".into()),
             (kw!(:age), 35_i64.into()),
-        ])]).await.unwrap();
+        ])])
+        .await
+        .unwrap();
 
         let query = parse_query(r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#).unwrap();
 
@@ -445,12 +566,20 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_key1 = match node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap() {
+        let tx_key1 = match node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap()
+        {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx1 should commit"),
         };
 
-        let tx_key2 = match node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap() {
+        let tx_key2 = match node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap()
+        {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx2 should commit"),
         };
@@ -482,7 +611,10 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -500,7 +632,10 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
-        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -525,10 +660,13 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let result = node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), TxValue::Ref(100_i64.into())),
-            (kw!(:name), "alice".into()),
-        ])]).await.unwrap();
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(100_i64.into())),
+                (kw!(:name), "alice".into()),
+            ])])
+            .await
+            .unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("expected commit"),
@@ -542,12 +680,13 @@ mod tests {
         // A waiter obtained after restart should resolve immediately for the
         // already-indexed tx_key. Without the fix this hangs forever.
         let waiter = node.indexer.read().await.tx_waiter();
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            waiter.await_tx(tx_key),
-        ).await;
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), waiter.await_tx(tx_key)).await;
 
-        assert!(result.is_ok(), "tx_waiter should not timeout for an already-indexed tx");
+        assert!(
+            result.is_ok(),
+            "tx_waiter should not timeout for an already-indexed tx"
+        );
         result.unwrap().expect("await_tx should succeed");
 
         node.close().await;
@@ -559,20 +698,30 @@ mod tests {
         define_test_schema(&node).await;
 
         // First transaction: insert alice
-        let result1 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        let result1 = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
         let tx_key1 = match result1 {
             TransactionResult::TxCommited(tk) => tk,
             _ => panic!("Expected TxCommited"),
         };
 
         // Second transaction: insert bob
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
         let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
         let results = db.query(&query).await.unwrap();
-        assert_eq!(results.len(), 1, "basis-pinned DB should only see alice, got {:?}", results);
+        assert_eq!(
+            results.len(),
+            1,
+            "basis-pinned DB should only see alice, got {:?}",
+            results
+        );
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         // latest db should see both
@@ -596,16 +745,14 @@ mod tests {
 
     /// Insert 3 people: Ivan (age=30), Bob (age=40), Dominic (age=50) with auto-assigned IDs.
     async fn insert_three_people(node: &impl SubmitNode) {
-        let people = vec![
-            ("Ivan", 30),
-            ("Bob", 40),
-            ("Dominic", 50),
-        ];
+        let people = vec![("Ivan", 30), ("Bob", 40), ("Dominic", 50)];
         for (name, age) in people {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
                 (kw!(:age), age.into()),
-            ])]).await.unwrap();
+            ])])
+            .await
+            .unwrap();
         }
     }
 
@@ -615,7 +762,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]").unwrap();
+        let query =
+            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]")
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -630,7 +779,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]").unwrap();
+        let query =
+            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]")
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -644,7 +795,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]").unwrap();
+        let query =
+            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]")
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -658,7 +811,8 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).unwrap();
+        let query =
+            parse_query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -686,14 +840,26 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]").unwrap();
+        let query = parse_query(
+            "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]",
+        )
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
-        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(20)]));
-        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(25)]));
+        assert!(result.contains(&vec![
+            DataType::String("Ivan".to_string()),
+            DataType::Long(15)
+        ]));
+        assert!(result.contains(&vec![
+            DataType::String("Bob".to_string()),
+            DataType::Long(20)
+        ]));
+        assert!(result.contains(&vec![
+            DataType::String("Dominic".to_string()),
+            DataType::Long(25)
+        ]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -707,7 +873,10 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], vec![DataType::String("Dominic".to_string()), DataType::Long(25)]);
+        assert_eq!(
+            result[0],
+            vec![DataType::String("Dominic".to_string()), DataType::Long(25)]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -716,14 +885,26 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]").unwrap();
+        let query = parse_query(
+            "[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]",
+        )
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
-        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(25)]));
-        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(35)]));
+        assert!(result.contains(&vec![
+            DataType::String("Ivan".to_string()),
+            DataType::Long(15)
+        ]));
+        assert!(result.contains(&vec![
+            DataType::String("Bob".to_string()),
+            DataType::Long(25)
+        ]));
+        assert!(result.contains(&vec![
+            DataType::String("Dominic".to_string()),
+            DataType::Long(35)
+        ]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -732,7 +913,8 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").unwrap();
+        let query =
+            parse_query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -749,9 +931,17 @@ mod tests {
         // Define "sex" attribute with keyword value type
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
-            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
-            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
-        ])]).await.unwrap();
+            (
+                kw!(:db/valueType),
+                DataType::Keyword(kw!(:db.type/keyword)).into(),
+            ),
+            (
+                kw!(:db/cardinality),
+                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+            ),
+        ])])
+        .await
+        .unwrap();
 
         let people = vec![
             ("Ivan", "male"),
@@ -763,7 +953,9 @@ mod tests {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
-            ])]).await.unwrap();
+            ])])
+            .await
+            .unwrap();
         }
 
         // find ?name where [?e :sex :male] [?e :name ?name]
@@ -787,9 +979,17 @@ mod tests {
 
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
-            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
-            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
-        ])]).await.unwrap();
+            (
+                kw!(:db/valueType),
+                DataType::Keyword(kw!(:db.type/keyword)).into(),
+            ),
+            (
+                kw!(:db/cardinality),
+                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+            ),
+        ])])
+        .await
+        .unwrap();
 
         let people = vec![
             ("Ivan", "male"),
@@ -801,7 +1001,9 @@ mod tests {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
-            ])]).await.unwrap();
+            ])])
+            .await
+            .unwrap();
         }
 
         // Same clause order as Clojure: name first (binds ?e), sex filter second
@@ -825,9 +1027,17 @@ mod tests {
         // Define "last-name" attribute
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:last-name)).into()),
-            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string)).into()),
-            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
-        ])]).await.unwrap();
+            (
+                kw!(:db/valueType),
+                DataType::Keyword(kw!(:db.type/string)).into(),
+            ),
+            (
+                kw!(:db/cardinality),
+                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+            ),
+        ])])
+        .await
+        .unwrap();
 
         // Insert entity 200 and entity 201 with last-names
         node.execute_tx(vec![
@@ -839,7 +1049,9 @@ mod tests {
                 (kw!(:db/id), TxValue::Ref(1201_i64.into())),
                 (kw!(:last-name), "Bobnev".into()),
             ]),
-        ]).await.unwrap();
+        ])
+        .await
+        .unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
         let query = parse_query("[:find ?ln :where [2200 :last-name ?ln]]").unwrap();
@@ -861,28 +1073,44 @@ mod tests {
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent/attr), "x".into())])]),
-        ).await.expect("Should not hang").expect("execute_tx should not return Err");
+        )
+        .await
+        .expect("Should not hang")
+        .expect("execute_tx should not return Err");
 
         match &result {
             TransactionResult::TxAborted(_, err) => {
                 let msg = err.to_string();
-                assert!(msg.contains("Unknown attribute"), "Expected 'Unknown attribute' error, got: {}", msg);
-            },
+                assert!(
+                    msg.contains("Unknown attribute"),
+                    "Expected 'Unknown attribute' error, got: {}",
+                    msg
+                );
+            }
             TransactionResult::TxCommited(_) => panic!("Expected TxAborted, got TxCommited"),
         }
 
         // Define schema and submit a valid tx — indexer should still be alive
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)),
-                "Expected TxCommited for schema tx, got: {:?}", result);
+        assert!(
+            matches!(result, TransactionResult::TxCommited(_)),
+            "Expected TxCommited for schema tx, got: {:?}",
+            result
+        );
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]),
-        ).await.expect("Should not hang").expect("execute_tx should not return Err");
+        )
+        .await
+        .expect("Should not hang")
+        .expect("execute_tx should not return Err");
 
-        assert!(matches!(result, TransactionResult::TxCommited(_)),
-                "Expected TxCommited for valid tx, got: {:?}", result);
+        assert!(
+            matches!(result, TransactionResult::TxCommited(_)),
+            "Expected TxCommited for valid tx, got: {:?}",
+            result
+        );
     }
 
     // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
@@ -897,14 +1125,18 @@ mod tests {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "rust".into(),
-        }]).await.unwrap();
+        }])
+        .await
+        .unwrap();
 
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
             entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
             value: "database".into(),
-        }]).await.unwrap();
+        }])
+        .await
+        .unwrap();
 
         // Query: find all tags for entity 2000
         let query = parse_query("[:find ?tag :where [2000 :tags ?tag]]").unwrap();
@@ -923,15 +1155,27 @@ mod tests {
         define_test_schema(&node).await;
 
         // tx1: valid insert — allocates first user entity
-        let result1 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        let result1 = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
         assert!(matches!(result1, TransactionResult::TxCommited(_)));
 
         // tx2: insert with unknown attribute — should fail
-        let result2 = node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent_attr), "oops".into())])]).await.unwrap();
+        let result2 = node
+            .execute_tx(vec![TxOp::put(vec![(
+                kw!(:nonexistent_attr),
+                "oops".into(),
+            )])])
+            .await
+            .unwrap();
         assert!(matches!(result2, TransactionResult::TxAborted(_, _)));
 
         // tx3: valid insert — should get the next contiguous entity ID
-        let result3 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        let result3 = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .await
+            .unwrap();
         assert!(matches!(result3, TransactionResult::TxCommited(_)));
 
         // Query all (entity, name) pairs and verify contiguous counter values
@@ -940,10 +1184,13 @@ mod tests {
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
-        let mut eids: Vec<i64> = result.iter().map(|row| match &row[0] {
-            DataType::Long(id) => *id,
-            _ => panic!("Expected Long entity ID"),
-        }).collect();
+        let mut eids: Vec<i64> = result
+            .iter()
+            .map(|row| match &row[0] {
+                DataType::Long(id) => *id,
+                _ => panic!("Expected Long entity ID"),
+            })
+            .collect();
         eids.sort();
 
         // Counters 0 and 1 — no gap from the failed tx
@@ -958,7 +1205,10 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .await
+            .unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("Expected committed"),
@@ -966,7 +1216,10 @@ mod tests {
 
         // Query for the tx entity matching this tx_id
         let db = node.db().await.unwrap();
-        let query_str = format!("[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]", tx_key.tx_id);
+        let query_str = format!(
+            "[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]",
+            tx_key.tx_id
+        );
         let query = parse_query(&query_str).unwrap();
         let result = db.query(&query).await.unwrap();
 
@@ -980,7 +1233,10 @@ mod tests {
         define_test_schema(&node).await;
 
         // Submit a transaction with an unknown attribute to trigger abort
-        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent), "x".into())])]).await.unwrap();
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent), "x".into())])])
+            .await
+            .unwrap();
         let tx_key = match &result {
             TransactionResult::TxAborted(k, _) => *k,
             _ => panic!("Expected aborted, got {:?}", result),
@@ -995,10 +1251,13 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));
         if let DataType::String(s) = &result[0][1] {
-            assert!(s.contains("nonexistent"), "Error should mention the unknown attribute, got: {}", s);
+            assert!(
+                s.contains("nonexistent"),
+                "Error should mention the unknown attribute, got: {}",
+                s
+            );
         } else {
             panic!("Expected String for error, got {:?}", result[0][1]);
         }
     }
-
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,17 +5,17 @@ use anyhow::Error;
 use tokio::runtime::Handle;
 
 use crate::clock;
+use edn::query::ParsedQuery;
 use crate::file_log::FileLog;
-use crate::indexer::{latest_tx_key_from_snapshot, Indexer};
+use crate::indexer::{Indexer, latest_tx_key_from_snapshot};
 use crate::log::{subscribe, TxLog, TxLogReader};
+use tokio::sync::RwLock;
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, TxOp};
 use crate::query::{execute_query, validate_query, QueryResult};
 use crate::schema::IdentMap;
 use crate::slate::{in_memory_slate, local_slate};
 pub use crate::transaction::{TransactionResult, TxKey};
-use edn::query::ParsedQuery;
-use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 #[allow(async_fn_in_trait)]
@@ -46,36 +46,14 @@ pub struct DB {
 
 #[allow(unused)]
 impl DB {
-    pub fn new(
-        snapshot: Arc<slatedb::DbSnapshot>,
-        ident_map: IdentMap,
-        handle: Handle,
-        tx_key: TxKey,
-        tx_eid: i64,
-    ) -> Self {
-        Self {
-            snapshot,
-            ident_map,
-            handle,
-            tx_key,
-            tx_eid,
-        }
+    pub fn new(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle, tx_key: TxKey, tx_eid: i64) -> Self {
+        Self { snapshot, ident_map, handle, tx_key, tx_eid }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
-    pub async fn from_latest_snapshot(
-        snapshot: Arc<slatedb::DbSnapshot>,
-        ident_map: IdentMap,
-        handle: Handle,
-    ) -> Result<Self, Error> {
+    pub async fn from_latest_snapshot(snapshot: Arc<slatedb::DbSnapshot>, ident_map: IdentMap, handle: Handle) -> Result<Self, Error> {
         let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
-        Ok(Self {
-            snapshot,
-            ident_map,
-            handle,
-            tx_key,
-            tx_eid,
-        })
+        Ok(Self { snapshot, ident_map, handle, tx_key, tx_eid })
     }
 
     pub fn tx_key(&self) -> &TxKey {
@@ -119,21 +97,12 @@ impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slatedb = Arc::new(in_memory_slate().await);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
-            slatedb.clone(),
-            metadata,
-            None,
-        )));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, None)));
         let log = Arc::new(RwLock::new(MemoryLog::new(Box::new(clock::SystemClock))));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
 
-        Node {
-            log,
-            indexer,
-            slatedb,
-            subscription,
-        }
+        Node { log, indexer, slatedb, subscription }
     }
 }
 
@@ -141,8 +110,7 @@ impl Node<FileLog> {
     pub async fn local_node(root_path: &Path) -> Result<Self, Error> {
         std::fs::create_dir_all(root_path.join("db"))?;
         let db_path = root_path.join("db");
-        let db_path_str = db_path
-            .to_str()
+        let db_path_str = db_path.to_str()
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
         let slatedb = Arc::new(local_slate(db_path_str).await);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
@@ -157,15 +125,10 @@ impl Node<FileLog> {
             None
         };
 
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
-            slatedb.clone(),
-            metadata,
-            latest_indexed_tx,
-        )));
-        let log = Arc::new(RwLock::new(FileLog::new(
-            &root_path.join("log"),
-            Box::new(clock::SystemClock),
-        )?));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(slatedb.clone(), metadata, latest_indexed_tx)));
+        let log = Arc::new(RwLock::new(
+            FileLog::new(&root_path.join("log"), Box::new(clock::SystemClock))?,
+        ));
 
         let after_tx_id = latest_indexed_tx.map(|k| k.tx_id);
 
@@ -189,12 +152,7 @@ impl Node<FileLog> {
             waiter.await_tx(tx_key).await?;
         }
 
-        Ok(Node {
-            log,
-            indexer,
-            slatedb,
-            subscription,
-        })
+        Ok(Node { log, indexer, slatedb, subscription })
     }
 }
 
@@ -229,28 +187,14 @@ impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
     async fn db(&self) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
         DB::from_latest_snapshot(snapshot, ident_map, handle).await
     }
     // TODO we are currently not checking that snapshot contains TxKey
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
         let snapshot = self.slatedb.snapshot().await?;
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
         let tx_eid = crate::indexer::tx_eid_for_tx_key(&snapshot, &tx_key).await?;
         Ok(DB::new(snapshot, ident_map, handle, tx_key, tx_eid))
@@ -259,21 +203,17 @@ impl<L: TxLog> QueryNode for Node<L> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use slatedb::config::ScanOptions;
 
-    use super::*;
     use crate::codec;
-    use crate::indexer::{
-        ae_key_to_parts, aev_key_to_parts, av_key_to_parts, ave_key_to_parts, eav_key_to_parts,
-    };
-    use crate::ops::{DataType, TxOp};
     use crate::parse::parse_query;
+    use crate::indexer::{eav_key_to_parts, ave_key_to_parts, aev_key_to_parts, ae_key_to_parts, av_key_to_parts};
+    use crate::ops::{DataType, EntityRef, TxOp};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
     use edn::Keyword;
+    use super::*;
 
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
     async fn define_test_schema(node: &impl SubmitNode) {
@@ -286,9 +226,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut map = BTreeMap::new();
-        map.insert("name".to_string(), DataType::String("bob".to_string()));
-        let tx_ops = vec![TxOp::Put(map)];
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "bob".into())])];
 
         let waiter = node.indexer.read().await.tx_waiter();
 
@@ -297,10 +235,7 @@ mod tests {
         assert_eq!(tx_key.tx_id, 1);
 
         // Wait for indexer to process the transaction
-        waiter
-            .await_tx(tx_key)
-            .await
-            .expect("Transaction should be indexed");
+        waiter.await_tx(tx_key).await.expect("Transaction should be indexed");
 
         // Verify data is queryable after async indexing
         let db = node.db().await.unwrap();
@@ -317,34 +252,22 @@ mod tests {
 
         // Use entity ID 1000 to avoid reserved bootstrap range (1-31)
         let tx_ops = vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:email),
-            value: DataType::String("test@example.com".to_string()),
+            value: "test@example.com".into(),
         }];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let slate = node.slatedb.clone();
-        let email_id = node
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:email))
-            .unwrap()
-            .0;
+        let email_id = node.indexer.read().await.metadata().schema.get_attribute(&kw!(:email)).unwrap().0;
 
         // Check EAV index — find entry for entity 2000
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter = slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, _timestamp, suffix) =
-                eav_key_to_parts(kv.key).unwrap();
+            let (entity_id, attribute, value, _timestamp, suffix) = eav_key_to_parts(kv.key).unwrap();
             if entity_id == DataType::Long(2000) {
                 assert_eq!(attribute, email_id);
                 assert_eq!(value, DataType::String("test@example.com".to_string()));
@@ -363,14 +286,8 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
 
         let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
 
@@ -387,14 +304,8 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
 
         let query = parse_query(r#"[:find ?e :where [?e :name "alice"]]"#).unwrap();
 
@@ -409,27 +320,16 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        doc1.insert("age".to_string(), DataType::Long(30));
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
 
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
-
-        let query =
-            parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
+        let query = parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("alice".to_string()), DataType::Long(30)]
-        );
+        assert_eq!(result[0], vec![DataType::String("alice".to_string()), DataType::Long(30)]);
     }
 
     // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
@@ -438,21 +338,16 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("db/id".to_string(), DataType::Long(2000));
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        doc1.insert("follows".to_string(), DataType::Long(2001));
-
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("db/id".to_string(), DataType::Long(2001));
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put_with_id(2000_i64, vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:follows), 2001_i64.into()),
+        ])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put_with_id(2001_i64, vec![
+            (kw!(:name), "bob".into()),
+        ])]).await.unwrap();
 
         // ?friend is in value position of :follows and entity position of :name
-        let query = parse_query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]")
-            .unwrap();
+        let query = parse_query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -466,23 +361,11 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into())])]).await.unwrap();
 
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        let mut doc3 = BTreeMap::new();
-        doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
-
-        let query = parse_query(
-            r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#,
-        )
-        .unwrap();
+        let query = parse_query(r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#).unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -498,21 +381,9 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        doc1.insert("age".to_string(), DataType::Long(30));
-
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-        doc2.insert("age".to_string(), DataType::Long(25));
-
-        let mut doc3 = BTreeMap::new();
-        doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
-        doc3.insert("age".to_string(), DataType::Long(35));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into()), (kw!(:age), 25_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into()), (kw!(:age), 35_i64.into())])]).await.unwrap();
 
         let query = parse_query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).unwrap();
 
@@ -520,14 +391,8 @@ mod tests {
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&vec![
-            DataType::String("alice".to_string()),
-            DataType::Long(30)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("bob".to_string()),
-            DataType::Long(25)
-        ]));
+        assert!(result.contains(&vec![DataType::String("alice".to_string()), DataType::Long(30)]));
+        assert!(result.contains(&vec![DataType::String("bob".to_string()), DataType::Long(25)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -535,21 +400,9 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        doc1.insert("age".to_string(), DataType::Long(30));
-
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-        doc2.insert("age".to_string(), DataType::Long(25));
-
-        let mut doc3 = BTreeMap::new();
-        doc3.insert("name".to_string(), DataType::String("charlie".to_string()));
-        doc3.insert("age".to_string(), DataType::Long(35));
-
-        node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
-        node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into()), (kw!(:age), 25_i64.into())])]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into()), (kw!(:age), 35_i64.into())])]).await.unwrap();
 
         let query = parse_query(r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#).unwrap();
 
@@ -569,18 +422,12 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let tx_key1 = match node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap() {
+        let tx_key1 = match node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap() {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx1 should commit"),
         };
 
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        let tx_key2 = match node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap() {
+        let tx_key2 = match node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap() {
             TransactionResult::TxCommited(tx_key) => tx_key,
             _ => panic!("Tx2 should commit"),
         };
@@ -612,10 +459,7 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let result = node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -633,10 +477,7 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-
-        let result = node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
@@ -661,11 +502,7 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
         define_test_schema(&node).await;
 
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(100));
-        doc.insert("name".to_string(), DataType::String("alice".to_string()));
-
-        let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])]).await.unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("expected commit"),
@@ -679,13 +516,12 @@ mod tests {
         // A waiter obtained after restart should resolve immediately for the
         // already-indexed tx_key. Without the fix this hangs forever.
         let waiter = node.indexer.read().await.tx_waiter();
-        let result =
-            tokio::time::timeout(std::time::Duration::from_secs(2), waiter.await_tx(tx_key)).await;
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            waiter.await_tx(tx_key),
+        ).await;
 
-        assert!(
-            result.is_ok(),
-            "tx_waiter should not timeout for an already-indexed tx"
-        );
+        assert!(result.is_ok(), "tx_waiter should not timeout for an already-indexed tx");
         result.unwrap().expect("await_tx should succeed");
 
         node.close().await;
@@ -697,29 +533,20 @@ mod tests {
         define_test_schema(&node).await;
 
         // First transaction: insert alice
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        let result1 = node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        let result1 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
         let tx_key1 = match result1 {
             TransactionResult::TxCommited(tk) => tk,
             _ => panic!("Expected TxCommited"),
         };
 
         // Second transaction: insert bob
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-        node.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
         let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
         let results = db.query(&query).await.unwrap();
-        assert_eq!(
-            results.len(),
-            1,
-            "basis-pinned DB should only see alice, got {:?}",
-            results
-        );
+        assert_eq!(results.len(), 1, "basis-pinned DB should only see alice, got {:?}", results);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         // latest db should see both
@@ -743,12 +570,16 @@ mod tests {
 
     /// Insert 3 people: Ivan (age=30), Bob (age=40), Dominic (age=50) with auto-assigned IDs.
     async fn insert_three_people(node: &impl SubmitNode) {
-        let people = vec![("Ivan", 30), ("Bob", 40), ("Dominic", 50)];
+        let people = vec![
+            ("Ivan", 30),
+            ("Bob", 40),
+            ("Dominic", 50),
+        ];
         for (name, age) in people {
-            let mut doc = BTreeMap::new();
-            doc.insert("name".to_string(), DataType::String(name.to_string()));
-            doc.insert("age".to_string(), DataType::Long(age));
-            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+            node.execute_tx(vec![TxOp::put(vec![
+                (kw!(:name), name.into()),
+                (kw!(:age), age.into()),
+            ])]).await.unwrap();
         }
     }
 
@@ -758,9 +589,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]")
-                .unwrap();
+        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -775,9 +604,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]")
-                .unwrap();
+        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -791,9 +618,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]")
-                .unwrap();
+        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -807,8 +632,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).unwrap();
+        let query = parse_query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -836,26 +660,14 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query(
-            "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]",
-        )
-        .unwrap();
+        let query = parse_query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![
-            DataType::String("Ivan".to_string()),
-            DataType::Long(15)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Bob".to_string()),
-            DataType::Long(20)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Dominic".to_string()),
-            DataType::Long(25)
-        ]));
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(20)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(25)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -869,10 +681,7 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("Dominic".to_string()), DataType::Long(25)]
-        );
+        assert_eq!(result[0], vec![DataType::String("Dominic".to_string()), DataType::Long(25)]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -881,26 +690,14 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query(
-            "[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]",
-        )
-        .unwrap();
+        let query = parse_query("[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![
-            DataType::String("Ivan".to_string()),
-            DataType::Long(15)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Bob".to_string()),
-            DataType::Long(25)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Dominic".to_string()),
-            DataType::Long(35)
-        ]));
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(25)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(35)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -909,8 +706,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").unwrap();
+        let query = parse_query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -925,17 +721,11 @@ mod tests {
         define_test_schema(&node).await;
 
         // Define "sex" attribute with keyword value type
-        let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:sex)));
-        sex_attr.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(kw!(:db.type/keyword)),
-        );
-        sex_attr.insert(
-            "db/cardinality".to_string(),
-            DataType::Keyword(kw!(:db.cardinality/one)),
-        );
-        node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
+        ])]).await.unwrap();
 
         let people = vec![
             ("Ivan", "male"),
@@ -944,10 +734,10 @@ mod tests {
             ("Doris", "female"),
         ];
         for (name, sex) in people {
-            let mut doc = BTreeMap::new();
-            doc.insert("name".to_string(), DataType::String(name.to_string()));
-            doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+            node.execute_tx(vec![TxOp::put(vec![
+                (kw!(:name), name.into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+            ])]).await.unwrap();
         }
 
         // find ?name where [?e :sex :male] [?e :name ?name]
@@ -969,17 +759,11 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut sex_attr = BTreeMap::new();
-        sex_attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:sex)));
-        sex_attr.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(kw!(:db.type/keyword)),
-        );
-        sex_attr.insert(
-            "db/cardinality".to_string(),
-            DataType::Keyword(kw!(:db.cardinality/one)),
-        );
-        node.execute_tx(vec![TxOp::Put(sex_attr)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
+        ])]).await.unwrap();
 
         let people = vec![
             ("Ivan", "male"),
@@ -988,10 +772,10 @@ mod tests {
             ("Jane", "female"),
         ];
         for (name, sex) in people {
-            let mut doc = BTreeMap::new();
-            doc.insert("name".to_string(), DataType::String(name.to_string()));
-            doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-            node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+            node.execute_tx(vec![TxOp::put(vec![
+                (kw!(:name), name.into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+            ])]).await.unwrap();
         }
 
         // Same clause order as Clojure: name first (binds ?e), sex filter second
@@ -1013,34 +797,17 @@ mod tests {
         define_test_schema(&node).await;
 
         // Define "last-name" attribute
-        let mut attr = BTreeMap::new();
-        attr.insert("db/ident".to_string(), DataType::Keyword(kw!(:last-name)));
-        attr.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(kw!(:db.type/string)),
-        );
-        attr.insert(
-            "db/cardinality".to_string(),
-            DataType::Keyword(kw!(:db.cardinality/one)),
-        );
-        node.execute_tx(vec![TxOp::Put(attr)]).await.unwrap();
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/ident), DataType::Keyword(kw!(:last-name)).into()),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
+        ])]).await.unwrap();
 
         // Insert entity 200 and entity 201 with last-names
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("db/id".to_string(), DataType::Long(2200));
-        doc1.insert(
-            "last-name".to_string(),
-            DataType::String("Ivannotov".to_string()),
-        );
-        let mut doc2 = BTreeMap::new();
-        doc2.insert("db/id".to_string(), DataType::Long(1201));
-        doc2.insert(
-            "last-name".to_string(),
-            DataType::String("Bobnev".to_string()),
-        );
-        node.execute_tx(vec![TxOp::Put(doc1), TxOp::Put(doc2)])
-            .await
-            .unwrap();
+        node.execute_tx(vec![
+            TxOp::put_with_id(2200_i64, vec![(kw!(:last-name), "Ivannotov".into())]),
+            TxOp::put_with_id(1201_i64, vec![(kw!(:last-name), "Bobnev".into())]),
+        ]).await.unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
         let query = parse_query("[:find ?ln :where [2200 :last-name ?ln]]").unwrap();
@@ -1059,56 +826,31 @@ mod tests {
         let node = Node::memory_node().await;
 
         // Submit a tx with unknown attribute — should fail with TxAborted
-        let mut bad_doc = BTreeMap::new();
-        bad_doc.insert(
-            "nonexistent/attr".to_string(),
-            DataType::String("x".to_string()),
-        );
-
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Put(bad_doc)]),
-        )
-        .await
-        .expect("Should not hang")
-        .expect("execute_tx should not return Err");
+            node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent/attr), "x".into())])]),
+        ).await.expect("Should not hang").expect("execute_tx should not return Err");
 
         match &result {
             TransactionResult::TxAborted(_, err) => {
                 let msg = err.to_string();
-                assert!(
-                    msg.contains("Unknown attribute"),
-                    "Expected 'Unknown attribute' error, got: {}",
-                    msg
-                );
-            }
+                assert!(msg.contains("Unknown attribute"), "Expected 'Unknown attribute' error, got: {}", msg);
+            },
             TransactionResult::TxCommited(_) => panic!("Expected TxAborted, got TxCommited"),
         }
 
         // Define schema and submit a valid tx — indexer should still be alive
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
-        assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
-            "Expected TxCommited for schema tx, got: {:?}",
-            result
-        );
-
-        let mut good_doc = BTreeMap::new();
-        good_doc.insert("name".to_string(), DataType::String("alice".to_string()));
+        assert!(matches!(result, TransactionResult::TxCommited(_)),
+                "Expected TxCommited for schema tx, got: {:?}", result);
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Put(good_doc)]),
-        )
-        .await
-        .expect("Should not hang")
-        .expect("execute_tx should not return Err");
+            node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]),
+        ).await.expect("Should not hang").expect("execute_tx should not return Err");
 
-        assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
-            "Expected TxCommited for valid tx, got: {:?}",
-            result
-        );
+        assert!(matches!(result, TransactionResult::TxCommited(_)),
+                "Expected TxCommited for valid tx, got: {:?}", result);
     }
 
     // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
@@ -1120,21 +862,17 @@ mod tests {
 
         // Insert entity 2000 with tags="rust"
         node.execute_tx(vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("rust".to_string()),
-        }])
-        .await
-        .unwrap();
+            value: "rust".into(),
+        }]).await.unwrap();
 
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
-            entity_id: 2000,
+            entity: EntityRef::Id(2000),
             attribute: kw!(:tags),
-            value: DataType::String("database".to_string()),
-        }])
-        .await
-        .unwrap();
+            value: "database".into(),
+        }]).await.unwrap();
 
         // Query: find all tags for entity 2000
         let query = parse_query("[:find ?tag :where [2000 :tags ?tag]]").unwrap();
@@ -1153,24 +891,15 @@ mod tests {
         define_test_schema(&node).await;
 
         // tx1: valid insert — allocates first user entity
-        let mut doc1 = BTreeMap::new();
-        doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-        let result1 = node.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+        let result1 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
         assert!(matches!(result1, TransactionResult::TxCommited(_)));
 
         // tx2: insert with unknown attribute — should fail
-        let mut bad_doc = BTreeMap::new();
-        bad_doc.insert(
-            "nonexistent_attr".to_string(),
-            DataType::String("oops".to_string()),
-        );
-        let result2 = node.execute_tx(vec![TxOp::Put(bad_doc)]).await.unwrap();
+        let result2 = node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent_attr), "oops".into())])]).await.unwrap();
         assert!(matches!(result2, TransactionResult::TxAborted(_, _)));
 
         // tx3: valid insert — should get the next contiguous entity ID
-        let mut doc3 = BTreeMap::new();
-        doc3.insert("name".to_string(), DataType::String("bob".to_string()));
-        let result3 = node.execute_tx(vec![TxOp::Put(doc3)]).await.unwrap();
+        let result3 = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])]).await.unwrap();
         assert!(matches!(result3, TransactionResult::TxCommited(_)));
 
         // Query all (entity, name) pairs and verify contiguous counter values
@@ -1179,13 +908,10 @@ mod tests {
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
-        let mut eids: Vec<i64> = result
-            .iter()
-            .map(|row| match &row[0] {
-                DataType::Long(id) => *id,
-                _ => panic!("Expected Long entity ID"),
-            })
-            .collect();
+        let mut eids: Vec<i64> = result.iter().map(|row| match &row[0] {
+            DataType::Long(id) => *id,
+            _ => panic!("Expected Long entity ID"),
+        }).collect();
         eids.sort();
 
         // Counters 0 and 1 — no gap from the failed tx
@@ -1200,9 +926,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let mut doc = BTreeMap::new();
-        doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]).await.unwrap();
         let tx_key = match result {
             TransactionResult::TxCommited(k) => k,
             _ => panic!("Expected committed"),
@@ -1210,10 +934,7 @@ mod tests {
 
         // Query for the tx entity matching this tx_id
         let db = node.db().await.unwrap();
-        let query_str = format!(
-            "[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]",
-            tx_key.tx_id
-        );
+        let query_str = format!("[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]", tx_key.tx_id);
         let query = parse_query(&query_str).unwrap();
         let result = db.query(&query).await.unwrap();
 
@@ -1227,9 +948,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Submit a transaction with an unknown attribute to trigger abort
-        let mut doc = BTreeMap::new();
-        doc.insert("nonexistent".to_string(), DataType::String("x".to_string()));
-        let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        let result = node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent), "x".into())])]).await.unwrap();
         let tx_key = match &result {
             TransactionResult::TxAborted(k, _) => *k,
             _ => panic!("Expected aborted, got {:?}", result),
@@ -1244,13 +963,10 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));
         if let DataType::String(s) = &result[0][1] {
-            assert!(
-                s.contains("nonexistent"),
-                "Error should mention the unknown attribute, got: {}",
-                s
-            );
+            assert!(s.contains("nonexistent"), "Error should mention the unknown attribute, got: {}", s);
         } else {
             panic!("Expected String for error, got {:?}", result[0][1]);
         }
     }
+
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 #[allow(unused_imports)]
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -8,10 +7,67 @@ use edn::symbols::NamespacedSymbol;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, BTreeSet};
-use std::str::FromStr;
 use uuid::Uuid;
+use anyhow::Result;
 
 pub type Entid = i64;
+
+/// How to identify an entity in a transaction.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Eq, Hash)]
+pub enum EntityRef {
+    Id(i64),
+    TempId(String),
+    Ident(Keyword),
+    /// Accepted in the type but errors at expansion (not yet supported).
+    LookupRef(Keyword, DataType),
+}
+
+impl From<i64> for EntityRef {
+    fn from(v: i64) -> Self { EntityRef::Id(v) }
+}
+
+impl From<Keyword> for EntityRef {
+    fn from(v: Keyword) -> Self { EntityRef::Ident(v) }
+}
+
+impl From<&str> for EntityRef {
+    fn from(v: &str) -> Self { EntityRef::TempId(v.to_string()) }
+}
+
+/// A transaction value: either concrete data or an entity reference.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum TxValue {
+    Data(DataType),
+    Ref(EntityRef),
+}
+
+impl From<DataType> for TxValue {
+    fn from(v: DataType) -> Self { TxValue::Data(v) }
+}
+
+impl From<EntityRef> for TxValue {
+    fn from(v: EntityRef) -> Self { TxValue::Ref(v) }
+}
+
+impl From<i64> for TxValue {
+    fn from(v: i64) -> Self { TxValue::Data(DataType::Long(v)) }
+}
+
+impl From<String> for TxValue {
+    fn from(v: String) -> Self { TxValue::Data(DataType::String(v)) }
+}
+
+impl From<&str> for TxValue {
+    fn from(v: &str) -> Self { TxValue::Data(DataType::String(v.to_string())) }
+}
+
+impl From<bool> for TxValue {
+    fn from(v: bool) -> Self { TxValue::Data(DataType::Boolean(v)) }
+}
+
+impl From<f64> for TxValue {
+    fn from(v: f64) -> Self { TxValue::Data(DataType::Double(v)) }
+}
 
 // TODO maybe use also clock::Instant here
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -26,7 +82,7 @@ pub enum DataType {
     Instant(DateTime<Utc>), // Timestamps or instants
     Keyword(Keyword),       // Keywords
     Long(i64),              // Long integers (also used for Ref values; see ValueType::Ref)
-    String(String),         // Strings
+    String(String), // Strings
     // Symbol(NamespacedSymbol),                  // Symbols (can be represented as strings)
     Tuple(Vec<DataType>), // Tuples (can be represented as a vector of DataTypes)
     Uuid(Uuid),           // Universally unique identifier
@@ -39,6 +95,7 @@ pub enum DataType {
     //Set(BTreeSet<DataType>),         // Set (BTreeSet of DataTypes)
     Map(BTreeMap<String, DataType>), // Map (BTreeMap of string keys and DataType values)
 }
+
 
 impl Eq for DataType {}
 
@@ -112,9 +169,7 @@ impl DataType {
             (Float(a), Double(b)) => (*a as f64).partial_cmp(b).ok_or_else(nan_err),
             (Double(a), Float(b)) => a.partial_cmp(&(*b as f64)).ok_or_else(nan_err),
             _ => Err(anyhow::anyhow!(
-                "cannot compare {:?} with {:?}",
-                self.value_type(),
-                other.value_type()
+                "cannot compare {:?} with {:?}", self.value_type(), other.value_type()
             )),
         }
     }
@@ -150,19 +205,25 @@ impl_from_for_enum!(
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
-    Put(BTreeMap<String, DataType>),
-    Add {
-        entity_id: Entid,
-        attribute: Keyword,
-        value: DataType,
-    },
-    Retract {
-        entity_id: Entid,
-        attribute: Keyword,
-        value: DataType,
-    },
-    Delete(Entid),
-    Erase(Entid),
+    Put(BTreeMap<Keyword, TxValue>),
+    Add { entity: EntityRef, attribute: Keyword, value: TxValue },
+    Retract { entity: EntityRef, attribute: Keyword, value: TxValue },
+    Delete(EntityRef),
+    Erase(EntityRef),
+}
+
+impl TxOp {
+    /// Build a Put without explicit entity ID (auto-allocated).
+    pub fn put(attrs: Vec<(Keyword, TxValue)>) -> Self {
+        TxOp::Put(attrs.into_iter().collect())
+    }
+
+    /// Build a Put with an explicit entity reference as `:db/id`.
+    pub fn put_with_id(id: impl Into<EntityRef>, attrs: Vec<(Keyword, TxValue)>) -> Self {
+        let mut map: BTreeMap<Keyword, TxValue> = attrs.into_iter().collect();
+        map.insert(Keyword::namespaced("db", "id"), TxValue::Ref(id.into()));
+        TxOp::Put(map)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -171,81 +232,15 @@ pub enum DatomOp {
     Retract,
 }
 
-/// A normalized fact: (entity, attribute, value, tx, op).
+/// A normalized fact: (entity, attribute, value, op).
 /// The attribute is an unresolved keyword ident.
+/// The tx_eid is not stored here — it's passed separately to write_index_entries.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Datom {
     pub entity: i64,
     pub attribute: Keyword,
     pub value: DataType,
-    pub tx: i64,
     pub op: DatomOp,
-}
-
-/// Expand TxOps into a flat vec of Datoms.
-/// - Put(doc) → N Assert datoms (one per non-db/id field)
-/// - Add(triple) → 1 Assert datom
-/// - Retract(triple) → 1 Retract datom
-/// - Delete/Erase → panics (not yet implemented)
-pub fn tx_ops_to_datoms(ops: &[TxOp], tx: i64) -> Result<Vec<Datom>> {
-    let mut datoms = Vec::new();
-    for op in ops {
-        match op {
-            TxOp::Put(doc) => {
-                let entity = match doc.get("db/id") {
-                    Some(DataType::Long(id)) => *id,
-                    Some(_) => return Err(anyhow::anyhow!("Document db/id must be a Long")),
-                    None => return Err(anyhow::anyhow!("Document must have a db/id")),
-                };
-                for (attr, value) in doc.iter().filter(|(k, _)| *k != "db/id") {
-                    // TODO(perf): allocates a fresh `:<attr>` String per attribute on the Put
-                    // hot path just to feed it to `Keyword::from_str`, which strips the `:`
-                    // and splits again. Could be replaced with a direct split-and-construct
-                    // once the Put doc key type is revisited (see client-side Keyword TODO).
-                    let kw = Keyword::from_str(&format!(":{}", attr)).map_err(|e| {
-                        anyhow::anyhow!("Invalid attribute ident {:?}: {}", attr, e)
-                    })?;
-                    datoms.push(Datom {
-                        entity,
-                        attribute: kw,
-                        value: value.clone(),
-                        tx,
-                        op: DatomOp::Assert,
-                    });
-                }
-            }
-            TxOp::Add {
-                entity_id,
-                attribute,
-                value,
-            } => {
-                datoms.push(Datom {
-                    entity: *entity_id,
-                    attribute: attribute.clone(),
-                    value: value.clone(),
-                    tx,
-                    op: DatomOp::Assert,
-                });
-            }
-            TxOp::Retract {
-                entity_id,
-                attribute,
-                value,
-            } => {
-                datoms.push(Datom {
-                    entity: *entity_id,
-                    attribute: attribute.clone(),
-                    value: value.clone(),
-                    tx,
-                    op: DatomOp::Retract,
-                });
-            }
-            TxOp::Delete(_) | TxOp::Erase(_) => {
-                panic!("Delete/Erase not yet implemented");
-            }
-        }
-    }
-    Ok(datoms)
 }
 
 #[cfg(test)]
@@ -257,41 +252,20 @@ mod tests {
     #[test]
     fn test_partial_compare_same_type() {
         use std::cmp::Ordering;
-        assert_eq!(
-            DataType::Long(1)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::Long(2)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            DataType::Long(3)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Greater
-        );
+        assert_eq!(DataType::Long(1).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Long(2).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Long(3).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Greater);
 
         assert_eq!(
-            DataType::String("a".into())
-                .partial_compare(&DataType::String("b".into()))
-                .unwrap(),
+            DataType::String("a".into()).partial_compare(&DataType::String("b".into())).unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Boolean(false)
-                .partial_compare(&DataType::Boolean(true))
-                .unwrap(),
+            DataType::Boolean(false).partial_compare(&DataType::Boolean(true)).unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Double(1.5)
-                .partial_compare(&DataType::Double(2.5))
-                .unwrap(),
+            DataType::Double(1.5).partial_compare(&DataType::Double(2.5)).unwrap(),
             Ordering::Less,
         );
     }
@@ -299,136 +273,58 @@ mod tests {
     #[test]
     fn test_partial_compare_cross_numeric() {
         use std::cmp::Ordering;
-        assert_eq!(
-            DataType::Long(10)
-                .partial_compare(&DataType::BigInt(20))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::BigInt(20)
-                .partial_compare(&DataType::Long(10))
-                .unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            DataType::Long(5)
-                .partial_compare(&DataType::Double(5.0))
-                .unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            DataType::Double(3.0)
-                .partial_compare(&DataType::Long(4))
-                .unwrap(),
-            Ordering::Less
-        );
+        assert_eq!(DataType::Long(10).partial_compare(&DataType::BigInt(20)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::BigInt(20).partial_compare(&DataType::Long(10)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Long(5).partial_compare(&DataType::Double(5.0)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Double(3.0).partial_compare(&DataType::Long(4)).unwrap(), Ordering::Less);
 
         // Float cross-numeric
-        assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::Long(2)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::Double(1.0))
-                .unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            DataType::Double(2.0)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::BigInt(2))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::BigInt(2)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            DataType::BigInt(1)
-                .partial_compare(&DataType::Double(2.0))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::Double(2.0)
-                .partial_compare(&DataType::BigInt(1))
-                .unwrap(),
-            Ordering::Greater
-        );
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Long(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Double(1.0)).unwrap(), Ordering::Equal);
+        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::BigInt(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::BigInt(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
+        assert_eq!(DataType::BigInt(1).partial_compare(&DataType::Double(2.0)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::BigInt(1)).unwrap(), Ordering::Greater);
     }
 
     #[test]
     fn test_partial_compare_incompatible() {
-        assert!(DataType::Long(1)
-            .partial_compare(&DataType::String("a".into()))
-            .is_err());
-        assert!(DataType::Boolean(true)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
+        assert!(DataType::Long(1).partial_compare(&DataType::String("a".into())).is_err());
+        assert!(DataType::Boolean(true).partial_compare(&DataType::Long(1)).is_err());
     }
 
     #[test]
     fn test_partial_compare_nan() {
         // Same-type NaN
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::Double(1.0))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Float(1.0))
-            .is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Float(1.0)).is_err());
         // Cross-type NaN
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Double(1.0))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::BigInt(1))
-            .is_err());
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::BigInt(1))
-            .is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::BigInt(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::BigInt(1)).is_err());
     }
 
     #[test]
-    fn test_op_put() {
-        let mut document: BTreeMap<String, DataType> = BTreeMap::new();
-        document.insert("string".to_string(), "string_value".to_string().into());
-        document.insert("int".to_string(), 1i64.into());
-        let op = TxOp::Put(document);
+    fn test_op_put_bincode() {
+        let op = TxOp::put(vec![
+            (kw!(:string), TxValue::Data("string_value".to_string().into())),
+            (kw!(:int), TxValue::Data(1i64.into())),
+        ]);
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
     }
 
     #[test]
-    fn test_op_add() {
+    fn test_op_add_bincode() {
         let op = TxOp::Add {
-            entity_id: 1,
+            entity: EntityRef::Id(1),
             attribute: kw!(:string),
-            value: DataType::String("string_value".to_string()),
+            value: TxValue::Data(DataType::String("string_value".to_string())),
         };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
@@ -436,11 +332,11 @@ mod tests {
     }
 
     #[test]
-    fn test_op_retract() {
+    fn test_op_retract_bincode() {
         let op = TxOp::Retract {
-            entity_id: 1,
+            entity: EntityRef::Id(1),
             attribute: kw!(:string),
-            value: DataType::String("string_value".to_string()),
+            value: TxValue::Data(DataType::String("string_value".to_string())),
         };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
@@ -448,106 +344,33 @@ mod tests {
     }
 
     #[test]
-    fn test_op_delete() {
-        let op = TxOp::Delete(1);
+    fn test_op_delete_bincode() {
+        let op = TxOp::Delete(EntityRef::Id(1));
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
     }
 
     #[test]
-    fn test_op_erase() {
-        let op = TxOp::Erase(1);
+    fn test_op_erase_bincode() {
+        let op = TxOp::Erase(EntityRef::Id(1));
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
     }
 
     #[test]
-    fn test_tx_ops_to_datoms_put() {
-        let tx = 1000_i64;
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(100));
-        doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        doc.insert("age".to_string(), DataType::Long(30));
-        let ops = vec![TxOp::Put(doc)];
-
-        let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
-        assert_eq!(datoms.len(), 2);
-        assert!(datoms.iter().all(|d| d.entity == 100));
-        assert!(datoms.iter().all(|d| d.op == DatomOp::Assert));
-        assert!(datoms.iter().all(|d| d.tx == tx));
+    fn test_entity_ref_from_impls() {
+        assert_eq!(EntityRef::from(42_i64), EntityRef::Id(42));
+        assert_eq!(EntityRef::from(kw!(:person/name)), EntityRef::Ident(kw!(:person/name)));
+        assert_eq!(EntityRef::from("temp-1"), EntityRef::TempId("temp-1".to_string()));
     }
 
     #[test]
-    fn test_tx_ops_to_datoms_add() {
-        let tx = 1000_i64;
-        let ops = vec![TxOp::Add {
-            entity_id: 200,
-            attribute: kw!(:name),
-            value: DataType::String("bob".to_string()),
-        }];
-
-        let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
-        assert_eq!(datoms.len(), 1);
-        assert_eq!(datoms[0].entity, 200);
-        assert_eq!(datoms[0].attribute, kw!(:name));
-        assert_eq!(datoms[0].value, DataType::String("bob".to_string()));
-        assert_eq!(datoms[0].op, DatomOp::Assert);
-    }
-
-    #[test]
-    fn test_tx_ops_to_datoms_retract() {
-        let tx = 1000_i64;
-        let ops = vec![TxOp::Retract {
-            entity_id: 200,
-            attribute: kw!(:name),
-            value: DataType::String("bob".to_string()),
-        }];
-
-        let datoms = tx_ops_to_datoms(&ops, tx).unwrap();
-        assert_eq!(datoms.len(), 1);
-        assert_eq!(datoms[0].op, DatomOp::Retract);
-    }
-
-    #[test]
-    #[should_panic(expected = "Delete/Erase not yet implemented")]
-    fn test_tx_ops_to_datoms_delete_panics() {
-        let tx = 1000_i64;
-        tx_ops_to_datoms(&[TxOp::Delete(100)], tx).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "Delete/Erase not yet implemented")]
-    fn test_tx_ops_to_datoms_erase_panics() {
-        let tx = 1000_i64;
-        tx_ops_to_datoms(&[TxOp::Erase(200)], tx).unwrap();
-    }
-
-    #[test]
-    fn test_tx_ops_to_datoms_put_missing_id() {
-        let tx = 1000_i64;
-        let mut doc = BTreeMap::new();
-        doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        let ops = vec![TxOp::Put(doc)];
-
-        let result = tx_ops_to_datoms(&ops, tx);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("db/id"));
-    }
-
-    #[test]
-    fn test_tx_ops_to_datoms_put_wrong_id_type() {
-        let tx = 1000_i64;
-        let mut doc = BTreeMap::new();
-        doc.insert(
-            "db/id".to_string(),
-            DataType::String("not-a-long".to_string()),
-        );
-        doc.insert("name".to_string(), DataType::String("alice".to_string()));
-        let ops = vec![TxOp::Put(doc)];
-
-        let result = tx_ops_to_datoms(&ops, tx);
-        assert!(result.is_err());
+    fn test_tx_value_from_impls() {
+        assert_eq!(TxValue::from(42_i64), TxValue::Data(DataType::Long(42)));
+        assert_eq!(TxValue::from("hello"), TxValue::Data(DataType::String("hello".to_string())));
+        assert_eq!(TxValue::from(true), TxValue::Data(DataType::Boolean(true)));
+        assert_eq!(TxValue::from(3.14_f64), TxValue::Data(DataType::Double(3.14)));
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -218,12 +218,7 @@ impl TxOp {
         TxOp::Put(attrs.into_iter().collect())
     }
 
-    /// Build a Put with an explicit entity reference as `:db/id`.
-    pub fn put_with_id(id: impl Into<EntityRef>, attrs: Vec<(Keyword, TxValue)>) -> Self {
-        let mut map: BTreeMap<Keyword, TxValue> = attrs.into_iter().collect();
-        map.insert(Keyword::namespaced("db", "id"), TxValue::Ref(id.into()));
-        TxOp::Put(map)
-    }
+
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -206,8 +206,8 @@ impl_from_for_enum!(
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(BTreeMap<Keyword, TxValue>),
-    Add { entity: EntityRef, attribute: Keyword, value: TxValue },
-    Retract { entity: EntityRef, attribute: Keyword, value: TxValue },
+    Add { entity_id: EntityRef, attribute: Keyword, value: TxValue },
+    Retract { entity_id: EntityRef, attribute: Keyword, value: TxValue },
     Delete(EntityRef),
     Erase(EntityRef),
 }
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_op_add_bincode() {
         let op = TxOp::Add {
-            entity: EntityRef::Id(1),
+            entity_id: EntityRef::Id(1),
             attribute: kw!(:string),
             value: TxValue::Data(DataType::String("string_value".to_string())),
         };
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn test_op_retract_bincode() {
         let op = TxOp::Retract {
-            entity: EntityRef::Id(1),
+            entity_id: EntityRef::Id(1),
             attribute: kw!(:string),
             value: TxValue::Data(DataType::String("string_value".to_string())),
         };

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -217,8 +217,6 @@ impl TxOp {
     pub fn put(attrs: Vec<(Keyword, TxValue)>) -> Self {
         TxOp::Put(attrs.into_iter().collect())
     }
-
-
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -206,8 +206,8 @@ impl_from_for_enum!(
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(BTreeMap<Keyword, TxValue>),
-    Add { entity_id: EntityRef, attribute: Keyword, value: TxValue },
-    Retract { entity_id: EntityRef, attribute: Keyword, value: TxValue },
+    Add { entity: EntityRef, attribute: Keyword, value: TxValue },
+    Retract { entity: EntityRef, attribute: Keyword, value: TxValue },
     Delete(EntityRef),
     Erase(EntityRef),
 }
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_op_add_bincode() {
         let op = TxOp::Add {
-            entity_id: EntityRef::Id(1),
+            entity: EntityRef::Id(1),
             attribute: kw!(:string),
             value: TxValue::Data(DataType::String("string_value".to_string())),
         };
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn test_op_retract_bincode() {
         let op = TxOp::Retract {
-            entity_id: EntityRef::Id(1),
+            entity: EntityRef::Id(1),
             attribute: kw!(:string),
             value: TxValue::Data(DataType::String("string_value".to_string())),
         };

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 #[allow(unused_imports)]
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -8,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
-use anyhow::Result;
 
 pub type Entid = i64;
 
@@ -23,15 +23,21 @@ pub enum EntityRef {
 }
 
 impl From<i64> for EntityRef {
-    fn from(v: i64) -> Self { EntityRef::Id(v) }
+    fn from(v: i64) -> Self {
+        EntityRef::Id(v)
+    }
 }
 
 impl From<Keyword> for EntityRef {
-    fn from(v: Keyword) -> Self { EntityRef::Ident(v) }
+    fn from(v: Keyword) -> Self {
+        EntityRef::Ident(v)
+    }
 }
 
 impl From<&str> for EntityRef {
-    fn from(v: &str) -> Self { EntityRef::TempId(v.to_string()) }
+    fn from(v: &str) -> Self {
+        EntityRef::TempId(v.to_string())
+    }
 }
 
 /// A transaction value: either concrete data or an entity reference.
@@ -42,31 +48,45 @@ pub enum TxValue {
 }
 
 impl From<DataType> for TxValue {
-    fn from(v: DataType) -> Self { TxValue::Data(v) }
+    fn from(v: DataType) -> Self {
+        TxValue::Data(v)
+    }
 }
 
 impl From<EntityRef> for TxValue {
-    fn from(v: EntityRef) -> Self { TxValue::Ref(v) }
+    fn from(v: EntityRef) -> Self {
+        TxValue::Ref(v)
+    }
 }
 
 impl From<i64> for TxValue {
-    fn from(v: i64) -> Self { TxValue::Data(DataType::Long(v)) }
+    fn from(v: i64) -> Self {
+        TxValue::Data(DataType::Long(v))
+    }
 }
 
 impl From<String> for TxValue {
-    fn from(v: String) -> Self { TxValue::Data(DataType::String(v)) }
+    fn from(v: String) -> Self {
+        TxValue::Data(DataType::String(v))
+    }
 }
 
 impl From<&str> for TxValue {
-    fn from(v: &str) -> Self { TxValue::Data(DataType::String(v.to_string())) }
+    fn from(v: &str) -> Self {
+        TxValue::Data(DataType::String(v.to_string()))
+    }
 }
 
 impl From<bool> for TxValue {
-    fn from(v: bool) -> Self { TxValue::Data(DataType::Boolean(v)) }
+    fn from(v: bool) -> Self {
+        TxValue::Data(DataType::Boolean(v))
+    }
 }
 
 impl From<f64> for TxValue {
-    fn from(v: f64) -> Self { TxValue::Data(DataType::Double(v)) }
+    fn from(v: f64) -> Self {
+        TxValue::Data(DataType::Double(v))
+    }
 }
 
 // TODO maybe use also clock::Instant here
@@ -82,7 +102,7 @@ pub enum DataType {
     Instant(DateTime<Utc>), // Timestamps or instants
     Keyword(Keyword),       // Keywords
     Long(i64),              // Long integers (also used for Ref values; see ValueType::Ref)
-    String(String), // Strings
+    String(String),         // Strings
     // Symbol(NamespacedSymbol),                  // Symbols (can be represented as strings)
     Tuple(Vec<DataType>), // Tuples (can be represented as a vector of DataTypes)
     Uuid(Uuid),           // Universally unique identifier
@@ -95,7 +115,6 @@ pub enum DataType {
     //Set(BTreeSet<DataType>),         // Set (BTreeSet of DataTypes)
     Map(BTreeMap<String, DataType>), // Map (BTreeMap of string keys and DataType values)
 }
-
 
 impl Eq for DataType {}
 
@@ -169,7 +188,9 @@ impl DataType {
             (Float(a), Double(b)) => (*a as f64).partial_cmp(b).ok_or_else(nan_err),
             (Double(a), Float(b)) => a.partial_cmp(&(*b as f64)).ok_or_else(nan_err),
             _ => Err(anyhow::anyhow!(
-                "cannot compare {:?} with {:?}", self.value_type(), other.value_type()
+                "cannot compare {:?} with {:?}",
+                self.value_type(),
+                other.value_type()
             )),
         }
     }
@@ -206,8 +227,16 @@ impl_from_for_enum!(
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(BTreeMap<Keyword, TxValue>),
-    Add { entity: EntityRef, attribute: Keyword, value: TxValue },
-    Retract { entity: EntityRef, attribute: Keyword, value: TxValue },
+    Add {
+        entity: EntityRef,
+        attribute: Keyword,
+        value: TxValue,
+    },
+    Retract {
+        entity: EntityRef,
+        attribute: Keyword,
+        value: TxValue,
+    },
     Delete(EntityRef),
     Erase(EntityRef),
 }
@@ -245,20 +274,41 @@ mod tests {
     #[test]
     fn test_partial_compare_same_type() {
         use std::cmp::Ordering;
-        assert_eq!(DataType::Long(1).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
-        assert_eq!(DataType::Long(2).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Equal);
-        assert_eq!(DataType::Long(3).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Greater);
+        assert_eq!(
+            DataType::Long(1)
+                .partial_compare(&DataType::Long(2))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            DataType::Long(2)
+                .partial_compare(&DataType::Long(2))
+                .unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            DataType::Long(3)
+                .partial_compare(&DataType::Long(2))
+                .unwrap(),
+            Ordering::Greater
+        );
 
         assert_eq!(
-            DataType::String("a".into()).partial_compare(&DataType::String("b".into())).unwrap(),
+            DataType::String("a".into())
+                .partial_compare(&DataType::String("b".into()))
+                .unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Boolean(false).partial_compare(&DataType::Boolean(true)).unwrap(),
+            DataType::Boolean(false)
+                .partial_compare(&DataType::Boolean(true))
+                .unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Double(1.5).partial_compare(&DataType::Double(2.5)).unwrap(),
+            DataType::Double(1.5)
+                .partial_compare(&DataType::Double(2.5))
+                .unwrap(),
             Ordering::Less,
         );
     }
@@ -266,45 +316,126 @@ mod tests {
     #[test]
     fn test_partial_compare_cross_numeric() {
         use std::cmp::Ordering;
-        assert_eq!(DataType::Long(10).partial_compare(&DataType::BigInt(20)).unwrap(), Ordering::Less);
-        assert_eq!(DataType::BigInt(20).partial_compare(&DataType::Long(10)).unwrap(), Ordering::Greater);
-        assert_eq!(DataType::Long(5).partial_compare(&DataType::Double(5.0)).unwrap(), Ordering::Equal);
-        assert_eq!(DataType::Double(3.0).partial_compare(&DataType::Long(4)).unwrap(), Ordering::Less);
+        assert_eq!(
+            DataType::Long(10)
+                .partial_compare(&DataType::BigInt(20))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            DataType::BigInt(20)
+                .partial_compare(&DataType::Long(10))
+                .unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            DataType::Long(5)
+                .partial_compare(&DataType::Double(5.0))
+                .unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            DataType::Double(3.0)
+                .partial_compare(&DataType::Long(4))
+                .unwrap(),
+            Ordering::Less
+        );
 
         // Float cross-numeric
-        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
-        assert_eq!(DataType::Long(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
-        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::Double(1.0)).unwrap(), Ordering::Equal);
-        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
-        assert_eq!(DataType::Float(1.0).partial_compare(&DataType::BigInt(2)).unwrap(), Ordering::Less);
-        assert_eq!(DataType::BigInt(2).partial_compare(&DataType::Float(1.0)).unwrap(), Ordering::Greater);
-        assert_eq!(DataType::BigInt(1).partial_compare(&DataType::Double(2.0)).unwrap(), Ordering::Less);
-        assert_eq!(DataType::Double(2.0).partial_compare(&DataType::BigInt(1)).unwrap(), Ordering::Greater);
+        assert_eq!(
+            DataType::Float(1.0)
+                .partial_compare(&DataType::Long(2))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            DataType::Long(2)
+                .partial_compare(&DataType::Float(1.0))
+                .unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            DataType::Float(1.0)
+                .partial_compare(&DataType::Double(1.0))
+                .unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            DataType::Double(2.0)
+                .partial_compare(&DataType::Float(1.0))
+                .unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            DataType::Float(1.0)
+                .partial_compare(&DataType::BigInt(2))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            DataType::BigInt(2)
+                .partial_compare(&DataType::Float(1.0))
+                .unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            DataType::BigInt(1)
+                .partial_compare(&DataType::Double(2.0))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            DataType::Double(2.0)
+                .partial_compare(&DataType::BigInt(1))
+                .unwrap(),
+            Ordering::Greater
+        );
     }
 
     #[test]
     fn test_partial_compare_incompatible() {
-        assert!(DataType::Long(1).partial_compare(&DataType::String("a".into())).is_err());
-        assert!(DataType::Boolean(true).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Long(1)
+            .partial_compare(&DataType::String("a".into()))
+            .is_err());
+        assert!(DataType::Boolean(true)
+            .partial_compare(&DataType::Long(1))
+            .is_err());
     }
 
     #[test]
     fn test_partial_compare_nan() {
         // Same-type NaN
-        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)).is_err());
-        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Float(1.0)).is_err());
+        assert!(DataType::Double(f64::NAN)
+            .partial_compare(&DataType::Double(1.0))
+            .is_err());
+        assert!(DataType::Float(f32::NAN)
+            .partial_compare(&DataType::Float(1.0))
+            .is_err());
         // Cross-type NaN
-        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Long(1)).is_err());
-        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Double(1.0)).is_err());
-        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::BigInt(1)).is_err());
-        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Long(1)).is_err());
-        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::BigInt(1)).is_err());
+        assert!(DataType::Float(f32::NAN)
+            .partial_compare(&DataType::Long(1))
+            .is_err());
+        assert!(DataType::Float(f32::NAN)
+            .partial_compare(&DataType::Double(1.0))
+            .is_err());
+        assert!(DataType::Float(f32::NAN)
+            .partial_compare(&DataType::BigInt(1))
+            .is_err());
+        assert!(DataType::Double(f64::NAN)
+            .partial_compare(&DataType::Long(1))
+            .is_err());
+        assert!(DataType::Double(f64::NAN)
+            .partial_compare(&DataType::BigInt(1))
+            .is_err());
     }
 
     #[test]
     fn test_op_put_bincode() {
         let op = TxOp::put(vec![
-            (kw!(:string), TxValue::Data("string_value".to_string().into())),
+            (
+                kw!(:string),
+                TxValue::Data("string_value".to_string().into()),
+            ),
             (kw!(:int), TxValue::Data(1i64.into())),
         ]);
         let serialized = bincode::serialize(&op).unwrap();
@@ -355,15 +486,27 @@ mod tests {
     #[test]
     fn test_entity_ref_from_impls() {
         assert_eq!(EntityRef::from(42_i64), EntityRef::Id(42));
-        assert_eq!(EntityRef::from(kw!(:person/name)), EntityRef::Ident(kw!(:person/name)));
-        assert_eq!(EntityRef::from("temp-1"), EntityRef::TempId("temp-1".to_string()));
+        assert_eq!(
+            EntityRef::from(kw!(:person/name)),
+            EntityRef::Ident(kw!(:person/name))
+        );
+        assert_eq!(
+            EntityRef::from("temp-1"),
+            EntityRef::TempId("temp-1".to_string())
+        );
     }
 
     #[test]
     fn test_tx_value_from_impls() {
         assert_eq!(TxValue::from(42_i64), TxValue::Data(DataType::Long(42)));
-        assert_eq!(TxValue::from("hello"), TxValue::Data(DataType::String("hello".to_string())));
+        assert_eq!(
+            TxValue::from("hello"),
+            TxValue::Data(DataType::String("hello".to_string()))
+        );
         assert_eq!(TxValue::from(true), TxValue::Data(DataType::Boolean(true)));
-        assert_eq!(TxValue::from(3.14_f64), TxValue::Data(DataType::Double(3.14)));
+        assert_eq!(
+            TxValue::from(3.14_f64),
+            TxValue::Data(DataType::Double(3.14))
+        );
     }
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -10,6 +10,7 @@ use crate::protocol;
 /// | S  | 0  | partition (20 bits) |          counter (42 bits)        |
 /// +----+----+---------------------+---+-------------------------------+
 /// ```
+
 pub const COUNTER_BITS: u32 = 42;
 pub const COUNTER_MASK: i64 = (1i64 << 42) - 1;
 pub const PARTITION_MASK: i64 = ((1i64 << 20) - 1) << 42;
@@ -43,10 +44,7 @@ pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
 /// For partition 0, the result equals the counter (small, readable IDs).
 pub fn make_entity_id(partition: u32, counter: i64) -> i64 {
     assert!(partition < (1 << 20), "partition must fit in 20 bits");
-    assert!(
-        (0..=COUNTER_MASK).contains(&counter),
-        "counter must fit in 42 bits"
-    );
+    assert!(counter >= 0 && counter <= COUNTER_MASK, "counter must fit in 42 bits");
     ((partition as i64) << COUNTER_BITS) | counter
 }
 
@@ -65,48 +63,6 @@ pub fn is_tempid(eid: i64) -> bool {
     eid < 0
 }
 
-/// Resolve entity IDs for Put documents that lack a `db/id` field.
-///
-/// - If `db/id` is `DataType::Long` → keep as-is (explicit ID).
-///   TODO: validate via `PartitionMap::contains_entid` once tempid resolution is implemented.
-/// - If `db/id` is missing → allocate from partition map:
-///   - Documents with `db/ident` → `DB_PARTITION` (schema/enum entities).
-///   - All other documents → `USER_PARTITION`.
-/// - Add/Retract/Delete/Erase → pass through unchanged (require explicit IDs).
-pub fn resolve_entity_ids(
-    ops: &[crate::ops::TxOp],
-    partition_map: &mut PartitionMap,
-) -> anyhow::Result<Vec<crate::ops::TxOp>> {
-    use crate::ops::{DataType, TxOp};
-
-    let mut resolved = Vec::with_capacity(ops.len());
-    for op in ops {
-        match op {
-            TxOp::Put(doc) => match doc.get("db/id") {
-                Some(DataType::Long(_)) => {
-                    resolved.push(op.clone());
-                }
-                None => {
-                    let partition = if doc.contains_key("db/ident") {
-                        DB_PARTITION
-                    } else {
-                        USER_PARTITION
-                    };
-                    let eid = partition_map.allocate_entid(partition);
-                    let mut new_doc = doc.clone();
-                    new_doc.insert("db/id".to_string(), DataType::Long(eid));
-                    resolved.push(TxOp::Put(new_doc));
-                }
-                Some(_) => {
-                    return Err(anyhow::anyhow!("Document db/id must be a Long"));
-                }
-            },
-            _ => resolved.push(op.clone()),
-        }
-    }
-    Ok(resolved)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,27 +77,11 @@ mod tests {
 
     #[test]
     fn test_bootstrap_ids_in_db_partition() {
-        // DB_PARTITION is 0, so make_entity_id(0, n) == n
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_IDENT),
-            crate::schema::DB_IDENT
-        );
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_VALUE_TYPE),
-            crate::schema::DB_VALUE_TYPE
-        );
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY),
-            crate::schema::DB_CARDINALITY
-        );
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_ONE),
-            crate::schema::DB_CARDINALITY_ONE
-        );
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_MANY),
-            crate::schema::DB_CARDINALITY_MANY
-        );
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_IDENT), crate::schema::DB_IDENT);
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_VALUE_TYPE), crate::schema::DB_VALUE_TYPE);
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY), crate::schema::DB_CARDINALITY);
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_ONE), crate::schema::DB_CARDINALITY_ONE);
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_MANY), crate::schema::DB_CARDINALITY_MANY);
     }
 
     #[test]
@@ -203,157 +143,5 @@ mod tests {
         let user_min = make_entity_id(USER_PARTITION, 0);
         assert!(db_max < tx_min);
         assert!(tx_max < user_min);
-    }
-
-    // --- resolve_entity_ids tests ---
-
-    use crate::ops::{DataType, TxOp};
-    use edn::kw;
-    use std::collections::BTreeMap;
-
-    #[test]
-    fn test_resolve_entity_ids_explicit_id_passthrough() {
-        let mut counters = PartitionMap::new();
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(42));
-        doc.insert("name".to_string(), DataType::String("alice".into()));
-        let ops = vec![TxOp::Put(doc)];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        assert!(
-            counters.is_empty(),
-            "counters should not advance for explicit IDs"
-        );
-        match &resolved[0] {
-            TxOp::Put(doc) => assert_eq!(doc.get("db/id"), Some(&DataType::Long(42))),
-            _ => panic!("Expected Put"),
-        }
-    }
-
-    #[test]
-    fn test_resolve_entity_ids_user_partition() {
-        let mut counters = PartitionMap::new();
-        let mut doc = BTreeMap::new();
-        doc.insert("name".to_string(), DataType::String("alice".into()));
-        let ops = vec![TxOp::Put(doc)];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        assert_eq!(counters[&USER_PARTITION], 1);
-        match &resolved[0] {
-            TxOp::Put(doc) => {
-                let eid = match doc.get("db/id") {
-                    Some(DataType::Long(id)) => *id,
-                    _ => panic!("Expected db/id Long"),
-                };
-                assert_eq!(extract_partition(eid), USER_PARTITION);
-            }
-            _ => panic!("Expected Put"),
-        }
-    }
-
-    #[test]
-    fn test_resolve_entity_ids_db_partition_for_schema() {
-        let mut counters = PartitionMap::new();
-        let mut doc = BTreeMap::new();
-        doc.insert(
-            "db/ident".to_string(),
-            DataType::Keyword(edn::kw!(:my-attr)),
-        );
-        doc.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(edn::kw!(:db.type/string)),
-        );
-        let ops = vec![TxOp::Put(doc)];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        assert_eq!(counters[&DB_PARTITION], 1);
-        match &resolved[0] {
-            TxOp::Put(doc) => {
-                let eid = match doc.get("db/id") {
-                    Some(DataType::Long(id)) => *id,
-                    _ => panic!("Expected db/id Long"),
-                };
-                assert_eq!(extract_partition(eid), DB_PARTITION);
-            }
-            _ => panic!("Expected Put"),
-        }
-    }
-
-    #[test]
-    fn test_resolve_entity_ids_db_partition_for_enum() {
-        let mut counters = PartitionMap::new();
-        let mut doc = BTreeMap::new();
-        doc.insert(
-            "db/ident".to_string(),
-            DataType::Keyword(edn::kw!(:db.type/string)),
-        );
-        let ops = vec![TxOp::Put(doc)];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        match &resolved[0] {
-            TxOp::Put(doc) => {
-                let eid = match doc.get("db/id") {
-                    Some(DataType::Long(id)) => *id,
-                    _ => panic!("Expected db/id Long"),
-                };
-                assert_eq!(extract_partition(eid), DB_PARTITION);
-            }
-            _ => panic!("Expected Put"),
-        }
-    }
-
-    #[test]
-    fn test_resolve_entity_ids_add_retract_passthrough() {
-        let mut counters = PartitionMap::new();
-        let ops = vec![
-            TxOp::Add {
-                entity_id: 100,
-                attribute: kw!(:name),
-                value: DataType::String("alice".into()),
-            },
-            TxOp::Retract {
-                entity_id: 100,
-                attribute: kw!(:name),
-                value: DataType::String("alice".into()),
-            },
-        ];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        assert!(counters.is_empty(), "Add/Retract should not allocate IDs");
-        assert_eq!(resolved.len(), 2);
-    }
-
-    #[test]
-    fn test_resolve_entity_ids_multiple_docs() {
-        let mut counters = PartitionMap::from([(USER_PARTITION, 5i64)]);
-        let ops = vec![
-            TxOp::Put({
-                let mut m = BTreeMap::new();
-                m.insert("name".to_string(), DataType::String("alice".into()));
-                m
-            }),
-            TxOp::Put({
-                let mut m = BTreeMap::new();
-                m.insert("name".to_string(), DataType::String("bob".into()));
-                m
-            }),
-        ];
-
-        let resolved = resolve_entity_ids(&ops, &mut counters).unwrap();
-        assert_eq!(counters[&USER_PARTITION], 7);
-
-        for (i, op) in resolved.iter().enumerate() {
-            match op {
-                TxOp::Put(doc) => {
-                    let eid = match doc.get("db/id") {
-                        Some(DataType::Long(id)) => *id,
-                        _ => panic!("Expected db/id Long"),
-                    };
-                    assert_eq!(extract_partition(eid), USER_PARTITION);
-                    assert_eq!(extract_counter(eid), 5 + i as i64);
-                }
-                _ => panic!("Expected Put"),
-            }
-        }
     }
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -10,7 +10,6 @@ use crate::protocol;
 /// | S  | 0  | partition (20 bits) |          counter (42 bits)        |
 /// +----+----+---------------------+---+-------------------------------+
 /// ```
-
 pub const COUNTER_BITS: u32 = 42;
 pub const COUNTER_MASK: i64 = (1i64 << 42) - 1;
 pub const PARTITION_MASK: i64 = ((1i64 << 20) - 1) << 42;
@@ -44,7 +43,10 @@ pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
 /// For partition 0, the result equals the counter (small, readable IDs).
 pub fn make_entity_id(partition: u32, counter: i64) -> i64 {
     assert!(partition < (1 << 20), "partition must fit in 20 bits");
-    assert!(counter >= 0 && counter <= COUNTER_MASK, "counter must fit in 42 bits");
+    assert!(
+        (0..=COUNTER_MASK).contains(&counter),
+        "counter must fit in 42 bits"
+    );
     ((partition as i64) << COUNTER_BITS) | counter
 }
 
@@ -77,11 +79,26 @@ mod tests {
 
     #[test]
     fn test_bootstrap_ids_in_db_partition() {
-        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_IDENT), crate::schema::DB_IDENT);
-        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_VALUE_TYPE), crate::schema::DB_VALUE_TYPE);
-        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY), crate::schema::DB_CARDINALITY);
-        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_ONE), crate::schema::DB_CARDINALITY_ONE);
-        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_MANY), crate::schema::DB_CARDINALITY_MANY);
+        assert_eq!(
+            make_entity_id(DB_PARTITION, crate::schema::DB_IDENT),
+            crate::schema::DB_IDENT
+        );
+        assert_eq!(
+            make_entity_id(DB_PARTITION, crate::schema::DB_VALUE_TYPE),
+            crate::schema::DB_VALUE_TYPE
+        );
+        assert_eq!(
+            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY),
+            crate::schema::DB_CARDINALITY
+        );
+        assert_eq!(
+            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_ONE),
+            crate::schema::DB_CARDINALITY_ONE
+        );
+        assert_eq!(
+            make_entity_id(DB_PARTITION, crate::schema::DB_CARDINALITY_MANY),
+            crate::schema::DB_CARDINALITY_MANY
+        );
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -308,14 +308,20 @@ fn encode_f64(buf: &mut Vec<u8>, v: f64) {
 /// message-size limit before encoding, which is well below `u32::MAX` (~4 GB).
 fn encode_string(buf: &mut Vec<u8>, s: &str) {
     let bytes = s.as_bytes();
-    encode_u32(buf, u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"));
+    encode_u32(
+        buf,
+        u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"),
+    );
     buf.extend_from_slice(bytes);
 }
 
 /// # Panics
 /// Panics if `b` exceeds `u32::MAX` bytes. Unreachable — see [`encode_string`].
 fn encode_bytes(buf: &mut Vec<u8>, b: &[u8]) {
-    encode_u32(buf, u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"));
+    encode_u32(
+        buf,
+        u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"),
+    );
     buf.extend_from_slice(b);
 }
 
@@ -467,13 +473,21 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
             encode_u8(buf, TXOP_PUT);
             encode_keyword_tx_value_map(buf, map);
         }
-        TxOp::Add { entity, attribute, value } => {
+        TxOp::Add {
+            entity,
+            attribute,
+            value,
+        } => {
             encode_u8(buf, TXOP_ADD);
             encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
             encode_tx_value(buf, value);
         }
-        TxOp::Retract { entity, attribute, value } => {
+        TxOp::Retract {
+            entity,
+            attribute,
+            value,
+        } => {
             encode_u8(buf, TXOP_RETRACT);
             encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
@@ -618,7 +632,11 @@ impl<'a> Cursor<'a> {
     fn read_string_map(&mut self) -> Result<BTreeMap<String, String>> {
         let count = self.read_u32()? as usize;
         if count > self.remaining() {
-            bail!("String map count {} exceeds remaining bytes {}", count, self.remaining());
+            bail!(
+                "String map count {} exceeds remaining bytes {}",
+                count,
+                self.remaining()
+            );
         }
         let mut map = BTreeMap::new();
         for _ in 0..count {
@@ -651,9 +669,7 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
         TAG_REF => bail!("TAG_REF is not currently supported"),
         TAG_STRING => Ok(DataType::String(cursor.read_string()?)),
         TAG_TUPLE => Ok(DataType::Tuple(decode_data_type_vec(cursor)?)),
-        TAG_UUID => {
-            Ok(DataType::Uuid(Uuid::from_bytes(cursor.read_array()?)))
-        }
+        TAG_UUID => Ok(DataType::Uuid(Uuid::from_bytes(cursor.read_array()?))),
         TAG_VECTOR => Ok(DataType::Vector(decode_data_type_vec(cursor)?)),
         TAG_MAP => Ok(DataType::Map(decode_data_type_map(cursor)?)),
         TAG_KEYWORD => {
@@ -667,7 +683,11 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
 fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!("Vec<DataType> count {} exceeds remaining bytes {}", count, cursor.remaining());
+        bail!(
+            "Vec<DataType> count {} exceeds remaining bytes {}",
+            count,
+            cursor.remaining()
+        );
     }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
@@ -679,7 +699,11 @@ fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
 fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!("Map count {} exceeds remaining bytes {}", count, cursor.remaining());
+        bail!(
+            "Map count {} exceeds remaining bytes {}",
+            count,
+            cursor.remaining()
+        );
     }
     let mut map = BTreeMap::new();
     for _ in 0..count {
@@ -725,7 +749,11 @@ fn decode_tx_value(cursor: &mut Cursor) -> Result<TxValue> {
 fn decode_keyword_tx_value_map(cursor: &mut Cursor) -> Result<BTreeMap<Keyword, TxValue>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!("Keyword-TxValue map count {} exceeds remaining bytes {}", count, cursor.remaining());
+        bail!(
+            "Keyword-TxValue map count {} exceeds remaining bytes {}",
+            count,
+            cursor.remaining()
+        );
     }
     let mut map = BTreeMap::new();
     for _ in 0..count {
@@ -747,13 +775,21 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
             let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Add { entity, attribute, value })
+            Ok(TxOp::Add {
+                entity,
+                attribute,
+                value,
+            })
         }
         TXOP_RETRACT => {
             let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Retract { entity, attribute, value })
+            Ok(TxOp::Retract {
+                entity,
+                attribute,
+                value,
+            })
         }
         TXOP_DELETE => Ok(TxOp::Delete(decode_entity_ref(cursor)?)),
         TXOP_ERASE => Ok(TxOp::Erase(decode_entity_ref(cursor)?)),
@@ -764,7 +800,11 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
 fn decode_tx_ops(cursor: &mut Cursor) -> Result<Vec<TxOp>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!("Vec<TxOp> count {} exceeds remaining bytes {}", count, cursor.remaining());
+        bail!(
+            "Vec<TxOp> count {} exceeds remaining bytes {}",
+            count,
+            cursor.remaining()
+        );
     }
     let mut ops = Vec::with_capacity(count);
     for _ in 0..count {
@@ -917,10 +957,7 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
     }
 }
 
-fn decode_backend_payload(
-    msg_type: u8,
-    cursor: &mut Cursor,
-) -> Result<BackendMessage> {
+fn decode_backend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<BackendMessage> {
     match msg_type {
         MSG_AUTHENTICATION_OK => Ok(BackendMessage::AuthenticationOk {
             server_version: cursor.read_string()?,
@@ -935,7 +972,11 @@ fn decode_backend_payload(
         MSG_ROW_DESCRIPTION => {
             let count = cursor.read_u32()? as usize;
             if count > cursor.remaining() {
-                bail!("RowDescription column count {} exceeds remaining bytes {}", count, cursor.remaining());
+                bail!(
+                    "RowDescription column count {} exceeds remaining bytes {}",
+                    count,
+                    cursor.remaining()
+                );
             }
             let mut columns = Vec::with_capacity(count);
             for _ in 0..count {
@@ -1137,9 +1178,9 @@ pub async fn write_backend_message<W: AsyncWrite + Unpin>(
 
 #[cfg(test)]
 mod tests {
-    use edn::kw;
     use super::*;
     use crate::ops::{EntityRef, TxValue};
+    use edn::kw;
     use std::collections::BTreeMap;
 
     // Helper: encode a frontend message to bytes and decode it back.
@@ -1283,7 +1324,10 @@ mod tests {
         inner_map.insert("x".to_string(), DataType::Long(1));
         let dt = DataType::Vector(vec![
             DataType::Map(inner_map),
-            DataType::Tuple(vec![DataType::String("hello".to_string()), DataType::Boolean(false)]),
+            DataType::Tuple(vec![
+                DataType::String("hello".to_string()),
+                DataType::Boolean(false),
+            ]),
         ]);
         assert_eq!(roundtrip_data_type(&dt), dt);
     }
@@ -1300,7 +1344,10 @@ mod tests {
     #[test]
     fn test_tx_op_put() {
         let op = TxOp::put(vec![
-            (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
+            (
+                kw!(:name),
+                TxValue::Data(DataType::String("alice".to_string())),
+            ),
             (kw!(:age), TxValue::Data(DataType::Long(30))),
         ]);
         assert_eq!(roundtrip_tx_op(&op), op);
@@ -1310,7 +1357,10 @@ mod tests {
     fn test_tx_op_put_with_id() {
         let op = TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(EntityRef::Id(1))),
-            (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
+            (
+                kw!(:name),
+                TxValue::Data(DataType::String("alice".to_string())),
+            ),
         ]);
         assert_eq!(roundtrip_tx_op(&op), op);
     }
@@ -1318,8 +1368,14 @@ mod tests {
     #[test]
     fn test_tx_op_put_with_tempid() {
         let op = TxOp::put(vec![
-            (kw!(:db/id), TxValue::Ref(EntityRef::TempId("temp-1".to_string()))),
-            (kw!(:name), TxValue::Data(DataType::String("bob".to_string()))),
+            (
+                kw!(:db/id),
+                TxValue::Ref(EntityRef::TempId("temp-1".to_string())),
+            ),
+            (
+                kw!(:name),
+                TxValue::Data(DataType::String("bob".to_string())),
+            ),
         ]);
         assert_eq!(roundtrip_tx_op(&op), op);
     }
@@ -1375,10 +1431,19 @@ mod tests {
             decode_entity_ref(&mut cursor).unwrap()
         }
         assert_eq!(roundtrip_er(&EntityRef::Id(42)), EntityRef::Id(42));
-        assert_eq!(roundtrip_er(&EntityRef::TempId("t-1".to_string())), EntityRef::TempId("t-1".to_string()));
-        assert_eq!(roundtrip_er(&EntityRef::Ident(kw!(:person/name))), EntityRef::Ident(kw!(:person/name)));
         assert_eq!(
-            roundtrip_er(&EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".to_string()))),
+            roundtrip_er(&EntityRef::TempId("t-1".to_string())),
+            EntityRef::TempId("t-1".to_string())
+        );
+        assert_eq!(
+            roundtrip_er(&EntityRef::Ident(kw!(:person/name))),
+            EntityRef::Ident(kw!(:person/name))
+        );
+        assert_eq!(
+            roundtrip_er(&EntityRef::LookupRef(
+                kw!(:email),
+                DataType::String("a@b.com".to_string())
+            )),
             EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".to_string())),
         );
     }
@@ -1445,9 +1510,10 @@ mod tests {
     async fn test_execute_roundtrip() {
         let msg = FrontendMessage::Execute {
             ops: vec![
-                TxOp::put(vec![
-                    (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
-                ]),
+                TxOp::put(vec![(
+                    kw!(:name),
+                    TxValue::Data(DataType::String("alice".to_string())),
+                )]),
                 TxOp::Delete(EntityRef::Id(99)),
             ],
             await_indexing: true,
@@ -1525,10 +1591,7 @@ mod tests {
     #[tokio::test]
     async fn test_data_row_query_mode_roundtrip() {
         let msg = BackendMessage::DataRow {
-            values: vec![
-                DataType::Long(1),
-                DataType::String("alice".to_string()),
-            ],
+            values: vec![DataType::Long(1), DataType::String("alice".to_string())],
         };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use std::str::FromStr;
 
-use crate::ops::{DataType, TxOp};
+use crate::ops::{DataType, EntityRef, TxOp, TxValue};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,6 +97,16 @@ pub const TXOP_ADD: u8 = 1;
 pub const TXOP_RETRACT: u8 = 2;
 pub const TXOP_DELETE: u8 = 3;
 pub const TXOP_ERASE: u8 = 4;
+
+// EntityRef tag bytes
+pub const ENTITY_REF_ID: u8 = 0x90;
+pub const ENTITY_REF_TEMPID: u8 = 0x91;
+pub const ENTITY_REF_IDENT: u8 = 0x92;
+pub const ENTITY_REF_LOOKUP: u8 = 0x93;
+
+// TxValue tag bytes
+pub const TXVALUE_DATA: u8 = 0x94;
+pub const TXVALUE_REF: u8 = 0x95;
 
 // ---------------------------------------------------------------------------
 // Error Codes
@@ -298,20 +308,14 @@ fn encode_f64(buf: &mut Vec<u8>, v: f64) {
 /// message-size limit before encoding, which is well below `u32::MAX` (~4 GB).
 fn encode_string(buf: &mut Vec<u8>, s: &str) {
     let bytes = s.as_bytes();
-    encode_u32(
-        buf,
-        u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"),
-    );
+    encode_u32(buf, u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"));
     buf.extend_from_slice(bytes);
 }
 
 /// # Panics
 /// Panics if `b` exceeds `u32::MAX` bytes. Unreachable — see [`encode_string`].
 fn encode_bytes(buf: &mut Vec<u8>, b: &[u8]) {
-    encode_u32(
-        buf,
-        u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"),
-    );
+    encode_u32(buf, u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"));
     buf.extend_from_slice(b);
 }
 
@@ -411,44 +415,77 @@ fn encode_data_type_map(buf: &mut Vec<u8>, map: &BTreeMap<String, DataType>) {
 }
 
 // ---------------------------------------------------------------------------
-// Wire Encoding: TxOp
+// Wire Encoding: EntityRef / TxValue / TxOp
 // ---------------------------------------------------------------------------
 
-fn encode_eav(buf: &mut Vec<u8>, entity_id: &i64, attribute: &Keyword, value: &DataType) {
-    encode_i64(buf, *entity_id);
-    encode_string(buf, &attribute.to_string());
-    encode_data_type(buf, value);
+fn encode_entity_ref(buf: &mut Vec<u8>, er: &EntityRef) {
+    match er {
+        EntityRef::Id(id) => {
+            encode_u8(buf, ENTITY_REF_ID);
+            encode_i64(buf, *id);
+        }
+        EntityRef::TempId(s) => {
+            encode_u8(buf, ENTITY_REF_TEMPID);
+            encode_string(buf, s);
+        }
+        EntityRef::Ident(kw) => {
+            encode_u8(buf, ENTITY_REF_IDENT);
+            encode_string(buf, &kw.to_string());
+        }
+        EntityRef::LookupRef(kw, dt) => {
+            encode_u8(buf, ENTITY_REF_LOOKUP);
+            encode_string(buf, &kw.to_string());
+            encode_data_type(buf, dt);
+        }
+    }
+}
+
+fn encode_tx_value(buf: &mut Vec<u8>, tv: &TxValue) {
+    match tv {
+        TxValue::Data(dt) => {
+            encode_u8(buf, TXVALUE_DATA);
+            encode_data_type(buf, dt);
+        }
+        TxValue::Ref(er) => {
+            encode_u8(buf, TXVALUE_REF);
+            encode_entity_ref(buf, er);
+        }
+    }
+}
+
+fn encode_keyword_tx_value_map(buf: &mut Vec<u8>, map: &BTreeMap<Keyword, TxValue>) {
+    encode_u32(buf, map.len() as u32);
+    for (k, v) in map {
+        encode_string(buf, &k.to_string());
+        encode_tx_value(buf, v);
+    }
 }
 
 fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
     match op {
-        TxOp::Put(doc) => {
+        TxOp::Put(map) => {
             encode_u8(buf, TXOP_PUT);
-            encode_data_type_map(buf, doc);
+            encode_keyword_tx_value_map(buf, map);
         }
-        TxOp::Add {
-            entity_id,
-            attribute,
-            value,
-        } => {
+        TxOp::Add { entity, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
-            encode_eav(buf, entity_id, attribute, value);
+            encode_entity_ref(buf, entity);
+            encode_string(buf, &attribute.to_string());
+            encode_tx_value(buf, value);
         }
-        TxOp::Retract {
-            entity_id,
-            attribute,
-            value,
-        } => {
+        TxOp::Retract { entity, attribute, value } => {
             encode_u8(buf, TXOP_RETRACT);
-            encode_eav(buf, entity_id, attribute, value);
+            encode_entity_ref(buf, entity);
+            encode_string(buf, &attribute.to_string());
+            encode_tx_value(buf, value);
         }
-        TxOp::Delete(eid) => {
+        TxOp::Delete(er) => {
             encode_u8(buf, TXOP_DELETE);
-            encode_i64(buf, *eid);
+            encode_entity_ref(buf, er);
         }
-        TxOp::Erase(eid) => {
+        TxOp::Erase(er) => {
             encode_u8(buf, TXOP_ERASE);
-            encode_i64(buf, *eid);
+            encode_entity_ref(buf, er);
         }
     }
 }
@@ -581,11 +618,7 @@ impl<'a> Cursor<'a> {
     fn read_string_map(&mut self) -> Result<BTreeMap<String, String>> {
         let count = self.read_u32()? as usize;
         if count > self.remaining() {
-            bail!(
-                "String map count {} exceeds remaining bytes {}",
-                count,
-                self.remaining()
-            );
+            bail!("String map count {} exceeds remaining bytes {}", count, self.remaining());
         }
         let mut map = BTreeMap::new();
         for _ in 0..count {
@@ -618,7 +651,9 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
         TAG_REF => bail!("TAG_REF is not currently supported"),
         TAG_STRING => Ok(DataType::String(cursor.read_string()?)),
         TAG_TUPLE => Ok(DataType::Tuple(decode_data_type_vec(cursor)?)),
-        TAG_UUID => Ok(DataType::Uuid(Uuid::from_bytes(cursor.read_array()?))),
+        TAG_UUID => {
+            Ok(DataType::Uuid(Uuid::from_bytes(cursor.read_array()?)))
+        }
         TAG_VECTOR => Ok(DataType::Vector(decode_data_type_vec(cursor)?)),
         TAG_MAP => Ok(DataType::Map(decode_data_type_map(cursor)?)),
         TAG_KEYWORD => {
@@ -632,11 +667,7 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
 fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Vec<DataType> count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Vec<DataType> count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
@@ -648,11 +679,7 @@ fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
 fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Map count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Map count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut map = BTreeMap::new();
     for _ in 0..count {
@@ -664,41 +691,72 @@ fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType
 }
 
 // ---------------------------------------------------------------------------
-// Wire Decoding: TxOp
+// Wire Decoding: EntityRef / TxValue / TxOp
 // ---------------------------------------------------------------------------
 
-fn decode_eav(cursor: &mut Cursor) -> Result<(i64, Keyword, DataType)> {
-    let entity_id = cursor.read_i64()?;
-    let attribute = Keyword::from_str(&cursor.read_string()?)?;
-    let value = decode_data_type(cursor)?;
-    Ok((entity_id, attribute, value))
+fn decode_entity_ref(cursor: &mut Cursor) -> Result<EntityRef> {
+    let tag = cursor.read_u8()?;
+    match tag {
+        ENTITY_REF_ID => Ok(EntityRef::Id(cursor.read_i64()?)),
+        ENTITY_REF_TEMPID => Ok(EntityRef::TempId(cursor.read_string()?)),
+        ENTITY_REF_IDENT => {
+            let s = cursor.read_string()?;
+            Ok(EntityRef::Ident(Keyword::from_str(&s)?))
+        }
+        ENTITY_REF_LOOKUP => {
+            let s = cursor.read_string()?;
+            let kw = Keyword::from_str(&s)?;
+            let dt = decode_data_type(cursor)?;
+            Ok(EntityRef::LookupRef(kw, dt))
+        }
+        _ => bail!("Unknown EntityRef tag: 0x{:02x}", tag),
+    }
+}
+
+fn decode_tx_value(cursor: &mut Cursor) -> Result<TxValue> {
+    let tag = cursor.read_u8()?;
+    match tag {
+        TXVALUE_DATA => Ok(TxValue::Data(decode_data_type(cursor)?)),
+        TXVALUE_REF => Ok(TxValue::Ref(decode_entity_ref(cursor)?)),
+        _ => bail!("Unknown TxValue tag: 0x{:02x}", tag),
+    }
+}
+
+fn decode_keyword_tx_value_map(cursor: &mut Cursor) -> Result<BTreeMap<Keyword, TxValue>> {
+    let count = cursor.read_u32()? as usize;
+    if count > cursor.remaining() {
+        bail!("Keyword-TxValue map count {} exceeds remaining bytes {}", count, cursor.remaining());
+    }
+    let mut map = BTreeMap::new();
+    for _ in 0..count {
+        let kw = Keyword::from_str(&cursor.read_string()?)?;
+        let tv = decode_tx_value(cursor)?;
+        map.insert(kw, tv);
+    }
+    Ok(map)
 }
 
 fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
     let tag = cursor.read_u8()?;
     match tag {
         TXOP_PUT => {
-            let map = decode_data_type_map(cursor)?;
+            let map = decode_keyword_tx_value_map(cursor)?;
             Ok(TxOp::Put(map))
         }
         TXOP_ADD => {
-            let (entity_id, attribute, value) = decode_eav(cursor)?;
-            Ok(TxOp::Add {
-                entity_id,
-                attribute,
-                value,
-            })
+            let entity = decode_entity_ref(cursor)?;
+            let attribute = Keyword::from_str(&cursor.read_string()?)?;
+            let value = decode_tx_value(cursor)?;
+            Ok(TxOp::Add { entity, attribute, value })
         }
         TXOP_RETRACT => {
-            let (entity_id, attribute, value) = decode_eav(cursor)?;
-            Ok(TxOp::Retract {
-                entity_id,
-                attribute,
-                value,
-            })
+            let entity = decode_entity_ref(cursor)?;
+            let attribute = Keyword::from_str(&cursor.read_string()?)?;
+            let value = decode_tx_value(cursor)?;
+            Ok(TxOp::Retract { entity, attribute, value })
         }
-        TXOP_DELETE => Ok(TxOp::Delete(cursor.read_i64()?)),
-        TXOP_ERASE => Ok(TxOp::Erase(cursor.read_i64()?)),
+        TXOP_DELETE => Ok(TxOp::Delete(decode_entity_ref(cursor)?)),
+        TXOP_ERASE => Ok(TxOp::Erase(decode_entity_ref(cursor)?)),
         _ => bail!("Unknown TxOp tag: {}", tag),
     }
 }
@@ -706,11 +764,7 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
 fn decode_tx_ops(cursor: &mut Cursor) -> Result<Vec<TxOp>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Vec<TxOp> count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Vec<TxOp> count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut ops = Vec::with_capacity(count);
     for _ in 0..count {
@@ -863,7 +917,10 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
     }
 }
 
-fn decode_backend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<BackendMessage> {
+fn decode_backend_payload(
+    msg_type: u8,
+    cursor: &mut Cursor,
+) -> Result<BackendMessage> {
     match msg_type {
         MSG_AUTHENTICATION_OK => Ok(BackendMessage::AuthenticationOk {
             server_version: cursor.read_string()?,
@@ -878,11 +935,7 @@ fn decode_backend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<BackendMe
         MSG_ROW_DESCRIPTION => {
             let count = cursor.read_u32()? as usize;
             if count > cursor.remaining() {
-                bail!(
-                    "RowDescription column count {} exceeds remaining bytes {}",
-                    count,
-                    cursor.remaining()
-                );
+                bail!("RowDescription column count {} exceeds remaining bytes {}", count, cursor.remaining());
             }
             let mut columns = Vec::with_capacity(count);
             for _ in 0..count {
@@ -1084,8 +1137,9 @@ pub async fn write_backend_message<W: AsyncWrite + Unpin>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use edn::kw;
+    use super::*;
+    use crate::ops::{EntityRef, TxValue};
     use std::collections::BTreeMap;
 
     // Helper: encode a frontend message to bytes and decode it back.
@@ -1229,10 +1283,7 @@ mod tests {
         inner_map.insert("x".to_string(), DataType::Long(1));
         let dt = DataType::Vector(vec![
             DataType::Map(inner_map),
-            DataType::Tuple(vec![
-                DataType::String("hello".to_string()),
-                DataType::Boolean(false),
-            ]),
+            DataType::Tuple(vec![DataType::String("hello".to_string()), DataType::Boolean(false)]),
         ]);
         assert_eq!(roundtrip_data_type(&dt), dt);
     }
@@ -1248,19 +1299,45 @@ mod tests {
 
     #[test]
     fn test_tx_op_put() {
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(1));
-        map.insert("name".to_string(), DataType::String("alice".to_string()));
-        let op = TxOp::Put(map);
+        let op = TxOp::put(vec![
+            (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
+            (kw!(:age), TxValue::Data(DataType::Long(30))),
+        ]);
+        assert_eq!(roundtrip_tx_op(&op), op);
+    }
+
+    #[test]
+    fn test_tx_op_put_with_id() {
+        let op = TxOp::put_with_id(EntityRef::Id(1), vec![
+            (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
+        ]);
+        assert_eq!(roundtrip_tx_op(&op), op);
+    }
+
+    #[test]
+    fn test_tx_op_put_with_tempid() {
+        let op = TxOp::put_with_id(EntityRef::TempId("temp-1".to_string()), vec![
+            (kw!(:name), TxValue::Data(DataType::String("bob".to_string()))),
+        ]);
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_add() {
         let op = TxOp::Add {
-            entity_id: 42,
+            entity: EntityRef::Id(42),
             attribute: kw!(:email),
-            value: DataType::String("test@example.com".to_string()),
+            value: TxValue::Data(DataType::String("test@example.com".to_string())),
+        };
+        assert_eq!(roundtrip_tx_op(&op), op);
+    }
+
+    #[test]
+    fn test_tx_op_add_with_ref_value() {
+        let op = TxOp::Add {
+            entity: EntityRef::Id(42),
+            attribute: kw!(:friend),
+            value: TxValue::Ref(EntityRef::TempId("temp-2".to_string())),
         };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
@@ -1268,23 +1345,54 @@ mod tests {
     #[test]
     fn test_tx_op_retract() {
         let op = TxOp::Retract {
-            entity_id: 42,
+            entity: EntityRef::Id(42),
             attribute: kw!(:email),
-            value: DataType::String("old@example.com".to_string()),
+            value: TxValue::Data(DataType::String("old@example.com".to_string())),
         };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_delete() {
-        let op = TxOp::Delete(99);
+        let op = TxOp::Delete(EntityRef::Id(99));
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_erase() {
-        let op = TxOp::Erase(100);
+        let op = TxOp::Erase(EntityRef::Id(100));
         assert_eq!(roundtrip_tx_op(&op), op);
+    }
+
+    #[test]
+    fn test_entity_ref_roundtrip() {
+        fn roundtrip_er(er: &EntityRef) -> EntityRef {
+            let mut buf = Vec::new();
+            encode_entity_ref(&mut buf, er);
+            let mut cursor = Cursor::new(&buf);
+            decode_entity_ref(&mut cursor).unwrap()
+        }
+        assert_eq!(roundtrip_er(&EntityRef::Id(42)), EntityRef::Id(42));
+        assert_eq!(roundtrip_er(&EntityRef::TempId("t-1".to_string())), EntityRef::TempId("t-1".to_string()));
+        assert_eq!(roundtrip_er(&EntityRef::Ident(kw!(:person/name))), EntityRef::Ident(kw!(:person/name)));
+        assert_eq!(
+            roundtrip_er(&EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".to_string()))),
+            EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".to_string())),
+        );
+    }
+
+    #[test]
+    fn test_tx_value_roundtrip() {
+        fn roundtrip_tv(tv: &TxValue) -> TxValue {
+            let mut buf = Vec::new();
+            encode_tx_value(&mut buf, tv);
+            let mut cursor = Cursor::new(&buf);
+            decode_tx_value(&mut cursor).unwrap()
+        }
+        let data = TxValue::Data(DataType::Long(42));
+        assert_eq!(roundtrip_tv(&data), data);
+        let refv = TxValue::Ref(EntityRef::TempId("t-1".to_string()));
+        assert_eq!(roundtrip_tv(&refv), refv);
     }
 
     // -- Frontend message round-trip tests --
@@ -1333,11 +1441,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_roundtrip() {
-        let mut map = BTreeMap::new();
-        map.insert("db/id".to_string(), DataType::Long(1));
-        map.insert("name".to_string(), DataType::String("alice".to_string()));
         let msg = FrontendMessage::Execute {
-            ops: vec![TxOp::Put(map), TxOp::Delete(99)],
+            ops: vec![
+                TxOp::put(vec![
+                    (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
+                ]),
+                TxOp::Delete(EntityRef::Id(99)),
+            ],
             await_indexing: true,
         };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
@@ -1413,7 +1523,10 @@ mod tests {
     #[tokio::test]
     async fn test_data_row_query_mode_roundtrip() {
         let msg = BackendMessage::DataRow {
-            values: vec![DataType::Long(1), DataType::String("alice".to_string())],
+            values: vec![
+                DataType::Long(1),
+                DataType::String("alice".to_string()),
+            ],
         };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1308,7 +1308,8 @@ mod tests {
 
     #[test]
     fn test_tx_op_put_with_id() {
-        let op = TxOp::put_with_id(EntityRef::Id(1), vec![
+        let op = TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(EntityRef::Id(1))),
             (kw!(:name), TxValue::Data(DataType::String("alice".to_string()))),
         ]);
         assert_eq!(roundtrip_tx_op(&op), op);
@@ -1316,7 +1317,8 @@ mod tests {
 
     #[test]
     fn test_tx_op_put_with_tempid() {
-        let op = TxOp::put_with_id(EntityRef::TempId("temp-1".to_string()), vec![
+        let op = TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(EntityRef::TempId("temp-1".to_string()))),
             (kw!(:name), TxValue::Data(DataType::String("bob".to_string()))),
         ]);
         assert_eq!(roundtrip_tx_op(&op), op);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -467,15 +467,15 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
             encode_u8(buf, TXOP_PUT);
             encode_keyword_tx_value_map(buf, map);
         }
-        TxOp::Add { entity_id, attribute, value } => {
+        TxOp::Add { entity, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
-            encode_entity_ref(buf, entity_id);
+            encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
             encode_tx_value(buf, value);
         }
-        TxOp::Retract { entity_id, attribute, value } => {
+        TxOp::Retract { entity, attribute, value } => {
             encode_u8(buf, TXOP_RETRACT);
-            encode_entity_ref(buf, entity_id);
+            encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
             encode_tx_value(buf, value);
         }
@@ -744,16 +744,16 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
             Ok(TxOp::Put(map))
         }
         TXOP_ADD => {
-            let entity_id = decode_entity_ref(cursor)?;
+            let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Add { entity_id, attribute, value })
+            Ok(TxOp::Add { entity, attribute, value })
         }
         TXOP_RETRACT => {
-            let entity_id = decode_entity_ref(cursor)?;
+            let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Retract { entity_id, attribute, value })
+            Ok(TxOp::Retract { entity, attribute, value })
         }
         TXOP_DELETE => Ok(TxOp::Delete(decode_entity_ref(cursor)?)),
         TXOP_ERASE => Ok(TxOp::Erase(decode_entity_ref(cursor)?)),
@@ -1327,7 +1327,7 @@ mod tests {
     #[test]
     fn test_tx_op_add() {
         let op = TxOp::Add {
-            entity_id: EntityRef::Id(42),
+            entity: EntityRef::Id(42),
             attribute: kw!(:email),
             value: TxValue::Data(DataType::String("test@example.com".to_string())),
         };
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn test_tx_op_add_with_ref_value() {
         let op = TxOp::Add {
-            entity_id: EntityRef::Id(42),
+            entity: EntityRef::Id(42),
             attribute: kw!(:friend),
             value: TxValue::Ref(EntityRef::TempId("temp-2".to_string())),
         };
@@ -1347,7 +1347,7 @@ mod tests {
     #[test]
     fn test_tx_op_retract() {
         let op = TxOp::Retract {
-            entity_id: EntityRef::Id(42),
+            entity: EntityRef::Id(42),
             attribute: kw!(:email),
             value: TxValue::Data(DataType::String("old@example.com".to_string())),
         };

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -467,15 +467,15 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
             encode_u8(buf, TXOP_PUT);
             encode_keyword_tx_value_map(buf, map);
         }
-        TxOp::Add { entity, attribute, value } => {
+        TxOp::Add { entity_id, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
-            encode_entity_ref(buf, entity);
+            encode_entity_ref(buf, entity_id);
             encode_string(buf, &attribute.to_string());
             encode_tx_value(buf, value);
         }
-        TxOp::Retract { entity, attribute, value } => {
+        TxOp::Retract { entity_id, attribute, value } => {
             encode_u8(buf, TXOP_RETRACT);
-            encode_entity_ref(buf, entity);
+            encode_entity_ref(buf, entity_id);
             encode_string(buf, &attribute.to_string());
             encode_tx_value(buf, value);
         }
@@ -744,16 +744,16 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
             Ok(TxOp::Put(map))
         }
         TXOP_ADD => {
-            let entity = decode_entity_ref(cursor)?;
+            let entity_id = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Add { entity, attribute, value })
+            Ok(TxOp::Add { entity_id, attribute, value })
         }
         TXOP_RETRACT => {
-            let entity = decode_entity_ref(cursor)?;
+            let entity_id = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_tx_value(cursor)?;
-            Ok(TxOp::Retract { entity, attribute, value })
+            Ok(TxOp::Retract { entity_id, attribute, value })
         }
         TXOP_DELETE => Ok(TxOp::Delete(decode_entity_ref(cursor)?)),
         TXOP_ERASE => Ok(TxOp::Erase(decode_entity_ref(cursor)?)),
@@ -1327,7 +1327,7 @@ mod tests {
     #[test]
     fn test_tx_op_add() {
         let op = TxOp::Add {
-            entity: EntityRef::Id(42),
+            entity_id: EntityRef::Id(42),
             attribute: kw!(:email),
             value: TxValue::Data(DataType::String("test@example.com".to_string())),
         };
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn test_tx_op_add_with_ref_value() {
         let op = TxOp::Add {
-            entity: EntityRef::Id(42),
+            entity_id: EntityRef::Id(42),
             attribute: kw!(:friend),
             value: TxValue::Ref(EntityRef::TempId("temp-2".to_string())),
         };
@@ -1347,7 +1347,7 @@ mod tests {
     #[test]
     fn test_tx_op_retract() {
         let op = TxOp::Retract {
-            entity: EntityRef::Id(42),
+            entity_id: EntityRef::Id(42),
             attribute: kw!(:email),
             value: TxValue::Data(DataType::String("old@example.com".to_string())),
         };

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -367,14 +367,16 @@ fn schema_attribute(ident: Keyword, value_type: &str) -> TxOp {
 
 /// Build a bootstrap Put with an explicit entity ID.
 fn bootstrap_put(id: i64, ident: Keyword) -> TxOp {
-    TxOp::put_with_id(id, vec![
+    TxOp::put(vec![
+        (kw!(:db/id), TxValue::Ref(id.into())),
         (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
     ])
 }
 
 /// Build a bootstrap Put for a schema attribute with an explicit entity ID.
 fn bootstrap_schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
-    TxOp::put_with_id(id, vec![
+    TxOp::put(vec![
+        (kw!(:db/id), TxValue::Ref(id.into())),
         (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
         (kw!(:db/valueType), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.type", value_type)))),
         (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.cardinality", "one")))),
@@ -595,7 +597,8 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_valid() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put_with_id(200_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:name), "Alice".into()),
         ])];
         assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
@@ -604,7 +607,8 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_unknown_attribute() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put_with_id(200_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:person/age), 30_i64.into()),
         ])];
         let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
@@ -614,7 +618,8 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_type_mismatch() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put_with_id(200_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:name), 42_i64.into()),
         ])];
         let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
@@ -633,7 +638,8 @@ mod tests {
         let schema = bootstrapped_schema_with_person_name();
         let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
 
-        let ops = [TxOp::put_with_id(name_id, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(name_id.into())),
             (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
             (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/long)))),
             (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(kw!(:db.cardinality/one)))),
@@ -669,13 +675,15 @@ mod tests {
         assert_eq!(attr.value_type, ValueType::Ref);
 
         // Long value accepted for ref-typed attribute
-        let ops = [TxOp::put_with_id(200_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:follows), 201_i64.into()),
         ])];
         assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
 
         // String value rejected for ref-typed attribute
-        let ops = [TxOp::put_with_id(300_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(300_i64.into())),
             (kw!(:follows), "not-a-ref".into()),
         ])];
         assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_err());
@@ -702,7 +710,8 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_missing_cardinality_errors() {
         let schema = bootstrapped_schema();
-        let ops = [TxOp::put_with_id(100_i64, vec![
+        let ops = [TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
             (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
             (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/string)))),
             // No db/cardinality

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -186,10 +186,14 @@ impl AttributeBuilder {
     /// Validate that all required fields are present for a new attribute.
     pub fn validate_install_attribute(&self) -> Result<()> {
         if self.value_type.is_none() {
-            return Err(anyhow::anyhow!("db/valueType is required for schema attribute"));
+            return Err(anyhow::anyhow!(
+                "db/valueType is required for schema attribute"
+            ));
         }
         if self.multival.is_none() {
-            return Err(anyhow::anyhow!("db/cardinality is required for schema attribute"));
+            return Err(anyhow::anyhow!(
+                "db/cardinality is required for schema attribute"
+            ));
         }
         Ok(())
     }
@@ -256,7 +260,9 @@ impl Schema {
             // Reject modifications to existing schema entities
             if let Some(ident) = self.entid_map.get(&datom.entity) {
                 return Err(anyhow::anyhow!(
-                    "Cannot modify schema entity {} ({})", datom.entity, ident
+                    "Cannot modify schema entity {} ({})",
+                    datom.entity,
+                    ident
                 ));
             }
 
@@ -269,7 +275,9 @@ impl Schema {
                 if !attr.value_type.matches(&datom.value) {
                     return Err(anyhow::anyhow!(
                         "Type mismatch for attribute {}: expected {}, got {:?}",
-                        datom.attribute, attr.value_type, datom.value
+                        datom.attribute,
+                        attr.value_type,
+                        datom.value
                     ));
                 }
             } else if !matches!(
@@ -299,7 +307,8 @@ impl Schema {
                 ("db", "cardinality") => match &datom.value {
                     DataType::Keyword(kw) => {
                         let card = Cardinality::from_keyword(kw)?;
-                        builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
+                        builders.entry(datom.entity).or_default().multival =
+                            Some(card == Cardinality::Many);
                     }
                     _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
                 },
@@ -315,7 +324,8 @@ impl Schema {
             // but that's the correct behavior.
             builder.validate_install_attribute().map_err(|e| {
                 // Find the ident for better error messages
-                let ident = ident_updates.iter()
+                let ident = ident_updates
+                    .iter()
                     .find(|(eid, _)| *eid == entity_id)
                     .map(|(_, kw)| kw.to_string())
                     .unwrap_or_else(|| "<unknown>".to_string());
@@ -356,8 +366,19 @@ impl Schema {
 fn schema_attribute_with_cardinality(ident: Keyword, value_type: &str, cardinality: &str) -> TxOp {
     TxOp::put(vec![
         (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
-        (kw!(:db/valueType), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.type", value_type)))),
-        (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)))),
+        (
+            kw!(:db/valueType),
+            TxValue::Data(DataType::Keyword(Keyword::namespaced(
+                "db.type", value_type,
+            ))),
+        ),
+        (
+            kw!(:db/cardinality),
+            TxValue::Data(DataType::Keyword(Keyword::namespaced(
+                "db.cardinality",
+                cardinality,
+            ))),
+        ),
     ])
 }
 
@@ -378,8 +399,19 @@ fn bootstrap_schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp
     TxOp::put(vec![
         (kw!(:db/id), TxValue::Ref(id.into())),
         (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
-        (kw!(:db/valueType), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.type", value_type)))),
-        (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.cardinality", "one")))),
+        (
+            kw!(:db/valueType),
+            TxValue::Data(DataType::Keyword(Keyword::namespaced(
+                "db.type", value_type,
+            ))),
+        ),
+        (
+            kw!(:db/cardinality),
+            TxValue::Data(DataType::Keyword(Keyword::namespaced(
+                "db.cardinality",
+                "one",
+            ))),
+        ),
     ])
 }
 
@@ -440,15 +472,20 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let handle = Handle::current();
 
     // Query 1: all entities with db/ident (populates ident_map/entid_map)
-    let ident_query = parse_query(
-        "[:find ?e ?ident :where [?e :db/ident ?ident]]"
-    ).expect("Ident query parse failed");
+    let ident_query = parse_query("[:find ?e ?ident :where [?e :db/ident ?ident]]")
+        .expect("Ident query parse failed");
 
     let snap_clone = snapshot.clone();
     let handle_clone = handle.clone();
     let ident_map_clone = bootstrap_ident_map.clone();
     let ident_results = tokio::task::spawn_blocking(move || {
-        execute_query(&ident_query, snap_clone, handle_clone, &ident_map_clone, i64::MAX)
+        execute_query(
+            &ident_query,
+            snap_clone,
+            handle_clone,
+            &ident_map_clone,
+            i64::MAX,
+        )
     })
     .await
     .expect("Ident query task failed")
@@ -460,7 +497,13 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     ).expect("Attribute query parse failed");
 
     let attr_results = tokio::task::spawn_blocking(move || {
-        execute_query(&attr_query, snapshot, handle, &bootstrap_ident_map, i64::MAX)
+        execute_query(
+            &attr_query,
+            snapshot,
+            handle,
+            &bootstrap_ident_map,
+            i64::MAX,
+        )
     })
     .await
     .expect("Attribute query task failed")
@@ -500,10 +543,13 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
             other => panic!("Expected Keyword for cardinality, got {:?}", other),
         };
 
-        schema.attribute_map.insert(entity_id, Attribute {
-            value_type,
-            multival: cardinality == Cardinality::Many,
-        });
+        schema.attribute_map.insert(
+            entity_id,
+            Attribute {
+                value_type,
+                multival: cardinality == Cardinality::Many,
+            },
+        );
     }
 
     schema
@@ -548,7 +594,9 @@ mod tests {
     fn bootstrapped_schema_with_person_name() -> Schema {
         let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
+        let update = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap();
         schema.apply_schema_update(update);
         schema
     }
@@ -601,7 +649,9 @@ mod tests {
             (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:name), "Alice".into()),
         ])];
-        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
+        assert!(schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .is_ok());
     }
 
     #[test]
@@ -611,7 +661,9 @@ mod tests {
             (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:person/age), 30_i64.into()),
         ])];
-        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
+        let err = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap_err();
         assert!(err.to_string().contains("Unknown attribute: :person/age"));
     }
 
@@ -622,7 +674,9 @@ mod tests {
             (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:name), 42_i64.into()),
         ])];
-        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
+        let err = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap_err();
         assert!(err.to_string().contains("Type mismatch"));
     }
 
@@ -630,7 +684,9 @@ mod tests {
     fn test_validate_and_prepare_schema_defining_tx() {
         let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
+        assert!(schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .is_ok());
     }
 
     #[test]
@@ -641,10 +697,18 @@ mod tests {
         let ops = [TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(name_id.into())),
             (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
-            (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/long)))),
-            (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(kw!(:db.cardinality/one)))),
+            (
+                kw!(:db/valueType),
+                TxValue::Data(DataType::Keyword(kw!(:db.type/long))),
+            ),
+            (
+                kw!(:db/cardinality),
+                TxValue::Data(DataType::Keyword(kw!(:db.cardinality/one))),
+            ),
         ])];
-        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
+        let err = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
 
@@ -661,14 +725,19 @@ mod tests {
     // TODO(#165): replace with from_entity_id test once db/valueType switches to ref
     #[test]
     fn test_value_type_from_keyword_ref() {
-        assert_eq!(ValueType::from_keyword(&kw!(:db.type/ref)).unwrap(), ValueType::Ref);
+        assert_eq!(
+            ValueType::from_keyword(&kw!(:db.type/ref)).unwrap(),
+            ValueType::Ref
+        );
     }
 
     #[test]
     fn test_schema_ref_attribute_validation() {
         let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:follows), "ref")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
+        let update = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap();
         schema.apply_schema_update(update);
 
         let (_eid, attr) = schema.get_attribute(&kw!(:follows)).unwrap();
@@ -679,21 +748,31 @@ mod tests {
             (kw!(:db/id), TxValue::Ref(200_i64.into())),
             (kw!(:follows), 201_i64.into()),
         ])];
-        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
+        assert!(schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .is_ok());
 
         // String value rejected for ref-typed attribute
         let ops = [TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(300_i64.into())),
             (kw!(:follows), "not-a-ref".into()),
         ])];
-        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_err());
+        assert!(schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .is_err());
     }
 
     #[test]
     fn test_validate_and_prepare_parses_cardinality_many() {
         let schema = bootstrapped_schema();
-        let ops = [schema_attribute_with_cardinality(kw!(:tags), "string", "many")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
+        let ops = [schema_attribute_with_cardinality(
+            kw!(:tags),
+            "string",
+            "many",
+        )];
+        let update = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap();
         assert_eq!(update.attributes.len(), 1);
         assert!(update.attributes[0].1.multival);
     }
@@ -702,7 +781,9 @@ mod tests {
     fn test_validate_and_prepare_parses_cardinality_one() {
         let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
+        let update = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap();
         assert_eq!(update.attributes.len(), 1);
         assert!(!update.attributes[0].1.multival);
     }
@@ -713,10 +794,15 @@ mod tests {
         let ops = [TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(100_i64.into())),
             (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
-            (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/string)))),
+            (
+                kw!(:db/valueType),
+                TxValue::Data(DataType::Keyword(kw!(:db.type/string))),
+            ),
             // No db/cardinality
         ])];
-        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
+        let err = schema
+            .validate_and_prepare(&to_datoms(&ops, &schema))
+            .unwrap_err();
         assert!(err.to_string().contains("db/cardinality is required"));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,7 @@ use edn::kw;
 use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
-use crate::ops::{DataType, Datom, DatomOp, TxOp};
+use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp, TxValue};
 use crate::parse::parse_query;
 use crate::query::execute_query;
 
@@ -186,14 +186,10 @@ impl AttributeBuilder {
     /// Validate that all required fields are present for a new attribute.
     pub fn validate_install_attribute(&self) -> Result<()> {
         if self.value_type.is_none() {
-            return Err(anyhow::anyhow!(
-                "db/valueType is required for schema attribute"
-            ));
+            return Err(anyhow::anyhow!("db/valueType is required for schema attribute"));
         }
         if self.multival.is_none() {
-            return Err(anyhow::anyhow!(
-                "db/cardinality is required for schema attribute"
-            ));
+            return Err(anyhow::anyhow!("db/cardinality is required for schema attribute"));
         }
         Ok(())
     }
@@ -260,9 +256,7 @@ impl Schema {
             // Reject modifications to existing schema entities
             if let Some(ident) = self.entid_map.get(&datom.entity) {
                 return Err(anyhow::anyhow!(
-                    "Cannot modify schema entity {} ({})",
-                    datom.entity,
-                    ident
+                    "Cannot modify schema entity {} ({})", datom.entity, ident
                 ));
             }
 
@@ -275,9 +269,7 @@ impl Schema {
                 if !attr.value_type.matches(&datom.value) {
                     return Err(anyhow::anyhow!(
                         "Type mismatch for attribute {}: expected {}, got {:?}",
-                        datom.attribute,
-                        attr.value_type,
-                        datom.value
+                        datom.attribute, attr.value_type, datom.value
                     ));
                 }
             } else if !matches!(
@@ -307,8 +299,7 @@ impl Schema {
                 ("db", "cardinality") => match &datom.value {
                     DataType::Keyword(kw) => {
                         let card = Cardinality::from_keyword(kw)?;
-                        builders.entry(datom.entity).or_default().multival =
-                            Some(card == Cardinality::Many);
+                        builders.entry(datom.entity).or_default().multival = Some(card == Cardinality::Many);
                     }
                     _ => return Err(anyhow::anyhow!("db/cardinality must be a Keyword")),
                 },
@@ -324,8 +315,7 @@ impl Schema {
             // but that's the correct behavior.
             builder.validate_install_attribute().map_err(|e| {
                 // Find the ident for better error messages
-                let ident = ident_updates
-                    .iter()
+                let ident = ident_updates.iter()
                     .find(|(eid, _)| *eid == entity_id)
                     .map(|(_, kw)| kw.to_string())
                     .unwrap_or_else(|| "<unknown>".to_string());
@@ -364,17 +354,11 @@ impl Schema {
 
 /// Build a Put for a schema attribute without explicit db/id.
 fn schema_attribute_with_cardinality(ident: Keyword, value_type: &str, cardinality: &str) -> TxOp {
-    let mut doc = BTreeMap::new();
-    doc.insert("db/ident".to_string(), DataType::Keyword(ident));
-    doc.insert(
-        "db/valueType".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.type", value_type)),
-    );
-    doc.insert(
-        "db/cardinality".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)),
-    );
-    TxOp::Put(doc)
+    TxOp::put(vec![
+        (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
+        (kw!(:db/valueType), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.type", value_type)))),
+        (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)))),
+    ])
 }
 
 fn schema_attribute(ident: Keyword, value_type: &str) -> TxOp {
@@ -383,26 +367,18 @@ fn schema_attribute(ident: Keyword, value_type: &str) -> TxOp {
 
 /// Build a bootstrap Put with an explicit entity ID.
 fn bootstrap_put(id: i64, ident: Keyword) -> TxOp {
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(id));
-    doc.insert("db/ident".to_string(), DataType::Keyword(ident));
-    TxOp::Put(doc)
+    TxOp::put_with_id(id, vec![
+        (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
+    ])
 }
 
 /// Build a bootstrap Put for a schema attribute with an explicit entity ID.
 fn bootstrap_schema_attribute(id: i64, ident: Keyword, value_type: &str) -> TxOp {
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(id));
-    doc.insert("db/ident".to_string(), DataType::Keyword(ident));
-    doc.insert(
-        "db/valueType".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.type", value_type)),
-    );
-    doc.insert(
-        "db/cardinality".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
-    );
-    TxOp::Put(doc)
+    TxOp::put_with_id(id, vec![
+        (kw!(:db/ident), TxValue::Data(DataType::Keyword(ident))),
+        (kw!(:db/valueType), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.type", value_type)))),
+        (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(Keyword::namespaced("db.cardinality", "one")))),
+    ])
 }
 
 /// Build the bootstrap schema transaction.
@@ -462,20 +438,15 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let handle = Handle::current();
 
     // Query 1: all entities with db/ident (populates ident_map/entid_map)
-    let ident_query = parse_query("[:find ?e ?ident :where [?e :db/ident ?ident]]")
-        .expect("Ident query parse failed");
+    let ident_query = parse_query(
+        "[:find ?e ?ident :where [?e :db/ident ?ident]]"
+    ).expect("Ident query parse failed");
 
     let snap_clone = snapshot.clone();
     let handle_clone = handle.clone();
     let ident_map_clone = bootstrap_ident_map.clone();
     let ident_results = tokio::task::spawn_blocking(move || {
-        execute_query(
-            &ident_query,
-            snap_clone,
-            handle_clone,
-            &ident_map_clone,
-            i64::MAX,
-        )
+        execute_query(&ident_query, snap_clone, handle_clone, &ident_map_clone, i64::MAX)
     })
     .await
     .expect("Ident query task failed")
@@ -487,13 +458,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     ).expect("Attribute query parse failed");
 
     let attr_results = tokio::task::spawn_blocking(move || {
-        execute_query(
-            &attr_query,
-            snapshot,
-            handle,
-            &bootstrap_ident_map,
-            i64::MAX,
-        )
+        execute_query(&attr_query, snapshot, handle, &bootstrap_ident_map, i64::MAX)
     })
     .await
     .expect("Attribute query task failed")
@@ -533,13 +498,10 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
             other => panic!("Expected Keyword for cardinality, got {:?}", other),
         };
 
-        schema.attribute_map.insert(
-            entity_id,
-            Attribute {
-                value_type,
-                multival: cardinality == Cardinality::Many,
-            },
-        );
+        schema.attribute_map.insert(entity_id, Attribute {
+            value_type,
+            multival: cardinality == Cardinality::Many,
+        });
     }
 
     schema
@@ -562,18 +524,20 @@ pub fn test_schema_tx() -> Vec<TxOp> {
 mod tests {
     use super::*;
     use crate::metadata::PartitionMap;
-    use crate::ops::tx_ops_to_datoms;
+    use crate::tx;
 
-    fn to_datoms(ops: &[TxOp]) -> Vec<Datom> {
+    fn to_datoms(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
         let mut pm = PartitionMap::new();
-        let resolved = crate::partition::resolve_entity_ids(ops, &mut pm).unwrap();
-        tx_ops_to_datoms(&resolved, 0_i64).unwrap()
+        let expanded = tx::expand_tx_ops(ops, schema).unwrap();
+        tx::resolve_tempids(&expanded, &mut pm, schema).unwrap()
     }
 
     fn bootstrapped_schema() -> Schema {
         let mut schema = Schema::default();
         let tx_ops = bootstrap_schema_tx();
-        let datoms = tx_ops_to_datoms(&tx_ops, 0_i64).unwrap();
+        let expanded = tx::expand_tx_ops(&tx_ops, &schema).unwrap();
+        let mut pm = PartitionMap::new();
+        let datoms = tx::resolve_tempids(&expanded, &mut pm, &schema).unwrap();
         let update = schema.validate_and_prepare(&datoms).unwrap();
         schema.apply_schema_update(update);
         schema
@@ -582,7 +546,7 @@ mod tests {
     fn bootstrapped_schema_with_person_name() -> Schema {
         let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
         schema.apply_schema_update(update);
         schema
     }
@@ -631,35 +595,29 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_valid() {
         let schema = bootstrapped_schema_with_person_name();
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(200));
-        doc.insert("name".to_string(), DataType::String("Alice".to_string()));
-        assert!(schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .is_ok());
+        let ops = [TxOp::put_with_id(200_i64, vec![
+            (kw!(:name), "Alice".into()),
+        ])];
+        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
     }
 
     #[test]
     fn test_validate_and_prepare_unknown_attribute() {
         let schema = bootstrapped_schema_with_person_name();
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(200));
-        doc.insert("person/age".to_string(), DataType::Long(30));
-        let err = schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .unwrap_err();
+        let ops = [TxOp::put_with_id(200_i64, vec![
+            (kw!(:person/age), 30_i64.into()),
+        ])];
+        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("Unknown attribute: :person/age"));
     }
 
     #[test]
     fn test_validate_and_prepare_type_mismatch() {
         let schema = bootstrapped_schema_with_person_name();
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(200));
-        doc.insert("name".to_string(), DataType::Long(42));
-        let err = schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .unwrap_err();
+        let ops = [TxOp::put_with_id(200_i64, vec![
+            (kw!(:name), 42_i64.into()),
+        ])];
+        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("Type mismatch"));
     }
 
@@ -667,7 +625,7 @@ mod tests {
     fn test_validate_and_prepare_schema_defining_tx() {
         let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        assert!(schema.validate_and_prepare(&to_datoms(&ops)).is_ok());
+        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
     }
 
     #[test]
@@ -675,21 +633,12 @@ mod tests {
         let schema = bootstrapped_schema_with_person_name();
         let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
 
-        // Cannot redefine existing schema entity
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(name_id));
-        doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
-        doc.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(kw!(:db.type/long)),
-        );
-        doc.insert(
-            "db/cardinality".to_string(),
-            DataType::Keyword(kw!(:db.cardinality/one)),
-        );
-        let err = schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .unwrap_err();
+        let ops = [TxOp::put_with_id(name_id, vec![
+            (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
+            (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/long)))),
+            (kw!(:db/cardinality), TxValue::Data(DataType::Keyword(kw!(:db.cardinality/one)))),
+        ])];
+        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
     }
 
@@ -706,48 +655,37 @@ mod tests {
     // TODO(#165): replace with from_entity_id test once db/valueType switches to ref
     #[test]
     fn test_value_type_from_keyword_ref() {
-        assert_eq!(
-            ValueType::from_keyword(&kw!(:db.type/ref)).unwrap(),
-            ValueType::Ref
-        );
+        assert_eq!(ValueType::from_keyword(&kw!(:db.type/ref)).unwrap(), ValueType::Ref);
     }
 
     #[test]
     fn test_schema_ref_attribute_validation() {
         let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:follows), "ref")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
         schema.apply_schema_update(update);
 
         let (_eid, attr) = schema.get_attribute(&kw!(:follows)).unwrap();
         assert_eq!(attr.value_type, ValueType::Ref);
 
         // Long value accepted for ref-typed attribute
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(200));
-        doc.insert("follows".to_string(), DataType::Long(201));
-        assert!(schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .is_ok());
+        let ops = [TxOp::put_with_id(200_i64, vec![
+            (kw!(:follows), 201_i64.into()),
+        ])];
+        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_ok());
 
         // String value rejected for ref-typed attribute
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(300));
-        doc.insert("follows".to_string(), DataType::String("not-a-ref".into()));
-        assert!(schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .is_err());
+        let ops = [TxOp::put_with_id(300_i64, vec![
+            (kw!(:follows), "not-a-ref".into()),
+        ])];
+        assert!(schema.validate_and_prepare(&to_datoms(&ops, &schema)).is_err());
     }
 
     #[test]
     fn test_validate_and_prepare_parses_cardinality_many() {
         let schema = bootstrapped_schema();
-        let ops = [schema_attribute_with_cardinality(
-            kw!(:tags),
-            "string",
-            "many",
-        )];
-        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        let ops = [schema_attribute_with_cardinality(kw!(:tags), "string", "many")];
+        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
         assert_eq!(update.attributes.len(), 1);
         assert!(update.attributes[0].1.multival);
     }
@@ -756,7 +694,7 @@ mod tests {
     fn test_validate_and_prepare_parses_cardinality_one() {
         let schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:name), "string")];
-        let update = schema.validate_and_prepare(&to_datoms(&ops)).unwrap();
+        let update = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap();
         assert_eq!(update.attributes.len(), 1);
         assert!(!update.attributes[0].1.multival);
     }
@@ -764,17 +702,12 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_missing_cardinality_errors() {
         let schema = bootstrapped_schema();
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(100));
-        doc.insert("db/ident".to_string(), DataType::Keyword(kw!(:name)));
-        doc.insert(
-            "db/valueType".to_string(),
-            DataType::Keyword(kw!(:db.type/string)),
-        );
-        // No db/cardinality
-        let err = schema
-            .validate_and_prepare(&to_datoms(&[TxOp::Put(doc)]))
-            .unwrap_err();
+        let ops = [TxOp::put_with_id(100_i64, vec![
+            (kw!(:db/ident), TxValue::Data(DataType::Keyword(kw!(:name)))),
+            (kw!(:db/valueType), TxValue::Data(DataType::Keyword(kw!(:db.type/string)))),
+            // No db/cardinality
+        ])];
+        let err = schema.validate_and_prepare(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("db/cardinality is required"));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -531,7 +531,7 @@ mod tests {
     fn to_datoms(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
         let mut pm = PartitionMap::new();
         let expanded = tx::expand_tx_ops(ops, schema).unwrap();
-        tx::resolve_tempids(&expanded, &mut pm, schema).unwrap()
+        tx::resolve_tempids(&expanded, &mut pm).unwrap()
     }
 
     fn bootstrapped_schema() -> Schema {
@@ -539,7 +539,7 @@ mod tests {
         let tx_ops = bootstrap_schema_tx();
         let expanded = tx::expand_tx_ops(&tx_ops, &schema).unwrap();
         let mut pm = PartitionMap::new();
-        let datoms = tx::resolve_tempids(&expanded, &mut pm, &schema).unwrap();
+        let datoms = tx::resolve_tempids(&expanded, &mut pm).unwrap();
         let update = schema.validate_and_prepare(&datoms).unwrap();
         schema.apply_schema_update(update);
         schema

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -128,7 +128,6 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
 pub fn resolve_tempids(
     datoms: &[DatomWithTempids],
     partition_map: &mut PartitionMap,
-    _schema: &Schema,
 ) -> Result<Vec<Datom>> {
     // Pre-scan: determine partition for each tempid
     let mut tempid_partitions: HashMap<&str, u32> = HashMap::new();
@@ -363,7 +362,7 @@ mod tests {
                 op: DatomOp::Assert,
             },
         ];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         assert_eq!(resolved[0].entity, resolved[1].entity);
     }
 
@@ -384,7 +383,7 @@ mod tests {
                 op: DatomOp::Assert,
             },
         ];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         assert_ne!(resolved[0].entity, resolved[1].entity);
     }
 
@@ -405,7 +404,7 @@ mod tests {
                 op: DatomOp::Assert,
             },
         ];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         let alice_eid = resolved[0].entity;
         assert_eq!(resolved[1].value, DataType::Long(alice_eid));
     }
@@ -419,7 +418,7 @@ mod tests {
             value: ValueWithTempIds::Data(DataType::Keyword(kw!(:my/attr))),
             op: DatomOp::Assert,
         }];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         assert_eq!(extract_partition(resolved[0].entity), DB_PARTITION);
     }
 
@@ -432,7 +431,7 @@ mod tests {
             value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
             op: DatomOp::Assert,
         }];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         assert_eq!(extract_partition(resolved[0].entity), USER_PARTITION);
     }
 
@@ -445,7 +444,7 @@ mod tests {
             value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
             op: DatomOp::Assert,
         }];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         assert_eq!(resolved[0].entity, 42);
         assert!(pm.is_empty(), "no allocation for explicit IDs");
     }
@@ -467,7 +466,7 @@ mod tests {
                 op: DatomOp::Assert,
             },
         ];
-        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let resolved = resolve_tempids(&datoms, &mut pm).unwrap();
         let mut counters: Vec<i64> = resolved.iter().map(|d| extract_counter(d.entity)).collect();
         counters.sort();
         assert_eq!(counters, vec![5, 6]);

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -97,17 +97,17 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     });
                 }
             }
-            TxOp::Add { entity, attribute, value } => {
+            TxOp::Add { entity_id, attribute, value } => {
                 datoms.push(DatomWithTempids {
-                    entity: resolve_entity_ref(entity, schema)?,
+                    entity: resolve_entity_ref(entity_id, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_tx_value(value, schema)?,
                     op: DatomOp::Assert,
                 });
             }
-            TxOp::Retract { entity, attribute, value } => {
+            TxOp::Retract { entity_id, attribute, value } => {
                 datoms.push(DatomWithTempids {
-                    entity: resolve_entity_ref(entity, schema)?,
+                    entity: resolve_entity_ref(entity_id, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_tx_value(value, schema)?,
                     op: DatomOp::Retract,
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn test_expand_add() {
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(200),
+            entity_id: EntityRef::Id(200),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::String("bob".to_string())),
         }];
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_expand_retract() {
         let ops = vec![TxOp::Retract {
-            entity: EntityRef::Id(200),
+            entity_id: EntityRef::Id(200),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::String("bob".to_string())),
         }];
@@ -263,7 +263,7 @@ mod tests {
     fn test_expand_ident_resolution() {
         let schema = schema_with_ident(kw!(:person/name), 42);
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Ident(kw!(:person/name)),
+            entity_id: EntityRef::Ident(kw!(:person/name)),
             attribute: kw!(:some/attr),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn test_expand_unknown_ident_errors() {
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Ident(kw!(:unknown/ident)),
+            entity_id: EntityRef::Ident(kw!(:unknown/ident)),
             attribute: kw!(:some/attr),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn test_expand_lookup_ref_errors() {
         let ops = vec![TxOp::Add {
-            entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
+            entity_id: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_tempid() {
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
+            entity_id: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::TempId("friend".to_string())),
         }];
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_id() {
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
+            entity_id: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::Id(200)),
         }];
@@ -321,7 +321,7 @@ mod tests {
     fn test_expand_value_ref_ident() {
         let schema = schema_with_ident(kw!(:person/bob), 99);
         let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
+            entity_id: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::Ident(kw!(:person/bob))),
         }];

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,0 +1,474 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use edn::kw;
+use edn::symbols::Keyword;
+
+use crate::metadata::PartitionMap;
+use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp, TxValue};
+use crate::partition::{DB_PARTITION, USER_PARTITION};
+use crate::schema::Schema;
+
+/// Entity reference after ident resolution: either a concrete ID or an unresolved tempid.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum IdOrTempId {
+    Id(i64),
+    TempId(String),
+}
+
+/// Value after ident resolution: either concrete data or a tempid reference.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueWithTempIds {
+    Data(DataType),
+    TempRef(String),
+}
+
+/// A datom-shaped tuple after TxOp expansion and ident resolution, but before tempid allocation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DatomWithTempids {
+    pub entity: IdOrTempId,
+    pub attribute: Keyword,
+    pub value: ValueWithTempIds,
+    pub op: DatomOp,
+}
+
+/// Resolve an EntityRef to IdOrTempId, resolving idents via schema.
+fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<IdOrTempId> {
+    match eref {
+        EntityRef::Id(id) => Ok(IdOrTempId::Id(*id)),
+        EntityRef::TempId(s) => Ok(IdOrTempId::TempId(s.clone())),
+        EntityRef::Ident(kw) => {
+            let eid = schema.ident_map.get(kw)
+                .ok_or_else(|| anyhow::anyhow!("Unknown ident: {}", kw))?;
+            Ok(IdOrTempId::Id(*eid))
+        }
+        EntityRef::LookupRef(_, _) => Err(anyhow::anyhow!("Lookup refs not yet supported")),
+    }
+}
+
+/// Resolve a TxValue to ValueWithTempIds, resolving idents via schema.
+fn resolve_tx_value(val: &TxValue, schema: &Schema) -> Result<ValueWithTempIds> {
+    match val {
+        TxValue::Data(d) => Ok(ValueWithTempIds::Data(d.clone())),
+        TxValue::Ref(EntityRef::Id(id)) => Ok(ValueWithTempIds::Data(DataType::Long(*id))),
+        TxValue::Ref(EntityRef::TempId(s)) => Ok(ValueWithTempIds::TempRef(s.clone())),
+        TxValue::Ref(EntityRef::Ident(kw)) => {
+            let eid = schema.ident_map.get(kw)
+                .ok_or_else(|| anyhow::anyhow!("Unknown ident in value position: {}", kw))?;
+            Ok(ValueWithTempIds::Data(DataType::Long(*eid)))
+        }
+        TxValue::Ref(EntityRef::LookupRef(_, _)) => {
+            Err(anyhow::anyhow!("Lookup refs not yet supported"))
+        }
+    }
+}
+
+/// Expand TxOps into DatomWithTempids, resolving idents via schema.
+///
+/// - `Put(map)` → N DatomWithTempids (one per non-`:db/id` attr). The `:db/id` key
+///   must map to `TxValue::Ref(EntityRef)`. If absent, generates an internal tempid.
+/// - `Add/Retract` → 1 DatomWithTempids
+/// - `Delete/Erase` → panics (not yet implemented)
+pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempids>> {
+    let db_id_kw = Keyword::namespaced("db", "id");
+    let mut datoms = Vec::new();
+    let mut auto_counter: u64 = 0;
+
+    for op in ops {
+        match op {
+            TxOp::Put(map) => {
+                let entity = match map.get(&db_id_kw) {
+                    Some(TxValue::Ref(eref)) => resolve_entity_ref(eref, schema)?,
+                    Some(other) => return Err(anyhow::anyhow!(
+                        "Put :db/id must be TxValue::Ref(EntityRef), got {:?}", other
+                    )),
+                    None => {
+                        let tempid = format!("__auto_{}", auto_counter);
+                        auto_counter += 1;
+                        IdOrTempId::TempId(tempid)
+                    }
+                };
+                for (attr, value) in map.iter().filter(|(k, _)| *k != &db_id_kw) {
+                    datoms.push(DatomWithTempids {
+                        entity: entity.clone(),
+                        attribute: attr.clone(),
+                        value: resolve_tx_value(value, schema)?,
+                        op: DatomOp::Assert,
+                    });
+                }
+            }
+            TxOp::Add { entity, attribute, value } => {
+                datoms.push(DatomWithTempids {
+                    entity: resolve_entity_ref(entity, schema)?,
+                    attribute: attribute.clone(),
+                    value: resolve_tx_value(value, schema)?,
+                    op: DatomOp::Assert,
+                });
+            }
+            TxOp::Retract { entity, attribute, value } => {
+                datoms.push(DatomWithTempids {
+                    entity: resolve_entity_ref(entity, schema)?,
+                    attribute: attribute.clone(),
+                    value: resolve_tx_value(value, schema)?,
+                    op: DatomOp::Retract,
+                });
+            }
+            TxOp::Delete(_) | TxOp::Erase(_) => {
+                panic!("Delete/Erase not yet implemented");
+            }
+        }
+    }
+    Ok(datoms)
+}
+
+/// Resolve tempids in DatomWithTempids to produce final Datoms.
+///
+/// Tempids with a `:db/ident` datom are allocated from DB_PARTITION;
+/// all others from USER_PARTITION.
+pub fn resolve_tempids(
+    datoms: &[DatomWithTempids],
+    partition_map: &mut PartitionMap,
+    _schema: &Schema,
+) -> Result<Vec<Datom>> {
+    // Pre-scan: determine partition for each tempid
+    let mut tempid_partitions: HashMap<&str, u32> = HashMap::new();
+    for d in datoms {
+        if let IdOrTempId::TempId(ref s) = d.entity {
+            if d.attribute == kw!(:db/ident) {
+                tempid_partitions.insert(s, DB_PARTITION);
+            } else {
+                tempid_partitions.entry(s).or_insert(USER_PARTITION);
+            }
+        }
+    }
+    // Also check tempids that only appear in value position
+    for d in datoms {
+        if let ValueWithTempIds::TempRef(ref s) = d.value {
+            tempid_partitions.entry(s).or_insert(USER_PARTITION);
+        }
+    }
+
+    // Allocate entids
+    let mut tempid_map: HashMap<&str, i64> = HashMap::new();
+    for (tempid, partition) in &tempid_partitions {
+        let eid = partition_map.allocate_entid(*partition);
+        tempid_map.insert(tempid, eid);
+    }
+
+    // Resolve
+    let mut resolved = Vec::with_capacity(datoms.len());
+    for d in datoms {
+        let entity = match &d.entity {
+            IdOrTempId::Id(id) => *id,
+            IdOrTempId::TempId(s) => *tempid_map.get(s.as_str()).unwrap(),
+        };
+        let value = match &d.value {
+            ValueWithTempIds::Data(data) => data.clone(),
+            ValueWithTempIds::TempRef(s) => DataType::Long(*tempid_map.get(s.as_str()).unwrap()),
+        };
+        resolved.push(Datom {
+            entity,
+            attribute: d.attribute.clone(),
+            value,
+            op: d.op,
+        });
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edn::kw;
+
+    fn empty_schema() -> Schema {
+        Schema::default()
+    }
+
+    fn schema_with_ident(kw: Keyword, eid: i64) -> Schema {
+        let mut schema = Schema::default();
+        schema.ident_map.insert(kw.clone(), eid);
+        schema.entid_map.insert(eid, kw);
+        schema
+    }
+
+    // --- expand_tx_ops tests ---
+
+    #[test]
+    fn test_expand_put_with_id() {
+        let ops = vec![TxOp::put_with_id(100_i64, vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms.len(), 2);
+        assert!(datoms.iter().all(|d| d.entity == IdOrTempId::Id(100)));
+        assert!(datoms.iter().all(|d| d.op == DatomOp::Assert));
+    }
+
+    #[test]
+    fn test_expand_put_without_id() {
+        let ops = vec![
+            TxOp::put(vec![(kw!(:name), "alice".into())]),
+            TxOp::put(vec![(kw!(:name), "bob".into())]),
+        ];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms.len(), 2);
+        // Different auto-tempids
+        assert_ne!(datoms[0].entity, datoms[1].entity);
+        assert!(matches!(datoms[0].entity, IdOrTempId::TempId(_)));
+        assert!(matches!(datoms[1].entity, IdOrTempId::TempId(_)));
+    }
+
+    #[test]
+    fn test_expand_put_attrs_share_entity() {
+        let ops = vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms.len(), 2);
+        assert_eq!(datoms[0].entity, datoms[1].entity);
+    }
+
+    #[test]
+    fn test_expand_add() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(200),
+            attribute: kw!(:name),
+            value: TxValue::Data(DataType::String("bob".to_string())),
+        }];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms.len(), 1);
+        assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
+        assert_eq!(datoms[0].attribute, kw!(:name));
+        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::String("bob".to_string())));
+        assert_eq!(datoms[0].op, DatomOp::Assert);
+    }
+
+    #[test]
+    fn test_expand_retract() {
+        let ops = vec![TxOp::Retract {
+            entity: EntityRef::Id(200),
+            attribute: kw!(:name),
+            value: TxValue::Data(DataType::String("bob".to_string())),
+        }];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms.len(), 1);
+        assert_eq!(datoms[0].op, DatomOp::Retract);
+    }
+
+    #[test]
+    fn test_expand_ident_resolution() {
+        let schema = schema_with_ident(kw!(:person/name), 42);
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Ident(kw!(:person/name)),
+            attribute: kw!(:some/attr),
+            value: TxValue::Data(DataType::Long(1)),
+        }];
+        let datoms = expand_tx_ops(&ops, &schema).unwrap();
+        assert_eq!(datoms[0].entity, IdOrTempId::Id(42));
+    }
+
+    #[test]
+    fn test_expand_unknown_ident_errors() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Ident(kw!(:unknown/ident)),
+            attribute: kw!(:some/attr),
+            value: TxValue::Data(DataType::Long(1)),
+        }];
+        let result = expand_tx_ops(&ops, &empty_schema());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown ident"));
+    }
+
+    #[test]
+    fn test_expand_lookup_ref_errors() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
+            attribute: kw!(:name),
+            value: TxValue::Data(DataType::Long(1)),
+        }];
+        let result = expand_tx_ops(&ops, &empty_schema());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Lookup refs"));
+    }
+
+    #[test]
+    fn test_expand_value_ref_tempid() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: TxValue::Ref(EntityRef::TempId("friend".to_string())),
+        }];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms[0].value, ValueWithTempIds::TempRef("friend".to_string()));
+    }
+
+    #[test]
+    fn test_expand_value_ref_id() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: TxValue::Ref(EntityRef::Id(200)),
+        }];
+        let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
+        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(200)));
+    }
+
+    #[test]
+    fn test_expand_value_ref_ident() {
+        let schema = schema_with_ident(kw!(:person/bob), 99);
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: TxValue::Ref(EntityRef::Ident(kw!(:person/bob))),
+        }];
+        let datoms = expand_tx_ops(&ops, &schema).unwrap();
+        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(99)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Delete/Erase not yet implemented")]
+    fn test_expand_delete_panics() {
+        expand_tx_ops(&[TxOp::Delete(EntityRef::Id(100))], &empty_schema()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Delete/Erase not yet implemented")]
+    fn test_expand_erase_panics() {
+        expand_tx_ops(&[TxOp::Erase(EntityRef::Id(200))], &empty_schema()).unwrap();
+    }
+
+    // --- resolve_tempids tests ---
+
+    use crate::partition::{extract_partition, extract_counter};
+
+    #[test]
+    fn test_resolve_same_tempid_same_entid() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t1".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t1".to_string()),
+                attribute: kw!(:age),
+                value: ValueWithTempIds::Data(DataType::Long(30)),
+                op: DatomOp::Assert,
+            },
+        ];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        assert_eq!(resolved[0].entity, resolved[1].entity);
+    }
+
+    #[test]
+    fn test_resolve_different_tempids_different_entids() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t1".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t2".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("bob".to_string())),
+                op: DatomOp::Assert,
+            },
+        ];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        assert_ne!(resolved[0].entity, resolved[1].entity);
+    }
+
+    #[test]
+    fn test_resolve_tempref_in_value() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("alice".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::Id(999),
+                attribute: kw!(:follows),
+                value: ValueWithTempIds::TempRef("alice".to_string()),
+                op: DatomOp::Assert,
+            },
+        ];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let alice_eid = resolved[0].entity;
+        assert_eq!(resolved[1].value, DataType::Long(alice_eid));
+    }
+
+    #[test]
+    fn test_resolve_db_ident_goes_to_db_partition() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![DatomWithTempids {
+            entity: IdOrTempId::TempId("schema-attr".to_string()),
+            attribute: kw!(:db/ident),
+            value: ValueWithTempIds::Data(DataType::Keyword(kw!(:my/attr))),
+            op: DatomOp::Assert,
+        }];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        assert_eq!(extract_partition(resolved[0].entity), DB_PARTITION);
+    }
+
+    #[test]
+    fn test_resolve_regular_tempid_goes_to_user_partition() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![DatomWithTempids {
+            entity: IdOrTempId::TempId("user-entity".to_string()),
+            attribute: kw!(:name),
+            value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
+            op: DatomOp::Assert,
+        }];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        assert_eq!(extract_partition(resolved[0].entity), USER_PARTITION);
+    }
+
+    #[test]
+    fn test_resolve_id_passthrough() {
+        let mut pm = PartitionMap::new();
+        let datoms = vec![DatomWithTempids {
+            entity: IdOrTempId::Id(42),
+            attribute: kw!(:name),
+            value: ValueWithTempIds::Data(DataType::String("alice".to_string())),
+            op: DatomOp::Assert,
+        }];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        assert_eq!(resolved[0].entity, 42);
+        assert!(pm.is_empty(), "no allocation for explicit IDs");
+    }
+
+    #[test]
+    fn test_resolve_counter_advances() {
+        let mut pm = PartitionMap::from([(USER_PARTITION, 5_i64)]);
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("a".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("a".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("b".to_string()),
+                attribute: kw!(:name),
+                value: ValueWithTempIds::Data(DataType::String("b".to_string())),
+                op: DatomOp::Assert,
+            },
+        ];
+        let resolved = resolve_tempids(&datoms, &mut pm, &empty_schema()).unwrap();
+        let mut counters: Vec<i64> = resolved.iter().map(|d| extract_counter(d.entity)).collect();
+        counters.sort();
+        assert_eq!(counters, vec![5, 6]);
+        assert_eq!(pm[&USER_PARTITION], 7);
+    }
+}

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -196,7 +196,8 @@ mod tests {
 
     #[test]
     fn test_expand_put_with_id() {
-        let ops = vec![TxOp::put_with_id(100_i64, vec![
+        let ops = vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])];

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -38,7 +38,9 @@ fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<IdOrTempId> {
         EntityRef::Id(id) => Ok(IdOrTempId::Id(*id)),
         EntityRef::TempId(s) => Ok(IdOrTempId::TempId(s.clone())),
         EntityRef::Ident(kw) => {
-            let eid = schema.ident_map.get(kw)
+            let eid = schema
+                .ident_map
+                .get(kw)
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident: {}", kw))?;
             Ok(IdOrTempId::Id(*eid))
         }
@@ -53,7 +55,9 @@ fn resolve_tx_value(val: &TxValue, schema: &Schema) -> Result<ValueWithTempIds> 
         TxValue::Ref(EntityRef::Id(id)) => Ok(ValueWithTempIds::Data(DataType::Long(*id))),
         TxValue::Ref(EntityRef::TempId(s)) => Ok(ValueWithTempIds::TempRef(s.clone())),
         TxValue::Ref(EntityRef::Ident(kw)) => {
-            let eid = schema.ident_map.get(kw)
+            let eid = schema
+                .ident_map
+                .get(kw)
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident in value position: {}", kw))?;
             Ok(ValueWithTempIds::Data(DataType::Long(*eid)))
         }
@@ -79,9 +83,12 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
             TxOp::Put(map) => {
                 let entity = match map.get(&db_id_kw) {
                     Some(TxValue::Ref(eref)) => resolve_entity_ref(eref, schema)?,
-                    Some(other) => return Err(anyhow::anyhow!(
-                        "Put :db/id must be TxValue::Ref(EntityRef), got {:?}", other
-                    )),
+                    Some(other) => {
+                        return Err(anyhow::anyhow!(
+                            "Put :db/id must be TxValue::Ref(EntityRef), got {:?}",
+                            other
+                        ))
+                    }
                     None => {
                         let tempid = format!("__auto_{}", auto_counter);
                         auto_counter += 1;
@@ -97,7 +104,11 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     });
                 }
             }
-            TxOp::Add { entity, attribute, value } => {
+            TxOp::Add {
+                entity,
+                attribute,
+                value,
+            } => {
                 datoms.push(DatomWithTempids {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
@@ -105,7 +116,11 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     op: DatomOp::Assert,
                 });
             }
-            TxOp::Retract { entity, attribute, value } => {
+            TxOp::Retract {
+                entity,
+                attribute,
+                value,
+            } => {
                 datoms.push(DatomWithTempids {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
@@ -245,7 +260,10 @@ mod tests {
         assert_eq!(datoms.len(), 1);
         assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
         assert_eq!(datoms[0].attribute, kw!(:name));
-        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::String("bob".to_string())));
+        assert_eq!(
+            datoms[0].value,
+            ValueWithTempIds::Data(DataType::String("bob".to_string()))
+        );
         assert_eq!(datoms[0].op, DatomOp::Assert);
     }
 
@@ -305,7 +323,10 @@ mod tests {
             value: TxValue::Ref(EntityRef::TempId("friend".to_string())),
         }];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
-        assert_eq!(datoms[0].value, ValueWithTempIds::TempRef("friend".to_string()));
+        assert_eq!(
+            datoms[0].value,
+            ValueWithTempIds::TempRef("friend".to_string())
+        );
     }
 
     #[test]
@@ -345,7 +366,7 @@ mod tests {
 
     // --- resolve_tempids tests ---
 
-    use crate::partition::{extract_partition, extract_counter};
+    use crate::partition::{extract_counter, extract_partition};
 
     #[test]
     fn test_resolve_same_tempid_same_entid() {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -97,17 +97,17 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     });
                 }
             }
-            TxOp::Add { entity_id, attribute, value } => {
+            TxOp::Add { entity, attribute, value } => {
                 datoms.push(DatomWithTempids {
-                    entity: resolve_entity_ref(entity_id, schema)?,
+                    entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_tx_value(value, schema)?,
                     op: DatomOp::Assert,
                 });
             }
-            TxOp::Retract { entity_id, attribute, value } => {
+            TxOp::Retract { entity, attribute, value } => {
                 datoms.push(DatomWithTempids {
-                    entity: resolve_entity_ref(entity_id, schema)?,
+                    entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_tx_value(value, schema)?,
                     op: DatomOp::Retract,
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn test_expand_add() {
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Id(200),
+            entity: EntityRef::Id(200),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::String("bob".to_string())),
         }];
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_expand_retract() {
         let ops = vec![TxOp::Retract {
-            entity_id: EntityRef::Id(200),
+            entity: EntityRef::Id(200),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::String("bob".to_string())),
         }];
@@ -263,7 +263,7 @@ mod tests {
     fn test_expand_ident_resolution() {
         let schema = schema_with_ident(kw!(:person/name), 42);
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Ident(kw!(:person/name)),
+            entity: EntityRef::Ident(kw!(:person/name)),
             attribute: kw!(:some/attr),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn test_expand_unknown_ident_errors() {
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Ident(kw!(:unknown/ident)),
+            entity: EntityRef::Ident(kw!(:unknown/ident)),
             attribute: kw!(:some/attr),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn test_expand_lookup_ref_errors() {
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
+            entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
             attribute: kw!(:name),
             value: TxValue::Data(DataType::Long(1)),
         }];
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_tempid() {
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Id(100),
+            entity: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::TempId("friend".to_string())),
         }];
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_id() {
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Id(100),
+            entity: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::Id(200)),
         }];
@@ -321,7 +321,7 @@ mod tests {
     fn test_expand_value_ref_ident() {
         let schema = schema_with_ident(kw!(:person/bob), 99);
         let ops = vec![TxOp::Add {
-            entity_id: EntityRef::Id(100),
+            entity: EntityRef::Id(100),
             attribute: kw!(:follows),
             value: TxValue::Ref(EntityRef::Ident(kw!(:person/bob))),
         }];

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -65,10 +65,10 @@ fn resolve_tx_value(val: &TxValue, schema: &Schema) -> Result<ValueWithTempIds> 
 
 /// Expand TxOps into DatomWithTempids, resolving idents via schema.
 ///
-/// - `Put(map)` → N DatomWithTempids (one per non-`:db/id` attr). The `:db/id` key
+/// - `Put(map)` -> N DatomWithTempids (one per non-`:db/id` attr). The `:db/id` key
 ///   must map to `TxValue::Ref(EntityRef)`. If absent, generates an internal tempid.
-/// - `Add/Retract` → 1 DatomWithTempids
-/// - `Delete/Erase` → panics (not yet implemented)
+/// - `Add/Retract` -> 1 DatomWithTempids
+/// - `Delete/Erase` -> panics (not yet implemented)
 pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempids>> {
     let db_id_kw = Keyword::namespaced("db", "id");
     let mut datoms = Vec::new();
@@ -134,8 +134,10 @@ pub fn resolve_tempids(
     for d in datoms {
         if let IdOrTempId::TempId(ref s) = d.entity {
             if d.attribute == kw!(:db/ident) {
+                // insert() overrides so :db/ident always wins regardless of ordering
                 tempid_partitions.insert(s, DB_PARTITION);
             } else {
+                // or_insert() preserves existing, so a prior :db/ident won't be overwritten
                 tempid_partitions.entry(s).or_insert(USER_PARTITION);
             }
         }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -163,6 +163,7 @@ pub fn resolve_tempids(
             IdOrTempId::TempId(s) => *tempid_map.get(s.as_str()).unwrap(),
         };
         let value = match &d.value {
+            // TODO: get rid of the clone()
             ValueWithTempIds::Data(data) => data.clone(),
             ValueWithTempIds::TempRef(s) => DataType::Long(*tempid_map.get(s.as_str()).unwrap()),
         };

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -1,14 +1,13 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-use edn::kw;
-use edn::symbols::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, TxOp};
+use edn::kw;
+use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
 use triplox::TransactionResult;
@@ -52,10 +51,10 @@ async fn test_execute_tx_and_query() {
     define_base_schema(&client).await;
 
     // Insert a document
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result = client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    let result = client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
 
     // Open a DB and query
@@ -66,10 +65,7 @@ async fn test_execute_tx_and_query() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(
-        result[0],
-        vec![DataType::Long(100), DataType::String("alice".to_string())]
-    );
+    assert_eq!(result[0], vec![DataType::Long(100), DataType::String("alice".to_string())]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -82,10 +78,10 @@ async fn test_submit_tx() {
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
 
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("bob".to_string()));
-    let tx_key = client.submit_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    let tx_key = client
+        .submit_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "bob".into())])])
+        .await
+        .unwrap();
     assert!(tx_key.tx_id >= 0);
 
     client.close().await.unwrap();
@@ -99,15 +95,15 @@ async fn test_multiple_transactions_and_query() {
     define_base_schema(&client).await;
 
     // Insert two documents in separate transactions
-    let mut doc1 = BTreeMap::new();
-    doc1.insert("db/id".to_string(), DataType::Long(100));
-    doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-    client.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
 
-    let mut doc2 = BTreeMap::new();
-    doc2.insert("db/id".to_string(), DataType::Long(200));
-    doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-    client.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(200_i64, vec![(kw!(:name), "bob".into())])])
+        .await
+        .unwrap();
 
     let db = client.db().await.unwrap();
     let result = db
@@ -116,14 +112,8 @@ async fn test_multiple_transactions_and_query() {
         .unwrap();
 
     assert_eq!(result.len(), 2);
-    assert!(result.contains(&vec![
-        DataType::Long(100),
-        DataType::String("alice".to_string())
-    ]));
-    assert!(result.contains(&vec![
-        DataType::Long(200),
-        DataType::String("bob".to_string())
-    ]));
+    assert!(result.contains(&vec![DataType::Long(100), DataType::String("alice".to_string())]));
+    assert!(result.contains(&vec![DataType::Long(200), DataType::String("bob".to_string())]));
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -137,24 +127,18 @@ async fn test_open_close_multiple_dbs() {
     define_base_schema(&client).await;
 
     // Insert data
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
 
     // Open two DB handles
     let db1 = client.db().await.unwrap();
     let db2 = client.db().await.unwrap();
 
     // Both should return same data
-    let r1 = db1
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
-        .await
-        .unwrap();
-    let r2 = db2
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
-        .await
-        .unwrap();
+    let r1 = db1.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
+    let r2 = db2.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
     assert_eq!(r1.len(), 1);
     assert_eq!(r2.len(), 1);
 
@@ -171,18 +155,15 @@ async fn test_two_connections() {
     // Connection 1 inserts data
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client1.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    client1
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
 
     // Connection 2 can see the data
     let client2 = ClientNode::connect(&addr).await.unwrap();
     let db = client2.db().await.unwrap();
-    let result = db
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
-        .await
-        .unwrap();
+    let result = db.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
     assert_eq!(result.len(), 1);
 
     db.close().await.unwrap();
@@ -197,10 +178,10 @@ async fn test_execute_tx_returns_tx_key() {
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
 
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result = client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    let result = client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
 
     match result {
         TransactionResult::TxCommited(tx_key) => {
@@ -220,20 +201,20 @@ async fn test_db_as_of() {
     define_base_schema(&client).await;
 
     // First transaction
-    let mut doc1 = BTreeMap::new();
-    doc1.insert("db/id".to_string(), DataType::Long(100));
-    doc1.insert("name".to_string(), DataType::String("alice".to_string()));
-    let result1 = client.execute_tx(vec![TxOp::Put(doc1)]).await.unwrap();
+    let result1 = client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
     let tx_key1 = match result1 {
         TransactionResult::TxCommited(tk) => tk,
         _ => panic!("Expected TxCommited"),
     };
 
     // Second transaction
-    let mut doc2 = BTreeMap::new();
-    doc2.insert("db/id".to_string(), DataType::Long(200));
-    doc2.insert("name".to_string(), DataType::String("bob".to_string()));
-    client.execute_tx(vec![TxOp::Put(doc2)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(200_i64, vec![(kw!(:name), "bob".into())])])
+        .await
+        .unwrap();
 
     // Open DB pinned to tx_key after first tx — should only see alice
     let db = client.db_as_of(tx_key1).await.unwrap();
@@ -243,10 +224,7 @@ async fn test_db_as_of() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(
-        result[0],
-        vec![DataType::Long(100), DataType::String("alice".to_string())]
-    );
+    assert_eq!(result[0], vec![DataType::Long(100), DataType::String("alice".to_string())]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -280,10 +258,10 @@ async fn test_dev_server_connections_are_isolated() {
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
 
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("alice".to_string()));
-    client1.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    client1
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .await
+        .unwrap();
 
     let db1 = client1.db().await.unwrap();
     let result1 = db1
@@ -311,21 +289,14 @@ async fn test_dev_server_connections_are_isolated() {
 }
 
 async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &str) {
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(id));
-    doc.insert(
-        "db/ident".to_string(),
-        DataType::Keyword(Keyword::plain(name)),
-    );
-    doc.insert(
-        "db/valueType".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.type", vtype)),
-    );
-    doc.insert(
-        "db/cardinality".to_string(),
-        DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
-    );
-    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(id, vec![
+            (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
+            (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", vtype)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into()),
+        ])])
+        .await
+        .unwrap();
 }
 
 async fn define_people_schema(client: &ClientNode) {
@@ -349,17 +320,15 @@ async fn test_query_keyword_value_comparison_via_wire() {
     define_people_schema(&client).await;
 
     // Insert 4 people with keyword sex values
-    for (id, name, sex) in [
-        (100, "Ivan", "male"),
-        (101, "Petr", "male"),
-        (102, "Doris", "female"),
-        (103, "Jane", "female"),
-    ] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("name".to_string(), DataType::String(name.to_string()));
-        doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    for (id, name, sex) in [(100, "Ivan", "male"), (101, "Petr", "male"),
+                             (102, "Doris", "female"), (103, "Jane", "female")] {
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:name), name.into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -370,12 +339,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
         .await
         .unwrap();
 
-    assert_eq!(
-        result.len(),
-        2,
-        "expected only Ivan and Petr, got {:?}",
-        result
-    );
+    assert_eq!(result.len(), 2, "expected only Ivan and Petr, got {:?}", result);
     assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
     assert!(result.contains(&vec![DataType::String("Petr".to_string())]));
 
@@ -401,13 +365,15 @@ async fn test_aggregates_and_or() {
         (101, "Alan", "Turing", "male", 22),
         (102, "Adam", "Smith", "male", 23),
     ] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("name".to_string(), DataType::String(name.to_string()));
-        doc.insert("last-name".to_string(), DataType::String(last.to_string()));
-        doc.insert("sex".to_string(), DataType::Keyword(Keyword::plain(sex)));
-        doc.insert("age".to_string(), DataType::Long(age));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:name), name.into()),
+                (kw!(:last-name), last.into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+                (kw!(:age), (age as i64).into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -428,18 +394,14 @@ async fn test_aggregates_and_or() {
 
     // count with top-level OR: Lovelace OR male → 3
     let result = db
-        .query_edn(
-            "{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}",
-        )
+        .query_edn("{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}")
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
 
     // Grouped: gender, count, sum
     let result = db
-        .query_edn(
-            "{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}",
-        )
+        .query_edn("{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 2, "expected 2 groups, got {:?}", result);
@@ -466,16 +428,14 @@ async fn test_aggregate_set_semantics() {
     define_base_schema(&client).await;
     define_people_schema(&client).await;
 
-    for (id, name, city) in [
-        (100, "Alice", "NYC"),
-        (101, "Bob", "NYC"),
-        (102, "Carol", "LA"),
-    ] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("name".to_string(), DataType::String(name.to_string()));
-        doc.insert("city".to_string(), DataType::String(city.to_string()));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:name), name.into()),
+                (kw!(:city), city.into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -501,10 +461,12 @@ async fn test_datascript_aggregates() {
 
     // Insert monsters with heads
     for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("heads".to_string(), DataType::Long(heads));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:heads), (heads as i64).into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -534,10 +496,12 @@ async fn test_aggregate_avg() {
     define_base_schema(&client).await;
 
     for (id, age) in [(100, 21), (101, 22), (102, 23)] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("age".to_string(), DataType::Long(age));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:age), (age as i64).into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -560,10 +524,12 @@ async fn test_aggregate_min_max_strings() {
     define_base_schema(&client).await;
 
     for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("name".to_string(), DataType::String(name.to_string()));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:name), name.into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -619,11 +585,13 @@ async fn test_order_and_limit() {
         (103, "Dave", 10),
         (104, "Eve", 50),
     ] {
-        let mut doc = BTreeMap::new();
-        doc.insert("db/id".to_string(), DataType::Long(id));
-        doc.insert("name".to_string(), DataType::String(name.to_string()));
-        doc.insert("age".to_string(), DataType::Long(age));
-        client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+        client
+            .execute_tx(vec![TxOp::put_with_id(id, vec![
+                (kw!(:name), name.into()),
+                (kw!(:age), (age as i64).into()),
+            ])])
+            .await
+            .unwrap();
     }
 
     let db = client.db().await.unwrap();
@@ -634,18 +602,9 @@ async fn test_order_and_limit() {
         .await
         .unwrap();
     assert_eq!(result.len(), 3);
-    assert_eq!(
-        result[0],
-        vec![DataType::String("Dave".to_string()), DataType::Long(10)]
-    );
-    assert_eq!(
-        result[1],
-        vec![DataType::String("Bob".to_string()), DataType::Long(20)]
-    );
-    assert_eq!(
-        result[2],
-        vec![DataType::String("Alice".to_string()), DataType::Long(30)]
-    );
+    assert_eq!(result[0], vec![DataType::String("Dave".to_string()), DataType::Long(10)]);
+    assert_eq!(result[1], vec![DataType::String("Bob".to_string()), DataType::Long(20)]);
+    assert_eq!(result[2], vec![DataType::String("Alice".to_string()), DataType::Long(30)]);
 
     // ORDER BY age descending, LIMIT 2 → oldest 2
     let result = db
@@ -653,14 +612,8 @@ async fn test_order_and_limit() {
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
-    assert_eq!(
-        result[0],
-        vec![DataType::String("Eve".to_string()), DataType::Long(50)]
-    );
-    assert_eq!(
-        result[1],
-        vec![DataType::String("Carol".to_string()), DataType::Long(40)]
-    );
+    assert_eq!(result[0], vec![DataType::String("Eve".to_string()), DataType::Long(50)]);
+    assert_eq!(result[1], vec![DataType::String("Carol".to_string()), DataType::Long(40)]);
 
     // LIMIT only (no order) — should return exactly 2 rows
     let result = db
@@ -671,20 +624,12 @@ async fn test_order_and_limit() {
 
     // ORDER BY only (no limit) — all 5 rows, sorted
     let result = db
-        .query_edn(
-            "{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}",
-        )
+        .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 5);
-    assert_eq!(
-        result[0],
-        vec![DataType::String("Dave".to_string()), DataType::Long(10)]
-    );
-    assert_eq!(
-        result[4],
-        vec![DataType::String("Eve".to_string()), DataType::Long(50)]
-    );
+    assert_eq!(result[0], vec![DataType::String("Dave".to_string()), DataType::Long(10)]);
+    assert_eq!(result[4], vec![DataType::String("Eve".to_string()), DataType::Long(50)]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -698,11 +643,13 @@ async fn test_aggregate_min_incompatible_types() {
     define_base_schema(&client).await;
 
     // Insert entity with both name (string) and age (long)
-    let mut doc = BTreeMap::new();
-    doc.insert("db/id".to_string(), DataType::Long(100));
-    doc.insert("name".to_string(), DataType::String("Alice".to_string()));
-    doc.insert("age".to_string(), DataType::Long(30));
-    client.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
+    client
+        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![
+            (kw!(:name), "Alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])])
+        .await
+        .unwrap();
 
     let db = client.db().await.unwrap();
 

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -52,7 +52,10 @@ async fn test_execute_tx_and_query() {
 
     // Insert a document
     let result = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -79,7 +82,10 @@ async fn test_submit_tx() {
     define_base_schema(&client).await;
 
     let tx_key = client
-        .submit_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "bob".into())])])
+        .submit_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "bob".into()),
+        ])])
         .await
         .unwrap();
     assert!(tx_key.tx_id >= 0);
@@ -96,12 +102,18 @@ async fn test_multiple_transactions_and_query() {
 
     // Insert two documents in separate transactions
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
 
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(200_i64.into())), (kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
+            (kw!(:name), "bob".into()),
+        ])])
         .await
         .unwrap();
 
@@ -128,7 +140,10 @@ async fn test_open_close_multiple_dbs() {
 
     // Insert data
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
 
@@ -156,7 +171,10 @@ async fn test_two_connections() {
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
     client1
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
 
@@ -179,7 +197,10 @@ async fn test_execute_tx_returns_tx_key() {
     define_base_schema(&client).await;
 
     let result = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
 
@@ -202,7 +223,10 @@ async fn test_db_as_of() {
 
     // First transaction
     let result1 = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
     let tx_key1 = match result1 {
@@ -212,7 +236,10 @@ async fn test_db_as_of() {
 
     // Second transaction
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(200_i64.into())), (kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(200_i64.into())),
+            (kw!(:name), "bob".into()),
+        ])])
         .await
         .unwrap();
 
@@ -259,7 +286,10 @@ async fn test_dev_server_connections_are_isolated() {
     define_base_schema(&client1).await;
 
     client1
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
+            (kw!(:name), "alice".into()),
+        ])])
         .await
         .unwrap();
 
@@ -290,7 +320,8 @@ async fn test_dev_server_connections_are_isolated() {
 
 async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &str) {
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(id.into())),
             (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
             (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", vtype)).into()),
             (kw!(:db/cardinality), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into()),
@@ -320,10 +351,15 @@ async fn test_query_keyword_value_comparison_via_wire() {
     define_people_schema(&client).await;
 
     // Insert 4 people with keyword sex values
-    for (id, name, sex) in [(100, "Ivan", "male"), (101, "Petr", "male"),
-                             (102, "Doris", "female"), (103, "Jane", "female")] {
+    for (id, name, sex) in [
+        (100, "Ivan", "male"),
+        (101, "Petr", "male"),
+        (102, "Doris", "female"),
+        (103, "Jane", "female"),
+    ] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
             ])])
@@ -366,7 +402,8 @@ async fn test_aggregates_and_or() {
         (102, "Adam", "Smith", "male", 23),
     ] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:last-name), last.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
@@ -378,21 +415,21 @@ async fn test_aggregates_and_or() {
 
     let db = client.db().await.unwrap();
 
-    // count with OR: Lovelace AND (name=Ada OR sex=male) → 1 (only Ada)
+    // count with OR: Lovelace AND (name=Ada OR sex=male) -> 1 (only Ada)
     let result = db
         .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :male])]}")
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
-    // count with OR: Lovelace AND (name=Ada OR sex=female) → 1
+    // count with OR: Lovelace AND (name=Ada OR sex=female) -> 1
     let result = db
         .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :female])]}")
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
-    // count with top-level OR: Lovelace OR male → 3
+    // count with top-level OR: Lovelace OR male -> 3
     let result = db
         .query_edn("{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}")
         .await
@@ -430,7 +467,8 @@ async fn test_aggregate_set_semantics() {
 
     for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:city), city.into()),
             ])])
@@ -440,7 +478,7 @@ async fn test_aggregate_set_semantics() {
 
     let db = client.db().await.unwrap();
 
-    // TODO: do we want Datomic (set → 2) or XTDB (bag → 3) semantics here?
+    // TODO: do we want Datomic (set -> 2) or XTDB (bag -> 3) semantics here?
     let result = db
         .query_edn("{:find [(count ?city)] :where [[?p :city ?city]]}")
         .await
@@ -462,7 +500,8 @@ async fn test_datascript_aggregates() {
     // Insert monsters with heads
     for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:heads), (heads as i64).into()),
             ])])
             .await
@@ -497,7 +536,8 @@ async fn test_aggregate_avg() {
 
     for (id, age) in [(100, 21), (101, 22), (102, 23)] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:age), (age as i64).into()),
             ])])
             .await
@@ -525,7 +565,8 @@ async fn test_aggregate_min_max_strings() {
 
     for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:name), name.into()),
             ])])
             .await
@@ -586,7 +627,8 @@ async fn test_order_and_limit() {
         (104, "Eve", 50),
     ] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), TxValue::Ref(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:age), (age as i64).into()),
             ])])
@@ -596,7 +638,7 @@ async fn test_order_and_limit() {
 
     let db = client.db().await.unwrap();
 
-    // ORDER BY age ascending, LIMIT 3 → youngest 3
+    // ORDER BY age ascending, LIMIT 3 -> youngest 3
     let result = db
         .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]] :limit 3}")
         .await
@@ -606,7 +648,7 @@ async fn test_order_and_limit() {
     assert_eq!(result[1], vec![DataType::String("Bob".to_string()), DataType::Long(20)]);
     assert_eq!(result[2], vec![DataType::String("Alice".to_string()), DataType::Long(30)]);
 
-    // ORDER BY age descending, LIMIT 2 → oldest 2
+    // ORDER BY age descending, LIMIT 2 -> oldest 2
     let result = db
         .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :desc]] :limit 2}")
         .await
@@ -644,7 +686,8 @@ async fn test_aggregate_min_incompatible_types() {
 
     // Insert entity with both name (string) and age (long)
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), 
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), TxValue::Ref(100_i64.into())),
             (kw!(:name), "Alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
@@ -653,7 +696,7 @@ async fn test_aggregate_min_incompatible_types() {
 
     let db = client.db().await.unwrap();
 
-    // OR binds ?v to both string and long values → min should error on incomparable types
+    // OR binds ?v to both string and long values -> min should error on incomparable types
     let result = db
         .query_edn("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
         .await;

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 
 use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
-use triplox::ops::{DataType, TxOp};
+use triplox::ops::{DataType, TxOp, TxValue};
 use edn::kw;
 use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
@@ -52,7 +52,7 @@ async fn test_execute_tx_and_query() {
 
     // Insert a document
     let result = client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -79,7 +79,7 @@ async fn test_submit_tx() {
     define_base_schema(&client).await;
 
     let tx_key = client
-        .submit_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "bob".into())])])
+        .submit_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "bob".into())])])
         .await
         .unwrap();
     assert!(tx_key.tx_id >= 0);
@@ -96,12 +96,12 @@ async fn test_multiple_transactions_and_query() {
 
     // Insert two documents in separate transactions
     client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
     client
-        .execute_tx(vec![TxOp::put_with_id(200_i64, vec![(kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(200_i64.into())), (kw!(:name), "bob".into())])])
         .await
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_open_close_multiple_dbs() {
 
     // Insert data
     client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -156,7 +156,7 @@ async fn test_two_connections() {
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
     client1
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -179,7 +179,7 @@ async fn test_execute_tx_returns_tx_key() {
     define_base_schema(&client).await;
 
     let result = client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -202,7 +202,7 @@ async fn test_db_as_of() {
 
     // First transaction
     let result1 = client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
     let tx_key1 = match result1 {
@@ -212,7 +212,7 @@ async fn test_db_as_of() {
 
     // Second transaction
     client
-        .execute_tx(vec![TxOp::put_with_id(200_i64, vec![(kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(200_i64.into())), (kw!(:name), "bob".into())])])
         .await
         .unwrap();
 
@@ -259,7 +259,7 @@ async fn test_dev_server_connections_are_isolated() {
     define_base_schema(&client1).await;
 
     client1
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), (kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -290,7 +290,7 @@ async fn test_dev_server_connections_are_isolated() {
 
 async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &str) {
     client
-        .execute_tx(vec![TxOp::put_with_id(id, vec![
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
             (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
             (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", vtype)).into()),
             (kw!(:db/cardinality), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into()),
@@ -323,7 +323,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
     for (id, name, sex) in [(100, "Ivan", "male"), (101, "Petr", "male"),
                              (102, "Doris", "female"), (103, "Jane", "female")] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
             ])])
@@ -366,7 +366,7 @@ async fn test_aggregates_and_or() {
         (102, "Adam", "Smith", "male", 23),
     ] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:name), name.into()),
                 (kw!(:last-name), last.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
@@ -430,7 +430,7 @@ async fn test_aggregate_set_semantics() {
 
     for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:name), name.into()),
                 (kw!(:city), city.into()),
             ])])
@@ -462,7 +462,7 @@ async fn test_datascript_aggregates() {
     // Insert monsters with heads
     for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:heads), (heads as i64).into()),
             ])])
             .await
@@ -497,7 +497,7 @@ async fn test_aggregate_avg() {
 
     for (id, age) in [(100, 21), (101, 22), (102, 23)] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:age), (age as i64).into()),
             ])])
             .await
@@ -525,7 +525,7 @@ async fn test_aggregate_min_max_strings() {
 
     for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:name), name.into()),
             ])])
             .await
@@ -586,7 +586,7 @@ async fn test_order_and_limit() {
         (104, "Eve", 50),
     ] {
         client
-            .execute_tx(vec![TxOp::put_with_id(id, vec![
+            .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(id.into())), 
                 (kw!(:name), name.into()),
                 (kw!(:age), (age as i64).into()),
             ])])
@@ -644,7 +644,7 @@ async fn test_aggregate_min_incompatible_types() {
 
     // Insert entity with both name (string) and age (long)
     client
-        .execute_tx(vec![TxOp::put_with_id(100_i64, vec![
+        .execute_tx(vec![TxOp::put(vec![(kw!(:db/id), TxValue::Ref(100_i64.into())), 
             (kw!(:name), "Alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use edn::kw;
+use edn::symbols::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, TxOp, TxValue};
-use edn::kw;
-use edn::symbols::Keyword;
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
 use triplox::TransactionResult;
@@ -68,7 +68,10 @@ async fn test_execute_tx_and_query() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], vec![DataType::Long(100), DataType::String("alice".to_string())]);
+    assert_eq!(
+        result[0],
+        vec![DataType::Long(100), DataType::String("alice".to_string())]
+    );
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -124,8 +127,14 @@ async fn test_multiple_transactions_and_query() {
         .unwrap();
 
     assert_eq!(result.len(), 2);
-    assert!(result.contains(&vec![DataType::Long(100), DataType::String("alice".to_string())]));
-    assert!(result.contains(&vec![DataType::Long(200), DataType::String("bob".to_string())]));
+    assert!(result.contains(&vec![
+        DataType::Long(100),
+        DataType::String("alice".to_string())
+    ]));
+    assert!(result.contains(&vec![
+        DataType::Long(200),
+        DataType::String("bob".to_string())
+    ]));
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -152,8 +161,14 @@ async fn test_open_close_multiple_dbs() {
     let db2 = client.db().await.unwrap();
 
     // Both should return same data
-    let r1 = db1.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
-    let r2 = db2.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
+    let r1 = db1
+        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .await
+        .unwrap();
+    let r2 = db2
+        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .await
+        .unwrap();
     assert_eq!(r1.len(), 1);
     assert_eq!(r2.len(), 1);
 
@@ -181,7 +196,10 @@ async fn test_two_connections() {
     // Connection 2 can see the data
     let client2 = ClientNode::connect(&addr).await.unwrap();
     let db = client2.db().await.unwrap();
-    let result = db.query_edn("{:find [?e] :where [[?e :name \"alice\"]]}").await.unwrap();
+    let result = db
+        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .await
+        .unwrap();
     assert_eq!(result.len(), 1);
 
     db.close().await.unwrap();
@@ -251,7 +269,10 @@ async fn test_db_as_of() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], vec![DataType::Long(100), DataType::String("alice".to_string())]);
+    assert_eq!(
+        result[0],
+        vec![DataType::Long(100), DataType::String("alice".to_string())]
+    );
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -322,9 +343,18 @@ async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &st
     client
         .execute_tx(vec![TxOp::put(vec![
             (kw!(:db/id), TxValue::Ref(id.into())),
-            (kw!(:db/ident), DataType::Keyword(Keyword::plain(name)).into()),
-            (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", vtype)).into()),
-            (kw!(:db/cardinality), DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into()),
+            (
+                kw!(:db/ident),
+                DataType::Keyword(Keyword::plain(name)).into(),
+            ),
+            (
+                kw!(:db/valueType),
+                DataType::Keyword(Keyword::namespaced("db.type", vtype)).into(),
+            ),
+            (
+                kw!(:db/cardinality),
+                DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into(),
+            ),
         ])])
         .await
         .unwrap();
@@ -375,7 +405,12 @@ async fn test_query_keyword_value_comparison_via_wire() {
         .await
         .unwrap();
 
-    assert_eq!(result.len(), 2, "expected only Ivan and Petr, got {:?}", result);
+    assert_eq!(
+        result.len(),
+        2,
+        "expected only Ivan and Petr, got {:?}",
+        result
+    );
     assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
     assert!(result.contains(&vec![DataType::String("Petr".to_string())]));
 
@@ -431,14 +466,18 @@ async fn test_aggregates_and_or() {
 
     // count with top-level OR: Lovelace OR male -> 3
     let result = db
-        .query_edn("{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}")
+        .query_edn(
+            "{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}",
+        )
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
 
     // Grouped: gender, count, sum
     let result = db
-        .query_edn("{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}")
+        .query_edn(
+            "{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}",
+        )
         .await
         .unwrap();
     assert_eq!(result.len(), 2, "expected 2 groups, got {:?}", result);
@@ -465,7 +504,11 @@ async fn test_aggregate_set_semantics() {
     define_base_schema(&client).await;
     define_people_schema(&client).await;
 
-    for (id, name, city) in [(100, "Alice", "NYC"), (101, "Bob", "NYC"), (102, "Carol", "LA")] {
+    for (id, name, city) in [
+        (100, "Alice", "NYC"),
+        (101, "Bob", "NYC"),
+        (102, "Carol", "LA"),
+    ] {
         client
             .execute_tx(vec![TxOp::put(vec![
                 (kw!(:db/id), TxValue::Ref(id.into())),
@@ -644,9 +687,18 @@ async fn test_order_and_limit() {
         .await
         .unwrap();
     assert_eq!(result.len(), 3);
-    assert_eq!(result[0], vec![DataType::String("Dave".to_string()), DataType::Long(10)]);
-    assert_eq!(result[1], vec![DataType::String("Bob".to_string()), DataType::Long(20)]);
-    assert_eq!(result[2], vec![DataType::String("Alice".to_string()), DataType::Long(30)]);
+    assert_eq!(
+        result[0],
+        vec![DataType::String("Dave".to_string()), DataType::Long(10)]
+    );
+    assert_eq!(
+        result[1],
+        vec![DataType::String("Bob".to_string()), DataType::Long(20)]
+    );
+    assert_eq!(
+        result[2],
+        vec![DataType::String("Alice".to_string()), DataType::Long(30)]
+    );
 
     // ORDER BY age descending, LIMIT 2 -> oldest 2
     let result = db
@@ -654,8 +706,14 @@ async fn test_order_and_limit() {
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0], vec![DataType::String("Eve".to_string()), DataType::Long(50)]);
-    assert_eq!(result[1], vec![DataType::String("Carol".to_string()), DataType::Long(40)]);
+    assert_eq!(
+        result[0],
+        vec![DataType::String("Eve".to_string()), DataType::Long(50)]
+    );
+    assert_eq!(
+        result[1],
+        vec![DataType::String("Carol".to_string()), DataType::Long(40)]
+    );
 
     // LIMIT only (no order) — should return exactly 2 rows
     let result = db
@@ -666,12 +724,20 @@ async fn test_order_and_limit() {
 
     // ORDER BY only (no limit) — all 5 rows, sorted
     let result = db
-        .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}")
+        .query_edn(
+            "{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}",
+        )
         .await
         .unwrap();
     assert_eq!(result.len(), 5);
-    assert_eq!(result[0], vec![DataType::String("Dave".to_string()), DataType::Long(10)]);
-    assert_eq!(result[4], vec![DataType::String("Eve".to_string()), DataType::Long(50)]);
+    assert_eq!(
+        result[0],
+        vec![DataType::String("Dave".to_string()), DataType::Long(10)]
+    );
+    assert_eq!(
+        result[4],
+        vec![DataType::String("Eve".to_string()), DataType::Long(50)]
+    );
 
     db.close().await.unwrap();
     client.close().await.unwrap();

--- a/triplox-jvm/src/main/clojure/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/triplox/tx.clj
@@ -1,29 +1,44 @@
 (ns triplox.tx
   "Convert Datomic-style transaction data to TxOp objects."
-  (:import [io.triplox.client TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
+  (:import [io.triplox.client EntityRef EntityRef$Id EntityRef$TempId EntityRef$Ident
+            TxValue TxValue$Data TxValue$Ref
+            TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 
-;; TODO(triplox-878) - check if this is really needed
-(defn- keyword->attr
-  "Convert a keyword to a string attribute name.
-   :person/name → \"person/name\"
-   :name → \"name\""
-  [kw]
-  (subs (str kw) 1))
+(defn- ->entity-ref
+  "Convert a Clojure value to an EntityRef."
+  [v]
+  (cond
+    (integer? v)  (EntityRef$Id. (long v))
+    (string? v)   (EntityRef$TempId. v)
+    (keyword? v)  (EntityRef$Ident. v)
+    :else (throw (ex-info "Cannot convert to EntityRef" {:value v}))))
+
+(defn- ->tx-value
+  "Convert a Clojure value to a TxValue.
+   The :db/id key is special: its value becomes a TxValue.Ref(EntityRef)."
+  [k v]
+  (if (= k :db/id)
+    (TxValue$Ref. (->entity-ref v))
+    (TxValue$Data. v)))
 
 (defn- map->put
   "Convert a Clojure map to a TxOp.Put."
   [m]
-  (TxOp$Put. (into {} (map (fn [[k v]] [(keyword->attr k) v])) m)))
+  (TxOp$Put. (into {} (map (fn [[k v]] [k (->tx-value k v)])) m)))
 
 (defn- vec->tx-op
   "Convert a Datomic-style tx-data vector to a TxOp."
   [v]
   (let [op (first v)]
     (case op
-      :db/add     (let [[_ e a val] v] (TxOp$Add. (long e) (keyword->attr a) val))
-      :db/retract (let [[_ e a val] v] (TxOp$Retract. (long e) (keyword->attr a) val))
-      :db/delete  (let [[_ eid] v]     (TxOp$Delete. (long eid)))
-      :db/erase   (let [[_ eid] v]     (TxOp$Erase. (long eid)))
+      :db/add     (let [[_ e a val] v]
+                    (TxOp$Add. (->entity-ref e) a (TxValue$Data. val)))
+      :db/retract (let [[_ e a val] v]
+                    (TxOp$Retract. (->entity-ref e) a (TxValue$Data. val)))
+      :db/delete  (let [[_ eid] v]
+                    (TxOp$Delete. (->entity-ref eid)))
+      :db/erase   (let [[_ eid] v]
+                    (TxOp$Erase. (->entity-ref eid)))
       (throw (ex-info (str "Unknown tx-data op: " op) {:op op :form v})))))
 
 (defn tx-data->ops

--- a/triplox-jvm/src/main/clojure/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/triplox/tx.clj
@@ -1,7 +1,6 @@
 (ns triplox.tx
   "Convert Datomic-style transaction data to TxOp objects."
-  (:import [io.triplox.client EntityRef EntityRef$Id EntityRef$TempId EntityRef$Ident
-            TxValue TxValue$Data TxValue$Ref
+  (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident TxValue$Data TxValue$Ref
             TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 
 (defn- ->entity-ref
@@ -28,18 +27,13 @@
 
 (defn- vec->tx-op
   "Convert a Datomic-style tx-data vector to a TxOp."
-  [v]
-  (let [op (first v)]
-    (case op
-      :db/add     (let [[_ e a val] v]
-                    (TxOp$Add. (->entity-ref e) a (TxValue$Data. val)))
-      :db/retract (let [[_ e a val] v]
-                    (TxOp$Retract. (->entity-ref e) a (TxValue$Data. val)))
-      :db/delete  (let [[_ eid] v]
-                    (TxOp$Delete. (->entity-ref eid)))
-      :db/erase   (let [[_ eid] v]
-                    (TxOp$Erase. (->entity-ref eid)))
-      (throw (ex-info (str "Unknown tx-data op: " op) {:op op :form v})))))
+  [[op :as v]]
+  (case op
+    :db/add     (let [[_ e a val] v] (TxOp$Add. (->entity-ref e) a (TxValue$Data. val)))
+    :db/retract (let [[_ e a val] v] (TxOp$Retract. (->entity-ref e) a (TxValue$Data. val)))
+    :db/delete  (let [[_ eid] v] (TxOp$Delete. (->entity-ref eid)))
+    :db/erase   (let [[_ eid] v] (TxOp$Erase. (->entity-ref eid)))
+    (throw (ex-info (str "Unknown tx-data op: " op) {:op op :form v}))))
 
 (defn tx-data->ops
   "Convert a sequence of Datomic-style tx-data forms to a List<TxOp>.

--- a/triplox-jvm/src/main/java/io/triplox/client/EntityRef.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/EntityRef.java
@@ -1,0 +1,13 @@
+package io.triplox.client;
+
+import clojure.lang.Keyword;
+
+/**
+ * Entity reference variants for the Triplox wire protocol.
+ */
+public sealed interface EntityRef {
+    record Id(long id) implements EntityRef {}
+    record TempId(String tempId) implements EntityRef {}
+    record Ident(Keyword ident) implements EntityRef {}
+    record LookupRef(Keyword attr, Object value) implements EntityRef {}
+}

--- a/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
@@ -64,4 +64,14 @@ public final class MessageTypes {
     public static final byte TXOP_RETRACT = 2;
     public static final byte TXOP_DELETE  = 3;
     public static final byte TXOP_ERASE   = 4;
+
+    // EntityRef tag bytes
+    public static final byte ENTITY_REF_ID      = (byte) 0x90;
+    public static final byte ENTITY_REF_TEMPID  = (byte) 0x91;
+    public static final byte ENTITY_REF_IDENT   = (byte) 0x92;
+    public static final byte ENTITY_REF_LOOKUP  = (byte) 0x93;
+
+    // TxValue tag bytes
+    public static final byte TXVALUE_DATA = (byte) 0x94;
+    public static final byte TXVALUE_REF  = (byte) 0x95;
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
@@ -9,8 +9,8 @@ import java.util.Map;
  */
 public sealed interface TxOp {
     record Put(Map<Keyword, TxValue> document) implements TxOp {}
-    record Add(EntityRef entityId, Keyword attribute, TxValue value) implements TxOp {}
-    record Retract(EntityRef entityId, Keyword attribute, TxValue value) implements TxOp {}
-    record Delete(EntityRef entityId) implements TxOp {}
-    record Erase(EntityRef entityId) implements TxOp {}
+    record Add(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
+    record Retract(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
+    record Delete(EntityRef entity) implements TxOp {}
+    record Erase(EntityRef entity) implements TxOp {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
@@ -1,14 +1,16 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
+
 import java.util.Map;
 
 /**
  * Transaction operations for the Triplox wire protocol.
  */
 public sealed interface TxOp {
-    record Put(Map<String, Object> document) implements TxOp {}
-    record Add(long entity, String attribute, Object value) implements TxOp {}
-    record Retract(long entity, String attribute, Object value) implements TxOp {}
-    record Delete(long entity) implements TxOp {}
-    record Erase(long entity) implements TxOp {}
+    record Put(Map<Keyword, TxValue> document) implements TxOp {}
+    record Add(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
+    record Retract(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
+    record Delete(EntityRef entity) implements TxOp {}
+    record Erase(EntityRef entity) implements TxOp {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
@@ -9,8 +9,8 @@ import java.util.Map;
  */
 public sealed interface TxOp {
     record Put(Map<Keyword, TxValue> document) implements TxOp {}
-    record Add(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
-    record Retract(EntityRef entity, Keyword attribute, TxValue value) implements TxOp {}
-    record Delete(EntityRef entity) implements TxOp {}
-    record Erase(EntityRef entity) implements TxOp {}
+    record Add(EntityRef entityId, Keyword attribute, TxValue value) implements TxOp {}
+    record Retract(EntityRef entityId, Keyword attribute, TxValue value) implements TxOp {}
+    record Delete(EntityRef entityId) implements TxOp {}
+    record Erase(EntityRef entityId) implements TxOp {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
@@ -1,11 +1,14 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static io.triplox.client.MessageTypes.*;
 
@@ -31,27 +34,102 @@ public final class TxOpCodec {
         return ops;
     }
 
+    // ---------------------------------------------------------------
+    // EntityRef
+    // ---------------------------------------------------------------
+
+    static void encodeEntityRef(DataOutputStream out, EntityRef ref) throws IOException {
+        switch (ref) {
+            case EntityRef.Id id -> {
+                out.writeByte(ENTITY_REF_ID);
+                out.writeLong(id.id());
+            }
+            case EntityRef.TempId tempId -> {
+                out.writeByte(ENTITY_REF_TEMPID);
+                DataTypeCodec.encodeString(out, tempId.tempId());
+            }
+            case EntityRef.Ident ident -> {
+                out.writeByte(ENTITY_REF_IDENT);
+                DataTypeCodec.encodeString(out, ident.ident().toString());
+            }
+            case EntityRef.LookupRef lr -> {
+                out.writeByte(ENTITY_REF_LOOKUP);
+                DataTypeCodec.encodeString(out, lr.attr().toString());
+                DataTypeCodec.encode(out, lr.value());
+            }
+        }
+    }
+
+    static EntityRef decodeEntityRef(DataInputStream in) throws IOException {
+        byte tag = in.readByte();
+        return switch (tag) {
+            case ENTITY_REF_ID -> new EntityRef.Id(in.readLong());
+            case ENTITY_REF_TEMPID -> new EntityRef.TempId(DataTypeCodec.decodeString(in));
+            case ENTITY_REF_IDENT -> new EntityRef.Ident(DataTypeCodec.parseKeyword(DataTypeCodec.decodeString(in)));
+            case ENTITY_REF_LOOKUP -> {
+                var attr = DataTypeCodec.parseKeyword(DataTypeCodec.decodeString(in));
+                var value = DataTypeCodec.decode(in);
+                yield new EntityRef.LookupRef(attr, value);
+            }
+            default -> throw new IOException("Unknown EntityRef tag: 0x" + Integer.toHexString(tag & 0xFF));
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // TxValue
+    // ---------------------------------------------------------------
+
+    static void encodeTxValue(DataOutputStream out, TxValue tv) throws IOException {
+        switch (tv) {
+            case TxValue.Data data -> {
+                out.writeByte(TXVALUE_DATA);
+                DataTypeCodec.encode(out, data.value());
+            }
+            case TxValue.Ref ref -> {
+                out.writeByte(TXVALUE_REF);
+                encodeEntityRef(out, ref.ref());
+            }
+        }
+    }
+
+    static TxValue decodeTxValue(DataInputStream in) throws IOException {
+        byte tag = in.readByte();
+        return switch (tag) {
+            case TXVALUE_DATA -> new TxValue.Data(DataTypeCodec.decode(in));
+            case TXVALUE_REF -> new TxValue.Ref(decodeEntityRef(in));
+            default -> throw new IOException("Unknown TxValue tag: 0x" + Integer.toHexString(tag & 0xFF));
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // TxOp
+    // ---------------------------------------------------------------
+
     static void encodeOp(DataOutputStream out, TxOp op) throws IOException {
         switch (op) {
             case TxOp.Put put -> {
                 out.writeByte(TXOP_PUT);
-                DataTypeCodec.encodeDataTypeMap(out, put.document());
+                encodeKeywordTxValueMap(out, put.document());
             }
             case TxOp.Add add -> {
                 out.writeByte(TXOP_ADD);
-                encodeTriple(out, add.entity(), add.attribute(), add.value());
+                encodeEntityRef(out, add.entity());
+                DataTypeCodec.encodeString(out, add.attribute().toString());
+                encodeTxValue(out, add.value());
             }
             case TxOp.Retract ret -> {
                 out.writeByte(TXOP_RETRACT);
-                encodeTriple(out, ret.entity(), ret.attribute(), ret.value());
+                encodeEntityRef(out, ret.entity());
+                DataTypeCodec.encodeString(out, ret.attribute().toString());
+                encodeTxValue(out, ret.value());
             }
             case TxOp.Delete del -> {
                 out.writeByte(TXOP_DELETE);
-                out.writeLong(del.entity());
+                encodeEntityRef(out, del.entity());
             }
             case TxOp.Erase erase -> {
                 out.writeByte(TXOP_ERASE);
-                out.writeLong(erase.entity());
+                encodeEntityRef(out, erase.entity());
             }
         }
     }
@@ -60,30 +138,48 @@ public final class TxOpCodec {
         byte tag = in.readByte();
         return switch (tag) {
             case TXOP_PUT -> {
-                Map<String, Object> doc = DataTypeCodec.decodeDataTypeMap(in);
-                yield new TxOp.Put(doc);
+                var map = decodeKeywordTxValueMap(in);
+                yield new TxOp.Put(map);
             }
             case TXOP_ADD -> {
-                long entity = in.readLong();
-                String attribute = DataTypeCodec.decodeString(in);
-                Object value = DataTypeCodec.decode(in);
+                var entity = decodeEntityRef(in);
+                var attribute = DataTypeCodec.parseKeyword(DataTypeCodec.decodeString(in));
+                var value = decodeTxValue(in);
                 yield new TxOp.Add(entity, attribute, value);
             }
             case TXOP_RETRACT -> {
-                long entity = in.readLong();
-                String attribute = DataTypeCodec.decodeString(in);
-                Object value = DataTypeCodec.decode(in);
+                var entity = decodeEntityRef(in);
+                var attribute = DataTypeCodec.parseKeyword(DataTypeCodec.decodeString(in));
+                var value = decodeTxValue(in);
                 yield new TxOp.Retract(entity, attribute, value);
             }
-            case TXOP_DELETE -> new TxOp.Delete(in.readLong());
-            case TXOP_ERASE -> new TxOp.Erase(in.readLong());
+            case TXOP_DELETE -> new TxOp.Delete(decodeEntityRef(in));
+            case TXOP_ERASE -> new TxOp.Erase(decodeEntityRef(in));
             default -> throw new IOException("Unknown TxOp tag: " + (tag & 0xFF));
         };
     }
 
-    private static void encodeTriple(DataOutputStream out, long entity, String attribute, Object value) throws IOException {
-        out.writeLong(entity);
-        DataTypeCodec.encodeString(out, attribute);
-        DataTypeCodec.encode(out, value);
+    // ---------------------------------------------------------------
+    // Keyword → TxValue map
+    // ---------------------------------------------------------------
+
+    private static void encodeKeywordTxValueMap(DataOutputStream out, Map<Keyword, TxValue> map) throws IOException {
+        var sorted = new TreeMap<>(map);
+        out.writeInt(sorted.size());
+        for (var entry : sorted.entrySet()) {
+            DataTypeCodec.encodeString(out, entry.getKey().toString());
+            encodeTxValue(out, entry.getValue());
+        }
+    }
+
+    private static Map<Keyword, TxValue> decodeKeywordTxValueMap(DataInputStream in) throws IOException {
+        int count = in.readInt();
+        var map = new TreeMap<Keyword, TxValue>();
+        for (int i = 0; i < count; i++) {
+            var key = DataTypeCodec.parseKeyword(DataTypeCodec.decodeString(in));
+            var value = decodeTxValue(in);
+            map.put(key, value);
+        }
+        return map;
     }
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
@@ -113,23 +113,23 @@ public final class TxOpCodec {
             }
             case TxOp.Add add -> {
                 out.writeByte(TXOP_ADD);
-                encodeEntityRef(out, add.entity());
+                encodeEntityRef(out, add.entityId());
                 DataTypeCodec.encodeString(out, add.attribute().toString());
                 encodeTxValue(out, add.value());
             }
             case TxOp.Retract ret -> {
                 out.writeByte(TXOP_RETRACT);
-                encodeEntityRef(out, ret.entity());
+                encodeEntityRef(out, ret.entityId());
                 DataTypeCodec.encodeString(out, ret.attribute().toString());
                 encodeTxValue(out, ret.value());
             }
             case TxOp.Delete del -> {
                 out.writeByte(TXOP_DELETE);
-                encodeEntityRef(out, del.entity());
+                encodeEntityRef(out, del.entityId());
             }
             case TxOp.Erase erase -> {
                 out.writeByte(TXOP_ERASE);
-                encodeEntityRef(out, erase.entity());
+                encodeEntityRef(out, erase.entityId());
             }
         }
     }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
@@ -113,23 +113,23 @@ public final class TxOpCodec {
             }
             case TxOp.Add add -> {
                 out.writeByte(TXOP_ADD);
-                encodeEntityRef(out, add.entityId());
+                encodeEntityRef(out, add.entity());
                 DataTypeCodec.encodeString(out, add.attribute().toString());
                 encodeTxValue(out, add.value());
             }
             case TxOp.Retract ret -> {
                 out.writeByte(TXOP_RETRACT);
-                encodeEntityRef(out, ret.entityId());
+                encodeEntityRef(out, ret.entity());
                 DataTypeCodec.encodeString(out, ret.attribute().toString());
                 encodeTxValue(out, ret.value());
             }
             case TxOp.Delete del -> {
                 out.writeByte(TXOP_DELETE);
-                encodeEntityRef(out, del.entityId());
+                encodeEntityRef(out, del.entity());
             }
             case TxOp.Erase erase -> {
                 out.writeByte(TXOP_ERASE);
-                encodeEntityRef(out, erase.entityId());
+                encodeEntityRef(out, erase.entity());
             }
         }
     }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxValue.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxValue.java
@@ -1,0 +1,10 @@
+package io.triplox.client;
+
+/**
+ * Transaction value variants for the Triplox wire protocol.
+ * Data wraps a concrete value; Ref wraps an entity reference.
+ */
+public sealed interface TxValue {
+    record Data(Object value) implements TxValue {}
+    record Ref(EntityRef ref) implements TxValue {}
+}

--- a/triplox-jvm/src/test/clojure/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/tx_test.clj
@@ -1,8 +1,7 @@
 (ns triplox.tx-test
   (:require [clojure.test :refer [deftest is testing]]
             [triplox.tx :as tx])
-  (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident
-            TxValue$Data TxValue$Ref
+  (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident TxValue$Data TxValue$Ref
             TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 
 (deftest map-to-put

--- a/triplox-jvm/src/test/clojure/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/tx_test.clj
@@ -19,7 +19,7 @@
     (let [ops (tx/tx-data->ops [[:db/add 42 :email "test@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Add op))
-      (is (= 42 (.id ^EntityRef$Id (.entityId ^TxOp$Add op))))
+      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Add op))))
       (is (= :email (.attribute ^TxOp$Add op)))
       (is (= "test@example.com" (.value ^TxValue$Data (.value ^TxOp$Add op)))))))
 
@@ -28,7 +28,7 @@
     (let [ops (tx/tx-data->ops [[:db/retract 42 :email "old@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Retract op))
-      (is (= 42 (.id ^EntityRef$Id (.entityId ^TxOp$Retract op))))
+      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Retract op))))
       (is (= :email (.attribute ^TxOp$Retract op)))
       (is (= "old@example.com" (.value ^TxValue$Data (.value ^TxOp$Retract op)))))))
 
@@ -37,14 +37,14 @@
     (let [ops (tx/tx-data->ops [[:db/delete 99]])
           op (first ops)]
       (is (instance? TxOp$Delete op))
-      (is (= 99 (.id ^EntityRef$Id (.entityId ^TxOp$Delete op)))))))
+      (is (= 99 (.id ^EntityRef$Id (.entity ^TxOp$Delete op)))))))
 
 (deftest vec-to-erase
   (testing "[:db/erase eid] -> TxOp.Erase"
     (let [ops (tx/tx-data->ops [[:db/erase 100]])
           op (first ops)]
       (is (instance? TxOp$Erase op))
-      (is (= 100 (.id ^EntityRef$Id (.entityId ^TxOp$Erase op)))))))
+      (is (= 100 (.id ^EntityRef$Id (.entity ^TxOp$Erase op)))))))
 
 (deftest mixed-tx-data
   (testing "Mixed tx-data forms"
@@ -64,15 +64,15 @@
   (testing "String entity becomes TempId"
     (let [ops (tx/tx-data->ops [[:db/add "tempid-1" :name "alice"]])
           op (first ops)]
-      (is (instance? EntityRef$TempId (.entityId ^TxOp$Add op)))
-      (is (= "tempid-1" (.tempId ^EntityRef$TempId (.entityId ^TxOp$Add op)))))))
+      (is (instance? EntityRef$TempId (.entity ^TxOp$Add op)))
+      (is (= "tempid-1" (.tempId ^EntityRef$TempId (.entity ^TxOp$Add op)))))))
 
 (deftest ident-entity-ref
   (testing "Keyword entity becomes Ident"
     (let [ops (tx/tx-data->ops [[:db/add :person/alice :name "Alice"]])
           op (first ops)]
-      (is (instance? EntityRef$Ident (.entityId ^TxOp$Add op)))
-      (is (= :person/alice (.ident ^EntityRef$Ident (.entityId ^TxOp$Add op)))))))
+      (is (instance? EntityRef$Ident (.entity ^TxOp$Add op)))
+      (is (= :person/alice (.ident ^EntityRef$Ident (.entity ^TxOp$Add op)))))))
 
 (deftest invalid-form-throws
   (testing "Invalid form throws"

--- a/triplox-jvm/src/test/clojure/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/tx_test.clj
@@ -19,7 +19,7 @@
     (let [ops (tx/tx-data->ops [[:db/add 42 :email "test@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Add op))
-      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Add op))))
+      (is (= 42 (.id ^EntityRef$Id (.entityId ^TxOp$Add op))))
       (is (= :email (.attribute ^TxOp$Add op)))
       (is (= "test@example.com" (.value ^TxValue$Data (.value ^TxOp$Add op)))))))
 
@@ -28,7 +28,7 @@
     (let [ops (tx/tx-data->ops [[:db/retract 42 :email "old@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Retract op))
-      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Retract op))))
+      (is (= 42 (.id ^EntityRef$Id (.entityId ^TxOp$Retract op))))
       (is (= :email (.attribute ^TxOp$Retract op)))
       (is (= "old@example.com" (.value ^TxValue$Data (.value ^TxOp$Retract op)))))))
 
@@ -37,14 +37,14 @@
     (let [ops (tx/tx-data->ops [[:db/delete 99]])
           op (first ops)]
       (is (instance? TxOp$Delete op))
-      (is (= 99 (.id ^EntityRef$Id (.entity ^TxOp$Delete op)))))))
+      (is (= 99 (.id ^EntityRef$Id (.entityId ^TxOp$Delete op)))))))
 
 (deftest vec-to-erase
   (testing "[:db/erase eid] -> TxOp.Erase"
     (let [ops (tx/tx-data->ops [[:db/erase 100]])
           op (first ops)]
       (is (instance? TxOp$Erase op))
-      (is (= 100 (.id ^EntityRef$Id (.entity ^TxOp$Erase op)))))))
+      (is (= 100 (.id ^EntityRef$Id (.entityId ^TxOp$Erase op)))))))
 
 (deftest mixed-tx-data
   (testing "Mixed tx-data forms"
@@ -64,15 +64,15 @@
   (testing "String entity becomes TempId"
     (let [ops (tx/tx-data->ops [[:db/add "tempid-1" :name "alice"]])
           op (first ops)]
-      (is (instance? EntityRef$TempId (.entity ^TxOp$Add op)))
-      (is (= "tempid-1" (.tempId ^EntityRef$TempId (.entity ^TxOp$Add op)))))))
+      (is (instance? EntityRef$TempId (.entityId ^TxOp$Add op)))
+      (is (= "tempid-1" (.tempId ^EntityRef$TempId (.entityId ^TxOp$Add op)))))))
 
 (deftest ident-entity-ref
   (testing "Keyword entity becomes Ident"
     (let [ops (tx/tx-data->ops [[:db/add :person/alice :name "Alice"]])
           op (first ops)]
-      (is (instance? EntityRef$Ident (.entity ^TxOp$Add op)))
-      (is (= :person/alice (.ident ^EntityRef$Ident (.entity ^TxOp$Add op)))))))
+      (is (instance? EntityRef$Ident (.entityId ^TxOp$Add op)))
+      (is (= :person/alice (.ident ^EntityRef$Ident (.entityId ^TxOp$Add op)))))))
 
 (deftest invalid-form-throws
   (testing "Invalid form throws"

--- a/triplox-jvm/src/test/clojure/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/triplox/tx_test.clj
@@ -1,47 +1,51 @@
 (ns triplox.tx-test
   (:require [clojure.test :refer [deftest is testing]]
             [triplox.tx :as tx])
-  (:import [io.triplox.client TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
+  (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident
+            TxValue$Data TxValue$Ref
+            TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 
 (deftest map-to-put
-  (testing "Map → TxOp.Put"
+  (testing "Map -> TxOp.Put"
     (let [ops (tx/tx-data->ops [{:db/id 1 :person/name "alice"}])
           op (first ops)]
       (is (instance? TxOp$Put op))
-      (is (= 1 (.get (.document ^TxOp$Put op) "db/id")))
-      (is (= "alice" (.get (.document ^TxOp$Put op) "person/name"))))))
+      (let [doc (.document ^TxOp$Put op)]
+        (is (instance? TxValue$Ref (.get doc :db/id)))
+        (is (= 1 (.id ^EntityRef$Id (.ref ^TxValue$Ref (.get doc :db/id)))))
+        (is (= "alice" (.value ^TxValue$Data (.get doc :person/name))))))))
 
 (deftest vec-to-add
-  (testing "[:db/add e a v] → TxOp.Add"
+  (testing "[:db/add e a v] -> TxOp.Add"
     (let [ops (tx/tx-data->ops [[:db/add 42 :email "test@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Add op))
-      (is (= 42 (.entity ^TxOp$Add op)))
-      (is (= "email" (.attribute ^TxOp$Add op)))
-      (is (= "test@example.com" (.value ^TxOp$Add op))))))
+      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Add op))))
+      (is (= :email (.attribute ^TxOp$Add op)))
+      (is (= "test@example.com" (.value ^TxValue$Data (.value ^TxOp$Add op)))))))
 
 (deftest vec-to-retract
-  (testing "[:db/retract e a v] → TxOp.Retract"
+  (testing "[:db/retract e a v] -> TxOp.Retract"
     (let [ops (tx/tx-data->ops [[:db/retract 42 :email "old@example.com"]])
           op (first ops)]
       (is (instance? TxOp$Retract op))
-      (is (= 42 (.entity ^TxOp$Retract op)))
-      (is (= "email" (.attribute ^TxOp$Retract op)))
-      (is (= "old@example.com" (.value ^TxOp$Retract op))))))
+      (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Retract op))))
+      (is (= :email (.attribute ^TxOp$Retract op)))
+      (is (= "old@example.com" (.value ^TxValue$Data (.value ^TxOp$Retract op)))))))
 
 (deftest vec-to-delete
-  (testing "[:db/delete eid] → TxOp.Delete"
+  (testing "[:db/delete eid] -> TxOp.Delete"
     (let [ops (tx/tx-data->ops [[:db/delete 99]])
           op (first ops)]
       (is (instance? TxOp$Delete op))
-      (is (= 99 (.entity ^TxOp$Delete op))))))
+      (is (= 99 (.id ^EntityRef$Id (.entity ^TxOp$Delete op)))))))
 
 (deftest vec-to-erase
-  (testing "[:db/erase eid] → TxOp.Erase"
+  (testing "[:db/erase eid] -> TxOp.Erase"
     (let [ops (tx/tx-data->ops [[:db/erase 100]])
           op (first ops)]
       (is (instance? TxOp$Erase op))
-      (is (= 100 (.entity ^TxOp$Erase op))))))
+      (is (= 100 (.id ^EntityRef$Id (.entity ^TxOp$Erase op)))))))
 
 (deftest mixed-tx-data
   (testing "Mixed tx-data forms"
@@ -56,6 +60,20 @@
       (is (instance? TxOp$Retract (nth ops 2)))
       (is (instance? TxOp$Delete (nth ops 3)))
       (is (instance? TxOp$Erase (nth ops 4))))))
+
+(deftest tempid-entity-ref
+  (testing "String entity becomes TempId"
+    (let [ops (tx/tx-data->ops [[:db/add "tempid-1" :name "alice"]])
+          op (first ops)]
+      (is (instance? EntityRef$TempId (.entity ^TxOp$Add op)))
+      (is (= "tempid-1" (.tempId ^EntityRef$TempId (.entity ^TxOp$Add op)))))))
+
+(deftest ident-entity-ref
+  (testing "Keyword entity becomes Ident"
+    (let [ops (tx/tx-data->ops [[:db/add :person/alice :name "Alice"]])
+          op (first ops)]
+      (is (instance? EntityRef$Ident (.entity ^TxOp$Add op)))
+      (is (= :person/alice (.ident ^EntityRef$Ident (.entity ^TxOp$Add op)))))))
 
 (deftest invalid-form-throws
   (testing "Invalid form throws"

--- a/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
@@ -1,5 +1,6 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -23,62 +24,70 @@ class TxOpCodecTest {
 
     @Test
     void testPut() throws IOException {
-        var doc = new TreeMap<String, Object>();
-        doc.put("db/id", 1L);
-        doc.put("name", "alice");
+        var doc = new TreeMap<Keyword, TxValue>();
+        doc.put(Keyword.intern("db", "id"), new TxValue.Ref(new EntityRef.Id(1)));
+        doc.put(Keyword.intern("name"), new TxValue.Data("alice"));
         var result = roundtrip(List.of(new TxOp.Put(doc)));
         assertEquals(1, result.size());
         var put = (TxOp.Put) result.get(0);
-        assertEquals(1L, put.document().get("db/id"));
-        assertEquals("alice", put.document().get("name"));
+        var idVal = (TxValue.Ref) put.document().get(Keyword.intern("db", "id"));
+        assertEquals(1L, ((EntityRef.Id) idVal.ref()).id());
+        var nameVal = (TxValue.Data) put.document().get(Keyword.intern("name"));
+        assertEquals("alice", nameVal.value());
     }
 
     @Test
     void testAdd() throws IOException {
-        var result = roundtrip(List.of(new TxOp.Add(42, "email", "test@example.com")));
+        var result = roundtrip(List.of(new TxOp.Add(
+                new EntityRef.Id(42),
+                Keyword.intern("email"),
+                new TxValue.Data("test@example.com"))));
         assertEquals(1, result.size());
         var add = (TxOp.Add) result.get(0);
-        assertEquals(42, add.entity());
-        assertEquals("email", add.attribute());
-        assertEquals("test@example.com", add.value());
+        assertEquals(42, ((EntityRef.Id) add.entity()).id());
+        assertEquals(Keyword.intern("email"), add.attribute());
+        assertEquals("test@example.com", ((TxValue.Data) add.value()).value());
     }
 
     @Test
     void testRetract() throws IOException {
-        var result = roundtrip(List.of(new TxOp.Retract(42, "email", "old@example.com")));
+        var result = roundtrip(List.of(new TxOp.Retract(
+                new EntityRef.Id(42),
+                Keyword.intern("email"),
+                new TxValue.Data("old@example.com"))));
         assertEquals(1, result.size());
         var ret = (TxOp.Retract) result.get(0);
-        assertEquals(42, ret.entity());
-        assertEquals("email", ret.attribute());
-        assertEquals("old@example.com", ret.value());
+        assertEquals(42, ((EntityRef.Id) ret.entity()).id());
+        assertEquals(Keyword.intern("email"), ret.attribute());
+        assertEquals("old@example.com", ((TxValue.Data) ret.value()).value());
     }
 
     @Test
     void testDelete() throws IOException {
-        var result = roundtrip(List.of(new TxOp.Delete(99)));
+        var result = roundtrip(List.of(new TxOp.Delete(new EntityRef.Id(99))));
         assertEquals(1, result.size());
-        assertEquals(new TxOp.Delete(99), result.get(0));
+        assertEquals(new TxOp.Delete(new EntityRef.Id(99)), result.get(0));
     }
 
     @Test
     void testErase() throws IOException {
-        var result = roundtrip(List.of(new TxOp.Erase(100)));
+        var result = roundtrip(List.of(new TxOp.Erase(new EntityRef.Id(100))));
         assertEquals(1, result.size());
-        assertEquals(new TxOp.Erase(100), result.get(0));
+        assertEquals(new TxOp.Erase(new EntityRef.Id(100)), result.get(0));
     }
 
     @Test
     void testMultipleOps() throws IOException {
-        var doc = new TreeMap<String, Object>();
-        doc.put("db/id", 1L);
-        doc.put("name", "bob");
+        var doc = new TreeMap<Keyword, TxValue>();
+        doc.put(Keyword.intern("db", "id"), new TxValue.Ref(new EntityRef.Id(1)));
+        doc.put(Keyword.intern("name"), new TxValue.Data("bob"));
 
         var ops = List.<TxOp>of(
                 new TxOp.Put(doc),
-                new TxOp.Add(1, "age", 30L),
-                new TxOp.Retract(1, "name", "old-bob"),
-                new TxOp.Delete(99),
-                new TxOp.Erase(100)
+                new TxOp.Add(new EntityRef.Id(1), Keyword.intern("age"), new TxValue.Data(30L)),
+                new TxOp.Retract(new EntityRef.Id(1), Keyword.intern("name"), new TxValue.Data("old-bob")),
+                new TxOp.Delete(new EntityRef.Id(99)),
+                new TxOp.Erase(new EntityRef.Id(100))
         );
         var result = roundtrip(ops);
         assertEquals(5, result.size());
@@ -87,5 +96,33 @@ class TxOpCodecTest {
         assertInstanceOf(TxOp.Retract.class, result.get(2));
         assertInstanceOf(TxOp.Delete.class, result.get(3));
         assertInstanceOf(TxOp.Erase.class, result.get(4));
+    }
+
+    @Test
+    void testEntityRefVariants() throws IOException {
+        var ops = List.<TxOp>of(
+                new TxOp.Delete(new EntityRef.Id(42)),
+                new TxOp.Delete(new EntityRef.TempId("temp-1")),
+                new TxOp.Delete(new EntityRef.Ident(Keyword.intern("db", "ident"))),
+                new TxOp.Delete(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"))
+        );
+        var result = roundtrip(ops);
+        assertEquals(4, result.size());
+        assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entity());
+        assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entity());
+        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entity());
+        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entity());
+    }
+
+    @Test
+    void testTxValueRef() throws IOException {
+        var result = roundtrip(List.of(new TxOp.Add(
+                new EntityRef.Id(1),
+                Keyword.intern("friend"),
+                new TxValue.Ref(new EntityRef.Id(2)))));
+        assertEquals(1, result.size());
+        var add = (TxOp.Add) result.get(0);
+        var ref = (TxValue.Ref) add.value();
+        assertEquals(new EntityRef.Id(2), ref.ref());
     }
 }

--- a/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
@@ -44,7 +44,7 @@ class TxOpCodecTest {
                 new TxValue.Data("test@example.com"))));
         assertEquals(1, result.size());
         var add = (TxOp.Add) result.get(0);
-        assertEquals(42, ((EntityRef.Id) add.entityId()).id());
+        assertEquals(42, ((EntityRef.Id) add.entity()).id());
         assertEquals(Keyword.intern("email"), add.attribute());
         assertEquals("test@example.com", ((TxValue.Data) add.value()).value());
     }
@@ -57,7 +57,7 @@ class TxOpCodecTest {
                 new TxValue.Data("old@example.com"))));
         assertEquals(1, result.size());
         var ret = (TxOp.Retract) result.get(0);
-        assertEquals(42, ((EntityRef.Id) ret.entityId()).id());
+        assertEquals(42, ((EntityRef.Id) ret.entity()).id());
         assertEquals(Keyword.intern("email"), ret.attribute());
         assertEquals("old@example.com", ((TxValue.Data) ret.value()).value());
     }
@@ -108,10 +108,10 @@ class TxOpCodecTest {
         );
         var result = roundtrip(ops);
         assertEquals(4, result.size());
-        assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entityId());
-        assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entityId());
-        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entityId());
-        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entityId());
+        assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entity());
+        assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entity());
+        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entity());
+        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entity());
     }
 
     @Test

--- a/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
@@ -44,7 +44,7 @@ class TxOpCodecTest {
                 new TxValue.Data("test@example.com"))));
         assertEquals(1, result.size());
         var add = (TxOp.Add) result.get(0);
-        assertEquals(42, ((EntityRef.Id) add.entity()).id());
+        assertEquals(42, ((EntityRef.Id) add.entityId()).id());
         assertEquals(Keyword.intern("email"), add.attribute());
         assertEquals("test@example.com", ((TxValue.Data) add.value()).value());
     }
@@ -57,7 +57,7 @@ class TxOpCodecTest {
                 new TxValue.Data("old@example.com"))));
         assertEquals(1, result.size());
         var ret = (TxOp.Retract) result.get(0);
-        assertEquals(42, ((EntityRef.Id) ret.entity()).id());
+        assertEquals(42, ((EntityRef.Id) ret.entityId()).id());
         assertEquals(Keyword.intern("email"), ret.attribute());
         assertEquals("old@example.com", ((TxValue.Data) ret.value()).value());
     }
@@ -108,10 +108,10 @@ class TxOpCodecTest {
         );
         var result = roundtrip(ops);
         assertEquals(4, result.size());
-        assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entity());
-        assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entity());
-        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entity());
-        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entity());
+        assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entityId());
+        assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entityId());
+        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entityId());
+        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entityId());
     }
 
     @Test

--- a/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
@@ -1,5 +1,6 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -301,8 +302,8 @@ class WireCodecTest {
 
     @Test
     void testExecuteFraming() throws IOException {
-        var doc = new TreeMap<String, Object>();
-        doc.put("db/id", 1L);
+        var doc = new TreeMap<Keyword, TxValue>();
+        doc.put(Keyword.intern("db", "id"), new TxValue.Ref(new EntityRef.Id(1)));
         var ops = List.<TxOp>of(new TxOp.Put(doc));
 
         var baos = new ByteArrayOutputStream();

--- a/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,15 +24,18 @@ class TriploxNodeTest {
     void testConnectTransactQueryClose() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
             // Schema: name attribute
-            node.executeTx(List.of(new TxOp.Put(Map.of(
-                    "db/id", 200L,
-                    "db/ident", Keyword.intern("name"),
-                    "db/valueType", Keyword.intern("db.type", "string"),
-                    "db/cardinality", Keyword.intern("db.cardinality", "one")))));
+            var schema = new TreeMap<Keyword, TxValue>();
+            schema.put(Keyword.intern("db", "id"), new TxValue.Ref(new EntityRef.Id(200)));
+            schema.put(Keyword.intern("db", "ident"), new TxValue.Data(Keyword.intern("name")));
+            schema.put(Keyword.intern("db", "valueType"), new TxValue.Data(Keyword.intern("db.type", "string")));
+            schema.put(Keyword.intern("db", "cardinality"), new TxValue.Data(Keyword.intern("db.cardinality", "one")));
+            node.executeTx(List.of(new TxOp.Put(schema)));
 
             // Data
-            var txResult = node.executeTx(List.of(new TxOp.Put(
-                    Map.of("db/id", 1000L, "name", "alice"))));
+            var data = new TreeMap<Keyword, TxValue>();
+            data.put(Keyword.intern("db", "id"), new TxValue.Ref(new EntityRef.Id(1000)));
+            data.put(Keyword.intern("name"), new TxValue.Data("alice"));
+            var txResult = node.executeTx(List.of(new TxOp.Put(data)));
             assertTrue(txResult.isCommitted());
 
             // Query


### PR DESCRIPTION
## Summary

- Introduce `EntityRef` (Id, TempId, Ident, LookupRef) and `TxValue` (Data, Ref) enums replacing bare `i64`/`DataType` in `TxOp`
- Restructure transaction pipeline: `expand_tx_ops` → `resolve_tempids` via new `DatomWithTempids` intermediate (in `src/tx.rs`)
- Remove `tx` field from `Datom` — passed separately to `write_index_entries`
- Tempid allocation with partition heuristic (`:db/ident` → DB_PARTITION, else USER_PARTITION)
- Ident resolution via schema during expansion
- Updated wire protocol encoding for new types
- LookupRef accepted in type but errors at expansion (deferred to follow-up)
- Tempid→entid mapping in TransactionResult deferred (#164)

## Test plan

- [x] All 376 unit tests pass
- [x] All 18 integration tests pass
- [x] Clean compilation, no clippy warnings in new code
- [x] New tests in `src/tx.rs` covering expand and resolve stages
- [x] Protocol round-trip tests for EntityRef and TxValue encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)