### PR TITLE
feat: unify query API with IntoQuery trait for ergonomic db.query("...") (#112)

### DIFF
--- a/edn/src/query.rs
+++ b/edn/src/query.rs
@@ -1511,6 +1511,14 @@ impl std::fmt::Display for Limit {
     }
 }
 
+impl std::str::FromStr for ParsedQuery {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parse::parse_query(s)
+    }
+}
+
 impl std::fmt::Display for ParsedQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{{:find [{}]", self.find_spec)?;

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -11,7 +11,6 @@ use anyhow::Result;
 use edn::kw;
 use edn::Keyword;
 use triplox::client::ClientNode;
-use edn::query::ParsedQuery;
 use triplox::node::{Database, QueryNode, SubmitNode, TransactionResult};
 use triplox::ops::{DataType, TxOp};
 
@@ -75,9 +74,9 @@ async fn main() -> Result<()> {
     let db = node.db().await?;
     println!("Opened DB snapshot (tx_id={}).", db.tx_id());
 
-    let edn_query: ParsedQuery =
-        r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#.parse()?;
-    let rows = db.query(&edn_query).await?;
+    let rows = db
+        .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)
+        .await?;
 
     println!("Query returned {} row(s):", rows.len());
     for row in &rows {

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -11,7 +11,8 @@ use anyhow::Result;
 use edn::kw;
 use edn::Keyword;
 use triplox::client::ClientNode;
-use triplox::node::{QueryNode, SubmitNode, TransactionResult};
+use edn::query::ParsedQuery;
+use triplox::node::{Database, QueryNode, SubmitNode, TransactionResult};
 use triplox::ops::{DataType, TxOp};
 
 /// Build a schema attribute definition as a Put document.
@@ -74,8 +75,9 @@ async fn main() -> Result<()> {
     let db = node.db().await?;
     println!("Opened DB snapshot (tx_id={}).", db.tx_id());
 
-    let edn_query = r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#;
-    let rows = db.query_edn(edn_query).await?;
+    let edn_query: ParsedQuery =
+        r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#.parse()?;
+    let rows = db.query(&edn_query).await?;
 
     println!("Query returned {} row(s):", rows.len());
     for row in &rows {

--- a/src/client.rs
+++ b/src/client.rs
@@ -293,10 +293,12 @@ impl Database for ClientDb {
         .await?;
         conn.writer.flush().await?;
 
+        // Read response: could be RowDescription + DataRow* + ReadyForQuery, or ErrorResponse
         let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
 
         match msg {
             BackendMessage::RowDescription { .. } => {
+                // Collect DataRows until ReadyForQuery
                 let mut rows = Vec::new();
                 loop {
                     let msg =

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
-use crate::node::{Database, QueryNode, SubmitNode, TransactionResult, TxKey};
+use crate::node::{Database, IntoQuery, QueryNode, SubmitNode, TransactionResult, TxKey};
 use crate::ops::{DataType, TxOp};
 use crate::protocol::*;
 use crate::query::QueryResult;
@@ -280,7 +280,8 @@ impl ClientDb {
 }
 
 impl Database for ClientDb {
-    async fn query(&self, query: &ParsedQuery) -> Result<QueryResult, Error> {
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
+        let query = query.into_query()?;
         let mut conn = self.conn.lock().await;
         write_frontend_message(
             &mut conn.writer,

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,6 @@
 //! both operating over TCP via the wire protocol.
 
 use std::collections::BTreeMap;
-use std::fmt::Write;
 use std::sync::Arc;
 
 use anyhow::{bail, Error, Result};
@@ -248,48 +247,6 @@ impl ClientDb {
         self.tx_id
     }
 
-    /// Execute a query using a raw EDN string.
-    pub async fn query_edn(&self, edn: &str) -> Result<QueryResult> {
-        let mut conn = self.conn.lock().await;
-        write_frontend_message(
-            &mut conn.writer,
-            &FrontendMessage::Query {
-                query_string: edn.to_string(),
-                db_id: self.db_id,
-            },
-        )
-        .await?;
-        conn.writer.flush().await?;
-
-        // Read response: could be RowDescription + DataRow* + ReadyForQuery, or ErrorResponse
-        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-
-        match msg {
-            BackendMessage::RowDescription { .. } => {
-                // Collect DataRows until ReadyForQuery
-                let mut rows = Vec::new();
-                loop {
-                    let msg =
-                        read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-                    match msg {
-                        BackendMessage::DataRow { values } => {
-                            rows.push(values);
-                        }
-                        BackendMessage::ReadyForQuery { .. } => break,
-                        other => bail!("Unexpected message during query: {:?}", other),
-                    }
-                }
-
-                Ok(rows)
-            }
-            BackendMessage::ErrorResponse { message, .. } => {
-                read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
-                bail!("Query error: {}", message);
-            }
-            other => bail!("Expected RowDescription or ErrorResponse, got {:?}", other),
-        }
-    }
-
     /// Release this DB handle on the server.
     pub async fn close(self) -> Result<()> {
         let mut conn = self.conn.lock().await;
@@ -324,7 +281,40 @@ impl ClientDb {
 
 impl Database for ClientDb {
     async fn query(&self, query: &ParsedQuery) -> Result<QueryResult, Error> {
-        let edn = query.to_string();
-        self.query_edn(&edn).await
+        let mut conn = self.conn.lock().await;
+        write_frontend_message(
+            &mut conn.writer,
+            &FrontendMessage::Query {
+                query_string: query.to_string(),
+                db_id: self.db_id,
+            },
+        )
+        .await?;
+        conn.writer.flush().await?;
+
+        let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+
+        match msg {
+            BackendMessage::RowDescription { .. } => {
+                let mut rows = Vec::new();
+                loop {
+                    let msg =
+                        read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+                    match msg {
+                        BackendMessage::DataRow { values } => {
+                            rows.push(values);
+                        }
+                        BackendMessage::ReadyForQuery { .. } => break,
+                        other => bail!("Unexpected message during query: {:?}", other),
+                    }
+                }
+                Ok(rows)
+            }
+            BackendMessage::ErrorResponse { message, .. } => {
+                read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
+                bail!("Query error: {}", message);
+            }
+            other => bail!("Expected RowDescription or ErrorResponse, got {:?}", other),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ pub mod logging;
 mod memory_log;
 pub(crate) mod metadata;
 pub mod ops;
-mod parse;
 pub mod partition;
 mod query;
 #[cfg(any(test, feature = "test-helpers"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub mod node;
 pub mod protocol;
 pub mod server;
 
-pub use node::{Database, Node, QueryNode, SubmitNode, TransactionResult, TxKey, DB};
+pub use node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult, TxKey, DB};

--- a/src/node.rs
+++ b/src/node.rs
@@ -34,6 +34,7 @@ impl IntoQuery for ParsedQuery {
     }
 }
 
+// TODO: consider using Cow or a lifetime on the trait to avoid cloning
 impl IntoQuery for &ParsedQuery {
     fn into_query(self) -> Result<ParsedQuery, Error> {
         Ok(self.clone())
@@ -44,6 +45,12 @@ impl IntoQuery for &str {
     fn into_query(self) -> Result<ParsedQuery, Error> {
         self.parse()
             .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))
+    }
+}
+
+impl IntoQuery for String {
+    fn into_query(self) -> Result<ParsedQuery, Error> {
+        self.as_str().into_query()
     }
 }
 
@@ -1255,7 +1262,7 @@ mod tests {
             "[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]",
             tx_key.tx_id
         );
-        let result = db.query(query_str.as_str()).await.unwrap();
+        let result = db.query(query_str).await.unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/committed)));
@@ -1279,7 +1286,7 @@ mod tests {
         // Query for the aborted tx entity
         let db = node.db().await.unwrap();
         let query_str = format!("[:find ?result ?error :where [?tx :db/txId {}] [?tx :db/txResult ?result] [?tx :db.tx/error ?error]]", tx_key.tx_id);
-        let result = db.query(query_str.as_str()).await.unwrap();
+        let result = db.query(query_str).await.unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,9 +24,32 @@ pub trait SubmitNode {
     async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error>;
 }
 
+pub trait IntoQuery {
+    fn into_query(self) -> Result<ParsedQuery, Error>;
+}
+
+impl IntoQuery for ParsedQuery {
+    fn into_query(self) -> Result<ParsedQuery, Error> {
+        Ok(self)
+    }
+}
+
+impl IntoQuery for &ParsedQuery {
+    fn into_query(self) -> Result<ParsedQuery, Error> {
+        Ok(self.clone())
+    }
+}
+
+impl IntoQuery for &str {
+    fn into_query(self) -> Result<ParsedQuery, Error> {
+        self.parse()
+            .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))
+    }
+}
+
 #[allow(async_fn_in_trait)]
 pub trait Database {
-    async fn query(&self, query: &ParsedQuery) -> Result<QueryResult, Error>;
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error>;
 }
 
 #[allow(async_fn_in_trait)]
@@ -90,13 +113,13 @@ impl DB {
 impl Database for DB {
     /// Execute a query against this database snapshot.
     /// Runs the sync join algorithm in a blocking task to avoid blocking the async runtime.
-    async fn query(&self, query: &ParsedQuery) -> Result<QueryResult, Error> {
-        validate_query(query)?;
+    async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
+        let query = query.into_query()?;
+        validate_query(&query)?;
 
         let snapshot = self.snapshot.clone();
         let handle = self.handle.clone();
         let ident_map = self.ident_map.clone();
-        let query = query.clone();
         let as_of = self.tx_eid;
 
         tokio::task::spawn_blocking(move || {
@@ -270,7 +293,6 @@ mod tests {
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
-    use edn::query::ParsedQuery;
     use edn::Keyword;
 
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
@@ -300,10 +322,10 @@ mod tests {
 
         // Verify data is queryable after async indexing
         let db = node.db().await.unwrap();
-        let query = "[:find ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
+        let result = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
             .unwrap();
-        let result = db.query(&query).await.unwrap();
         assert_eq!(result, vec![vec![DataType::String("bob".to_string())]]);
     }
 
@@ -368,12 +390,11 @@ mod tests {
             .await
             .unwrap();
 
-        let query = "[:find ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("alice".to_string())]));
@@ -392,10 +413,11 @@ mod tests {
             .await
             .unwrap();
 
-        let query: ParsedQuery = r#"[:find ?e :where [?e :name "alice"]]"#.parse().unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query(r#"[:find ?e :where [?e :name "alice"]]"#)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
     }
@@ -415,12 +437,11 @@ mod tests {
             .await
             .unwrap();
 
-        let query = "[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(
@@ -450,12 +471,12 @@ mod tests {
         .unwrap();
 
         // ?friend is in value position of :follows and entity position of :name
-        let query = "[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]")
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], vec![DataType::String("bob".to_string())]);
@@ -476,13 +497,13 @@ mod tests {
             .await
             .unwrap();
 
-        let query: ParsedQuery =
-            r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#
-                .parse()
-                .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query(
+                r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("alice".to_string())]));
@@ -514,10 +535,8 @@ mod tests {
         .await
         .unwrap();
 
-        let query: ParsedQuery = r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#.parse().unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).await.unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![
@@ -554,10 +573,8 @@ mod tests {
         .await
         .unwrap();
 
-        let query: ParsedQuery = r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#.parse().unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query(r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#).await.unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("alice".to_string())]));
@@ -590,19 +607,21 @@ mod tests {
             _ => panic!("Tx2 should commit"),
         };
 
-        let query = "[:find ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         // db_as_of(tx_key1): should only see alice
         let db1 = node.db_as_of(tx_key1).await.unwrap();
-        let result1 = db1.query(&query).await.unwrap();
+        let result1 = db1
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(result1.len(), 1);
         assert_eq!(result1[0], vec![DataType::String("alice".to_string())]);
 
         // db_as_of(tx_key2): should see both
         let db2 = node.db_as_of(tx_key2).await.unwrap();
-        let result2 = db2.query(&query).await.unwrap();
+        let result2 = db2
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(result2.len(), 2);
         assert!(result2.contains(&vec![DataType::String("alice".to_string())]));
         assert!(result2.contains(&vec![DataType::String("bob".to_string())]));
@@ -612,10 +631,6 @@ mod tests {
     async fn test_local_node_survives_restart() {
         let dir = tempfile::tempdir().unwrap();
         let root_path = dir.path().to_path_buf();
-
-        let query = "[:find ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         // First node: insert data
         let node = Node::local_node(&root_path).await.unwrap();
@@ -628,7 +643,10 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
-        let results = db.query(&query).await.unwrap();
+        let results = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
@@ -638,7 +656,10 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
 
         let db = node.db().await.unwrap();
-        let results = db.query(&query).await.unwrap();
+        let results = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
@@ -649,7 +670,10 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
-        let results = db.query(&query).await.unwrap();
+        let results = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.contains(&vec![DataType::String("alice".to_string())]));
         assert!(results.contains(&vec![DataType::String("bob".to_string())]));
@@ -724,10 +748,10 @@ mod tests {
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
-        let query = "[:find ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
+        let results = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
             .unwrap();
-        let results = db.query(&query).await.unwrap();
         assert_eq!(
             results.len(),
             1,
@@ -738,7 +762,10 @@ mod tests {
 
         // latest db should see both
         let db_latest = node.db().await.unwrap();
-        let results_latest = db_latest.query(&query).await.unwrap();
+        let results_latest = db_latest
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
         assert_eq!(results_latest.len(), 2);
 
         node.close().await;
@@ -774,12 +801,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]")
+            .await
+            .unwrap();
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
         assert!(result.contains(&vec![DataType::String("Bob".to_string())]));
@@ -791,12 +817,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]")
+            .await
+            .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], vec![DataType::String("Dominic".to_string())]);
     }
@@ -807,12 +832,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]")
+            .await
+            .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], vec![DataType::String("Ivan".to_string())]);
     }
@@ -823,12 +847,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query: ParsedQuery = r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#
-            .parse()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#)
+            .await
+            .unwrap();
         assert_eq!(result.len(), 1);
     }
 
@@ -838,10 +861,8 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name1 ?name2 :where [?e1 :name ?name1] [?e1 :age ?age1] [?e2 :name ?name2] [?e2 :age ?age2] [(<= ?age1 ?age2)]]".parse::<ParsedQuery>().unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query("[:find ?name1 ?name2 :where [?e1 :name ?name1] [?e1 :age ?age1] [?e2 :name ?name2] [?e2 :age ?age2] [(<= ?age1 ?age2)]]").await.unwrap();
         // 3 people → 6 pairs where age1 <= age2:
         // (Ivan,Ivan), (Ivan,Bob), (Ivan,Dominic), (Bob,Bob), (Bob,Dominic), (Dominic,Dominic)
         assert_eq!(result.len(), 6);
@@ -853,13 +874,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query: ParsedQuery =
-            "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]"
-                .parse()
-                .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]")
+            .await
+            .unwrap();
         assert_eq!(result.len(), 3);
         assert!(result.contains(&vec![
             DataType::String("Ivan".to_string()),
@@ -881,10 +900,8 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half] [(> ?half 20)]]".parse::<ParsedQuery>().unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half] [(> ?half 20)]]").await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0],
@@ -898,13 +915,8 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query: ParsedQuery =
-            "[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]"
-                .parse()
-                .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query("[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]").await.unwrap();
         assert_eq!(result.len(), 3);
         assert!(result.contains(&vec![
             DataType::String("Ivan".to_string()),
@@ -926,12 +938,11 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = "[:find ?name :where [?e :name ?name] (not [?e :age 50])]"
-            .parse::<ParsedQuery>()
-            .unwrap();
-
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]")
+            .await
+            .unwrap();
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
         assert!(result.contains(&vec![DataType::String("Bob".to_string())]));
@@ -973,12 +984,12 @@ mod tests {
         }
 
         // find ?name where [?e :sex :male] [?e :name ?name]
-        let query = "[:find ?name :where [?e :sex :male] [?e :name ?name]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :sex :male] [?e :name ?name]]")
+            .await
+            .unwrap();
 
         // Only Ivan and Petr are male
         assert_eq!(result.len(), 2);
@@ -1023,12 +1034,12 @@ mod tests {
         }
 
         // Same clause order as Clojure: name first (binds ?e), sex filter second
-        let query = "[:find ?name :where [?e :name ?name] [?e :sex :male]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] [?e :sex :male]]")
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
@@ -1072,12 +1083,12 @@ mod tests {
         .unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
-        let query = "[:find ?ln :where [2200 :last-name ?ln]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?ln :where [2200 :last-name ?ln]]")
+            .await
+            .unwrap();
 
         // Should return exactly one row: "Ivannotov"
         assert_eq!(result.len(), 1);
@@ -1159,12 +1170,12 @@ mod tests {
         .unwrap();
 
         // Query: find all tags for entity 2000
-        let query = "[:find ?tag :where [2000 :tags ?tag]]"
-            .parse::<ParsedQuery>()
-            .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db
+            .query("[:find ?tag :where [2000 :tags ?tag]]")
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2, "Expected both tags, got {:?}", result);
         assert!(result.contains(&vec![DataType::String("rust".to_string())]));
@@ -1202,10 +1213,10 @@ mod tests {
 
         // Query all (entity, name) pairs and verify contiguous counter values
         let db = node.db().await.unwrap();
-        let query = "[:find ?e ?name :where [?e :name ?name]]"
-            .parse::<ParsedQuery>()
+        let result = db
+            .query("[:find ?e ?name :where [?e :name ?name]]")
+            .await
             .unwrap();
-        let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
         let mut eids: Vec<i64> = result
@@ -1244,8 +1255,7 @@ mod tests {
             "[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]",
             tx_key.tx_id
         );
-        let query = query_str.parse::<ParsedQuery>().unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query(query_str.as_str()).await.unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/committed)));
@@ -1269,8 +1279,7 @@ mod tests {
         // Query for the aborted tx entity
         let db = node.db().await.unwrap();
         let query_str = format!("[:find ?result ?error :where [?tx :db/txId {}] [?tx :db/txResult ?result] [?tx :db.tx/error ?error]]", tx_key.tx_id);
-        let query = query_str.parse::<ParsedQuery>().unwrap();
-        let result = db.query(&query).await.unwrap();
+        let result = db.query(query_str.as_str()).await.unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));

--- a/src/node.rs
+++ b/src/node.rs
@@ -267,10 +267,10 @@ mod tests {
         ae_key_to_parts, aev_key_to_parts, av_key_to_parts, ave_key_to_parts, eav_key_to_parts,
     };
     use crate::ops::{DataType, EntityRef, TxOp};
-    use crate::parse::parse_query;
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
+    use edn::query::ParsedQuery;
     use edn::Keyword;
 
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
@@ -300,7 +300,9 @@ mod tests {
 
         // Verify data is queryable after async indexing
         let db = node.db().await.unwrap();
-        let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
         let result = db.query(&query).await.unwrap();
         assert_eq!(result, vec![vec![DataType::String("bob".to_string())]]);
     }
@@ -366,7 +368,9 @@ mod tests {
             .await
             .unwrap();
 
-        let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -388,7 +392,7 @@ mod tests {
             .await
             .unwrap();
 
-        let query = parse_query(r#"[:find ?e :where [?e :name "alice"]]"#).unwrap();
+        let query: ParsedQuery = r#"[:find ?e :where [?e :name "alice"]]"#.parse().unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -411,8 +415,9 @@ mod tests {
             .await
             .unwrap();
 
-        let query =
-            parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").unwrap();
+        let query = "[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -445,7 +450,8 @@ mod tests {
         .unwrap();
 
         // ?friend is in value position of :follows and entity position of :name
-        let query = parse_query("[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]")
+        let query = "[:find ?name :where [?e :follows ?friend] [?friend :name ?name]]"
+            .parse::<ParsedQuery>()
             .unwrap();
 
         let db = node.db().await.unwrap();
@@ -470,10 +476,10 @@ mod tests {
             .await
             .unwrap();
 
-        let query = parse_query(
-            r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#,
-        )
-        .unwrap();
+        let query: ParsedQuery =
+            r#"[:find ?name :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name]]"#
+                .parse()
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -508,7 +514,7 @@ mod tests {
         .await
         .unwrap();
 
-        let query = parse_query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).unwrap();
+        let query: ParsedQuery = r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#.parse().unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -548,7 +554,7 @@ mod tests {
         .await
         .unwrap();
 
-        let query = parse_query(r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#).unwrap();
+        let query: ParsedQuery = r#"[:find ?name :where (or (and [?e :name "alice"] [?e :age 30]) (and [?e :name "charlie"] [?e :age 35])) [?e :name ?name]]"#.parse().unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -584,7 +590,9 @@ mod tests {
             _ => panic!("Tx2 should commit"),
         };
 
-        let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         // db_as_of(tx_key1): should only see alice
         let db1 = node.db_as_of(tx_key1).await.unwrap();
@@ -605,7 +613,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root_path = dir.path().to_path_buf();
 
-        let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         // First node: insert data
         let node = Node::local_node(&root_path).await.unwrap();
@@ -714,7 +724,9 @@ mod tests {
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
-        let query = parse_query("[:find ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
         let results = db.query(&query).await.unwrap();
         assert_eq!(
             results.len(),
@@ -762,9 +774,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]")
-                .unwrap();
+        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(< ?age 50)]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -779,9 +791,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]")
-                .unwrap();
+        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(>= ?age 50)]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -795,9 +807,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]")
-                .unwrap();
+        let query = "[:find ?name :where [?e :name ?name] [?e :age ?age] [(= 30 ?age)]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -811,8 +823,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).unwrap();
+        let query: ParsedQuery = r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#
+            .parse()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -825,7 +838,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name1 ?name2 :where [?e1 :name ?name1] [?e1 :age ?age1] [?e2 :name ?name2] [?e2 :age ?age2] [(<= ?age1 ?age2)]]").unwrap();
+        let query = "[:find ?name1 ?name2 :where [?e1 :name ?name1] [?e1 :age ?age1] [?e2 :name ?name2] [?e2 :age ?age2] [(<= ?age1 ?age2)]]".parse::<ParsedQuery>().unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -840,10 +853,10 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query(
-            "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]",
-        )
-        .unwrap();
+        let query: ParsedQuery =
+            "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half]]"
+                .parse()
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -868,7 +881,7 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half] [(> ?half 20)]]").unwrap();
+        let query = "[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half] [(> ?half 20)]]".parse::<ParsedQuery>().unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -885,10 +898,10 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query = parse_query(
-            "[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]",
-        )
-        .unwrap();
+        let query: ParsedQuery =
+            "[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]"
+                .parse()
+                .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -913,8 +926,9 @@ mod tests {
         define_test_schema(&node).await;
         insert_three_people(&node).await;
 
-        let query =
-            parse_query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name] (not [?e :age 50])]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -959,7 +973,9 @@ mod tests {
         }
 
         // find ?name where [?e :sex :male] [?e :name ?name]
-        let query = parse_query("[:find ?name :where [?e :sex :male] [?e :name ?name]]").unwrap();
+        let query = "[:find ?name :where [?e :sex :male] [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -1007,7 +1023,9 @@ mod tests {
         }
 
         // Same clause order as Clojure: name first (binds ?e), sex filter second
-        let query = parse_query("[:find ?name :where [?e :name ?name] [?e :sex :male]]").unwrap();
+        let query = "[:find ?name :where [?e :name ?name] [?e :sex :male]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -1054,7 +1072,9 @@ mod tests {
         .unwrap();
 
         // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
-        let query = parse_query("[:find ?ln :where [2200 :last-name ?ln]]").unwrap();
+        let query = "[:find ?ln :where [2200 :last-name ?ln]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -1139,7 +1159,9 @@ mod tests {
         .unwrap();
 
         // Query: find all tags for entity 2000
-        let query = parse_query("[:find ?tag :where [2000 :tags ?tag]]").unwrap();
+        let query = "[:find ?tag :where [2000 :tags ?tag]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db.query(&query).await.unwrap();
@@ -1180,7 +1202,9 @@ mod tests {
 
         // Query all (entity, name) pairs and verify contiguous counter values
         let db = node.db().await.unwrap();
-        let query = parse_query("[:find ?e ?name :where [?e :name ?name]]").unwrap();
+        let query = "[:find ?e ?name :where [?e :name ?name]]"
+            .parse::<ParsedQuery>()
+            .unwrap();
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 2);
@@ -1220,7 +1244,7 @@ mod tests {
             "[:find ?result :where [?tx :db/txId {}] [?tx :db/txResult ?result]]",
             tx_key.tx_id
         );
-        let query = parse_query(&query_str).unwrap();
+        let query = query_str.parse::<ParsedQuery>().unwrap();
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 1);
@@ -1245,7 +1269,7 @@ mod tests {
         // Query for the aborted tx entity
         let db = node.db().await.unwrap();
         let query_str = format!("[:find ?result ?error :where [?tx :db/txId {}] [?tx :db/txResult ?result] [?tx :db.tx/error ?error]]", tx_key.tx_id);
-        let query = parse_query(&query_str).unwrap();
+        let query = query_str.parse::<ParsedQuery>().unwrap();
         let result = db.query(&query).await.unwrap();
 
         assert_eq!(result.len(), 1);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,0 @@
-use anyhow::{anyhow, Result};
-
-use edn::parse::parse_query as edn_parse_query;
-use edn::query::ParsedQuery;
-
-pub fn parse_query(input: &str) -> Result<ParsedQuery> {
-    edn_parse_query(input).map_err(|e| anyhow!("EDN parse error: {}", e))
-}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,8 +7,8 @@ use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
 use crate::ops::{DataType, Datom, DatomOp, TxOp};
-use crate::parse::parse_query;
 use crate::query::execute_query;
+use edn::query::ParsedQuery;
 
 // --- Reserved entity IDs ---
 // Used as explicit db/id values in bootstrap_schema_tx().
@@ -462,7 +462,8 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let handle = Handle::current();
 
     // Query 1: all entities with db/ident (populates ident_map/entid_map)
-    let ident_query = parse_query("[:find ?e ?ident :where [?e :db/ident ?ident]]")
+    let ident_query: ParsedQuery = "[:find ?e ?ident :where [?e :db/ident ?ident]]"
+        .parse()
         .expect("Ident query parse failed");
 
     let snap_clone = snapshot.clone();
@@ -482,9 +483,9 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     .expect("Ident query execution failed");
 
     // Query 2: entities with db/ident + db/valueType + db/cardinality (populates attribute_map)
-    let attr_query = parse_query(
-        "[:find ?e ?ident ?vt ?card :where [?e :db/ident ?ident] [?e :db/valueType ?vt] [?e :db/cardinality ?card]]"
-    ).expect("Attribute query parse failed");
+    let attr_query: ParsedQuery = "[:find ?e ?ident ?vt ?card :where [?e :db/ident ?ident] [?e :db/valueType ?vt] [?e :db/cardinality ?card]]"
+        .parse()
+        .expect("Attribute query parse failed");
 
     let attr_results = tokio::task::spawn_blocking(move || {
         execute_query(

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::log::TxLog;
-use crate::node::{Database, Node, QueryNode, SubmitNode, TransactionResult, DB};
+use crate::node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult, DB};
 use crate::protocol::*;
 use crate::query::QueryResult;
 
@@ -605,9 +605,7 @@ async fn handle_query(
         .get_db(db_id)
         .ok_or_else(|| anyhow::anyhow!("Invalid DB handle: {}", db_id))?;
 
-    let parsed: edn::query::ParsedQuery = query_string
-        .parse()
-        .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))?;
+    let parsed = query_string.into_query()?;
 
     // Extract find variable names for RowDescription
     let find_vars: Vec<String> = match &parsed.find_spec {

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,6 @@ use tracing::{info, warn};
 
 use crate::log::TxLog;
 use crate::node::{Database, Node, QueryNode, SubmitNode, TransactionResult, DB};
-use crate::parse::parse_query;
 use crate::protocol::*;
 use crate::query::QueryResult;
 
@@ -606,7 +605,9 @@ async fn handle_query(
         .get_db(db_id)
         .ok_or_else(|| anyhow::anyhow!("Invalid DB handle: {}", db_id))?;
 
-    let parsed = parse_query(query_string)?;
+    let parsed: edn::query::ParsedQuery = query_string
+        .parse()
+        .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))?;
 
     // Extract find variable names for RowDescription
     let find_vars: Vec<String> = match &parsed.find_spec {

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -4,9 +4,10 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 use edn::kw;
+use edn::query::ParsedQuery;
 use edn::symbols::Keyword;
 use triplox::client::ClientNode;
-use triplox::node::{Node, QueryNode, SubmitNode};
+use triplox::node::{Database, Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, TxOp};
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
@@ -63,7 +64,11 @@ async fn test_execute_tx_and_query() {
     // Open a DB and query
     let db = client.db().await.unwrap();
     let result = db
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [?e ?name] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -122,7 +127,11 @@ async fn test_multiple_transactions_and_query() {
 
     let db = client.db().await.unwrap();
     let result = db
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [?e ?name] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -162,11 +171,11 @@ async fn test_open_close_multiple_dbs() {
 
     // Both should return same data
     let r1 = db1
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     let r2 = db2
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(r1.len(), 1);
@@ -197,7 +206,7 @@ async fn test_two_connections() {
     let client2 = ClientNode::connect(&addr).await.unwrap();
     let db = client2.db().await.unwrap();
     let result = db
-        .query_edn("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -264,7 +273,11 @@ async fn test_db_as_of() {
     // Open DB pinned to tx_key after first tx — should only see alice
     let db = client.db_as_of(tx_key1).await.unwrap();
     let result = db
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [?e ?name] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -316,7 +329,11 @@ async fn test_dev_server_connections_are_isolated() {
 
     let db1 = client1.db().await.unwrap();
     let result1 = db1
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [?e ?name] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result1.len(), 1, "client1 should see its own data");
@@ -327,7 +344,11 @@ async fn test_dev_server_connections_are_isolated() {
 
     let db2 = client2.db().await.unwrap();
     let result2 = db2
-        .query_edn("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [?e ?name] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result2.len(), 0, "client2 should not see client1's data");
@@ -372,7 +393,7 @@ async fn define_heads_schema(client: &ClientNode) {
 }
 
 /// Mirror of Clojure test-query-using-keywords, exercised through the full
-/// client-server wire protocol via query_edn.
+/// client-server wire protocol.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_query_keyword_value_comparison_via_wire() {
     let (addr, token) = start_test_server().await;
@@ -401,7 +422,11 @@ async fn test_query_keyword_value_comparison_via_wire() {
 
     // Same clause order as Clojure: name first (binds ?e), sex filter second
     let result = db
-        .query_edn("{:find [?name] :where [[?e :name ?name] [?e :sex :male]]}")
+        .query(
+            &"{:find [?name] :where [[?e :name ?name] [?e :sex :male]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -452,22 +477,24 @@ async fn test_aggregates_and_or() {
 
     // count with OR: Lovelace AND (name=Ada OR sex=male) -> 1 (only Ada)
     let result = db
-        .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :male])]}")
+        .query(&r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :male])]}"#.parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
     // count with OR: Lovelace AND (name=Ada OR sex=female) -> 1
     let result = db
-        .query_edn("{:find [(count ?p)] :where [[?p :last-name \"Lovelace\"] (or [?p :name \"Ada\"] [?p :sex :female])]}")
+        .query(&r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :female])]}"#.parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
     // count with top-level OR: Lovelace OR male -> 3
     let result = db
-        .query_edn(
-            "{:find [(count ?p)] :where [(or [?p :last-name \"Lovelace\"] [?p :sex :male])]}",
+        .query(
+            &r#"{:find [(count ?p)] :where [(or [?p :last-name "Lovelace"] [?p :sex :male])]}"#
+                .parse::<ParsedQuery>()
+                .unwrap(),
         )
         .await
         .unwrap();
@@ -475,8 +502,10 @@ async fn test_aggregates_and_or() {
 
     // Grouped: gender, count, sum
     let result = db
-        .query_edn(
-            "{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}",
+        .query(
+            &"{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
         )
         .await
         .unwrap();
@@ -523,7 +552,11 @@ async fn test_aggregate_set_semantics() {
 
     // TODO: do we want Datomic (set -> 2) or XTDB (bag -> 3) semantics here?
     let result = db
-        .query_edn("{:find [(count ?city)] :where [[?p :city ?city]]}")
+        .query(
+            &"{:find [(count ?city)] :where [[?p :city ?city]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
@@ -555,7 +588,7 @@ async fn test_datascript_aggregates() {
 
     // All aggregate functions at once
     let result = db
-        .query_edn("{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)] :where [[?monster :heads ?heads]]}")
+        .query(&"{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)] :where [[?monster :heads ?heads]]}".parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result.len(), 1, "expected single row, got {:?}", result);
@@ -590,7 +623,11 @@ async fn test_aggregate_avg() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query_edn("{:find [(avg ?age)] :where [[?e :age ?age]]}")
+        .query(
+            &"{:find [(avg ?age)] :where [[?e :age ?age]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Double(22.0)]]);
@@ -619,7 +656,11 @@ async fn test_aggregate_min_max_strings() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query_edn("{:find [(min ?name) (max ?name)] :where [[?e :name ?name]]}")
+        .query(
+            &"{:find [(min ?name) (max ?name)] :where [[?e :name ?name]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -641,7 +682,11 @@ async fn test_aggregate_empty_result() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query_edn("{:find [(count ?e)] :where [[?e :name \"nobody\"]]}")
+        .query(
+            &r#"{:find [(count ?e)] :where [[?e :name "nobody"]]}"#
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(0)]]);
@@ -683,7 +728,7 @@ async fn test_order_and_limit() {
 
     // ORDER BY age ascending, LIMIT 3 -> youngest 3
     let result = db
-        .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]] :limit 3}")
+        .query(&"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]] :limit 3}".parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result.len(), 3);
@@ -702,7 +747,7 @@ async fn test_order_and_limit() {
 
     // ORDER BY age descending, LIMIT 2 -> oldest 2
     let result = db
-        .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :desc]] :limit 2}")
+        .query(&"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :desc]] :limit 2}".parse::<ParsedQuery>().unwrap())
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
@@ -717,15 +762,21 @@ async fn test_order_and_limit() {
 
     // LIMIT only (no order) — should return exactly 2 rows
     let result = db
-        .query_edn("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :limit 2}")
+        .query(
+            &"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :limit 2}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
 
     // ORDER BY only (no limit) — all 5 rows, sorted
     let result = db
-        .query_edn(
-            "{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}",
+        .query(
+            &"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
         )
         .await
         .unwrap();
@@ -764,7 +815,11 @@ async fn test_aggregate_min_incompatible_types() {
 
     // OR binds ?v to both string and long values -> min should error on incomparable types
     let result = db
-        .query_edn("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
+        .query(
+            &"{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}"
+                .parse::<ParsedQuery>()
+                .unwrap(),
+        )
         .await;
     assert!(result.is_err(), "min over incompatible types should error");
 

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -4,7 +4,6 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 use edn::kw;
-use edn::query::ParsedQuery;
 use edn::symbols::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{Database, Node, QueryNode, SubmitNode};
@@ -64,11 +63,7 @@ async fn test_execute_tx_and_query() {
     // Open a DB and query
     let db = client.db().await.unwrap();
     let result = db
-        .query(
-            &"{:find [?e ?name] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
@@ -127,11 +122,7 @@ async fn test_multiple_transactions_and_query() {
 
     let db = client.db().await.unwrap();
     let result = db
-        .query(
-            &"{:find [?e ?name] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
@@ -171,11 +162,11 @@ async fn test_open_close_multiple_dbs() {
 
     // Both should return same data
     let r1 = db1
-        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
+        .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
         .await
         .unwrap();
     let r2 = db2
-        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
+        .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
         .await
         .unwrap();
     assert_eq!(r1.len(), 1);
@@ -206,7 +197,7 @@ async fn test_two_connections() {
     let client2 = ClientNode::connect(&addr).await.unwrap();
     let db = client2.db().await.unwrap();
     let result = db
-        .query(&r#"{:find [?e] :where [[?e :name "alice"]]}"#.parse::<ParsedQuery>().unwrap())
+        .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
         .await
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -273,11 +264,7 @@ async fn test_db_as_of() {
     // Open DB pinned to tx_key after first tx — should only see alice
     let db = client.db_as_of(tx_key1).await.unwrap();
     let result = db
-        .query(
-            &"{:find [?e ?name] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
@@ -329,11 +316,7 @@ async fn test_dev_server_connections_are_isolated() {
 
     let db1 = client1.db().await.unwrap();
     let result1 = db1
-        .query(
-            &"{:find [?e ?name] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
     assert_eq!(result1.len(), 1, "client1 should see its own data");
@@ -344,11 +327,7 @@ async fn test_dev_server_connections_are_isolated() {
 
     let db2 = client2.db().await.unwrap();
     let result2 = db2
-        .query(
-            &"{:find [?e ?name] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
     assert_eq!(result2.len(), 0, "client2 should not see client1's data");
@@ -422,11 +401,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
 
     // Same clause order as Clojure: name first (binds ?e), sex filter second
     let result = db
-        .query(
-            &"{:find [?name] :where [[?e :name ?name] [?e :sex :male]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?name] :where [[?e :name ?name] [?e :sex :male]]}")
         .await
         .unwrap();
 
@@ -477,36 +452,28 @@ async fn test_aggregates_and_or() {
 
     // count with OR: Lovelace AND (name=Ada OR sex=male) -> 1 (only Ada)
     let result = db
-        .query(&r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :male])]}"#.parse::<ParsedQuery>().unwrap())
+        .query(r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :male])]}"#)
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
     // count with OR: Lovelace AND (name=Ada OR sex=female) -> 1
     let result = db
-        .query(&r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :female])]}"#.parse::<ParsedQuery>().unwrap())
+        .query(r#"{:find [(count ?p)] :where [[?p :last-name "Lovelace"] (or [?p :name "Ada"] [?p :sex :female])]}"#)
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(1)]]);
 
     // count with top-level OR: Lovelace OR male -> 3
     let result = db
-        .query(
-            &r#"{:find [(count ?p)] :where [(or [?p :last-name "Lovelace"] [?p :sex :male])]}"#
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query(r#"{:find [(count ?p)] :where [(or [?p :last-name "Lovelace"] [?p :sex :male])]}"#)
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
 
     // Grouped: gender, count, sum
     let result = db
-        .query(
-            &"{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?gender (count ?p) (sum ?age)] :where [[?p :sex ?gender] [?p :age ?age]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 2, "expected 2 groups, got {:?}", result);
@@ -552,11 +519,7 @@ async fn test_aggregate_set_semantics() {
 
     // TODO: do we want Datomic (set -> 2) or XTDB (bag -> 3) semantics here?
     let result = db
-        .query(
-            &"{:find [(count ?city)] :where [[?p :city ?city]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [(count ?city)] :where [[?p :city ?city]]}")
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
@@ -588,7 +551,7 @@ async fn test_datascript_aggregates() {
 
     // All aggregate functions at once
     let result = db
-        .query(&"{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)] :where [[?monster :heads ?heads]]}".parse::<ParsedQuery>().unwrap())
+        .query("{:find [(sum ?heads) (min ?heads) (max ?heads) (count ?heads) (count-distinct ?heads)] :where [[?monster :heads ?heads]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 1, "expected single row, got {:?}", result);
@@ -623,11 +586,7 @@ async fn test_aggregate_avg() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query(
-            &"{:find [(avg ?age)] :where [[?e :age ?age]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [(avg ?age)] :where [[?e :age ?age]]}")
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Double(22.0)]]);
@@ -656,11 +615,7 @@ async fn test_aggregate_min_max_strings() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query(
-            &"{:find [(min ?name) (max ?name)] :where [[?e :name ?name]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [(min ?name) (max ?name)] :where [[?e :name ?name]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -682,11 +637,7 @@ async fn test_aggregate_empty_result() {
     let db = client.db().await.unwrap();
 
     let result = db
-        .query(
-            &r#"{:find [(count ?e)] :where [[?e :name "nobody"]]}"#
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query(r#"{:find [(count ?e)] :where [[?e :name "nobody"]]}"#)
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(0)]]);
@@ -728,7 +679,7 @@ async fn test_order_and_limit() {
 
     // ORDER BY age ascending, LIMIT 3 -> youngest 3
     let result = db
-        .query(&"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]] :limit 3}".parse::<ParsedQuery>().unwrap())
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]] :limit 3}")
         .await
         .unwrap();
     assert_eq!(result.len(), 3);
@@ -747,7 +698,7 @@ async fn test_order_and_limit() {
 
     // ORDER BY age descending, LIMIT 2 -> oldest 2
     let result = db
-        .query(&"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :desc]] :limit 2}".parse::<ParsedQuery>().unwrap())
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :desc]] :limit 2}")
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
@@ -762,22 +713,14 @@ async fn test_order_and_limit() {
 
     // LIMIT only (no order) — should return exactly 2 rows
     let result = db
-        .query(
-            &"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :limit 2}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :limit 2}")
         .await
         .unwrap();
     assert_eq!(result.len(), 2);
 
     // ORDER BY only (no limit) — all 5 rows, sorted
     let result = db
-        .query(
-            &"{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]] :order [[?age :asc]]}")
         .await
         .unwrap();
     assert_eq!(result.len(), 5);
@@ -815,11 +758,7 @@ async fn test_aggregate_min_incompatible_types() {
 
     // OR binds ?v to both string and long values -> min should error on incomparable types
     let result = db
-        .query(
-            &"{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}"
-                .parse::<ParsedQuery>()
-                .unwrap(),
-        )
+        .query("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
         .await;
     assert!(result.is_err(), "min over incompatible types should error");
 


### PR DESCRIPTION
## Summary
- Add `IntoQuery` trait implemented for `&str`, `ParsedQuery`, and `&ParsedQuery`
- Change `Database::query` to accept `impl IntoQuery` instead of `&ParsedQuery`
- Callers can now write `db.query("[:find ...]").await?` directly — no explicit parse step
- Add `FromStr` impl for `ParsedQuery` (enables `.parse()` when needed)
- Remove `query_edn(&str)` convenience method from `ClientDb`
- Delete `src/parse.rs` wrapper (redundant with `FromStr`)

Closes #112

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 382 tests pass (364 unit + 18 integration)
- [x] `cargo fmt` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)