### PR TITLE
Prepare Clojars publishing for xyz.triplox/triplox

### DIFF
--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
     id("dev.clojurephant.clojure") version "0.8.0-beta.7"
 }
 
@@ -49,3 +50,53 @@ tasks.checkClojure {
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "com.github.fiv0"
+            artifactId = "triplox"
+            version = project.version.toString()
+
+            from(components["java"])
+
+            pom {
+                name.set("triplox")
+                description.set("A triple store built on top of XTDB")
+                url.set("https://github.com/FiV0/triplox")
+
+                licenses {
+                    license {
+                        // TODO: choose a license
+                        name.set("TODO")
+                        url.set("TODO")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("FiV0")
+                        name.set("Finn Völkel")
+                    }
+                }
+
+                scm {
+                    url.set("https://github.com/FiV0/triplox")
+                    connection.set("scm:git:git://github.com/FiV0/triplox.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/FiV0/triplox.git")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "clojars"
+            url = uri("https://repo.clojars.org/")
+            credentials {
+                username = findProperty("clojarsUsername") as String?
+                password = findProperty("clojarsPassword") as String?
+            }
+        }
+    }
+}

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -54,9 +54,9 @@ java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "com.github.fiv0"
+            groupId = "xyz.triplox"
             artifactId = "triplox"
-            version = project.version.toString()
+            version = "0.1.0-alpha"
 
             from(components["java"])
 
@@ -67,9 +67,8 @@ publishing {
 
                 licenses {
                     license {
-                        // TODO: choose a license
-                        name.set("TODO")
-                        url.set("TODO")
+                        name.set("Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
                     }
                 }
 

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -1,7 +1,7 @@
-(ns triplox.api
+(ns io.triplox.api
   "Clojure client API for Triplox."
-  (:require [triplox.types :as types]
-            [triplox.tx :as tx])
+  (:require [io.triplox.types :as types]
+            [io.triplox.tx :as tx])
   (:import [io.triplox.client TriploxNode Db TxKeyResult TxResultValue]))
 
 (defn connect

--- a/triplox-jvm/src/main/clojure/io/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/tx.clj
@@ -1,4 +1,4 @@
-(ns triplox.tx
+(ns io.triplox.tx
   "Convert Datomic-style transaction data to TxOp objects."
   (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident
             TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))

--- a/triplox-jvm/src/main/clojure/io/triplox/types.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/types.clj
@@ -1,4 +1,4 @@
-(ns triplox.types
+(ns io.triplox.types
   "Conversion between Triplox wire types and Clojure types."
   (:import [java.util Map]
            [io.triplox.client DataTypeCodec$TaggedTuple]))

--- a/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/integration/query_test.clj
@@ -1,6 +1,6 @@
-(ns triplox.integration.query-test
+(ns io.triplox.integration.query-test
   (:require [clojure.test :as t :refer [deftest is testing use-fixtures]]
-            [triplox.api :as tc])
+            [io.triplox.api :as tc])
   (:import (io.triplox.client TriploxException)))
 
 ;; ---------------------------------------------------------------------------

--- a/triplox-jvm/src/test/clojure/io/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/tx_test.clj
@@ -1,6 +1,6 @@
-(ns triplox.tx-test
+(ns io.triplox.tx-test
   (:require [clojure.test :refer [deftest is testing]]
-            [triplox.tx :as tx])
+            [io.triplox.tx :as tx])
   (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident
             TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 

--- a/triplox-jvm/src/test/clojure/io/triplox/types_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/types_test.clj
@@ -1,6 +1,6 @@
-(ns triplox.types-test
+(ns io.triplox.types-test
   (:require [clojure.test :refer [deftest is testing]]
-            [triplox.types :as types])
+            [io.triplox.types :as types])
   (:import [java.util TreeMap ArrayList]
            [io.triplox.client DataTypeCodec$TaggedTuple]))
 


### PR DESCRIPTION
## Summary
- Set maven coordinates to `xyz.triplox/triplox` version `0.1.0-alpha` with Apache-2.0 license
- Move Clojure namespaces from `triplox.*` to `io.triplox.*` to match the Java package structure in the JAR
- Add `maven-publish` config with Clojars repository and POM metadata

## Test plan
- [x] Unit tests pass (`./gradlew test`)
- [x] JAR contents verified — Clojure files now under `io/triplox/`
- [ ] Verify Clojars deploy with credentials configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)