### PR TITLE
refactor: use TxOp::Add for all single-attribute assertions

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -624,7 +624,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(2),
         };
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alan".into(), attribute: kw!(:name), value: "alan".into() }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // The entity was auto-assigned an ID in USER_PARTITION
@@ -663,7 +663,7 @@ mod tests {
             system_time: st_from_unix_epoch(2),
         };
 
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alan".into(), attribute: kw!(:name), value: "alan".into() }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Verify an EAV entry in USER_PARTITION exists
@@ -732,7 +732,7 @@ mod tests {
             system_time: st_from_unix_epoch(1000),
         };
 
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
@@ -764,7 +764,7 @@ mod tests {
                 tx_id,
                 system_time: st_from_unix_epoch(tx_id as u64 * 100),
             };
-            let tx_ops = vec![TxOp::put(vec![(kw!(:name), format!("user{}", i).into())])];
+            let tx_ops = vec![TxOp::Add { entity: format!("user{}", i).into(), attribute: kw!(:name), value: format!("user{}", i).into() }];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -784,7 +784,7 @@ mod tests {
             system_time: st_from_unix_epoch(1000),
         };
 
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         let snapshot = Arc::new(slate.snapshot().await?);
@@ -821,7 +821,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(2),
         };
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
         indexer.tx_waiter().await_tx(tx_key).await?;
@@ -845,7 +845,7 @@ mod tests {
 
         {
             let mut guard = indexer.write().await;
-            let tx_ops = vec![TxOp::put(vec![(kw!(:name), "bob".into())])];
+            let tx_ops = vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }];
 
             guard.transact_tx(tx_key_1, tx_ops).await?;
         }
@@ -893,7 +893,7 @@ mod tests {
                 tx_id,
                 system_time: st_from_unix_epoch(tx_id as u64 * 100),
             };
-            let tx_ops = vec![TxOp::put(vec![(kw!(:name), format!("user{}", i).into())])];
+            let tx_ops = vec![TxOp::Add { entity: format!("user{}", i).into(), attribute: kw!(:name), value: format!("user{}", i).into() }];
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
@@ -932,7 +932,7 @@ mod tests {
         // Index the transaction
         {
             let mut guard = indexer.write().await;
-            let tx_ops = vec![TxOp::put(vec![(kw!(:name), "shared".into())])];
+            let tx_ops = vec![TxOp::Add { entity: "shared".into(), attribute: kw!(:name), value: "shared".into() }];
 
             guard.transact_tx(tx_key, tx_ops).await?;
         }
@@ -962,7 +962,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find the auto-assigned entity ID
@@ -990,10 +990,7 @@ mod tests {
         indexer
             .transact_tx(
                 tx2,
-                vec![TxOp::put(vec![
-                    (kw!(:db/id), DataType::Long(entity_id)),
-                    (kw!(:name), "bob".into()),
-                ])],
+                vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:name), value: "bob".into() }],
             )
             .await?;
 
@@ -1046,7 +1043,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alice".into())])];
+        let tx_ops = vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }];
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find auto-assigned entity ID
@@ -1073,10 +1070,7 @@ mod tests {
         indexer
             .transact_tx(
                 tx2,
-                vec![TxOp::put(vec![
-                    (kw!(:db/id), DataType::Long(entity_id)),
-                    (kw!(:name), "alice".into()),
-                ])],
+                vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:name), value: "alice".into() }],
             )
             .await?;
 
@@ -1130,7 +1124,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops1 = vec![TxOp::put(vec![(kw!(:tags), "rust".into())])];
+        let tx_ops1 = vec![TxOp::Add { entity: "tagged".into(), attribute: kw!(:tags), value: "rust".into() }];
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Discover auto-assigned entity ID
@@ -1193,7 +1187,7 @@ mod tests {
             tx_id: 1,
             system_time: st_from_unix_epoch(100),
         };
-        let tx_ops1 = vec![TxOp::put(vec![(kw!(:tags), "rust".into())])];
+        let tx_ops1 = vec![TxOp::Add { entity: "tagged".into(), attribute: kw!(:tags), value: "rust".into() }];
         indexer.transact_tx(tx1, tx_ops1).await?;
 
         // Discover auto-assigned entity ID

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1458,7 +1458,7 @@ mod tests {
     async fn test_execute_roundtrip() {
         let msg = FrontendMessage::Execute {
             ops: vec![
-                TxOp::put(vec![(kw!(:name), DataType::String("alice".to_string()))]),
+                TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: DataType::String("alice".to_string()) },
                 TxOp::Delete(EntityRef::Id(99)),
             ],
             await_indexing: true,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -636,7 +636,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_valid() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![(kw!(:name), "Alice".into())])];
+        let ops = [TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "Alice".into() }];
         assert!(schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .is_ok());
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_unknown_attribute() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![(kw!(:person/age), 30_i64.into())])];
+        let ops = [TxOp::Add { entity: "person".into(), attribute: kw!(:person/age), value: 30_i64.into() }];
         let err = schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .unwrap_err();
@@ -655,7 +655,7 @@ mod tests {
     #[test]
     fn test_validate_and_prepare_type_mismatch() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::put(vec![(kw!(:name), 42_i64.into())])];
+        let ops = [TxOp::Add { entity: "person".into(), attribute: kw!(:name), value: 42_i64.into() }];
         let err = schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .unwrap_err();
@@ -723,16 +723,17 @@ mod tests {
         assert_eq!(attr.value_type, ValueType::Ref);
 
         // Long value accepted for ref-typed attribute
-        let ops = [TxOp::put(vec![(kw!(:follows), 201_i64.into())])];
+        let ops = [TxOp::Add { entity: "follower".into(), attribute: kw!(:follows), value: 201_i64.into() }];
         assert!(schema
             .validate_and_prepare(&to_datoms(&ops, &schema))
             .is_ok());
 
         // String in ref position is interpreted as tempid (resolved to Long)
-        let ops = [TxOp::put(vec![(
-            kw!(:follows),
-            DataType::String("some-tempid".to_string()),
-        )])];
+        let ops = [TxOp::Add {
+            entity: "follower".into(),
+            attribute: kw!(:follows),
+            value: DataType::String("some-tempid".to_string()),
+        }];
         let datoms = to_datoms(&ops, &schema);
         // After expand_tx_ops, the string becomes a TempRef which resolves to a Long,
         // so validate_and_prepare should accept it.

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -7,7 +7,7 @@ use edn::kw;
 use edn::symbols::Keyword;
 use triplox::client::ClientNode;
 use triplox::node::{Database, Node, QueryNode, SubmitNode};
-use triplox::ops::{DataType, TxOp};
+use triplox::ops::{DataType, EntityRef, TxOp};
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
 use triplox::TransactionResult;
@@ -52,7 +52,7 @@ async fn test_execute_tx_and_query() {
 
     // Insert a document
     let result = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
     assert!(matches!(result, TransactionResult::TxCommited(_)));
@@ -79,7 +79,7 @@ async fn test_submit_tx() {
     define_base_schema(&client).await;
 
     let tx_key = client
-        .submit_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+        .submit_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
     assert!(tx_key.tx_id >= 0);
@@ -96,12 +96,12 @@ async fn test_multiple_transactions_and_query() {
 
     // Insert two documents in separate transactions
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
 
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_open_close_multiple_dbs() {
 
     // Insert data
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
 
@@ -162,7 +162,7 @@ async fn test_two_connections() {
     let client1 = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client1).await;
     client1
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
 
@@ -188,7 +188,7 @@ async fn test_execute_tx_returns_tx_key() {
     define_base_schema(&client).await;
 
     let result = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
 
@@ -211,7 +211,7 @@ async fn test_db_as_of() {
 
     // First transaction
     let result1 = client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
     let tx_key1 = match result1 {
@@ -221,7 +221,7 @@ async fn test_db_as_of() {
 
     // Second transaction
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "bob".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }])
         .await
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn test_dev_server_connections_are_isolated() {
     define_base_schema(&client1).await;
 
     client1
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "alice".into())])])
+        .execute_tx(vec![TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() }])
         .await
         .unwrap();
 
@@ -489,7 +489,7 @@ async fn test_datascript_aggregates() {
     // Insert monsters with heads
     for heads in [3, 1, 1, 1] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:heads), (heads as i64).into())])])
+            .execute_tx(vec![TxOp::Add { entity: "monster".into(), attribute: kw!(:heads), value: (heads as i64).into() }])
             .await
             .unwrap();
     }
@@ -522,7 +522,7 @@ async fn test_aggregate_avg() {
 
     for age in [21, 22, 23] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:age), (age as i64).into())])])
+            .execute_tx(vec![TxOp::Add { entity: "person".into(), attribute: kw!(:age), value: (age as i64).into() }])
             .await
             .unwrap();
     }
@@ -548,7 +548,7 @@ async fn test_aggregate_min_max_strings() {
 
     for name in ["Charlie", "Alice", "Bob"] {
         client
-            .execute_tx(vec![TxOp::put(vec![(kw!(:name), name.into())])])
+            .execute_tx(vec![TxOp::Add { entity: name.into(), attribute: kw!(:name), value: name.into() }])
             .await
             .unwrap();
     }
@@ -736,10 +736,7 @@ async fn test_upsert_with_resolved_entity_id() {
 
     // Upsert: update age using the discovered entity ID
     client
-        .execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/id), DataType::Long(entity_id)),
-            (kw!(:age), 31_i64.into()),
-        ])])
+        .execute_tx(vec![TxOp::Add { entity: EntityRef::Id(entity_id), attribute: kw!(:age), value: 31_i64.into() }])
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- Replace all single-attribute `TxOp::put(vec![(attr, val)])` calls with `TxOp::Add { entity, attribute, value }` across tests and protocol code
- Convert `:db/id` + single-attr puts to `TxOp::Add` with `EntityRef::Id`
- Keep multi-attribute puts (schema defs, entities with 2+ attrs, cross-entity tempid references) as `TxOp::Put`

Closes #180

## Test plan
- [x] `cargo test` — all 378 unit + 19 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)