### PR TITLE
feat: add Clojure example and reorganize examples directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 .lsp/
 .clj-kondo/
+.cpcache/
+.nrepl-port

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,10 +29,20 @@ Then run the examples as shown below. The Docker image binds to `0.0.0.0:5490`, 
 
 ## Running
 
-In a separate terminal, from the `examples/` directory:
+### Rust
+
+From the `examples/rust/` directory:
 
 ```bash
 cargo run --bin simple-example
+```
+
+### Clojure
+
+From the `examples/clojure/` directory:
+
+```bash
+clj -M -m simple-example
 ```
 
 ### simple-example

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ cargo run --bin simple-example
 From the `examples/clojure/` directory:
 
 ```bash
-clj -M -m simple-example
+clj -M src/simple_example.clj
 ```
 
 ### simple-example

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,11 +39,9 @@ cargo run --bin simple-example
 
 ### Clojure
 
-From the `examples/clojure/` directory:
+See `examples/clojure/src/simple_example.clj` for a simple REPL session of how to interact
+with the server.
 
-```bash
-clj -M src/simple_example.clj
-```
 
 ### simple-example
 

--- a/examples/clojure/deps.edn
+++ b/examples/clojure/deps.edn
@@ -1,0 +1,2 @@
+{:deps {xyz.triplox/triplox {:mvn/version "0.1.0-alpha"}}
+ :paths ["src"]}

--- a/examples/clojure/deps.edn
+++ b/examples/clojure/deps.edn
@@ -1,2 +1,4 @@
-{:deps {xyz.triplox/triplox {:mvn/version "0.1.0-alpha"}}
- :paths ["src"]}
+{:paths ["src"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        xyz.triplox/triplox {:mvn/version "0.1.0-alpha"}}}

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -1,0 +1,46 @@
+(ns simple-example
+  "Simple example: connect to a running Triplox server, define schema
+  attributes, insert data, and query it back.
+
+  Start the server first:
+    cargo run                      (from project root, uses config/triplox.toml)
+
+  Then run this example:
+    clj -M -m simple-example       (from examples/clojure/)"
+  (:require [io.triplox.api :as tc]))
+
+(defn -main [& _args]
+  (let [host "localhost"
+        port 5490]
+    (println (str "Connecting to " host ":" port "..."))
+    (with-open [conn (tc/connect host port)]
+      (println "Connected.")
+
+      ;; 1. Define schema attributes
+      (let [result (tc/transact conn [{:db/id 200 :db/ident :name
+                                       :db/valueType :db.type/string
+                                       :db/cardinality :db.cardinality/one}
+                                      {:db/id 201 :db/ident :age
+                                       :db/valueType :db.type/long
+                                       :db/cardinality :db.cardinality/one}])]
+        (if (:committed? result)
+          (println (str "Schema defined (tx_id=" (:tx-id result) ")."))
+          (throw (ex-info (str "Schema transaction aborted: " (:error-message result)) {}))))
+
+      ;; 2. Insert some data
+      (let [result (tc/transact conn [{:db/id 100 :name "alice" :age 30}
+                                      {:db/id 101 :name "bob" :age 25}])]
+        (if (:committed? result)
+          (println (str "Data inserted (tx_id=" (:tx-id result) ")."))
+          (throw (ex-info (str "Data transaction aborted: " (:error-message result)) {}))))
+
+      ;; 3. Open a DB snapshot and query
+      (with-open [db (tc/db conn)]
+        (let [rows (tc/q db '{:find [?e ?name ?age]
+                              :where [[?e :name ?name]
+                                      [?e :age ?age]]})]
+          (println (str "Query returned " (count rows) " row(s):"))
+          (doseq [row rows]
+            (println (str "  " (pr-str row))))))
+
+      (println "Done."))))

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -8,11 +8,10 @@
 (def conn (tc/connect host port))
 
 ;; 1. Transact a schema
-(tc/transact conn [{:db/id 200
-                    :db/ident :name
+(tc/transact conn [{:db/ident :name
                     :db/valueType :db.type/string
                     :db/cardinality :db.cardinality/one}
-                   {:db/id 201 :db/ident :age
+                   {:db/ident :age
                     :db/valueType :db.type/long
                     :db/cardinality :db.cardinality/one}])
 ;; => {:tx-id 0,
@@ -21,8 +20,8 @@
 ;;     :error-message nil}
 
 ;; 2. Transact some data
-(tc/transact conn [{:db/id 100 :name "alice" :age 30}
-                   {:db/id 101 :name "bob" :age 25}])
+(tc/transact conn [{:name "alice" :age 30}
+                   {:name "bob" :age 25}])
 ;; => {:tx-id 1,
 ;;     :system-time 1775733942779513,
 ;;     :committed? true,
@@ -35,4 +34,4 @@
   (tc/q db '{:find [?e ?name ?age]
              :where [[?e :name ?name]
                      [?e :age ?age]]}))
-;; => [[101 "bob" 25] [100 "alice" 30]]
+;; => [[8796093022209 "alice" 30] [8796093022208 "bob" 25]]

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -5,34 +5,34 @@
 
 (println (str "Connecting to " host ":" port "..."))
 
-(with-open [conn (tc/connect host port)]
-  (println "Connected.")
+(def conn (tc/connect host port))
 
-  ;; 1. Define schema attributes
-  (let [result (tc/transact conn [{:db/id 200 :db/ident :name
-                                   :db/valueType :db.type/string
-                                   :db/cardinality :db.cardinality/one}
-                                  {:db/id 201 :db/ident :age
-                                   :db/valueType :db.type/long
-                                   :db/cardinality :db.cardinality/one}])]
-    (if (:committed? result)
-      (println (str "Schema defined (tx_id=" (:tx-id result) ")."))
-      (throw (ex-info (str "Schema transaction aborted: " (:error-message result)) {}))))
+;; 1. Transact a schema
+(tc/transact conn [{:db/id 200
+                    :db/ident :name
+                    :db/valueType :db.type/string
+                    :db/cardinality :db.cardinality/one}
+                   {:db/id 201 :db/ident :age
+                    :db/valueType :db.type/long
+                    :db/cardinality :db.cardinality/one}])
+;; => {:tx-id 0,
+;;     :system-time 1775733871873835,
+;;     :committed? true,
+;;     :error-message nil}
 
-  ;; 2. Insert some data
-  (let [result (tc/transact conn [{:db/id 100 :name "alice" :age 30}
-                                  {:db/id 101 :name "bob" :age 25}])]
-    (if (:committed? result)
-      (println (str "Data inserted (tx_id=" (:tx-id result) ")."))
-      (throw (ex-info (str "Data transaction aborted: " (:error-message result)) {}))))
+;; 2. Transact some data
+(tc/transact conn [{:db/id 100 :name "alice" :age 30}
+                   {:db/id 101 :name "bob" :age 25}])
+;; => {:tx-id 1,
+;;     :system-time 1775733942779513,
+;;     :committed? true,
+;;     :error-message nil}
 
-  ;; 3. Open a DB snapshot and query
-  (with-open [db (tc/db conn)]
-    (let [rows (tc/q db '{:find [?e ?name ?age]
-                          :where [[?e :name ?name]
-                                  [?e :age ?age]]})]
-      (println (str "Query returned " (count rows) " row(s):"))
-      (doseq [row rows]
-        (println (str "  " (pr-str row))))))
 
-  (println "Done."))
+
+;; 3. Open a DB snapshot and query
+(with-open [db (tc/db conn)]
+  (tc/q db '{:find [?e ?name ?age]
+             :where [[?e :name ?name]
+                     [?e :age ?age]]}))
+;; => [[101 "bob" 25] [100 "alice" 30]]

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -1,46 +1,38 @@
-(ns simple-example
-  "Simple example: connect to a running Triplox server, define schema
-  attributes, insert data, and query it back.
+(require '[io.triplox.api :as tc])
 
-  Start the server first:
-    cargo run                      (from project root, uses config/triplox.toml)
+(def host "localhost")
+(def port 5490)
 
-  Then run this example:
-    clj -M -m simple-example       (from examples/clojure/)"
-  (:require [io.triplox.api :as tc]))
+(println (str "Connecting to " host ":" port "..."))
 
-(defn -main [& _args]
-  (let [host "localhost"
-        port 5490]
-    (println (str "Connecting to " host ":" port "..."))
-    (with-open [conn (tc/connect host port)]
-      (println "Connected.")
+(with-open [conn (tc/connect host port)]
+  (println "Connected.")
 
-      ;; 1. Define schema attributes
-      (let [result (tc/transact conn [{:db/id 200 :db/ident :name
-                                       :db/valueType :db.type/string
-                                       :db/cardinality :db.cardinality/one}
-                                      {:db/id 201 :db/ident :age
-                                       :db/valueType :db.type/long
-                                       :db/cardinality :db.cardinality/one}])]
-        (if (:committed? result)
-          (println (str "Schema defined (tx_id=" (:tx-id result) ")."))
-          (throw (ex-info (str "Schema transaction aborted: " (:error-message result)) {}))))
+  ;; 1. Define schema attributes
+  (let [result (tc/transact conn [{:db/id 200 :db/ident :name
+                                   :db/valueType :db.type/string
+                                   :db/cardinality :db.cardinality/one}
+                                  {:db/id 201 :db/ident :age
+                                   :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one}])]
+    (if (:committed? result)
+      (println (str "Schema defined (tx_id=" (:tx-id result) ")."))
+      (throw (ex-info (str "Schema transaction aborted: " (:error-message result)) {}))))
 
-      ;; 2. Insert some data
-      (let [result (tc/transact conn [{:db/id 100 :name "alice" :age 30}
-                                      {:db/id 101 :name "bob" :age 25}])]
-        (if (:committed? result)
-          (println (str "Data inserted (tx_id=" (:tx-id result) ")."))
-          (throw (ex-info (str "Data transaction aborted: " (:error-message result)) {}))))
+  ;; 2. Insert some data
+  (let [result (tc/transact conn [{:db/id 100 :name "alice" :age 30}
+                                  {:db/id 101 :name "bob" :age 25}])]
+    (if (:committed? result)
+      (println (str "Data inserted (tx_id=" (:tx-id result) ")."))
+      (throw (ex-info (str "Data transaction aborted: " (:error-message result)) {}))))
 
-      ;; 3. Open a DB snapshot and query
-      (with-open [db (tc/db conn)]
-        (let [rows (tc/q db '{:find [?e ?name ?age]
-                              :where [[?e :name ?name]
-                                      [?e :age ?age]]})]
-          (println (str "Query returned " (count rows) " row(s):"))
-          (doseq [row rows]
-            (println (str "  " (pr-str row))))))
+  ;; 3. Open a DB snapshot and query
+  (with-open [db (tc/db conn)]
+    (let [rows (tc/q db '{:find [?e ?name ?age]
+                          :where [[?e :name ?name]
+                                  [?e :age ?age]]})]
+      (println (str "Query returned " (count rows) " row(s):"))
+      (doseq [row rows]
+        (println (str "  " (pr-str row))))))
 
-      (println "Done."))))
+  (println "Done."))

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 bench = false
 
 [dependencies]
-triplox = { path = ".." }
-edn = { path = "../edn" }
+triplox = { path = "../.." }
+edn = { path = "../../edn" }
 anyhow = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -5,7 +5,7 @@
 //!   cargo run                     (from project root, uses config/triplox.toml)
 //!
 //! Then run this example:
-//!   cargo run --bin simple-example  (from examples/)
+//!   cargo run --bin simple-example  (from examples/rust/)
 
 use anyhow::Result;
 use edn::kw;


### PR DESCRIPTION
## Summary
- Move the Rust example into `examples/rust/` subfolder (updated dependency paths)
- Add a Clojure example in `examples/clojure/` that mirrors the Rust simple-example using the `xyz.triplox/triplox` Clojars dependency (from #177)
- Update `examples/README.md` with run instructions for both languages

## Test plan
- [x] Clojure example tested against running server — connects, defines schema, inserts data, queries, and prints results successfully
- [ ] Rust example: verify `cargo run --bin simple-example` from `examples/rust/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)