### PR TITLE
feat: implement :in parameter binding for Datalog queries

### DIFF
--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -164,7 +164,7 @@ Example with `:in` binding:
 ```edn
 [:find ?e ?name :in ?name :where [?e :person/name ?name]]
 ```
-with args: `[Scalar("Alice")]`
+with args: `["alice"]`
 
 ### 4.9 RowDescription (Backend, `T`)
 

--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -147,17 +147,24 @@ Sent after: AuthenticationOk, DbOpened, DbClosed, DataRow (end of query results)
 
 Execute a one-shot Datalog query against an open DB snapshot.
 
-| Field        | Type   | Description                          |
-|--------------|--------|--------------------------------------|
-| query_string | String | Datalog query in EDN text            |
-| db_id        | u32    | DB snapshot handle to query against  |
+| Field        | Type              | Description                             |
+|--------------|-------------------|-----------------------------------------|
+| query_string | String            | Datalog query in EDN text               |
+| db_id        | u32               | DB snapshot handle to query against     |
+| args         | Vec\<QueryArg\>   | Input binding arguments (see §11.10)    |
 
-The client must open a DB with OpenDb before issuing a Query.
+The client must open a DB with OpenDb before issuing a Query. The `args` field provides values for variables declared in the query's `:in` clause. The number and order of args must match the `:in` variables. For queries without `:in`, pass an empty vector (count = 0).
 
 Example query string:
 ```edn
 {:find [?name ?age] :where [[?e :person/name ?name] [?e :person/age ?age]]}
 ```
+
+Example with `:in` binding:
+```edn
+[:find ?e ?name :in ?name :where [?e :person/name ?name]]
+```
+with args: `[Scalar("Alice")]`
 
 ### 4.9 RowDescription (Backend, `T`)
 
@@ -243,10 +250,11 @@ Returned for awaited transactions (Execute with `await_indexing = true`). Maps d
 
 Start a live push subscription. Blocks the connection until cancelled.
 
-| Field        | Type   | Description                                                    |
-|--------------|--------|----------------------------------------------------------------|
-| query_string | String | Datalog query in EDN text                                      |
-| db_id        | u32    | DB snapshot; subscription streams changes after this point     |
+| Field        | Type              | Description                                                    |
+|--------------|-------------------|----------------------------------------------------------------|
+| query_string | String            | Datalog query in EDN text                                      |
+| db_id        | u32               | DB snapshot; subscription streams changes after this point     |
+| args         | Vec\<QueryArg\>   | Input binding arguments (see §11.10)                           |
 
 The client must open a DB with OpenDb before subscribing. The subscription uses the DB's tx_id as the starting point: initial results are computed from that snapshot, and subsequent pushes contain changes from later transactions.
 
@@ -706,6 +714,7 @@ status : u8
 ```
 query_string : String
 db_id        : u32
+args         : Vec<QueryArg>
 ```
 
 **RowDescription** (`T`):
@@ -755,6 +764,7 @@ error_message : Option<String>
 ```
 query_string : String
 db_id        : u32
+args         : Vec<QueryArg>
 ```
 
 **DataBatchComplete** (`B`):
@@ -790,6 +800,28 @@ hint     : Option<String>
 ```
 (empty)
 ```
+
+### 11.10 QueryArg Encoding
+
+A `QueryArg` value is encoded as a 1-byte variant tag followed by the variant payload:
+
+| Tag | Name       | Payload                                              |
+|-----|------------|------------------------------------------------------|
+| 0   | Scalar     | `DataType` (one tagged value)                        |
+| 1   | Collection | `Vec<DataType>` (u32 count + elements)               |
+| 2   | Tuple      | `Vec<DataType>` (u32 count + elements)               |
+| 3   | Relation   | `u32` row count + `Vec<DataType>` per row            |
+
+**Binding forms:**
+
+| QueryArg   | EDN `:in` syntax | Description                           |
+|------------|------------------|---------------------------------------|
+| Scalar     | `?x`             | Single value for one variable         |
+| Collection | `[?x ...]`       | Multiple values for one variable      |
+| Tuple      | `[?x ?y]`        | One row of multiple variables         |
+| Relation   | `[[?x ?y]]`      | Multiple rows of multiple variables   |
+
+> **Note**: Only Scalar bindings are currently implemented. Collection, Tuple, and Relation are reserved for future use.
 
 ---
 

--- a/edn/src/parse.rs
+++ b/edn/src/parse.rs
@@ -455,7 +455,6 @@ peg::parser! {
         rule map_query_part() -> query::QueryPart
             = __() ":find" __() "[" fs:find_spec() "]" __() { query::QueryPart::FindSpec(fs) }
             / __() ":in" __() "[" __() in_vars:variable()* "]" __() { query::QueryPart::InVars(in_vars) }
-            / __() ":with" __() "[" __() with_vars:variable()* "]" __() { query::QueryPart::WithVars(with_vars) }
             / __() ":where" __() "[" ws:where_clause()+ "]" __() { query::QueryPart::WhereClauses(ws) }
             / __() ":order" __() "[" os:order()+ "]" __() { query::QueryPart::Order(os) }
             / __() ":limit" l:limit() { query::QueryPart::Limit(l) }

--- a/edn/src/parse.rs
+++ b/edn/src/parse.rs
@@ -446,7 +446,7 @@ peg::parser! {
 
         rule query_part() -> query::QueryPart
             = __() ":find" fs:find_spec() { query::QueryPart::FindSpec(fs) }
-            / __() ":in" in_vars:variable()+ { query::QueryPart::InVars(in_vars) }
+            / __() ":in" in_vars:variable()* { query::QueryPart::InVars(in_vars) }
             / __() ":limit" l:limit() { query::QueryPart::Limit(l) }
             / __() ":order" os:order()+ { query::QueryPart::Order(os) }
             / __() ":where" ws:where_clause()+ { query::QueryPart::WhereClauses(ws) }

--- a/edn/src/parse.rs
+++ b/edn/src/parse.rs
@@ -454,6 +454,8 @@ peg::parser! {
 
         rule map_query_part() -> query::QueryPart
             = __() ":find" __() "[" fs:find_spec() "]" __() { query::QueryPart::FindSpec(fs) }
+            / __() ":in" __() "[" __() in_vars:variable()* "]" __() { query::QueryPart::InVars(in_vars) }
+            / __() ":with" __() "[" __() with_vars:variable()* "]" __() { query::QueryPart::WithVars(with_vars) }
             / __() ":where" __() "[" ws:where_clause()+ "]" __() { query::QueryPart::WhereClauses(ws) }
             / __() ":order" __() "[" os:order()+ "]" __() { query::QueryPart::Order(os) }
             / __() ":limit" l:limit() { query::QueryPart::Limit(l) }

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -424,13 +424,6 @@ fn can_parse_map_form_in_vars() {
 }
 
 #[test]
-fn can_parse_map_form_with_vars() {
-    let s = "{:find [?e] :with [?name] :where [[?e :name ?name]]}";
-    let parsed = parse_query(s).expect("map-form :with should parse");
-    assert_eq!(parsed.with, vec!["?name".to_var()]);
-}
-
-#[test]
 fn can_parse_list_form_in_vars() {
     // Single :in variable in list form
     let single = "[:find ?e :in ?name :where [?e :name ?name]]";

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -429,3 +429,21 @@ fn can_parse_map_form_with_vars() {
     let parsed = parse_query(s).expect("map-form :with should parse");
     assert_eq!(parsed.with, vec!["?name".to_var()]);
 }
+
+#[test]
+fn can_parse_list_form_in_vars() {
+    // Single :in variable in list form
+    let single = "[:find ?e :in ?name :where [?e :name ?name]]";
+    let parsed = parse_query(single).expect("list-form :in should parse");
+    assert_eq!(parsed.in_vars, vec!["?name".to_var()]);
+
+    // Multiple :in variables in list form
+    let multi = "[:find ?e :in ?name ?age :where [?e :name ?name] [?e :age ?age]]";
+    let parsed = parse_query(multi).expect("list-form multi :in should parse");
+    assert_eq!(parsed.in_vars, vec!["?name".to_var(), "?age".to_var()]);
+
+    // Empty :in in list form (no variables between :in and the next clause)
+    let empty = "[:find ?e :in :where [?e :name ?name]]";
+    let parsed = parse_query(empty).expect("list-form empty :in should parse");
+    assert!(parsed.in_vars.is_empty());
+}

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -404,3 +404,28 @@ fn round_trip_multiple_predicates() {
 fn round_trip_or_and() {
     assert_round_trip("[:find ?x :where (or (and [?x :foo/bar _] [?x :foo/baz _]) [?x _ 10])]");
 }
+
+#[test]
+fn can_parse_map_form_in_vars() {
+    // Single :in variable in map form
+    let single = "{:find [?e] :in [?name] :where [[?e :name ?name]]}";
+    let parsed = parse_query(single).expect("map-form :in should parse");
+    assert_eq!(parsed.in_vars, vec!["?name".to_var()]);
+
+    // Multiple :in variables in map form
+    let multi = "{:find [?e] :in [?name ?age] :where [[?e :name ?name] [?e :age ?age]]}";
+    let parsed = parse_query(multi).expect("map-form multi :in should parse");
+    assert_eq!(parsed.in_vars, vec!["?name".to_var(), "?age".to_var()]);
+
+    // Empty :in in map form
+    let empty = "{:find [?e] :in [] :where [[?e :name ?name]]}";
+    let parsed = parse_query(empty).expect("map-form empty :in should parse");
+    assert!(parsed.in_vars.is_empty());
+}
+
+#[test]
+fn can_parse_map_form_with_vars() {
+    let s = "{:find [?e] :with [?name] :where [[?e :name ?name]]}";
+    let parsed = parse_query(s).expect("map-form :with should parse");
+    assert_eq!(parsed.with, vec!["?name".to_var()]);
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -331,6 +331,11 @@ impl ClientDb {
 }
 
 impl Database for ClientDb {
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
+        let parsed = query.into_query()?;
+        self.query_edn_with_args(&parsed.to_string(), vec![]).await
+    }
+
     async fn query_with_args(
         &self,
         query: &ParsedQuery,

--- a/src/client.rs
+++ b/src/client.rs
@@ -247,13 +247,8 @@ impl ClientDb {
         self.tx_id
     }
 
-    /// Execute a query using a raw EDN string.
-    pub async fn query_edn(&self, edn: &str) -> Result<QueryResult> {
-        self.query_edn_with_args(edn, vec![]).await
-    }
-
-    /// Execute a query with input binding arguments.
-    pub async fn query_edn_with_args(
+    /// Send a raw EDN query string with input binding arguments over the wire.
+    async fn query_edn_with_args(
         &self,
         edn: &str,
         args: Vec<QueryArg>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
 use crate::node::{Database, IntoQuery, QueryNode, SubmitNode, TransactionResult, TxKey};
-use crate::ops::{DataType, TxOp};
+use crate::ops::{DataType, QueryArg, TxOp};
 use crate::protocol::*;
 use crate::query::QueryResult;
 use edn::query::ParsedQuery;
@@ -247,6 +247,57 @@ impl ClientDb {
         self.tx_id
     }
 
+    /// Execute a query using a raw EDN string.
+    pub async fn query_edn(&self, edn: &str) -> Result<QueryResult> {
+        self.query_edn_with_args(edn, vec![]).await
+    }
+
+    /// Execute a query with input binding arguments.
+    pub async fn query_edn_with_args(
+        &self,
+        edn: &str,
+        args: Vec<QueryArg>,
+    ) -> Result<QueryResult> {
+        let mut conn = self.conn.lock().await;
+        write_frontend_message(
+            &mut conn.writer,
+            &FrontendMessage::Query {
+                query_string: edn.to_string(),
+                db_id: self.db_id,
+                args,
+            },
+        )
+        .await?;
+        conn.writer.flush().await?;
+
+        // Read response: could be RowDescription + DataRow* + ReadyForQuery, or ErrorResponse
+        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+
+        match msg {
+            BackendMessage::RowDescription { .. } => {
+                // Collect DataRows until ReadyForQuery
+                let mut rows = Vec::new();
+                loop {
+                    let msg =
+                        read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+                    match msg {
+                        BackendMessage::DataRow { values } => {
+                            rows.push(values);
+                        }
+                        BackendMessage::ReadyForQuery { .. } => break,
+                        other => bail!("Unexpected message during query: {:?}", other),
+                    }
+                }
+                Ok(rows)
+            }
+            BackendMessage::ErrorResponse { message, .. } => {
+                read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+                bail!("Query error: {}", message);
+            }
+            other => bail!("Expected RowDescription or ErrorResponse, got {:?}", other),
+        }
+    }
+
     /// Release this DB handle on the server.
     pub async fn close(self) -> Result<()> {
         let mut conn = self.conn.lock().await;
@@ -280,44 +331,12 @@ impl ClientDb {
 }
 
 impl Database for ClientDb {
-    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
-        let query = query.into_query()?;
-        let mut conn = self.conn.lock().await;
-        write_frontend_message(
-            &mut conn.writer,
-            &FrontendMessage::Query {
-                query_string: query.to_string(),
-                db_id: self.db_id,
-            },
-        )
-        .await?;
-        conn.writer.flush().await?;
-
-        // Read response: could be RowDescription + DataRow* + ReadyForQuery, or ErrorResponse
-        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-
-        match msg {
-            BackendMessage::RowDescription { .. } => {
-                // Collect DataRows until ReadyForQuery
-                let mut rows = Vec::new();
-                loop {
-                    let msg =
-                        read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-                    match msg {
-                        BackendMessage::DataRow { values } => {
-                            rows.push(values);
-                        }
-                        BackendMessage::ReadyForQuery { .. } => break,
-                        other => bail!("Unexpected message during query: {:?}", other),
-                    }
-                }
-                Ok(rows)
-            }
-            BackendMessage::ErrorResponse { message, .. } => {
-                read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-                bail!("Query error: {}", message);
-            }
-            other => bail!("Expected RowDescription or ErrorResponse, got {:?}", other),
-        }
+    async fn query_with_args(
+        &self,
+        query: &ParsedQuery,
+        args: &[QueryArg],
+    ) -> Result<QueryResult, Error> {
+        let edn = query.to_string();
+        self.query_edn_with_args(&edn, args.to_vec()).await
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -595,6 +595,78 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_with_variable_limit_in_binding() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Insert three named entities so LIMIT can actually truncate.
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("a".to_string())),
+                (kw!(:name), "Alice".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("b".to_string())),
+                (kw!(:name), "Bob".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("c".to_string())),
+                (kw!(:name), "Carol".into()),
+            ]),
+        ])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let parsed = edn::parse::parse_query(
+            "[:find ?name :in ?limit :where [?e :name ?name] :order [?name :asc] :limit ?limit]",
+        )
+        .unwrap();
+
+        // Variable limit resolved to 2.
+        let result = db
+            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(2))])
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            vec![
+                vec![DataType::String("Alice".to_string())],
+                vec![DataType::String("Bob".to_string())],
+            ]
+        );
+
+        // Zero limit yields an empty result.
+        let result = db
+            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(0))])
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+
+        // Non-Long binding for a variable limit is rejected.
+        let err = db
+            .query_with_args(&parsed, &[QueryArg::Scalar("two".into())])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("must be bound to a Long"),
+            "unexpected error: {}",
+            err
+        );
+
+        // Negative limit is rejected.
+        let err = db
+            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(-1))])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("non-negative"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_entity_value_join() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -505,6 +505,96 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_with_scalar_in_bindings() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("ivan".to_string())),
+                (kw!(:name), "Ivan".into()),
+                (kw!(:email), "ivan@example.com".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("petr".to_string())),
+                (kw!(:name), "Petr".into()),
+                (kw!(:email), "petr@example.com".into()),
+            ]),
+        ])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let parsed = edn::parse::parse_query(
+            "[:find ?name ?email :in ?name :where [?e :name ?name] [?e :email ?email]]",
+        )
+        .unwrap();
+
+        // Bind ?name to "Petr": only Petr's row should match.
+        let result = db
+            .query_with_args(&parsed, &[QueryArg::Scalar("Petr".into())])
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            vec![vec![
+                DataType::String("Petr".to_string()),
+                DataType::String("petr@example.com".to_string()),
+            ]]
+        );
+
+        // Bind ?name to "Ivan": only Ivan's row.
+        let result = db
+            .query_with_args(&parsed, &[QueryArg::Scalar("Ivan".into())])
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            vec![vec![
+                DataType::String("Ivan".to_string()),
+                DataType::String("ivan@example.com".to_string()),
+            ]]
+        );
+
+        // A name with no match yields no rows.
+        let result = db
+            .query_with_args(&parsed, &[QueryArg::Scalar("Bob".into())])
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+
+        // Multiple scalar bindings: constrain on both name and email.
+        let parsed = edn::parse::parse_query(
+            "[:find ?e :in ?name ?email :where [?e :name ?name] [?e :email ?email]]",
+        )
+        .unwrap();
+        let result = db
+            .query_with_args(
+                &parsed,
+                &[
+                    QueryArg::Scalar("Petr".into()),
+                    QueryArg::Scalar("petr@example.com".into()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+
+        // Mismatched pair: no rows.
+        let result = db
+            .query_with_args(
+                &parsed,
+                &[
+                    QueryArg::Scalar("Petr".into()),
+                    QueryArg::Scalar("ivan@example.com".into()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_entity_value_join() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::file_log::FileLog;
 use crate::indexer::{latest_tx_key_from_snapshot, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader};
 use crate::memory_log::MemoryLog;
-use crate::ops::{Entid, TxOp};
+use crate::ops::{Entid, QueryArg, TxOp};
 use crate::query::{execute_query, validate_query, QueryResult};
 use crate::schema::IdentMap;
 use crate::slate::{in_memory_slate, local_slate};
@@ -56,7 +56,16 @@ impl IntoQuery for String {
 
 #[allow(async_fn_in_trait)]
 pub trait Database {
-    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error>;
+    async fn query_with_args(
+        &self,
+        query: &ParsedQuery,
+        args: &[QueryArg],
+    ) -> Result<QueryResult, Error>;
+
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
+        let parsed = query.into_query()?;
+        self.query_with_args(&parsed, &[]).await
+    }
 }
 
 #[allow(async_fn_in_trait)]
@@ -120,17 +129,22 @@ impl DB {
 impl Database for DB {
     /// Execute a query against this database snapshot.
     /// Runs the sync join algorithm in a blocking task to avoid blocking the async runtime.
-    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
-        let query = query.into_query()?;
-        validate_query(&query)?;
+    async fn query_with_args(
+        &self,
+        query: &ParsedQuery,
+        args: &[QueryArg],
+    ) -> Result<QueryResult, Error> {
+        validate_query(query, args)?;
 
         let snapshot = self.snapshot.clone();
         let handle = self.handle.clone();
         let ident_map = self.ident_map.clone();
+        let query = query.clone();
+        let args = args.to_vec();
         let as_of = self.tx_eid;
 
         tokio::task::spawn_blocking(move || {
-            execute_query(&query, snapshot, handle, &ident_map, as_of)
+            execute_query(&query, &args, snapshot, handle, &ident_map, as_of)
         })
         .await
         .map_err(|e| anyhow::anyhow!("Query task failed: {}", e))?

--- a/src/node.rs
+++ b/src/node.rs
@@ -56,16 +56,13 @@ impl IntoQuery for String {
 
 #[allow(async_fn_in_trait)]
 pub trait Database {
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error>;
+
     async fn query_with_args(
         &self,
         query: &ParsedQuery,
         args: &[QueryArg],
     ) -> Result<QueryResult, Error>;
-
-    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
-        let parsed = query.into_query()?;
-        self.query_with_args(&parsed, &[]).await
-    }
 }
 
 #[allow(async_fn_in_trait)]
@@ -127,6 +124,11 @@ impl DB {
 }
 
 impl Database for DB {
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
+        let parsed = query.into_query()?;
+        self.query_with_args(&parsed, &[]).await
+    }
+
     /// Execute a query against this database snapshot.
     /// Runs the sync join algorithm in a blocking task to avoid blocking the async runtime.
     async fn query_with_args(

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -212,6 +212,16 @@ impl TxOp {
     }
 }
 
+/// A query input argument corresponding to an `:in` binding form.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryArg {
+    Scalar(DataType),
+    // TODO: Collection, Tuple, Relation are not yet supported in the EDN parser
+    Collection(Vec<DataType>),
+    Tuple(Vec<DataType>),
+    Relation(Vec<Vec<DataType>>),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DatomOp {
     Assert,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use std::str::FromStr;
 
-use crate::ops::{DataType, EntityRef, TxOp};
+use crate::ops::{DataType, EntityRef, QueryArg, TxOp};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -103,6 +103,12 @@ pub const ENTITY_REF_ID: u8 = 0x90;
 pub const ENTITY_REF_TEMPID: u8 = 0x91;
 pub const ENTITY_REF_IDENT: u8 = 0x92;
 pub const ENTITY_REF_LOOKUP: u8 = 0x93;
+
+// QueryArg tag bytes
+pub const QUERY_ARG_SCALAR: u8 = 0;
+pub const QUERY_ARG_COLLECTION: u8 = 1;
+pub const QUERY_ARG_TUPLE: u8 = 2;
+pub const QUERY_ARG_RELATION: u8 = 3;
 
 // ---------------------------------------------------------------------------
 // Error Codes
@@ -196,6 +202,7 @@ pub enum FrontendMessage {
     Query {
         query_string: String,
         db_id: u32,
+        args: Vec<QueryArg>,
     },
     Execute {
         ops: Vec<TxOp>,
@@ -204,6 +211,7 @@ pub enum FrontendMessage {
     Subscribe {
         query_string: String,
         db_id: u32,
+        args: Vec<QueryArg>,
     },
     Unsubscribe,
     Terminate,
@@ -491,6 +499,37 @@ fn encode_tx_ops(buf: &mut Vec<u8>, ops: &[TxOp]) {
     encode_u32(buf, ops.len() as u32);
     for op in ops {
         encode_tx_op(buf, op);
+    }
+}
+
+fn encode_query_arg(buf: &mut Vec<u8>, arg: &QueryArg) {
+    match arg {
+        QueryArg::Scalar(dt) => {
+            encode_u8(buf, QUERY_ARG_SCALAR);
+            encode_data_type(buf, dt);
+        }
+        QueryArg::Collection(items) => {
+            encode_u8(buf, QUERY_ARG_COLLECTION);
+            encode_data_type_vec(buf, items);
+        }
+        QueryArg::Tuple(items) => {
+            encode_u8(buf, QUERY_ARG_TUPLE);
+            encode_data_type_vec(buf, items);
+        }
+        QueryArg::Relation(rows) => {
+            encode_u8(buf, QUERY_ARG_RELATION);
+            encode_u32(buf, rows.len() as u32);
+            for row in rows {
+                encode_data_type_vec(buf, row);
+            }
+        }
+    }
+}
+
+fn encode_query_args(buf: &mut Vec<u8>, args: &[QueryArg]) {
+    encode_u32(buf, args.len() as u32);
+    for arg in args {
+        encode_query_arg(buf, arg);
     }
 }
 
@@ -787,6 +826,39 @@ fn decode_tx_ops(cursor: &mut Cursor) -> Result<Vec<TxOp>> {
     Ok(ops)
 }
 
+fn decode_query_arg(cursor: &mut Cursor) -> Result<QueryArg> {
+    let tag = cursor.read_u8()?;
+    match tag {
+        QUERY_ARG_SCALAR => Ok(QueryArg::Scalar(decode_data_type(cursor)?)),
+        QUERY_ARG_COLLECTION => Ok(QueryArg::Collection(decode_data_type_vec(cursor)?)),
+        QUERY_ARG_TUPLE => Ok(QueryArg::Tuple(decode_data_type_vec(cursor)?)),
+        QUERY_ARG_RELATION => {
+            let row_count = cursor.read_u32()? as usize;
+            if row_count > cursor.remaining() {
+                bail!("Relation row count {} exceeds remaining bytes {}", row_count, cursor.remaining());
+            }
+            let mut rows = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
+                rows.push(decode_data_type_vec(cursor)?);
+            }
+            Ok(QueryArg::Relation(rows))
+        }
+        _ => bail!("Unknown QueryArg tag: {}", tag),
+    }
+}
+
+fn decode_query_args(cursor: &mut Cursor) -> Result<Vec<QueryArg>> {
+    let count = cursor.read_u32()? as usize;
+    if count > cursor.remaining() {
+        bail!("Vec<QueryArg> count {} exceeds remaining bytes {}", count, cursor.remaining());
+    }
+    let mut args = Vec::with_capacity(count);
+    for _ in 0..count {
+        args.push(decode_query_arg(cursor)?);
+    }
+    Ok(args)
+}
+
 // ---------------------------------------------------------------------------
 // Message Payload Encoding
 // ---------------------------------------------------------------------------
@@ -812,9 +884,11 @@ fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
         FrontendMessage::Query {
             query_string,
             db_id,
+            args,
         } => {
             encode_string(buf, query_string);
             encode_u32(buf, *db_id);
+            encode_query_args(buf, args);
         }
         FrontendMessage::Execute {
             ops,
@@ -826,9 +900,11 @@ fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
         FrontendMessage::Subscribe {
             query_string,
             db_id,
+            args,
         } => {
             encode_string(buf, query_string);
             encode_u32(buf, *db_id);
+            encode_query_args(buf, args);
         }
         FrontendMessage::Unsubscribe => {}
         FrontendMessage::Terminate => {}
@@ -912,6 +988,7 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
         MSG_QUERY => Ok(FrontendMessage::Query {
             query_string: cursor.read_string()?,
             db_id: cursor.read_u32()?,
+            args: decode_query_args(cursor)?,
         }),
         MSG_EXECUTE => {
             let ops = decode_tx_ops(cursor)?;
@@ -924,6 +1001,7 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
         MSG_SUBSCRIBE => Ok(FrontendMessage::Subscribe {
             query_string: cursor.read_string()?,
             db_id: cursor.read_u32()?,
+            args: decode_query_args(cursor)?,
         }),
         MSG_UNSUBSCRIBE => Ok(FrontendMessage::Unsubscribe),
         MSG_TERMINATE => Ok(FrontendMessage::Terminate),
@@ -1450,6 +1528,7 @@ mod tests {
         let msg = FrontendMessage::Query {
             query_string: "{:find [?e ?name] :where [[?e :person/name ?name]]}".to_string(),
             db_id: 1,
+            args: vec![],
         };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
     }
@@ -1471,6 +1550,7 @@ mod tests {
         let msg = FrontendMessage::Subscribe {
             query_string: "{:find [?name] :where [[?e :person/name ?name]]}".to_string(),
             db_id: 3,
+            args: vec![],
         };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -16,7 +16,7 @@ use edn::query::{
 };
 
 use crate::aggregate::{make_accumulator, Accumulator};
-use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple};
+use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple, SingleLevelExtender};
 use crate::codec::{Decode, Encode};
 use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr};
 use crate::index::IndexType;
@@ -26,7 +26,7 @@ use crate::iterator::generic_not_prefix_extender::GenericNotPrefixExtender;
 use crate::iterator::generic_or_prefix_extender::GenericOrPrefixExtender;
 use crate::iterator::generic_predicate_prefix_extender::GenericPredicatePrefixExtender;
 use crate::iterator::generic_prefix_extender::GenericPrefixExtender;
-use crate::ops::DataType;
+use crate::ops::{DataType, QueryArg};
 
 /// Each inner Vec is a projected row of decoded DataType values.
 pub type QueryResult = Vec<Vec<DataType>>;
@@ -324,9 +324,16 @@ fn collect_variables_from_clause(clause: &WhereClause) -> Vec<Variable> {
 /// Pattern/OrJoin variables in the join order.
 /// TODO: refine to only require the clauses that bind a WhereFn's input variables
 /// to appear before that WhereFn (topological sort).
-pub fn query_variable_order(where_clauses: &[WhereClause]) -> Vec<Variable> {
+pub fn query_variable_order(in_vars: &[Variable], where_clauses: &[WhereClause]) -> Vec<Variable> {
     let mut seen = HashSet::new();
     let mut order = Vec::new();
+
+    // In-binding variables come first in the join order.
+    for var in in_vars {
+        if seen.insert(var.clone()) {
+            order.push(var.clone());
+        }
+    }
 
     // Non-WhereFn clauses first, then WhereFn clauses, preserving relative order within each group.
     let reordered: Vec<&WhereClause> = where_clauses
@@ -1002,10 +1009,10 @@ fn apply_order_and_limit(
         Limit::Fixed(n) => {
             results.truncate(*n as usize);
         }
-        // Defense-in-depth: validate_query() rejects this earlier, but guard here too.
+        // Defense-in-depth: execute_query resolves variable limits before calling this.
         Limit::Variable(v) => {
             return Err(anyhow::anyhow!(
-                "Variable limit {} is not yet supported (requires input bindings)",
+                "Variable limit {} should have been resolved from :in bindings",
                 v
             ));
         }
@@ -1017,8 +1024,29 @@ fn apply_order_and_limit(
 /// Validate a query before execution.
 // TODO: Move query validation into the edn parsing crate so that invalid
 // queries are rejected at parse time rather than at execution time.
-pub fn validate_query(query: &ParsedQuery) -> Result<(), Error> {
-    let join_order = query_variable_order(&query.where_clauses);
+pub fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Error> {
+    // Validate :in binding count matches args
+    if query.in_vars.len() != args.len() {
+        return Err(anyhow::anyhow!(
+            ":in clause declares {} variable(s) but {} argument(s) provided",
+            query.in_vars.len(),
+            args.len()
+        ));
+    }
+
+    // Only scalar bindings are supported for now
+    for (i, arg) in args.iter().enumerate() {
+        if !matches!(arg, QueryArg::Scalar(_)) {
+            return Err(anyhow::anyhow!(
+                "Only scalar bindings are currently supported, but argument {} for {} is {:?}",
+                i,
+                query.in_vars[i],
+                arg
+            ));
+        }
+    }
+
+    let join_order = query_variable_order(&query.in_vars, &query.where_clauses);
     if join_order.is_empty() {
         return Err(anyhow::anyhow!("Query has no variables"));
     }
@@ -1038,12 +1066,15 @@ pub fn validate_query(query: &ParsedQuery) -> Result<(), Error> {
         resolve_order_columns(orders, &query.find_spec)?;
     }
 
-    // Variable limits are not yet supported.
+    // Variable limits: resolve from :in bindings if possible
     if let Limit::Variable(v) = &query.limit {
-        return Err(anyhow::anyhow!(
-            "Variable limit {} is not yet supported (requires input bindings)",
-            v
-        ));
+        let in_idx = query.in_vars.iter().position(|iv| iv == v);
+        if in_idx.is_none() {
+            return Err(anyhow::anyhow!(
+                "Variable limit {} is not bound in :in clause",
+                v
+            ));
+        }
     }
 
     Ok(())
@@ -1135,22 +1166,67 @@ fn compile_where_clause(
     }
 }
 
+/// Resolve a variable limit from :in bindings.
+fn resolve_limit(limit: &Limit, in_vars: &[Variable], args: &[QueryArg]) -> Result<Limit, Error> {
+    match limit {
+        Limit::Variable(v) => {
+            let idx = in_vars.iter().position(|iv| iv == v).ok_or_else(|| {
+                anyhow::anyhow!("Variable limit {} is not bound in :in clause", v)
+            })?;
+            match &args[idx] {
+                QueryArg::Scalar(DataType::Long(n)) => {
+                    if *n < 0 {
+                        return Err(anyhow::anyhow!("Limit must be non-negative, got {}", n));
+                    }
+                    Ok(Limit::Fixed(*n as u64))
+                }
+                other => Err(anyhow::anyhow!(
+                    "Variable limit {} must be bound to a Long, got {:?}",
+                    v,
+                    other
+                )),
+            }
+        }
+        other => Ok(other.clone()),
+    }
+}
+
 /// Execute a query against the database.
 pub fn execute_query(
     query: &ParsedQuery,
+    args: &[QueryArg],
     slate: Arc<slatedb::DbSnapshot>,
     handle: Handle,
     ident_map: &IdentMap,
     as_of: i64,
 ) -> Result<QueryResult, Error> {
-    // 1. Extract variable order
-    let join_order = query_variable_order(&query.where_clauses);
+    // 1. Extract variable order (in_vars prepended)
+    let join_order = query_variable_order(&query.in_vars, &query.where_clauses);
     let num_levels = join_order.len();
     let var_index = build_var_index(&join_order);
 
-    // 2. Compile patterns into extenders
+    // 2. Compile in-binding arguments into extenders
     let mut extenders: Vec<Box<dyn PrefixExtender>> = Vec::new();
 
+    for (in_var, arg) in query.in_vars.iter().zip(args.iter()) {
+        let level = *var_index.get(in_var).expect("in_var must be in join order");
+        match arg {
+            QueryArg::Scalar(dt) => {
+                let encoded = dt.encode();
+                extenders.push(Box::new(SingleLevelExtender::new(
+                    vec![bytes::Bytes::from(encoded)],
+                    level,
+                )));
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Only scalar bindings are currently supported"
+                ));
+            }
+        }
+    }
+
+    // 3. Compile WHERE patterns into extenders
     for clause in &query.where_clauses {
         extenders.push(compile_where_clause(
             clause,
@@ -1163,12 +1239,12 @@ pub fn execute_query(
         )?);
     }
 
-    // 3. Run GenericJoin
+    // 4. Run GenericJoin
     let extender_refs: Vec<&dyn PrefixExtender> = extenders.iter().map(|e| e.as_ref()).collect();
     let join = GenericJoin::new(extender_refs, num_levels);
     let results = join.join();
 
-    // 4. Project and aggregate results based on find clause
+    // 5. Project and aggregate results based on find clause
     let plan = compile_find_plan(&query.find_spec, &var_index)?;
     let projected = if plan.has_aggregates {
         execute_aggregation(results, &plan)?
@@ -1176,8 +1252,9 @@ pub fn execute_query(
         project_results(results, &plan)?
     };
 
-    // 5. Apply ORDER BY and LIMIT
-    apply_order_and_limit(projected, &query.order, &query.limit, &query.find_spec)
+    // 6. Resolve variable limit from :in bindings and apply ORDER BY + LIMIT
+    let resolved_limit = resolve_limit(&query.limit, &query.in_vars, args)?;
+    apply_order_and_limit(projected, &query.order, &resolved_limit, &query.find_spec)
 }
 
 #[cfg(test)]
@@ -1192,14 +1269,14 @@ mod tests {
     #[test]
     fn test_query_variable_order_single_pattern() {
         let parsed = parse_query("[:find ?e ?name :where [?e :name ?name]]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(order, vec!["?e".to_var(), "?name".to_var()]);
     }
 
     #[test]
     fn test_query_variable_order_multiple_patterns() {
         let parsed = parse_query("[:find ?e ?name ?age :where [?e :name ?name] [?e :age ?age]]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(
             order,
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
@@ -1209,14 +1286,14 @@ mod tests {
     #[test]
     fn test_query_variable_order_with_constants() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"]]"#);
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(order, vec!["?e".to_var()]);
     }
 
     #[test]
     fn test_query_variable_order_with_or_clause() {
         let parsed = parse_query("[:find ?e :where (or [?e _ 10] [?e _ 15])]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(order, vec!["?e".to_var()]);
     }
 
@@ -1225,21 +1302,21 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :age ?age]]"#,
         );
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(order, vec!["?e".to_var(), "?age".to_var(),]);
     }
 
     #[test]
     fn test_query_variable_order_ignores_predicates() {
         let parsed = parse_query("[:find ?e ?age :where [?e :age ?age] [(< ?age 30)]]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(order, vec!["?e".to_var(), "?age".to_var(),]);
     }
 
     #[test]
     fn test_validate_predicate_unbound_variable() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"] [(< ?unbound 30)]]"#);
-        let result = validate_query(&parsed);
+        let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("?unbound"));
     }
@@ -1247,7 +1324,7 @@ mod tests {
     #[test]
     fn test_validate_predicate_no_variables() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#);
-        let result = validate_query(&parsed);
+        let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -1259,7 +1336,7 @@ mod tests {
     fn test_query_variable_order_with_fn_expr() {
         let parsed =
             parse_query("[:find ?e ?next_age :where [?e :age ?age] [(+ ?age 1) ?next_age]]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(
             order,
             vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
@@ -1270,7 +1347,7 @@ mod tests {
     fn test_validate_fn_unbound_input() {
         let parsed =
             parse_query(r#"[:find ?e :where [?e :name "Alice"] [(+ ?unbound 1) ?result]]"#);
-        let result = validate_query(&parsed);
+        let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("?unbound"));
     }
@@ -1279,7 +1356,7 @@ mod tests {
     fn test_validate_fn_input_must_precede_output() {
         // Output ?e is at level 0 (from Triple), input ?age is at level 1 — input doesn't precede output
         let parsed = parse_query("[:find ?e :where [?e :age ?age] [(+ ?age 1) ?e]]");
-        let result = validate_query(&parsed);
+        let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("must precede"));
     }
@@ -1290,7 +1367,7 @@ mod tests {
         // because query_variable_order reorders FnExpr clauses after Triples
         let parsed =
             parse_query("[:find ?e ?next_age :where [(+ ?age 1) ?next_age] [?e :age ?age]]");
-        let result = validate_query(&parsed);
+        let result = validate_query(&parsed, &[]);
         assert!(result.is_ok());
     }
 
@@ -1299,7 +1376,7 @@ mod tests {
         // FnExpr appears first, but its output should still come after Triple vars
         let parsed =
             parse_query("[:find ?e ?next_age :where [(+ ?age 1) ?next_age] [?e :age ?age]]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(
             order,
             vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
@@ -1310,7 +1387,7 @@ mod tests {
     fn test_query_variable_order_with_and_inside_or() {
         let parsed =
             parse_query("[:find ?e ?name ?age :where (or (and [?e :name ?name] [?e :age ?age]))]");
-        let order = query_variable_order(&parsed.where_clauses);
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
         assert_eq!(
             order,
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
@@ -1462,7 +1539,7 @@ mod tests {
     #[test]
     fn test_validate_order_var_not_in_find() {
         let parsed = parse_query("[:find ?e :where [?e :name ?name] :order [?name :asc]]");
-        let err = validate_query(&parsed).unwrap_err();
+        let err = validate_query(&parsed, &[]).unwrap_err();
         assert!(
             err.to_string().contains("ORDER BY variable"),
             "unexpected error: {}",
@@ -1471,13 +1548,52 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_limit_variable_unsupported() {
-        let parsed = parse_query("[:find ?e :in ?limit :where [?e :name ?name] :limit ?limit]");
-        let err = validate_query(&parsed).unwrap_err();
+    fn test_validate_limit_variable_requires_in_binding() {
+        // Variable limit without :in binding should fail
+        let parsed = parse_query("[:find ?e :where [?e :name ?name] :limit ?limit]");
+        let err = validate_query(&parsed, &[]).unwrap_err();
         assert!(
-            err.to_string().contains("not yet supported"),
+            err.to_string().contains("not bound in :in clause"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    #[test]
+    fn test_validate_limit_variable_with_in_binding() {
+        let parsed = parse_query(
+            "[:find ?e :in ?limit :where [?e :name ?name] :limit ?limit]",
+        );
+        // Providing a scalar Long arg should pass validation
+        assert!(validate_query(&parsed, &[QueryArg::Scalar(DataType::Long(10))]).is_ok());
+    }
+
+    #[test]
+    fn test_validate_in_arg_count_mismatch() {
+        let parsed = parse_query(
+            "[:find ?e :in ?x :where [?e :name ?x]]",
+        );
+        let err = validate_query(&parsed, &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("1 variable(s) but 0 argument(s)"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_query_variable_order_with_in_vars() {
+        let parsed = parse_query(
+            "[:find ?e ?name :in ?name :where [?e :person/name ?name]]",
+        );
+        let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
+        // ?name from :in should come first, then ?e from WHERE
+        assert_eq!(
+            order,
+            vec![
+                "?name".to_var(),
+                "?e".to_var(),
+            ]
         );
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1066,14 +1066,24 @@ pub fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Erro
         resolve_order_columns(orders, &query.find_spec)?;
     }
 
-    // Variable limits: resolve from :in bindings if possible
+    // Variable limits must be bound in :in to a non-negative Long.
     if let Limit::Variable(v) = &query.limit {
-        let in_idx = query.in_vars.iter().position(|iv| iv == v);
-        if in_idx.is_none() {
-            return Err(anyhow::anyhow!(
-                "Variable limit {} is not bound in :in clause",
-                v
-            ));
+        let idx = query.in_vars.iter().position(|iv| iv == v).ok_or_else(|| {
+            anyhow::anyhow!("Variable limit {} is not bound in :in clause", v)
+        })?;
+        match &args[idx] {
+            QueryArg::Scalar(DataType::Long(n)) => {
+                if *n < 0 {
+                    return Err(anyhow::anyhow!("Limit must be non-negative, got {}", n));
+                }
+            }
+            other => {
+                return Err(anyhow::anyhow!(
+                    "Variable limit {} must be bound to a Long, got {:?}",
+                    v,
+                    other
+                ));
+            }
         }
     }
 
@@ -1167,27 +1177,22 @@ fn compile_where_clause(
 }
 
 /// Resolve a variable limit from :in bindings.
-fn resolve_limit(limit: &Limit, in_vars: &[Variable], args: &[QueryArg]) -> Result<Limit, Error> {
+///
+/// `validate_query` guarantees the variable is present in `in_vars` and bound
+/// to a non-negative `Long`, so this is infallible for validated queries.
+fn resolve_limit(limit: &Limit, in_vars: &[Variable], args: &[QueryArg]) -> Limit {
     match limit {
         Limit::Variable(v) => {
-            let idx = in_vars.iter().position(|iv| iv == v).ok_or_else(|| {
-                anyhow::anyhow!("Variable limit {} is not bound in :in clause", v)
-            })?;
+            let idx = in_vars
+                .iter()
+                .position(|iv| iv == v)
+                .expect("validate_query ensures variable limit is in :in");
             match &args[idx] {
-                QueryArg::Scalar(DataType::Long(n)) => {
-                    if *n < 0 {
-                        return Err(anyhow::anyhow!("Limit must be non-negative, got {}", n));
-                    }
-                    Ok(Limit::Fixed(*n as u64))
-                }
-                other => Err(anyhow::anyhow!(
-                    "Variable limit {} must be bound to a Long, got {:?}",
-                    v,
-                    other
-                )),
+                QueryArg::Scalar(DataType::Long(n)) => Limit::Fixed(*n as u64),
+                _ => unreachable!("validate_query ensures variable limit binds to a Long"),
             }
         }
-        other => Ok(other.clone()),
+        other => other.clone(),
     }
 }
 
@@ -1210,20 +1215,15 @@ pub fn execute_query(
 
     for (in_var, arg) in query.in_vars.iter().zip(args.iter()) {
         let level = *var_index.get(in_var).expect("in_var must be in join order");
-        match arg {
-            QueryArg::Scalar(dt) => {
-                let encoded = dt.encode();
-                extenders.push(Box::new(SingleLevelExtender::new(
-                    vec![bytes::Bytes::from(encoded)],
-                    level,
-                )));
-            }
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "Only scalar bindings are currently supported"
-                ));
-            }
-        }
+        // validate_query ensures every arg is a Scalar; non-scalars are rejected there.
+        let QueryArg::Scalar(dt) = arg else {
+            unreachable!("validate_query ensures only scalar bindings reach execute_query");
+        };
+        let encoded = dt.encode();
+        extenders.push(Box::new(SingleLevelExtender::new(
+            vec![bytes::Bytes::from(encoded)],
+            level,
+        )));
     }
 
     // 3. Compile WHERE patterns into extenders
@@ -1253,7 +1253,7 @@ pub fn execute_query(
     };
 
     // 6. Resolve variable limit from :in bindings and apply ORDER BY + LIMIT
-    let resolved_limit = resolve_limit(&query.limit, &query.in_vars, args)?;
+    let resolved_limit = resolve_limit(&query.limit, &query.in_vars, args);
     apply_order_and_limit(projected, &query.order, &resolved_limit, &query.find_spec)
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -549,6 +549,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let ident_results = tokio::task::spawn_blocking(move || {
         execute_query(
             &ident_query,
+            &[],
             snap_clone,
             handle_clone,
             &ident_map_clone,
@@ -567,6 +568,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let attr_results = tokio::task::spawn_blocking(move || {
         execute_query(
             &attr_query,
+            &[],
             snapshot,
             handle,
             &bootstrap_ident_map,

--- a/src/server.rs
+++ b/src/server.rs
@@ -456,8 +456,9 @@ async fn handle_connection<L: TxLog + 'static>(
             FrontendMessage::Query {
                 query_string,
                 db_id,
+                args,
             } => {
-                match handle_query(&conn_state, &query_string, db_id).await {
+                match handle_query(&conn_state, &query_string, db_id, &args).await {
                     Ok((result, find_vars)) => {
                         // Send RowDescription
                         let columns: Vec<ColumnDescription> = find_vars
@@ -600,6 +601,7 @@ async fn handle_query(
     conn_state: &ConnectionState,
     query_string: &str,
     db_id: u32,
+    args: &[crate::ops::QueryArg],
 ) -> Result<(QueryResult, Vec<String>)> {
     let db = conn_state
         .get_db(db_id)
@@ -613,7 +615,7 @@ async fn handle_query(
         _ => vec![],
     };
 
-    let result = db.query(&parsed).await?;
+    let result = db.query_with_args(&parsed, args).await?;
     Ok((result, find_vars))
 }
 

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -2,7 +2,7 @@
   "Clojure client API for Triplox."
   (:require [io.triplox.types :as types]
             [io.triplox.tx :as tx])
-  (:import [io.triplox.client TriploxNode Db TxKeyResult TxResultValue]))
+  (:import [io.triplox.client TriploxNode Db TxKeyResult TxResultValue QueryArg QueryArg$Scalar]))
 
 (defn connect
   "Connect to a Triplox server. Returns a TriploxNode (AutoCloseable)."
@@ -19,10 +19,15 @@
    (.openDb ^TriploxNode conn (when tx-id (long tx-id)))))
 
 (defn q
-  "Execute a Datalog query. Returns a vector of vectors."
-  [db query]
-  (mapv (fn [row] (mapv types/wire->clj row))
-        (.query ^Db db (pr-str query))))
+  "Execute a Datalog query. Returns a vector of vectors.
+  Optionally accepts :in binding arguments."
+  ([db query]
+   (mapv (fn [row] (mapv types/wire->clj row))
+         (.query ^Db db (pr-str query))))
+  ([db query args]
+   (let [query-args (mapv (fn [a] (QueryArg$Scalar. a)) args)]
+     (mapv (fn [row] (mapv types/wire->clj row))
+           (.query ^Db db (pr-str query) query-args)))))
 
 (defn transact
   "Execute a transaction and wait for indexing. Returns result map."

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -20,14 +20,14 @@
 
 (defn q
   "Execute a Datalog query. Returns a vector of vectors.
-  Optionally accepts :in binding arguments."
-  ([db query]
-   (mapv (fn [row] (mapv types/wire->clj row))
-         (.query ^Db db (pr-str query))))
-  ([db query args]
-   (let [query-args (mapv (fn [a] (QueryArg$Scalar. a)) args)]
-     (mapv (fn [row] (mapv types/wire->clj row))
-           (.query ^Db db (pr-str query) query-args)))))
+  Additional arguments bind `:in` variables as scalars."
+  [db query & args]
+  (if (seq args)
+    (let [query-args (mapv (fn [a] (QueryArg$Scalar. a)) args)]
+      (mapv (fn [row] (mapv types/wire->clj row))
+            (.query ^Db db (pr-str query) query-args)))
+    (mapv (fn [row] (mapv types/wire->clj row))
+          (.query ^Db db (pr-str query)))))
 
 (defn transact
   "Execute a transaction and wait for indexing. Returns result map."

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -19,8 +19,7 @@
    (.openDb ^TriploxNode conn (when tx-id (long tx-id)))))
 
 (defn q
-  "Execute a Datalog query. Returns a vector of vectors.
-  Additional arguments bind `:in` variables as scalars."
+  "Execute a Datalog query. Returns a vector of vectors."
   [db query & args]
   (if (seq args)
     (let [query-args (mapv (fn [a] (QueryArg$Scalar. a)) args)]

--- a/triplox-jvm/src/main/java/io/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/Db.java
@@ -31,6 +31,13 @@ public class Db implements AutoCloseable {
     }
 
     /**
+     * Execute a Datalog query with input binding arguments.
+     */
+    public List<List<Object>> query(String edn, List<QueryArg> args) throws IOException {
+        return node.queryInternal(this, edn, args).rows();
+    }
+
+    /**
      * Release this DB snapshot on the server.
      */
     @Override

--- a/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
@@ -71,4 +71,9 @@ public final class MessageTypes {
     public static final byte ENTITY_REF_IDENT   = (byte) 0x92;
     public static final byte ENTITY_REF_LOOKUP  = (byte) 0x93;
 
+    // QueryArg tag bytes
+    public static final byte QUERY_ARG_SCALAR     = 0;
+    public static final byte QUERY_ARG_COLLECTION = 1;
+    public static final byte QUERY_ARG_TUPLE      = 2;
+    public static final byte QUERY_ARG_RELATION   = 3;
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/QueryArg.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/QueryArg.java
@@ -1,0 +1,52 @@
+package io.triplox.client;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static io.triplox.client.MessageTypes.*;
+
+/**
+ * A query input argument corresponding to an {@code :in} binding form.
+ */
+public sealed interface QueryArg {
+
+    record Scalar(Object value) implements QueryArg {}
+
+    // TODO: Collection, Tuple, Relation are not yet supported in the EDN parser
+    record Collection(List<Object> values) implements QueryArg {}
+    record Tuple(List<Object> values) implements QueryArg {}
+    record Relation(List<List<Object>> rows) implements QueryArg {}
+
+    static void encode(DataOutputStream out, QueryArg arg) throws IOException {
+        switch (arg) {
+            case Scalar s -> {
+                out.writeByte(QUERY_ARG_SCALAR);
+                DataTypeCodec.encode(out, s.value());
+            }
+            case Collection c -> {
+                out.writeByte(QUERY_ARG_COLLECTION);
+                DataTypeCodec.encodeDataTypeVec(out, c.values());
+            }
+            case Tuple t -> {
+                out.writeByte(QUERY_ARG_TUPLE);
+                DataTypeCodec.encodeDataTypeVec(out, t.values());
+            }
+            case Relation r -> {
+                out.writeByte(QUERY_ARG_RELATION);
+                out.writeInt(r.rows().size());
+                for (List<Object> row : r.rows()) {
+                    DataTypeCodec.encodeDataTypeVec(out, row);
+                }
+            }
+        }
+    }
+
+    static void encodeArgs(DataOutputStream out, List<QueryArg> args) throws IOException {
+        out.writeInt(args.size());
+        for (QueryArg arg : args) {
+            encode(out, arg);
+        }
+    }
+}

--- a/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
@@ -89,7 +89,14 @@ public class TriploxNode implements AutoCloseable {
      * Execute a Datalog query against an open DB snapshot.
      */
     QueryResult queryInternal(Db db, String edn) throws IOException {
-        WireCodec.writeQuery(out, edn, db.dbId());
+        return queryInternal(db, edn, List.of());
+    }
+
+    /**
+     * Execute a Datalog query with input binding arguments.
+     */
+    QueryResult queryInternal(Db db, String edn, List<QueryArg> args) throws IOException {
+        WireCodec.writeQuery(out, edn, db.dbId(), args);
         out.flush();
 
         // Read RowDescription

--- a/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
@@ -54,9 +54,14 @@ public final class WireCodec {
     }
 
     public static void writeQuery(OutputStream out, String query, int dbId) throws IOException {
+        writeQuery(out, query, dbId, List.of());
+    }
+
+    public static void writeQuery(OutputStream out, String query, int dbId, List<QueryArg> args) throws IOException {
         writeFramed(out, MSG_QUERY, dos -> {
             DataTypeCodec.encodeString(dos, query);
             dos.writeInt(dbId);
+            QueryArg.encodeArgs(dos, args);
         });
     }
 
@@ -68,9 +73,14 @@ public final class WireCodec {
     }
 
     public static void writeSubscribe(OutputStream out, String query, int dbId) throws IOException {
+        writeSubscribe(out, query, dbId, List.of());
+    }
+
+    public static void writeSubscribe(OutputStream out, String query, int dbId, List<QueryArg> args) throws IOException {
         writeFramed(out, MSG_SUBSCRIBE, dos -> {
             DataTypeCodec.encodeString(dos, query);
             dos.writeInt(dbId);
+            QueryArg.encodeArgs(dos, args);
         });
     }
 

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -287,17 +287,21 @@
                                :where [[?e :name "Ivan"]
                                        [?e :last-name "Ivanov"]]}))]
       ;; Exclude entities whose :name matches Ivan's :name
-      (is (= 0 (count (q {:find  '[?e]
-                          :where [['?e :name '?name]
-                                  (list 'not [ivan-id :name '?name])]})))))
+      (is (= 0 (count (q '{:find [?e]
+                           :in [?ivan-id]
+                           :where [[?e :name ?name]
+                                   (not [?ivan-id :name ?name])]}
+                         ivan-id)))))
 
     ;; Discover entity with last-name "Ivannotov"
     (let [ivannotov-id (ffirst (q '{:find [?e]
                                     :where [[?e :last-name "Ivannotov"]]}))]
       ;; Only entities whose last-name differs from Ivannotov's
-      (is (= 2 (count (q {:find  '[?e]
-                          :where [['?e :last-name '?last-name]
-                                  (list 'not [ivannotov-id :last-name '?last-name])]}))))))
+      (is (= 2 (count (q '{:find [?e]
+                           :in [?ivannotov-id]
+                           :where [[?e :last-name ?last-name]
+                                   (not [?ivannotov-id :last-name ?last-name])]}
+                         ivannotov-id))))))
 
   (testing "not can come before positive clauses"
     (is (= 2 (count (q '{:find [?e]
@@ -364,9 +368,11 @@
     (let [ivan-id (ffirst (q '{:find [?e]
                                :where [[?e :name "Ivan"]]}))]
       (is (= #{["Ivan"]}
-             (q {:find  '[?name]
-                 :where [['?e :name '?name]
-                         [(list '= ivan-id '?e)]]}))))
+             (q '{:find [?name]
+                  :in [?ivan-id]
+                  :where [[?e :name ?name]
+                          [(= ?ivan-id ?e)]]}
+                ivan-id))))
 
     (testing "Filtered by value"
       (is (= 2 (count (q '{:find [?e]

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -34,11 +34,11 @@
 (use-fixtures :each with-conn with-people-schema)
 
 (defn q
-  "Open a DB, run query, close DB, return results as a set."
-  ([query-edn] (q *conn* query-edn))
-  ([conn query-edn]
-   (with-open [db (tc/db conn)]
-     (set (tc/q db query-edn)))))
+  "Open a DB, run query, close DB, return results as a set.
+  Additional arguments bind `:in` variables as scalars."
+  [query-edn & args]
+  (with-open [db (tc/db *conn*)]
+    (set (apply tc/q db query-edn args))))
 
 (defn q-ordered
   "Open a DB, run query, close DB, return results as a vector (preserves order)."
@@ -577,3 +577,140 @@
       (is (= 5 (count result)))
       (is (= ["Dave" 10] (first result)))
       (is (= ["Eve" 50] (last result))))))
+
+(deftest test-query-with-arguments
+  (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov"}
+                       {:name "Petr" :last-name "Petrov"}])
+
+  (testing "Can query entity by single field"
+    (is (= #{["Ivan" "Ivanov"]}
+           (q '{:find [?name ?last-name]
+                :in [?name]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              "Ivan")))
+
+    (is (= #{["Petr" "Petrov"]}
+           (q '{:find [?name ?last-name]
+                :in [?name]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              "Petr"))))
+
+  (testing "Can query entity by entity position"
+    ;; Collection binding `[[?e ...]]` — not yet supported.
+    #_
+    (is (= #{["Ivan"]
+             ["Petr"]}
+           (q '{:find [?name]
+                :in [[?e ...]]
+                :where [[?e :name ?name]]}
+              [:ivan :petr])))
+
+    #_
+    (is (= #{["Ivan" "Ivanov"]
+             ["Petr" "Petrov"]}
+           (q '{:find [?name ?last-name]
+                :in [[?e ...]]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              [:ivan :petr]))))
+
+  (testing "Can match on both entity and value position"
+    (is (= #{["Ivan" "Ivanov"]}
+           (q '{:find [?name ?last-name]
+                :in [?name ?last-name]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              "Ivan" "Ivanov")))
+
+    ;; Inline `:args` clause — not yet supported.
+    #_
+    (is (= #{}
+           (q '{:find [?name]
+                :in [?e ?name]
+                :where [[?e :name ?name]]
+                :args [{:e :ivan :name "Petr"}]}
+              :ivan "Petr"))))
+
+  (testing "Can query entity by single field with several arguments"
+    ;; Collection binding `[[?name ...]]` — not yet supported.
+    #_
+    (is (= #{["Ivan"] ["Petr"]}
+           (q '{:find [?name]
+                :in [[?name ...]]
+                :where [[?e :name ?name]]}
+              ["Ivan" "Petr"]))))
+
+  (testing "Can query entity by single field with literals"
+    ;; Collection bindings — not yet supported.
+    #_
+    (is (= #{["Ivan"]}
+           (q '{:find [?name]
+                :in [[?name ...]]
+                :where [[?e :name ?name]
+                        [?e :last-name "Ivanov"]]}
+              ["Ivan" "Petr"]))))
+
+  (testing "Can query entity by non existent argument"
+    (is (= #{}
+           (q '{:find [?name]
+                :in [?name]
+                :where [[?e :name ?name]]}
+              "Bob"))))
+
+  (testing "Can query entity with empty arguments"
+    (is (= #{["Ivan"] ["Petr"]}
+           (q '{:find [?name]
+                :in []
+                :where [[?e :name ?name]]}))))
+
+  (testing "Can query entity with tuple arguments"
+    ;; Tuple binding `[[?name ?last-name]]` — not yet supported.
+    #_
+    (is (= #{["Ivan"]}
+           (q '{:find [?name]
+                :in [[?name ?last-name]]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              ["Ivan" "Ivanov"]))))
+
+  (testing "Can query entity with collection arguments"
+    ;; Relation binding `[[[?name ?last-name]]]` — not yet supported.
+    #_
+    (is (= #{["Ivan"] ["Petr"]}
+           (q '{:find [?name]
+                :in [[[?name ?last-name]]]
+                :where [[?e :name ?name]
+                        [?e :last-name ?last-name]]}
+              [["Ivan" "Ivanov"] ["Petr" "Petrov"]]))))
+
+  (testing "Can query predicates based on arguments alone"
+    ;; Inline `:args` clause — not yet supported.
+    #_
+    (is (= #{["Ivan"]}
+           (q '{:find [?name]
+                :where [[(re-find #"I" ?name)]]
+                :args [{:name "Ivan"} {:name "Petr"}]})))
+
+    ;; Collection binding — not yet supported.
+    #_
+    (is (= #{["Ivan"] ["Petr"]}
+           (q '{:find [?name]
+                :in [[?name ...]]
+                :where [[(string? ?name)]]}
+              ["Ivan" "Petr"])))
+
+    ;; Range constraints on a scalar `:in` binding — supported.
+    (testing "Can use range constraints on arguments"
+      (is (= #{}
+             (q '{:find [?age]
+                  :in [?age]
+                  :where [[(>= ?age 21)]]}
+                20)))
+
+      (is (= #{[22]}
+             (q '{:find [?age]
+                  :in [?age]
+                  :where [[(>= ?age 21)]]}
+                22))))))


### PR DESCRIPTION
## Summary

- Add `QueryArg` ADT (Scalar, Collection, Tuple, Relation) for typed query input bindings
- Extend wire protocol: Query and Subscribe messages now carry `Vec<QueryArg>` args
- `Database` trait gains `query_with_args()`; `query()` remains as a no-args convenience default
- Query engine prepends `:in` vars to join order, creates `SingleLevelExtender` per scalar binding, resolves variable limits from `:in` args
- JVM client: `QueryArg.java` sealed interface, `Db`/`TriploxNode` query overloads, `triplox.api/q` 3-arity
- Wire protocol spec updated with §11.10 QueryArg Encoding

Only scalar bindings are implemented for now; Collection/Tuple/Relation are defined in the ADT but reserved for future EDN parser support.

Closes #60

## Test plan

- [x] `cargo test` — all 367 unit + 18 integration tests pass
- [ ] Manual test: parameterized query with scalar `:in` binding via JVM client
- [ ] TPCH Q3/Q5 with `:in` parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)