### PR TITLE
refactor: remove explicit entity IDs in favor of tempids

### DIFF
--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -16,9 +16,8 @@ use triplox::ops::{DataType, TxOp};
 
 /// Build a schema attribute definition as a Put document.
 /// This mirrors the internal `plain_schema_attribute` helper.
-fn schema_attribute(id: i64, name: &str, value_type: &str) -> TxOp {
+fn schema_attribute(name: &str, value_type: &str) -> TxOp {
     TxOp::put(vec![
-        (kw!(:db/id), DataType::Long(id)),
         (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
         (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type))),
         (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one))),
@@ -32,10 +31,10 @@ async fn main() -> Result<()> {
     let node = ClientNode::connect(addr).await?;
     println!("Connected.");
 
-    // 1. Define schema attributes (entity IDs 50-51, above bootstrap range 1-31)
+    // 1. Define schema attributes
     let schema_ops = vec![
-        schema_attribute(50, "name", "string"),
-        schema_attribute(51, "age", "long"),
+        schema_attribute("name", "string"),
+        schema_attribute("age", "long"),
     ];
     let result = node.execute_tx(schema_ops).await?;
     match &result {
@@ -50,12 +49,10 @@ async fn main() -> Result<()> {
     // 2. Insert some data
     let data_ops = vec![
         TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ]),
         TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(101)),
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
         ]),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1144,11 +1144,7 @@ mod tests {
             tx_id: 2,
             system_time: st_from_unix_epoch(200),
         };
-        let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(entity_id),
-            attribute: kw!(:tags),
-            value: "database".into(),
-        }];
+        let tx_ops2 = vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:tags), value: "database".into() }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs, 0 RETRACTs
@@ -1221,11 +1217,7 @@ mod tests {
             tx_id: 2,
             system_time: st_from_unix_epoch(200),
         };
-        let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(entity_id),
-            attribute: kw!(:tags),
-            value: "rust".into(),
-        }];
+        let tx_ops2 = vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:tags), value: "rust".into() }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs (both written)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1030,7 +1030,6 @@ mod tests {
         Ok(())
     }
 
-    // TODO(triplox-qj0): replace explicit entity IDs with query-based verification
     #[tokio::test]
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
@@ -1104,23 +1103,41 @@ mod tests {
         Ok(())
     }
 
-    // TODO(triplox-qj0): replace explicit entity IDs with query-based verification
     #[tokio::test]
     async fn test_cardinality_many_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
-        // First tx: assert tags="rust" for entity 2000
+        // First tx: assert tags="rust" for a new entity (auto-assigned ID)
         let tx1 = TxKey {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops1 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
-            attribute: kw!(:tags),
-            value: "rust".into(),
-        }];
+        let tx_ops1 = vec![TxOp::put(vec![(kw!(:tags), "rust".into())])];
         indexer.transact_tx(tx1, tx_ops1).await?;
+
+        // Discover auto-assigned entity ID
+        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let tags_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:tags))
+            .unwrap()
+            .0;
+        let mut entity_id: i64 = 0;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
+            if let DataType::Long(id) = eid {
+                if id >= user_base {
+                    entity_id = id;
+                    break;
+                }
+            }
+        }
+        assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
         let tx2 = TxKey {
@@ -1128,27 +1145,21 @@ mod tests {
             system_time: st_from_unix_epoch(200),
         };
         let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity: EntityRef::Id(entity_id),
             attribute: kw!(:tags),
             value: "database".into(),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
-        // Scan EAV for entity 2000, tags attr (entity_id 1000) — expect 2 ADDs, 0 RETRACTs
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
+        // Scan EAV for entity, tags attr — expect 2 ADDs, 0 RETRACTs
         let mut iter = slate
             .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
             .await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if entity_id != DataType::Long(2000) || attribute != tags_id {
+            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if eid != DataType::Long(entity_id) || attribute != tags_id {
                 continue;
             }
             match op {
@@ -1169,23 +1180,41 @@ mod tests {
     // NOTE: Currently cardinality-many has bag semantics (duplicate values are stored).
     // Datomic uses set semantics where asserting the same value twice is a no-op.
     // We may want to switch to set semantics in the future.
-    // TODO(triplox-qj0): replace explicit entity IDs with query-based verification
     #[tokio::test]
     async fn test_cardinality_many_same_value() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
-        // First tx: assert tags="rust" for entity 2000
+        // First tx: assert tags="rust" for a new entity (auto-assigned ID)
         let tx1 = TxKey {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops1 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
-            attribute: kw!(:tags),
-            value: "rust".into(),
-        }];
+        let tx_ops1 = vec![TxOp::put(vec![(kw!(:tags), "rust".into())])];
         indexer.transact_tx(tx1, tx_ops1).await?;
+
+        // Discover auto-assigned entity ID
+        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let tags_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:tags))
+            .unwrap()
+            .0;
+        let mut entity_id: i64 = 0;
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
+            if let DataType::Long(id) = eid {
+                if id >= user_base {
+                    entity_id = id;
+                    break;
+                }
+            }
+        }
+        assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
         let tx2 = TxKey {
@@ -1193,26 +1222,20 @@ mod tests {
             system_time: st_from_unix_epoch(200),
         };
         let tx_ops2 = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity: EntityRef::Id(entity_id),
             attribute: kw!(:tags),
             value: "rust".into(),
         }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
-        // Scan EAV for entity 2000, tags attr — expect 2 ADDs (both written)
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
+        // Scan EAV for entity, tags attr — expect 2 ADDs (both written)
         let mut iter = slate
             .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
             .await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {
-            let (entity_id, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if entity_id != DataType::Long(2000) || attribute != tags_id {
+            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if eid != DataType::Long(entity_id) || attribute != tags_id {
                 continue;
             }
             if op == codec::ADD {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1103,6 +1103,23 @@ mod tests {
         Ok(())
     }
 
+    /// Find the first user-partition entity ID by scanning the EAV index.
+    async fn find_first_user_entity(slate: &Arc<slatedb::Db>) -> Result<i64, Error> {
+        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
+            if let DataType::Long(id) = eid {
+                if id >= user_base {
+                    return Ok(id);
+                }
+            }
+        }
+        panic!("No user-partition entity found in EAV index");
+    }
+
     #[tokio::test]
     async fn test_cardinality_many_no_retract() -> Result<(), Error> {
         let slate = Arc::new(in_memory_slate().await);
@@ -1117,34 +1134,24 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Discover auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let entity_id = find_first_user_entity(&slate).await?;
         let tags_id = indexer
             .metadata()
             .schema
             .get_attribute(&kw!(:tags))
             .unwrap()
             .0;
-        let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
-            }
-        }
-        assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
         let tx2 = TxKey {
             tx_id: 2,
             system_time: st_from_unix_epoch(200),
         };
-        let tx_ops2 = vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:tags), value: "database".into() }];
+        let tx_ops2 = vec![TxOp::Add {
+            entity: EntityRef::Id(entity_id),
+            attribute: kw!(:tags),
+            value: "database".into(),
+        }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs, 0 RETRACTs
@@ -1190,34 +1197,24 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Discover auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let entity_id = find_first_user_entity(&slate).await?;
         let tags_id = indexer
             .metadata()
             .schema
             .get_attribute(&kw!(:tags))
             .unwrap()
             .0;
-        let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
-            }
-        }
-        assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
         let tx2 = TxKey {
             tx_id: 2,
             system_time: st_from_unix_epoch(200),
         };
-        let tx_ops2 = vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:tags), value: "rust".into() }];
+        let tx_ops2 = vec![TxOp::Add {
+            entity: EntityRef::Id(entity_id),
+            attribute: kw!(:tags),
+            value: "rust".into(),
+        }];
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs (both written)

--- a/src/node.rs
+++ b/src/node.rs
@@ -289,14 +289,8 @@ impl<L: TxLog> QueryNode for Node<L> {
 
 #[cfg(test)]
 mod tests {
-    use slatedb::config::ScanOptions;
-
     use super::*;
-    use crate::codec;
-    use crate::indexer::{
-        ae_key_to_parts, aev_key_to_parts, av_key_to_parts, ave_key_to_parts, eav_key_to_parts,
-    };
-    use crate::ops::{DataType, EntityRef, TxOp};
+    use crate::ops::{DataType, TxOp};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
@@ -313,7 +307,11 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "bob".into())])];
+        let tx_ops = vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }];
 
         let waiter = node.indexer.read().await.tx_waiter();
 
@@ -336,15 +334,13 @@ mod tests {
         assert_eq!(result, vec![vec![DataType::String("bob".to_string())]]);
     }
 
-    // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
     #[tokio::test]
     async fn test_execute_tx_with_add_triple() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        // Use entity ID 1000 to avoid reserved bootstrap range (1-31)
         let tx_ops = vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity: "e".into(),
             attribute: kw!(:email),
             value: "test@example.com".into(),
         }];
@@ -352,35 +348,16 @@ mod tests {
         let result = node.execute_tx(tx_ops).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
-        let slate = node.slatedb.clone();
-        let email_id = node
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:email))
-            .unwrap()
-            .0;
-
-        // Check EAV index — find entry for entity 2000
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(r#"[:find ?email :where [?e :email ?email]]"#)
             .await
             .unwrap();
-        let mut found = false;
-        while let Some(kv) = iter.next().await.unwrap() {
-            let (entity_id, attribute, value, _timestamp, suffix) =
-                eav_key_to_parts(kv.key).unwrap();
-            if entity_id == DataType::Long(2000) {
-                assert_eq!(attribute, email_id);
-                assert_eq!(value, DataType::String("test@example.com".to_string()));
-                assert_eq!(suffix, codec::ADD);
-                found = true;
-                break;
-            }
-        }
-        assert!(found, "Expected EAV entry for entity 2000");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            vec![DataType::String("test@example.com".to_string())]
+        );
     }
 
     // End-to-end query tests
@@ -390,12 +367,20 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
-            .await
-            .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
-            .await
-            .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db
@@ -413,12 +398,20 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
-            .await
-            .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
-            .await
-            .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db
@@ -440,9 +433,13 @@ mod tests {
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
-            .await
-            .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db
@@ -493,15 +490,27 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
-            .await
-            .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
-            .await
-            .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "charlie".into())])])
-            .await
-            .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "charlie".into(),
+            attribute: kw!(:name),
+            value: "charlie".into(),
+        }])
+        .await
+        .unwrap();
 
         let db = node.db().await.unwrap();
         let result = db
@@ -596,7 +605,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let tx_key1 = match node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap()
         {
@@ -605,7 +618,11 @@ mod tests {
         };
 
         let tx_key2 = match node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap()
         {
@@ -643,7 +660,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -670,7 +691,11 @@ mod tests {
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -701,7 +726,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -736,7 +765,11 @@ mod tests {
 
         // First transaction: insert alice
         let result1 = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key1 = match result1 {
@@ -745,9 +778,13 @@ mod tests {
         };
 
         // Second transaction: insert bob
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
-            .await
-            .unwrap();
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
@@ -800,10 +837,11 @@ mod tests {
         };
 
         // Upsert: update age using the discovered entity ID
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(entity_id)),
-            (kw!(:age), 31_i64.into()),
-        ])])
+        node.execute_tx(vec![TxOp::Add {
+            entity: entity_id.into(),
+            attribute: kw!(:age),
+            value: 31_i64.into(),
+        }])
         .await
         .unwrap();
 
@@ -1121,8 +1159,16 @@ mod tests {
 
         // Insert two entities with last-names
         node.execute_tx(vec![
-            TxOp::put(vec![(kw!(:last-name), "Ivannotov".into())]),
-            TxOp::put(vec![(kw!(:last-name), "Bobnev".into())]),
+            TxOp::Add {
+                entity: "ivannotov".into(),
+                attribute: kw!(:last-name),
+                value: "Ivannotov".into(),
+            },
+            TxOp::Add {
+                entity: "bobnev".into(),
+                attribute: kw!(:last-name),
+                value: "Bobnev".into(),
+            },
         ])
         .await
         .unwrap();
@@ -1158,7 +1204,11 @@ mod tests {
         // Submit a tx with unknown attribute — should fail with TxAborted
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent/attr), "x".into())])]),
+            node.execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent/attr),
+                value: "x".into(),
+            }]),
         )
         .await
         .expect("Should not hang")
@@ -1186,7 +1236,11 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])]),
+            node.execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }]),
         )
         .await
         .expect("Should not hang")
@@ -1199,36 +1253,48 @@ mod tests {
         );
     }
 
-    // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
     /// Cardinality-many attributes accumulate values without retracting old ones.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cardinality_many_attribute() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        // Insert entity 2000 with tags="rust"
+        // Insert entity with tags="rust"
         node.execute_tx(vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity: "e".into(),
             attribute: kw!(:tags),
             value: "rust".into(),
         }])
         .await
         .unwrap();
 
+        // Discover the auto-assigned entity ID
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(r#"[:find ?e :where [?e :tags "rust"]]"#)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        let entity_id = match &result[0][0] {
+            DataType::Long(id) => *id,
+            other => panic!("Expected Long entity ID, got {:?}", other),
+        };
+
         // Add another tag to the same entity — should NOT retract "rust"
         node.execute_tx(vec![TxOp::Add {
-            entity: EntityRef::Id(2000),
+            entity: entity_id.into(),
             attribute: kw!(:tags),
             value: "database".into(),
         }])
         .await
         .unwrap();
 
-        // Query: find all tags for entity 2000
-
+        // Query: find all tags for the entity
         let db = node.db().await.unwrap();
         let result = db
-            .query("[:find ?tag :where [2000 :tags ?tag]]")
+            .query(format!(
+                "[:find ?tag :where [{entity_id} :tags ?tag]]"
+            ))
             .await
             .unwrap();
 
@@ -1244,24 +1310,33 @@ mod tests {
 
         // tx1: valid insert — allocates first user entity
         let result1 = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result1, TransactionResult::TxCommited(_)));
 
         // tx2: insert with unknown attribute — should fail
         let result2 = node
-            .execute_tx(vec![TxOp::put(vec![(
-                kw!(:nonexistent_attr),
-                "oops".into(),
-            )])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent_attr),
+                value: "oops".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result2, TransactionResult::TxAborted(_, _)));
 
         // tx3: valid insert — should get the next contiguous entity ID
         let result3 = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result3, TransactionResult::TxCommited(_)));
@@ -1296,7 +1371,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -1323,7 +1402,11 @@ mod tests {
 
         // Submit a transaction with an unknown attribute to trigger abort
         let result = node
-            .execute_tx(vec![TxOp::put(vec![(kw!(:nonexistent), "x".into())])])
+            .execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent),
+                value: "x".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match &result {

--- a/src/node.rs
+++ b/src/node.rs
@@ -307,11 +307,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }];
+        let tx_ops = vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }];
 
         let waiter = node.indexer.read().await.tx_waiter();
 
@@ -339,11 +335,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::Add {
-            entity: "e".into(),
-            attribute: kw!(:email),
-            value: "test@example.com".into(),
-        }];
+        let tx_ops = vec![TxOp::Add { entity: "e".into(), attribute: kw!(:email), value: "test@example.com".into() }];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -367,18 +359,10 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "alice".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -398,18 +382,10 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "alice".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -433,11 +409,7 @@ mod tests {
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -490,25 +462,13 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "alice".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add {
-            entity: "charlie".into(),
-            attribute: kw!(:name),
-            value: "charlie".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "charlie".into(), attribute: kw!(:name), value: "charlie".into() }])
         .await
         .unwrap();
 
@@ -605,11 +565,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let tx_key1 = match node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap()
         {
@@ -618,11 +574,7 @@ mod tests {
         };
 
         let tx_key2 = match node
-            .execute_tx(vec![TxOp::Add {
-                entity: "bob".into(),
-                attribute: kw!(:name),
-                value: "bob".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
             .await
             .unwrap()
         {
@@ -660,11 +612,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -691,11 +639,7 @@ mod tests {
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         let result = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "bob".into(),
-                attribute: kw!(:name),
-                value: "bob".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -726,11 +670,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -765,11 +705,7 @@ mod tests {
 
         // First transaction: insert alice
         let result1 = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap();
         let tx_key1 = match result1 {
@@ -778,11 +714,7 @@ mod tests {
         };
 
         // Second transaction: insert bob
-        node.execute_tx(vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -837,11 +769,7 @@ mod tests {
         };
 
         // Upsert: update age using the discovered entity ID
-        node.execute_tx(vec![TxOp::Add {
-            entity: entity_id.into(),
-            attribute: kw!(:age),
-            value: 31_i64.into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: entity_id.into(), attribute: kw!(:age), value: 31_i64.into() }])
         .await
         .unwrap();
 
@@ -1159,16 +1087,8 @@ mod tests {
 
         // Insert two entities with last-names
         node.execute_tx(vec![
-            TxOp::Add {
-                entity: "ivannotov".into(),
-                attribute: kw!(:last-name),
-                value: "Ivannotov".into(),
-            },
-            TxOp::Add {
-                entity: "bobnev".into(),
-                attribute: kw!(:last-name),
-                value: "Bobnev".into(),
-            },
+            TxOp::Add { entity: "ivannotov".into(), attribute: kw!(:last-name), value: "Ivannotov".into() },
+            TxOp::Add { entity: "bobnev".into(), attribute: kw!(:last-name), value: "Bobnev".into() },
         ])
         .await
         .unwrap();
@@ -1204,11 +1124,7 @@ mod tests {
         // Submit a tx with unknown attribute — should fail with TxAborted
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Add {
-                entity: "e".into(),
-                attribute: kw!(:nonexistent/attr),
-                value: "x".into(),
-            }]),
+            node.execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent/attr), value: "x".into() }]),
         )
         .await
         .expect("Should not hang")
@@ -1236,11 +1152,7 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }]),
+            node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }]),
         )
         .await
         .expect("Should not hang")
@@ -1260,11 +1172,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Insert entity with tags="rust"
-        node.execute_tx(vec![TxOp::Add {
-            entity: "e".into(),
-            attribute: kw!(:tags),
-            value: "rust".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:tags), value: "rust".into() }])
         .await
         .unwrap();
 
@@ -1281,11 +1189,7 @@ mod tests {
         };
 
         // Add another tag to the same entity — should NOT retract "rust"
-        node.execute_tx(vec![TxOp::Add {
-            entity: entity_id.into(),
-            attribute: kw!(:tags),
-            value: "database".into(),
-        }])
+        node.execute_tx(vec![TxOp::Add { entity: entity_id.into(), attribute: kw!(:tags), value: "database".into() }])
         .await
         .unwrap();
 
@@ -1310,33 +1214,21 @@ mod tests {
 
         // tx1: valid insert — allocates first user entity
         let result1 = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap();
         assert!(matches!(result1, TransactionResult::TxCommited(_)));
 
         // tx2: insert with unknown attribute — should fail
         let result2 = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "e".into(),
-                attribute: kw!(:nonexistent_attr),
-                value: "oops".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent_attr), value: "oops".into() }])
             .await
             .unwrap();
         assert!(matches!(result2, TransactionResult::TxAborted(_, _)));
 
         // tx3: valid insert — should get the next contiguous entity ID
         let result3 = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "bob".into(),
-                attribute: kw!(:name),
-                value: "bob".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
             .await
             .unwrap();
         assert!(matches!(result3, TransactionResult::TxCommited(_)));
@@ -1371,11 +1263,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -1402,11 +1290,7 @@ mod tests {
 
         // Submit a transaction with an unknown attribute to trigger abort
         let result = node
-            .execute_tx(vec![TxOp::Add {
-                entity: "e".into(),
-                attribute: kw!(:nonexistent),
-                value: "x".into(),
-            }])
+            .execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent), value: "x".into() }])
             .await
             .unwrap();
         let tx_key = match &result {

--- a/src/node.rs
+++ b/src/node.rs
@@ -307,7 +307,11 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }];
+        let tx_ops = vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }];
 
         let waiter = node.indexer.read().await.tx_waiter();
 
@@ -335,7 +339,11 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::Add { entity: "e".into(), attribute: kw!(:email), value: "test@example.com".into() }];
+        let tx_ops = vec![TxOp::Add {
+            entity: "e".into(),
+            attribute: kw!(:email),
+            value: "test@example.com".into(),
+        }];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -359,10 +367,18 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
         .await
         .unwrap();
 
@@ -382,10 +398,18 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
         .await
         .unwrap();
 
@@ -409,7 +433,11 @@ mod tests {
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
         .await
         .unwrap();
 
@@ -462,13 +490,25 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::Add { entity: "charlie".into(), attribute: kw!(:name), value: "charlie".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "charlie".into(),
+            attribute: kw!(:name),
+            value: "charlie".into(),
+        }])
         .await
         .unwrap();
 
@@ -565,7 +605,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let tx_key1 = match node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap()
         {
@@ -574,7 +618,11 @@ mod tests {
         };
 
         let tx_key2 = match node
-            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap()
         {
@@ -612,7 +660,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -639,7 +691,11 @@ mod tests {
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         let result = node
-            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -670,7 +726,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -705,7 +765,11 @@ mod tests {
 
         // First transaction: insert alice
         let result1 = node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key1 = match result1 {
@@ -714,7 +778,11 @@ mod tests {
         };
 
         // Second transaction: insert bob
-        node.execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
         .await
         .unwrap();
 
@@ -769,7 +837,11 @@ mod tests {
         };
 
         // Upsert: update age using the discovered entity ID
-        node.execute_tx(vec![TxOp::Add { entity: entity_id.into(), attribute: kw!(:age), value: 31_i64.into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: entity_id.into(),
+            attribute: kw!(:age),
+            value: 31_i64.into(),
+        }])
         .await
         .unwrap();
 
@@ -1087,8 +1159,16 @@ mod tests {
 
         // Insert two entities with last-names
         node.execute_tx(vec![
-            TxOp::Add { entity: "ivannotov".into(), attribute: kw!(:last-name), value: "Ivannotov".into() },
-            TxOp::Add { entity: "bobnev".into(), attribute: kw!(:last-name), value: "Bobnev".into() },
+            TxOp::Add {
+                entity: "ivannotov".into(),
+                attribute: kw!(:last-name),
+                value: "Ivannotov".into(),
+            },
+            TxOp::Add {
+                entity: "bobnev".into(),
+                attribute: kw!(:last-name),
+                value: "Bobnev".into(),
+            },
         ])
         .await
         .unwrap();
@@ -1124,7 +1204,11 @@ mod tests {
         // Submit a tx with unknown attribute — should fail with TxAborted
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent/attr), value: "x".into() }]),
+            node.execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent/attr),
+                value: "x".into(),
+            }]),
         )
         .await
         .expect("Should not hang")
@@ -1152,7 +1236,11 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            node.execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }]),
+            node.execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }]),
         )
         .await
         .expect("Should not hang")
@@ -1172,7 +1260,11 @@ mod tests {
         define_test_schema(&node).await;
 
         // Insert entity with tags="rust"
-        node.execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:tags), value: "rust".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: "e".into(),
+            attribute: kw!(:tags),
+            value: "rust".into(),
+        }])
         .await
         .unwrap();
 
@@ -1189,16 +1281,18 @@ mod tests {
         };
 
         // Add another tag to the same entity — should NOT retract "rust"
-        node.execute_tx(vec![TxOp::Add { entity: entity_id.into(), attribute: kw!(:tags), value: "database".into() }])
+        node.execute_tx(vec![TxOp::Add {
+            entity: entity_id.into(),
+            attribute: kw!(:tags),
+            value: "database".into(),
+        }])
         .await
         .unwrap();
 
         // Query: find all tags for the entity
         let db = node.db().await.unwrap();
         let result = db
-            .query(format!(
-                "[:find ?tag :where [{entity_id} :tags ?tag]]"
-            ))
+            .query(format!("[:find ?tag :where [{entity_id} :tags ?tag]]"))
             .await
             .unwrap();
 
@@ -1214,21 +1308,33 @@ mod tests {
 
         // tx1: valid insert — allocates first user entity
         let result1 = node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result1, TransactionResult::TxCommited(_)));
 
         // tx2: insert with unknown attribute — should fail
         let result2 = node
-            .execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent_attr), value: "oops".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent_attr),
+                value: "oops".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result2, TransactionResult::TxAborted(_, _)));
 
         // tx3: valid insert — should get the next contiguous entity ID
         let result3 = node
-            .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            }])
             .await
             .unwrap();
         assert!(matches!(result3, TransactionResult::TxCommited(_)));
@@ -1263,7 +1369,11 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match result {
@@ -1290,7 +1400,11 @@ mod tests {
 
         // Submit a transaction with an unknown attribute to trigger abort
         let result = node
-            .execute_tx(vec![TxOp::Add { entity: "e".into(), attribute: kw!(:nonexistent), value: "x".into() }])
+            .execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent),
+                value: "x".into(),
+            }])
             .await
             .unwrap();
         let tx_key = match &result {

--- a/src/node.rs
+++ b/src/node.rs
@@ -457,23 +457,22 @@ mod tests {
         );
     }
 
-    // TODO(triplox-6s6): convert to auto-assigned IDs once tempids are implemented
     #[tokio::test(flavor = "multi_thread")]
     async fn test_query_entity_value_join() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(2000)),
-            (kw!(:name), "alice".into()),
-            (kw!(:follows), 2001_i64.into()),
-        ])])
-        .await
-        .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(2001)),
-            (kw!(:name), "bob".into()),
-        ])])
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("alice".to_string())),
+                (kw!(:name), "alice".into()),
+                (kw!(:follows), DataType::String("bob".to_string())),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("bob".to_string())),
+                (kw!(:name), "bob".into()),
+            ]),
+        ])
         .await
         .unwrap();
 
@@ -702,10 +701,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(100)),
-                (kw!(:name), "alice".into()),
-            ])])
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
             .await
             .unwrap();
         let tx_key = match result {
@@ -774,6 +770,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results_latest.len(), 2);
+
+        node.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_upsert_with_resolved_entity_id() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Insert entity with auto-assigned ID
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])])
+        .await
+        .unwrap();
+
+        // Discover the auto-assigned entity ID
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(r#"[:find ?e :where [?e :name "alice"]]"#)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        let entity_id = match &result[0][0] {
+            DataType::Long(id) => *id,
+            other => panic!("Expected Long entity ID, got {:?}", other),
+        };
+
+        // Upsert: update age using the discovered entity ID
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), DataType::Long(entity_id)),
+            (kw!(:age), 31_i64.into()),
+        ])])
+        .await
+        .unwrap();
+
+        // Verify: alice should now have age 31 (cardinality-one retracted 30)
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            vec![DataType::String("alice".to_string()), DataType::Long(31)]
+        );
 
         node.close().await;
     }
@@ -1075,25 +1119,29 @@ mod tests {
         .await
         .unwrap();
 
-        // Insert entity 200 and entity 201 with last-names
+        // Insert two entities with last-names
         node.execute_tx(vec![
-            TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(2200)),
-                (kw!(:last-name), "Ivannotov".into()),
-            ]),
-            TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(1201)),
-                (kw!(:last-name), "Bobnev".into()),
-            ]),
+            TxOp::put(vec![(kw!(:last-name), "Ivannotov".into())]),
+            TxOp::put(vec![(kw!(:last-name), "Bobnev".into())]),
         ])
         .await
         .unwrap();
 
-        // find ?ln where [200 :last-name ?ln] — literal entity ID in entity position
-
+        // Discover the entity ID for "Ivannotov"
         let db = node.db().await.unwrap();
+        let ids = db
+            .query(r#"[:find ?e :where [?e :last-name "Ivannotov"]]"#)
+            .await
+            .unwrap();
+        assert_eq!(ids.len(), 1);
+        let entity_id = match &ids[0][0] {
+            DataType::Long(id) => *id,
+            other => panic!("Expected Long entity ID, got {:?}", other),
+        };
+
+        // Use literal entity ID in entity position of a query
         let result = db
-            .query("[:find ?ln :where [2200 :last-name ?ln]]")
+            .query(format!("[:find ?ln :where [{entity_id} :last-name ?ln]]"))
             .await
             .unwrap();
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -406,7 +406,11 @@ mod tests {
 
     #[test]
     fn test_op_add_bincode() {
-        let op = TxOp::Add { entity: EntityRef::Id(1), attribute: kw!(:string), value: DataType::String("string_value".to_string()) };
+        let op = TxOp::Add {
+            entity: EntityRef::Id(1),
+            attribute: kw!(:string),
+            value: DataType::String("string_value".to_string()),
+        };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -40,6 +40,12 @@ impl From<&str> for EntityRef {
     }
 }
 
+impl From<String> for EntityRef {
+    fn from(v: String) -> Self {
+        EntityRef::TempId(v)
+    }
+}
+
 // TODO maybe use also clock::Instant here
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum DataType {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -406,11 +406,7 @@ mod tests {
 
     #[test]
     fn test_op_add_bincode() {
-        let op = TxOp::Add {
-            entity: EntityRef::Id(1),
-            attribute: kw!(:string),
-            value: DataType::String("string_value".to_string()),
-        };
+        let op = TxOp::Add { entity: EntityRef::Id(1), attribute: kw!(:string), value: DataType::String("string_value".to_string()) };
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1458,10 +1458,7 @@ mod tests {
     async fn test_execute_roundtrip() {
         let msg = FrontendMessage::Execute {
             ops: vec![
-                TxOp::put(vec![(
-                    kw!(:name),
-                    DataType::String("alice".to_string()),
-                )]),
+                TxOp::put(vec![(kw!(:name), DataType::String("alice".to_string()))]),
                 TxOp::Delete(EntityRef::Id(99)),
             ],
             await_indexing: true,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1344,13 +1344,21 @@ mod tests {
 
     #[test]
     fn test_tx_op_add() {
-        let op = TxOp::Add { entity: EntityRef::Id(42), attribute: kw!(:email), value: DataType::String("test@example.com".to_string()) };
+        let op = TxOp::Add {
+            entity: EntityRef::Id(42),
+            attribute: kw!(:email),
+            value: DataType::String("test@example.com".to_string()),
+        };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_add_with_ref_value() {
-        let op = TxOp::Add { entity: EntityRef::Id(42), attribute: kw!(:friend), value: DataType::String("temp-2".to_string()) };
+        let op = TxOp::Add {
+            entity: EntityRef::Id(42),
+            attribute: kw!(:friend),
+            value: DataType::String("temp-2".to_string()),
+        };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1344,21 +1344,13 @@ mod tests {
 
     #[test]
     fn test_tx_op_add() {
-        let op = TxOp::Add {
-            entity: EntityRef::Id(42),
-            attribute: kw!(:email),
-            value: DataType::String("test@example.com".to_string()),
-        };
+        let op = TxOp::Add { entity: EntityRef::Id(42), attribute: kw!(:email), value: DataType::String("test@example.com".to_string()) };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 
     #[test]
     fn test_tx_op_add_with_ref_value() {
-        let op = TxOp::Add {
-            entity: EntityRef::Id(42),
-            attribute: kw!(:friend),
-            value: DataType::String("temp-2".to_string()),
-        };
+        let op = TxOp::Add { entity: EntityRef::Id(42), attribute: kw!(:friend), value: DataType::String("temp-2".to_string()) };
         assert_eq!(roundtrip_tx_op(&op), op);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -636,10 +636,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_valid() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:name), "Alice".into()),
-        ])];
+        let ops = [TxOp::put(vec![(kw!(:name), "Alice".into())])];
         assert!(schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .is_ok());
@@ -648,10 +645,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_unknown_attribute() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:person/age), 30_i64.into()),
-        ])];
+        let ops = [TxOp::put(vec![(kw!(:person/age), 30_i64.into())])];
         let err = schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .unwrap_err();
@@ -661,10 +655,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_type_mismatch() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:name), 42_i64.into()),
-        ])];
+        let ops = [TxOp::put(vec![(kw!(:name), 42_i64.into())])];
         let err = schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .unwrap_err();
@@ -735,19 +726,16 @@ mod tests {
         assert_eq!(attr.value_type, ValueType::Ref);
 
         // Long value accepted for ref-typed attribute
-        let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:follows), 201_i64.into()),
-        ])];
+        let ops = [TxOp::put(vec![(kw!(:follows), 201_i64.into())])];
         assert!(schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .is_ok());
 
         // String in ref position is interpreted as tempid (resolved to Long)
-        let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(300)),
-            (kw!(:follows), DataType::String("some-tempid".to_string())),
-        ])];
+        let ops = [TxOp::put(vec![(
+            kw!(:follows),
+            DataType::String("some-tempid".to_string()),
+        )])];
         let datoms = to_datoms(&ops, &schema);
         // After expand_tx_ops, the string becomes a TempRef which resolves to a Long,
         // so validate_and_prepare should accept it.
@@ -784,7 +772,6 @@ mod tests {
     fn test_validate_and_prepare_missing_cardinality_errors() {
         let schema = bootstrapped_schema();
         let ops = [TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
             (kw!(:db/ident), DataType::Keyword(kw!(:name))),
             (
                 kw!(:db/valueType),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -679,10 +679,7 @@ mod tests {
         let ops = [TxOp::put(vec![
             (kw!(:db/id), DataType::Long(name_id)),
             (kw!(:db/ident), DataType::Keyword(kw!(:name))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/long)),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/long))),
             (
                 kw!(:db/cardinality),
                 DataType::Keyword(kw!(:db.cardinality/one)),
@@ -773,10 +770,7 @@ mod tests {
         let schema = bootstrapped_schema();
         let ops = [TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:name))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/string)),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string))),
             // No db/cardinality
         ])];
         let err = schema

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -288,7 +288,11 @@ mod tests {
 
     #[test]
     fn test_expand_add() {
-        let ops = vec![TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:name), value: DataType::String("bob".to_string()) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(200),
+            attribute: kw!(:name),
+            value: DataType::String("bob".to_string()),
+        }];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 1);
         assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
@@ -315,14 +319,22 @@ mod tests {
     #[test]
     fn test_expand_ident_resolution() {
         let schema = schema_with_ident(kw!(:person/name), 42);
-        let ops = vec![TxOp::Add { entity: EntityRef::Ident(kw!(:person/name)), attribute: kw!(:some/attr), value: DataType::Long(1) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Ident(kw!(:person/name)),
+            attribute: kw!(:some/attr),
+            value: DataType::Long(1),
+        }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].entity, IdOrTempId::Id(42));
     }
 
     #[test]
     fn test_expand_unknown_ident_errors() {
-        let ops = vec![TxOp::Add { entity: EntityRef::Ident(kw!(:unknown/ident)), attribute: kw!(:some/attr), value: DataType::Long(1) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Ident(kw!(:unknown/ident)),
+            attribute: kw!(:some/attr),
+            value: DataType::Long(1),
+        }];
         let result = expand_tx_ops(&ops, &empty_schema());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unknown ident"));
@@ -330,7 +342,11 @@ mod tests {
 
     #[test]
     fn test_expand_lookup_ref_errors() {
-        let ops = vec![TxOp::Add { entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())), attribute: kw!(:name), value: DataType::Long(1) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
+            attribute: kw!(:name),
+            value: DataType::Long(1),
+        }];
         let result = expand_tx_ops(&ops, &empty_schema());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Lookup refs"));
@@ -339,7 +355,11 @@ mod tests {
     #[test]
     fn test_expand_value_ref_tempid() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::String("friend".to_string()) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::String("friend".to_string()),
+        }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(
             datoms[0].value,
@@ -350,7 +370,11 @@ mod tests {
     #[test]
     fn test_expand_value_ref_id() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Long(200) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Long(200),
+        }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(200)));
     }
@@ -360,7 +384,11 @@ mod tests {
         let mut schema = schema_with_ref_attr(kw!(:follows), 999);
         schema.ident_map.insert(kw!(:person/bob), 99);
         schema.entid_map.insert(99, kw!(:person/bob));
-        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Keyword(kw!(:person/bob)) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Keyword(kw!(:person/bob)),
+        }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(99)));
     }
@@ -368,7 +396,11 @@ mod tests {
     #[test]
     fn test_expand_value_ref_rejects_invalid_type() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Boolean(true) }];
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Boolean(true),
+        }];
         let result = expand_tx_ops(&ops, &schema);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -78,10 +78,9 @@ fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<Valu
         match val {
             DataType::Long(id) => Ok(ValueWithTempIds::Data(DataType::Long(*id))),
             DataType::Keyword(kw) => {
-                let eid = schema
-                    .ident_map
-                    .get(kw)
-                    .ok_or_else(|| anyhow::anyhow!("Unknown ident in ref value position: {}", kw))?;
+                let eid = schema.ident_map.get(kw).ok_or_else(|| {
+                    anyhow::anyhow!("Unknown ident in ref value position: {}", kw)
+                })?;
                 Ok(ValueWithTempIds::Data(DataType::Long(*eid)))
             }
             DataType::String(s) => Ok(ValueWithTempIds::TempRef(s.clone())),

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -288,11 +288,7 @@ mod tests {
 
     #[test]
     fn test_expand_add() {
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(200),
-            attribute: kw!(:name),
-            value: DataType::String("bob".to_string()),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:name), value: DataType::String("bob".to_string()) }];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 1);
         assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
@@ -319,22 +315,14 @@ mod tests {
     #[test]
     fn test_expand_ident_resolution() {
         let schema = schema_with_ident(kw!(:person/name), 42);
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Ident(kw!(:person/name)),
-            attribute: kw!(:some/attr),
-            value: DataType::Long(1),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Ident(kw!(:person/name)), attribute: kw!(:some/attr), value: DataType::Long(1) }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].entity, IdOrTempId::Id(42));
     }
 
     #[test]
     fn test_expand_unknown_ident_errors() {
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Ident(kw!(:unknown/ident)),
-            attribute: kw!(:some/attr),
-            value: DataType::Long(1),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Ident(kw!(:unknown/ident)), attribute: kw!(:some/attr), value: DataType::Long(1) }];
         let result = expand_tx_ops(&ops, &empty_schema());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unknown ident"));
@@ -342,11 +330,7 @@ mod tests {
 
     #[test]
     fn test_expand_lookup_ref_errors() {
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
-            attribute: kw!(:name),
-            value: DataType::Long(1),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())), attribute: kw!(:name), value: DataType::Long(1) }];
         let result = expand_tx_ops(&ops, &empty_schema());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Lookup refs"));
@@ -355,11 +339,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_tempid() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
-            attribute: kw!(:follows),
-            value: DataType::String("friend".to_string()),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::String("friend".to_string()) }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(
             datoms[0].value,
@@ -370,11 +350,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_id() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
-            attribute: kw!(:follows),
-            value: DataType::Long(200),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Long(200) }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(200)));
     }
@@ -384,11 +360,7 @@ mod tests {
         let mut schema = schema_with_ref_attr(kw!(:follows), 999);
         schema.ident_map.insert(kw!(:person/bob), 99);
         schema.entid_map.insert(99, kw!(:person/bob));
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
-            attribute: kw!(:follows),
-            value: DataType::Keyword(kw!(:person/bob)),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Keyword(kw!(:person/bob)) }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(99)));
     }
@@ -396,11 +368,7 @@ mod tests {
     #[test]
     fn test_expand_value_ref_rejects_invalid_type() {
         let schema = schema_with_ref_attr(kw!(:follows), 999);
-        let ops = vec![TxOp::Add {
-            entity: EntityRef::Id(100),
-            attribute: kw!(:follows),
-            value: DataType::Boolean(true),
-        }];
+        let ops = vec![TxOp::Add { entity: EntityRef::Id(100), attribute: kw!(:follows), value: DataType::Boolean(true) }];
         let result = expand_tx_ops(&ops, &schema);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -52,10 +52,7 @@ async fn test_execute_tx_and_query() {
 
     // Insert a document
     let result = client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -63,15 +60,12 @@ async fn test_execute_tx_and_query() {
     // Open a DB and query
     let db = client.db().await.unwrap();
     let result = db
-        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(
-        result[0],
-        vec![DataType::Long(100), DataType::String("alice".to_string())]
-    );
+    assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -85,10 +79,7 @@ async fn test_submit_tx() {
     define_base_schema(&client).await;
 
     let tx_key = client
-        .submit_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "bob".into()),
-        ])])
+        .submit_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
         .await
         .unwrap();
     assert!(tx_key.tx_id >= 0);
@@ -105,36 +96,24 @@ async fn test_multiple_transactions_and_query() {
 
     // Insert two documents in separate transactions
     client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
     client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:name), "bob".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
         .await
         .unwrap();
 
     let db = client.db().await.unwrap();
     let result = db
-        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
     assert_eq!(result.len(), 2);
-    assert!(result.contains(&vec![
-        DataType::Long(100),
-        DataType::String("alice".to_string())
-    ]));
-    assert!(result.contains(&vec![
-        DataType::Long(200),
-        DataType::String("bob".to_string())
-    ]));
+    assert!(result.contains(&vec![DataType::String("alice".to_string())]));
+    assert!(result.contains(&vec![DataType::String("bob".to_string())]));
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -149,10 +128,7 @@ async fn test_open_close_multiple_dbs() {
 
     // Insert data
     client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -186,10 +162,7 @@ async fn test_two_connections() {
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
     client1
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -215,10 +188,7 @@ async fn test_execute_tx_returns_tx_key() {
     define_base_schema(&client).await;
 
     let result = client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
@@ -241,10 +211,7 @@ async fn test_db_as_of() {
 
     // First transaction
     let result1 = client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
     let tx_key1 = match result1 {
@@ -254,25 +221,19 @@ async fn test_db_as_of() {
 
     // Second transaction
     client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(200)),
-            (kw!(:name), "bob".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
         .await
         .unwrap();
 
     // Open DB pinned to tx_key after first tx — should only see alice
     let db = client.db_as_of(tx_key1).await.unwrap();
     let result = db
-        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(
-        result[0],
-        vec![DataType::Long(100), DataType::String("alice".to_string())]
-    );
+    assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();
@@ -307,16 +268,13 @@ async fn test_dev_server_connections_are_isolated() {
     define_base_schema(&client1).await;
 
     client1
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
-            (kw!(:name), "alice".into()),
-        ])])
+        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
         .await
         .unwrap();
 
     let db1 = client1.db().await.unwrap();
     let result1 = db1
-        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
     assert_eq!(result1.len(), 1, "client1 should see its own data");
@@ -327,7 +285,7 @@ async fn test_dev_server_connections_are_isolated() {
 
     let db2 = client2.db().await.unwrap();
     let result2 = db2
-        .query("{:find [?e ?name] :where [[?e :name ?name]]}")
+        .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
         .unwrap();
     assert_eq!(result2.len(), 0, "client2 should not see client1's data");
@@ -339,10 +297,9 @@ async fn test_dev_server_connections_are_isolated() {
     token.cancel();
 }
 
-async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &str) {
+async fn define_schema_attr(client: &ClientNode, name: &str, vtype: &str) {
     client
         .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(id.into())),
             (
                 kw!(:db/ident),
                 DataType::Keyword(Keyword::plain(name)).into(),
@@ -361,14 +318,14 @@ async fn define_schema_attr(client: &ClientNode, id: i64, name: &str, vtype: &st
 }
 
 async fn define_people_schema(client: &ClientNode) {
-    define_schema_attr(client, 54, "last-name", "string").await;
-    define_schema_attr(client, 55, "sex", "keyword").await;
-    define_schema_attr(client, 56, "salary", "long").await;
-    define_schema_attr(client, 57, "city", "string").await;
+    define_schema_attr(client, "last-name", "string").await;
+    define_schema_attr(client, "sex", "keyword").await;
+    define_schema_attr(client, "salary", "long").await;
+    define_schema_attr(client, "city", "string").await;
 }
 
 async fn define_heads_schema(client: &ClientNode) {
-    define_schema_attr(client, 58, "heads", "long").await;
+    define_schema_attr(client, "heads", "long").await;
 }
 
 /// Mirror of Clojure test-query-using-keywords, exercised through the full
@@ -381,15 +338,14 @@ async fn test_query_keyword_value_comparison_via_wire() {
     define_people_schema(&client).await;
 
     // Insert 4 people with keyword sex values
-    for (id, name, sex) in [
-        (100, "Ivan", "male"),
-        (101, "Petr", "male"),
-        (102, "Doris", "female"),
-        (103, "Jane", "female"),
+    for (name, sex) in [
+        ("Ivan", "male"),
+        ("Petr", "male"),
+        ("Doris", "female"),
+        ("Jane", "female"),
     ] {
         client
             .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
             ])])
@@ -431,14 +387,13 @@ async fn test_aggregates_and_or() {
     define_people_schema(&client).await;
 
     // Insert Ada, Alan, Adam
-    for (id, name, last, sex, age) in [
-        (100, "Ada", "Lovelace", "female", 21),
-        (101, "Alan", "Turing", "male", 22),
-        (102, "Adam", "Smith", "male", 23),
+    for (name, last, sex, age) in [
+        ("Ada", "Lovelace", "female", 21),
+        ("Alan", "Turing", "male", 22),
+        ("Adam", "Smith", "male", 23),
     ] {
         client
             .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:last-name), last.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
@@ -500,14 +455,9 @@ async fn test_aggregate_set_semantics() {
     define_base_schema(&client).await;
     define_people_schema(&client).await;
 
-    for (id, name, city) in [
-        (100, "Alice", "NYC"),
-        (101, "Bob", "NYC"),
-        (102, "Carol", "LA"),
-    ] {
+    for (name, city) in [("Alice", "NYC"), ("Bob", "NYC"), ("Carol", "LA")] {
         client
             .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:city), city.into()),
             ])])
@@ -537,12 +487,9 @@ async fn test_datascript_aggregates() {
     define_heads_schema(&client).await;
 
     // Insert monsters with heads
-    for (id, heads) in [(100, 3), (101, 1), (102, 1), (103, 1)] {
+    for heads in [3, 1, 1, 1] {
         client
-            .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
-                (kw!(:heads), (heads as i64).into()),
-            ])])
+            .execute_tx(vec![TxOp::put(vec![(kw!(:heads), (heads as i64).into())])])
             .await
             .unwrap();
     }
@@ -573,12 +520,9 @@ async fn test_aggregate_avg() {
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
 
-    for (id, age) in [(100, 21), (101, 22), (102, 23)] {
+    for age in [21, 22, 23] {
         client
-            .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
-                (kw!(:age), (age as i64).into()),
-            ])])
+            .execute_tx(vec![TxOp::put(vec![(kw!(:age), (age as i64).into())])])
             .await
             .unwrap();
     }
@@ -602,12 +546,9 @@ async fn test_aggregate_min_max_strings() {
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
 
-    for (id, name) in [(100, "Charlie"), (101, "Alice"), (102, "Bob")] {
+    for name in ["Charlie", "Alice", "Bob"] {
         client
-            .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
-                (kw!(:name), name.into()),
-            ])])
+            .execute_tx(vec![TxOp::put(vec![(kw!(:name), name.into())])])
             .await
             .unwrap();
     }
@@ -658,16 +599,15 @@ async fn test_order_and_limit() {
     define_base_schema(&client).await;
 
     // Insert 5 people with different ages
-    for (id, name, age) in [
-        (100, "Alice", 30),
-        (101, "Bob", 20),
-        (102, "Carol", 40),
-        (103, "Dave", 10),
-        (104, "Eve", 50),
+    for (name, age) in [
+        ("Alice", 30),
+        ("Bob", 20),
+        ("Carol", 40),
+        ("Dave", 10),
+        ("Eve", 50),
     ] {
         client
             .execute_tx(vec![TxOp::put(vec![
-                (kw!(:db/id), DataType::Long(id.into())),
                 (kw!(:name), name.into()),
                 (kw!(:age), (age as i64).into()),
             ])])
@@ -747,7 +687,6 @@ async fn test_aggregate_min_incompatible_types() {
     // Insert entity with both name (string) and age (long)
     client
         .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(100)),
             (kw!(:name), "Alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
@@ -761,6 +700,60 @@ async fn test_aggregate_min_incompatible_types() {
         .query("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
         .await;
     assert!(result.is_err(), "min over incompatible types should error");
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_upsert_with_resolved_entity_id() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+
+    // Insert entity with auto-assigned ID
+    client
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "alice".into()),
+            (kw!(:age), 30_i64.into()),
+        ])])
+        .await
+        .unwrap();
+
+    // Discover the auto-assigned entity ID
+    let db = client.db().await.unwrap();
+    let result = db
+        .query("{:find [?e] :where [[?e :name \"alice\"]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    let entity_id = match &result[0][0] {
+        DataType::Long(id) => *id,
+        other => panic!("Expected Long entity ID, got {:?}", other),
+    };
+    db.close().await.unwrap();
+
+    // Upsert: update age using the discovered entity ID
+    client
+        .execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/id), DataType::Long(entity_id)),
+            (kw!(:age), 31_i64.into()),
+        ])])
+        .await
+        .unwrap();
+
+    // Verify: alice should now have age 31 (cardinality-one retracted 30)
+    let db = client.db().await.unwrap();
+    let result = db
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0],
+        vec![DataType::String("alice".to_string()), DataType::Long(31)]
+    );
 
     db.close().await.unwrap();
     client.close().await.unwrap();

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -22,7 +22,7 @@
   "Execute a Datalog query. Returns a vector of vectors."
   [db query]
   (mapv (fn [row] (mapv types/wire->clj row))
-        (.query ^Db db (pr-str query))))
+        (.query ^Db db (if (string? query) query (pr-str query)))))
 
 (defn transact
   "Execute a transaction and wait for indexing. Returns result map."

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -22,7 +22,7 @@
   "Execute a Datalog query. Returns a vector of vectors."
   [db query]
   (mapv (fn [row] (mapv types/wire->clj row))
-        (.query ^Db db (if (string? query) query (pr-str query)))))
+        (.query ^Db db (pr-str query))))
 
 (defn transact
   "Execute a transaction and wait for indexing. Returns result map."

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -509,10 +509,10 @@
   (tc/transact *conn* [{:db/ident :heads
                         :db/valueType :db.type/long
                         :db/cardinality :db.cardinality/one}])
-  (tc/transact *conn* [{:heads 3}
-                       {:heads 1}
-                       {:heads 1}
-                       {:heads 1}])
+  (tc/transact *conn* [{:db/id "cerberus" :heads 3}
+                       {:db/id "medusa" :heads 1}
+                       {:db/id "cyclops" :heads 1}
+                       {:db/id "chimera" :heads 1}])
 
   (testing "Multiple aggregates, correct grouping"
     (is (= #{[6 1 3 4 2]}

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -10,12 +10,12 @@
 (def ^:dynamic *conn* nil)
 
 (def people-schema
-  [{:db/id 200 :db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
-   {:db/id 201 :db/ident :last-name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
-   {:db/id 202 :db/ident :sex :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
-   {:db/id 203 :db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-   {:db/id 204 :db/ident :salary :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-   {:db/id 205 :db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+  [{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+   {:db/ident :last-name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+   {:db/ident :sex :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :salary :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
 
 (defn connect []
   (let [host (System/getProperty "triplox.host" "localhost")
@@ -52,13 +52,13 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-sanity-check
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan"}])
-  (is (= #{[1000]} (q '{:find [?e]
-                       :where [[?e :name "Ivan"]]}))))
+  (tc/transact *conn* [{:name "Ivan"}])
+  (is (= 1 (count (q '{:find [?e]
+                        :where [[?e :name "Ivan"]]})))))
 
 (deftest test-basic-query
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :last-name "Ivanov"}
-                       {:db/id 1001 :name "Petr" :last-name "Petrov"}])
+  (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov"}
+                       {:name "Petr" :last-name "Petrov"}])
 
   (testing "Can query value by single field"
     (is (= #{["Ivan"]} (q '{:find [?name]
@@ -69,10 +69,10 @@
                                     [?e :name ?name]]}))))
 
   (testing "Can query entity by single field"
-    (is (= #{[1000]} (q '{:find [?e]
-                         :where [[?e :name "Ivan"]]})))
-    (is (= #{[1001]} (q '{:find [?e]
-                         :where [[?e :name "Petr"]]}))))
+    (is (= 1 (count (q '{:find [?e]
+                         :where [[?e :name "Ivan"]]}))))
+    (is (= 1 (count (q '{:find [?e]
+                         :where [[?e :name "Petr"]]})))))
 
   (testing "Can query using multiple terms"
     (is (= #{["Ivan" "Ivanov"]} (q '{:find [?name ?last-name]
@@ -90,31 +90,29 @@
     (is (= #{["Ivan"] ["Petr"]}
            (q '{:find [?name] :where [[?e :name ?name]]}))))
 
-  (tc/transact *conn* [{:db/id 1002 :name "Smith" :last-name "Smith"}])
+  (tc/transact *conn* [{:name "Smith" :last-name "Smith"}])
 
   (testing "Can query across fields for same value"
-    (is (= #{[1002]}
-           (q '{:find [?p1] :where [[?p1 :name ?name]
-                                    [?p1 :last-name ?name]]}))))
+    (is (= 1 (count (q '{:find [?p1] :where [[?p1 :name ?name]
+                                              [?p1 :last-name ?name]]})))))
 
   (testing "Can query across fields for same value when value is passed in"
-    (is (= #{[1002]}
-           (q '{:find [?p1] :where [[?p1 :name ?name]
-                                    [?p1 :last-name ?name]
-                                    [?p1 :name "Smith"]]})))))
+    (is (= 1 (count (q '{:find [?p1] :where [[?p1 :name ?name]
+                                              [?p1 :last-name ?name]
+                                              [?p1 :name "Smith"]]}))))))
 
 (deftest test-multiple-results
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :last-name "1"}
-                       {:db/id 1001 :name "Ivan" :last-name "2"}])
+  (tc/transact *conn* [{:name "Ivan" :last-name "1"}
+                       {:name "Ivan" :last-name "2"}])
 
   (is (= 2
          (count (q '{:find [?e] :where [[?e :name "Ivan"]]})))))
 
 (deftest test-query-using-keywords
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :sex :male}
-                       {:db/id 1001 :name "Petr" :sex :male}
-                       {:db/id 1002 :name "Doris" :sex :female}
-                       {:db/id 1003 :name "Jane" :sex :female}])
+  (tc/transact *conn* [{:name "Ivan" :sex :male}
+                       {:name "Petr" :sex :male}
+                       {:name "Doris" :sex :female}
+                       {:name "Jane" :sex :female}])
 
   (testing "Can query by single field"
     (is (= #{["Ivan"] ["Petr"]} (q '{:find [?name]
@@ -125,11 +123,11 @@
                                               [?e :sex :female]]})))))
 
 (deftest test-query-across-entities-using-join
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :age 30 :salary 50000}
-                       {:db/id 1001 :name "Petr" :age 25 :salary 45000}
-                       {:db/id 1002 :name "Sergei" :age 35 :salary 55000}
-                       {:db/id 1003 :name "Denis" :age 28 :salary 48000}
-                       {:db/id 1004 :name "Denis" :age 32 :salary 52000}])
+  (tc/transact *conn* [{:name "Ivan" :age 30 :salary 50000}
+                       {:name "Petr" :age 25 :salary 45000}
+                       {:name "Sergei" :age 35 :salary 55000}
+                       {:name "Denis" :age 28 :salary 48000}
+                       {:name "Denis" :age 32 :salary 52000}])
 
   (testing "Five people, without a join"
     (is (= 5 (count (q '{:find [?p1]
@@ -142,10 +140,10 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-or-query
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :last-name "Ivanov"}
-                       {:db/id 1001 :name "Ivan" :last-name "Ivanov"}
-                       {:db/id 1002 :name "Ivan" :last-name "Ivannotov"}
-                       {:db/id 1003 :name "Bob" :last-name "Controlguy"}])
+  (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov"}
+                       {:name "Ivan" :last-name "Ivanov"}
+                       {:name "Ivan" :last-name "Ivannotov"}
+                       {:name "Bob" :last-name "Controlguy"}])
 
   (testing "Or works as expected"
     (is (= 3 (count (q '{:find [?e]
@@ -185,9 +183,9 @@
                                  (or [?e :last-name "Ivanov"])]}))))))
 
 (deftest test-or-query-can-use-and
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :sex :male}
-                       {:db/id 1001 :name "Bob" :sex :male}
-                       {:db/id 1002 :name "Ivana" :sex :female}])
+  (tc/transact *conn* [{:name "Ivan" :sex :male}
+                       {:name "Bob" :sex :male}
+                       {:name "Ivana" :sex :female}])
 
   (is (= #{["Ivan"]
            ["Ivana"]}
@@ -197,9 +195,8 @@
                           (and [?e :sex :male]
                                [?e :name "Ivan"]))]})))
 
-  (is (= #{[1000]}
-         (q '{:find [?e]
-              :where [(or [?e :name "Ivan"])]})))
+  (is (= 1 (count (q '{:find [?e]
+                        :where [(or [?e :name "Ivan"])]}))))
 
   (is (= #{}
          (q '{:find [?name]
@@ -219,9 +216,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-not-query
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :last-name "Ivanov"}
-                       {:db/id 1001 :name "Ivan" :last-name "Ivanov"}
-                       {:db/id 1002 :name "Ivan" :last-name "Ivannotov"}])
+  (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov"}
+                       {:name "Ivan" :last-name "Ivanov"}
+                       {:name "Ivan" :last-name "Ivannotov"}])
 
   (testing "literal v"
     (is (= 1 (count (q '{:find [?e]
@@ -276,19 +273,31 @@
                          :where [[?e :name ?name]
                                  (not [?e :name ?name])]}))))
 
+    ;; Use a join to find the entity with last-name "Ivannotov" and exclude
+    ;; entities sharing that last-name
     (is (= 2 (count (q '{:find [?e]
                          :where [[?e :name ?name]
-                                 [1002 :last-name ?i-name]
+                                 [?ref :last-name "Ivannotov"]
+                                 [?ref :last-name ?i-name]
                                  (not [?e :last-name ?i-name])]})))))
 
-  (testing "literal entities"
-    (is (= 0 (count (q '{:find [?e]
-                         :where [[?e :name ?name]
-                                 (not [1000 :name ?name])]}))))
+  (testing "literal entities — use discovered entity IDs"
+    ;; Discover the entity ID for one of the "Ivan"/"Ivanov" entities
+    (let [ivan-ids (q '{:find [?e]
+                        :where [[?e :name "Ivan"]
+                                [?e :last-name "Ivanov"]]})
+          ivan-id (ffirst ivan-ids)
+          ;; Exclude entities whose :name matches Ivan's :name
+          query-str (format "{:find [?e] :where [[?e :name ?name] (not [%d :name ?name])]}" ivan-id)]
+      (is (= 0 (count (q query-str)))))
 
-    (is (= 1 (count (q '{:find [?e]
-                         :where [[?e :last-name ?last-name]
-                                 (not [1000 :last-name ?last-name])]})))))
+    ;; Discover entity with last-name "Ivannotov"
+    (let [ivannotov-ids (q '{:find [?e]
+                             :where [[?e :last-name "Ivannotov"]]})
+          ivannotov-id (ffirst ivannotov-ids)
+          ;; Only entities whose last-name differs from Ivannotov's
+          query-str (format "{:find [?e] :where [[?e :last-name ?last-name] (not [%d :last-name ?last-name])]}" ivannotov-id)]
+      (is (= 2 (count (q query-str))))))
 
   (testing "not can come before positive clauses"
     (is (= 2 (count (q '{:find [?e]
@@ -301,9 +310,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-predicate-expression
-  (tc/transact *conn* [{:db/id 1000 :name "Ivan" :last-name "Ivanov" :age 30}
-                       {:db/id 1001 :name "Bob" :last-name "Ivanov" :age 40}
-                       {:db/id 1002 :name "Dominic" :last-name "Monroe" :age 50}])
+  (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov" :age 30}
+                       {:name "Bob" :last-name "Ivanov" :age 40}
+                       {:name "Dominic" :last-name "Monroe" :age 50}])
 
   (testing "range expressions"
     (is (= #{["Ivan"] ["Bob"]}
@@ -351,23 +360,22 @@
                             (not [(re-find #"o" ?name)])]})))))
 
   (testing "Entity variable"
-    (is (= #{["Ivan"]}
-           (q '{:find [?name]
-                :where [[?e :name ?name]
-                        [(= 1000 ?e)]]})))
+    ;; Discover Ivan's entity ID, then use it in a predicate
+    (let [ivan-id (ffirst (q '{:find [?e]
+                               :where [[?e :name "Ivan"]]}))]
+      (is (= #{["Ivan"]}
+             (q (format "{:find [?name] :where [[?e :name ?name] [(= %d ?e)]]}" ivan-id)))))
 
     (testing "Filtered by value"
-      (is (= #{[1001] [1000]}
-             (q '{:find [?e]
-                  :where [[?e :last-name ?last-name]
-                          [(= "Ivanov" ?last-name)]]})))
+      (is (= 2 (count (q '{:find [?e]
+                           :where [[?e :last-name ?last-name]
+                                   [(= "Ivanov" ?last-name)]]}))))
 
-      (is (= #{[1000]}
-             (q '{:find [?e]
-                  :where [[?e :last-name ?last-name]
-                          [?e :age ?age]
-                          [(= "Ivanov" ?last-name)]
-                          [(= 30 ?age)]]})))))
+      (is (= 1 (count (q '{:find [?e]
+                           :where [[?e :last-name ?last-name]
+                                   [?e :age ?age]
+                                   [(= "Ivanov" ?last-name)]
+                                   [(= 30 ?age)]]})))))))
 
   ;; re-find tests commented out — see triplox-bwi
   #_(testing "Several variables with re-find"
@@ -430,25 +438,40 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest datomic-style-addition
-  (tc/transact *conn* [{:db/id 1000 :name "Alice"}])
+  (tc/transact *conn* [{:name "Alice"}])
 
   (is (= #{["Alice"]} (q '{:find [?name]
                            :where [[?p :name ?name]]})))
 
-  (tc/transact *conn* [{:db/id 1000 :city "NYC"}])
+  ;; Discover entity ID, then add :city to the same entity
+  (let [alice-id (ffirst (q '{:find [?e] :where [[?e :name "Alice"]]}))]
+    (tc/transact *conn* [{:db/id alice-id :city "NYC"}])
 
-  (is (= #{["Alice" "NYC"]} (q '{:find [?name ?city]
-                                 :where [[?p :name ?name]
-                                         [?p :city ?city]]}))))
+    (is (= #{["Alice" "NYC"]} (q '{:find [?name ?city]
+                                   :where [[?p :name ?name]
+                                           [?p :city ?city]]})))))
+
+(deftest test-upsert-with-resolved-entity-id
+  (tc/transact *conn* [{:name "Alice" :age 30}])
+
+  ;; Discover auto-assigned entity ID
+  (let [alice-id (ffirst (q '{:find [?e] :where [[?e :name "Alice"]]}))]
+    ;; Upsert: update age using the discovered entity ID
+    (tc/transact *conn* [{:db/id alice-id :age 31}])
+
+    ;; Verify: Alice should now have age 31 (cardinality-one retracted 30)
+    (is (= #{["Alice" 31]} (q '{:find [?name ?age]
+                                :where [[?e :name ?name]
+                                        [?e :age ?age]]})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tests — aggregates
 ;; ---------------------------------------------------------------------------
 
 (deftest test-aggregates-and-or
-  (tc/transact *conn* [{:db/id 1000 :name "Ada" :last-name "Lovelace" :sex :female :age 21}
-                       {:db/id 1001 :name "Alan" :last-name "Turing" :sex :male :age 22}
-                       {:db/id 1002 :name "Adam" :last-name "Smith" :sex :male :age 23}])
+  (tc/transact *conn* [{:name "Ada" :last-name "Lovelace" :sex :female :age 21}
+                       {:name "Alan" :last-name "Turing" :sex :male :age 22}
+                       {:name "Adam" :last-name "Smith" :sex :male :age 23}])
 
   (is (= #{[1]} (q '{:find [(count ?p)]
                      :where [[?p :last-name "Lovelace"]
@@ -471,22 +494,22 @@
       "implicit grouping"))
 
 (deftest test-aggregate-set-semantics
-  (tc/transact *conn* [{:db/id 1000 :name "Alice" :city "NYC"}
-                       {:db/id 1001 :name "Bob" :city "NYC"}
-                       {:db/id 1002 :name "Carol" :city "LA"}])
+  (tc/transact *conn* [{:name "Alice" :city "NYC"}
+                       {:name "Bob" :city "NYC"}
+                       {:name "Carol" :city "LA"}])
 
   ;; TODO: do we want Datomic or XTDB semantics here?
   (is (= #{[3]} (q '{:find [(count ?city)]
                      :where [[?p :city ?city]]}))))
 
 (deftest test-datascript-aggregates
-  (tc/transact *conn* [{:db/id 2000 :db/ident :heads
+  (tc/transact *conn* [{:db/ident :heads
                         :db/valueType :db.type/long
                         :db/cardinality :db.cardinality/one}])
-  (tc/transact *conn* [{:db/id 1000 :heads 3}
-                       {:db/id 1001 :heads 1}
-                       {:db/id 1002 :heads 1}
-                       {:db/id 1003 :heads 1}])
+  (tc/transact *conn* [{:heads 3}
+                       {:heads 1}
+                       {:heads 1}
+                       {:heads 1}])
 
   (testing "Multiple aggregates, correct grouping"
     (is (= #{[6 1 3 4 2]}
@@ -494,17 +517,17 @@
                 :where [[?monster :heads ?heads]]})))))
 
 (deftest test-aggregate-avg
-  (tc/transact *conn* [{:db/id 1000 :age 21}
-                       {:db/id 1001 :age 22}
-                       {:db/id 1002 :age 23}])
+  (tc/transact *conn* [{:age 21}
+                       {:age 22}
+                       {:age 23}])
 
   (is (= #{[22.0]} (q '{:find [(avg ?age)]
                         :where [[?e :age ?age]]}))))
 
 (deftest test-aggregate-min-max-strings
-  (tc/transact *conn* [{:db/id 1000 :name "Charlie"}
-                       {:db/id 1001 :name "Alice"}
-                       {:db/id 1002 :name "Bob"}])
+  (tc/transact *conn* [{:name "Charlie"}
+                       {:name "Alice"}
+                       {:name "Bob"}])
 
   (is (= #{["Alice" "Charlie"]}
          (q '{:find [(min ?name) (max ?name)]
@@ -519,11 +542,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest test-order-by-and-limit
-  (tc/transact *conn* [{:db/id 1000 :name "Alice" :age 30}
-                       {:db/id 1001 :name "Bob" :age 20}
-                       {:db/id 1002 :name "Carol" :age 40}
-                       {:db/id 1003 :name "Dave" :age 10}
-                       {:db/id 1004 :name "Eve" :age 50}])
+  (tc/transact *conn* [{:name "Alice" :age 30}
+                       {:name "Bob" :age 20}
+                       {:name "Carol" :age 40}
+                       {:name "Dave" :age 10}
+                       {:name "Eve" :age 50}])
 
   (testing "order ascending with limit"
     (is (= [["Dave" 10] ["Bob" 20] ["Alice" 30]]

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -283,23 +283,21 @@
 
   (testing "literal entities — use discovered entity IDs"
     ;; Discover the entity ID for one of the "Ivan"/"Ivanov" entities
-    (let [ivan-ids (q '{:find [?e]
-                        :where [[?e :name "Ivan"]
-                                [?e :last-name "Ivanov"]]})
-          ivan-id (ffirst ivan-ids)
-          ;; Exclude entities whose :name matches Ivan's :name
-          ;; TODO replace with :in
-          query-str (format "{:find [?e] :where [[?e :name ?name] (not [%d :name ?name])]}" ivan-id)]
-      (is (= 0 (count (q query-str)))))
+    (let [ivan-id (ffirst (q '{:find [?e]
+                               :where [[?e :name "Ivan"]
+                                       [?e :last-name "Ivanov"]]}))]
+      ;; Exclude entities whose :name matches Ivan's :name
+      (is (= 0 (count (q {:find  '[?e]
+                           :where [['?e :name '?name]
+                                   (list 'not [ivan-id :name '?name])]})))))
 
     ;; Discover entity with last-name "Ivannotov"
-    (let [ivannotov-ids (q '{:find [?e]
-                             :where [[?e :last-name "Ivannotov"]]})
-          ivannotov-id (ffirst ivannotov-ids)
-          ;; Only entities whose last-name differs from Ivannotov's
-          ;; TODO replace with :in
-          query-str (format "{:find [?e] :where [[?e :last-name ?last-name] (not [%d :last-name ?last-name])]}" ivannotov-id)]
-      (is (= 2 (count (q query-str))))))
+    (let [ivannotov-id (ffirst (q '{:find [?e]
+                                    :where [[?e :last-name "Ivannotov"]]}))]
+      ;; Only entities whose last-name differs from Ivannotov's
+      (is (= 2 (count (q {:find  '[?e]
+                           :where [['?e :last-name '?last-name]
+                                   (list 'not [ivannotov-id :last-name '?last-name])]}))))))
 
   (testing "not can come before positive clauses"
     (is (= 2 (count (q '{:find [?e]
@@ -366,8 +364,9 @@
     (let [ivan-id (ffirst (q '{:find [?e]
                                :where [[?e :name "Ivan"]]}))]
       (is (= #{["Ivan"]}
-             ;; TODO replace with :in
-             (q (format "{:find [?name] :where [[?e :name ?name] [(= %d ?e)]]}" ivan-id)))))
+             (q {:find  '[?name]
+                 :where [['?e :name '?name]
+                         [(list '= ivan-id '?e)]]}))))
 
     (testing "Filtered by value"
       (is (= 2 (count (q '{:find [?e]

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -375,7 +375,8 @@
                            :where [[?e :last-name ?last-name]
                                    [?e :age ?age]
                                    [(= "Ivanov" ?last-name)]
-                                   [(= 30 ?age)]]})))))))
+                                   [(= 30 ?age)]]}))))))
+
 
   ;; re-find tests commented out — see triplox-bwi
   #_(testing "Several variables with re-find"

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -54,7 +54,7 @@
 (deftest test-sanity-check
   (tc/transact *conn* [{:name "Ivan"}])
   (is (= 1 (count (q '{:find [?e]
-                        :where [[?e :name "Ivan"]]})))))
+                       :where [[?e :name "Ivan"]]})))))
 
 (deftest test-basic-query
   (tc/transact *conn* [{:name "Ivan" :last-name "Ivanov"}
@@ -94,12 +94,12 @@
 
   (testing "Can query across fields for same value"
     (is (= 1 (count (q '{:find [?p1] :where [[?p1 :name ?name]
-                                              [?p1 :last-name ?name]]})))))
+                                             [?p1 :last-name ?name]]})))))
 
   (testing "Can query across fields for same value when value is passed in"
     (is (= 1 (count (q '{:find [?p1] :where [[?p1 :name ?name]
-                                              [?p1 :last-name ?name]
-                                              [?p1 :name "Smith"]]}))))))
+                                             [?p1 :last-name ?name]
+                                             [?p1 :name "Smith"]]}))))))
 
 (deftest test-multiple-results
   (tc/transact *conn* [{:name "Ivan" :last-name "1"}
@@ -196,7 +196,7 @@
                                [?e :name "Ivan"]))]})))
 
   (is (= 1 (count (q '{:find [?e]
-                        :where [(or [?e :name "Ivan"])]}))))
+                       :where [(or [?e :name "Ivan"])]}))))
 
   (is (= #{}
          (q '{:find [?name]
@@ -288,16 +288,16 @@
                                        [?e :last-name "Ivanov"]]}))]
       ;; Exclude entities whose :name matches Ivan's :name
       (is (= 0 (count (q {:find  '[?e]
-                           :where [['?e :name '?name]
-                                   (list 'not [ivan-id :name '?name])]})))))
+                          :where [['?e :name '?name]
+                                  (list 'not [ivan-id :name '?name])]})))))
 
     ;; Discover entity with last-name "Ivannotov"
     (let [ivannotov-id (ffirst (q '{:find [?e]
                                     :where [[?e :last-name "Ivannotov"]]}))]
       ;; Only entities whose last-name differs from Ivannotov's
       (is (= 2 (count (q {:find  '[?e]
-                           :where [['?e :last-name '?last-name]
-                                   (list 'not [ivannotov-id :last-name '?last-name])]}))))))
+                          :where [['?e :last-name '?last-name]
+                                  (list 'not [ivannotov-id :last-name '?last-name])]}))))))
 
   (testing "not can come before positive clauses"
     (is (= 2 (count (q '{:find [?e]

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -288,6 +288,7 @@
                                 [?e :last-name "Ivanov"]]})
           ivan-id (ffirst ivan-ids)
           ;; Exclude entities whose :name matches Ivan's :name
+          ;; TODO replace with :in
           query-str (format "{:find [?e] :where [[?e :name ?name] (not [%d :name ?name])]}" ivan-id)]
       (is (= 0 (count (q query-str)))))
 
@@ -296,6 +297,7 @@
                              :where [[?e :last-name "Ivannotov"]]})
           ivannotov-id (ffirst ivannotov-ids)
           ;; Only entities whose last-name differs from Ivannotov's
+          ;; TODO replace with :in
           query-str (format "{:find [?e] :where [[?e :last-name ?last-name] (not [%d :last-name ?last-name])]}" ivannotov-id)]
       (is (= 2 (count (q query-str))))))
 
@@ -364,6 +366,7 @@
     (let [ivan-id (ffirst (q '{:find [?e]
                                :where [[?e :name "Ivan"]]}))]
       (is (= #{["Ivan"]}
+             ;; TODO replace with :in
              (q (format "{:find [?name] :where [[?e :name ?name] [(= %d ?e)]]}" ivan-id)))))
 
     (testing "Filtered by value"


### PR DESCRIPTION
## Summary
- Remove all explicit numeric entity IDs from tests, examples, and helpers — replaced with auto-assigned IDs or tempids for cross-entity references
- Bootstrap schema transaction retains explicit IDs (required for bootstrapping)
- Serialization/wire-protocol tests that specifically test `EntityRef::Id` encoding are kept as-is
- Add `test_upsert_with_resolved_entity_id` end-to-end tests in Rust (node + client-server) and Clojure that verify the discover-and-reuse-entity-ID upsert pattern

## Test plan
- [x] `cargo test` — all 378 unit + 19 integration tests pass
- [ ] JVM integration tests (`triplox-jvm`) — Clojure changes need verification against a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)