### PR TITLE
fix: sort participating_levels in compile_pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,8 @@ triplox = { path = ".", features = ["test-helpers"] }
 
 [lints.rust]
 unused = "allow"
+
+# debug_assertions are on by default for dev/test; enable them for bench too so
+# invariant checks run everywhere except release binaries.
+[profile.bench]
+debug-assertions = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,5 @@ triplox = { path = ".", features = ["test-helpers"] }
 [lints.rust]
 unused = "allow"
 
-# debug_assertions are on by default for dev/test; enable them for bench too so
-# invariant checks run everywhere except release binaries.
 [profile.bench]
 debug-assertions = true

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -127,11 +127,6 @@ pub struct FromPrefixExtender {
 }
 
 impl FromPrefixExtender {
-    /// `participating_levels` must be sorted strictly ascending, and `partial_prefix`
-    /// must be indexed in the same order (i.e. `partial_prefix[i]` is the value at
-    /// `participating_levels[i]`). `is_prefix_matching` / `next_level_index` break at
-    /// the first not-yet-bound level, so an out-of-order list would silently skip
-    /// earlier bound positions.
     pub fn new(participating_levels: Vec<usize>, partial_prefix: Prefix) -> Self {
         debug_assert!(
             participating_levels.windows(2).all(|w| w[0] < w[1]),
@@ -216,9 +211,6 @@ pub struct FromPrefixesExtender {
 }
 
 impl FromPrefixesExtender {
-    /// `participating_levels` must be sorted strictly ascending, and every entry in
-    /// `partial_prefixes` must be indexed in that same order. See `FromPrefixExtender::new`
-    /// for the rationale.
     pub fn new(participating_levels: Vec<usize>, partial_prefixes: Vec<Prefix>) -> Self {
         debug_assert!(
             participating_levels.windows(2).all(|w| w[0] < w[1]),

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -127,7 +127,17 @@ pub struct FromPrefixExtender {
 }
 
 impl FromPrefixExtender {
+    /// `participating_levels` must be sorted strictly ascending, and `partial_prefix`
+    /// must be indexed in the same order (i.e. `partial_prefix[i]` is the value at
+    /// `participating_levels[i]`). `is_prefix_matching` / `next_level_index` break at
+    /// the first not-yet-bound level, so an out-of-order list would silently skip
+    /// earlier bound positions.
     pub fn new(participating_levels: Vec<usize>, partial_prefix: Prefix) -> Self {
+        debug_assert!(
+            participating_levels.windows(2).all(|w| w[0] < w[1]),
+            "participating_levels must be sorted strictly ascending, got {:?}",
+            participating_levels
+        );
         let level_set = participating_levels.iter().cloned().collect();
         Self {
             participating_levels,
@@ -206,7 +216,15 @@ pub struct FromPrefixesExtender {
 }
 
 impl FromPrefixesExtender {
+    /// `participating_levels` must be sorted strictly ascending, and every entry in
+    /// `partial_prefixes` must be indexed in that same order. See `FromPrefixExtender::new`
+    /// for the rationale.
     pub fn new(participating_levels: Vec<usize>, partial_prefixes: Vec<Prefix>) -> Self {
+        debug_assert!(
+            participating_levels.windows(2).all(|w| w[0] < w[1]),
+            "participating_levels must be sorted strictly ascending, got {:?}",
+            participating_levels
+        );
         let level_set = participating_levels.iter().cloned().collect();
         Self {
             participating_levels,

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -25,6 +25,9 @@ pub struct GenericPrefixExtender {
 }
 
 impl GenericPrefixExtender {
+    /// `participating_levels` must be sorted strictly ascending. `build_slate_prefix`
+    /// iterates it and breaks at the first not-yet-bound level; out-of-order levels
+    /// would silently drop bound components from the seek key.
     pub fn new(
         slate: Arc<slatedb::DbSnapshot>,
         handle: Handle,
@@ -34,6 +37,12 @@ impl GenericPrefixExtender {
         participating_levels: Vec<usize>,
         as_of: i64,
     ) -> Self {
+        debug_assert!(
+            participating_levels.windows(2).all(|w| w[0] < w[1]),
+            "participating_levels must be sorted strictly ascending, got {:?}",
+            participating_levels
+        );
+
         let mut full_prefix = Vec::new();
         codec::encode_i64(attribute_id, &mut full_prefix);
         full_prefix.extend_from_slice(&constant_prefix);

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -25,9 +25,6 @@ pub struct GenericPrefixExtender {
 }
 
 impl GenericPrefixExtender {
-    /// `participating_levels` must be sorted strictly ascending. `build_slate_prefix`
-    /// iterates it and breaks at the first not-yet-bound level; out-of-order levels
-    /// would silently drop bound components from the seek key.
     pub fn new(
         slate: Arc<slatedb::DbSnapshot>,
         handle: Handle,

--- a/src/node.rs
+++ b/src/node.rs
@@ -454,21 +454,6 @@ mod tests {
         );
     }
 
-    /// Regression: self-join on a value variable.
-    ///
-    /// Query: `[:find ?a ?b :where [?a :name ?x] [?b :name ?x]]`
-    ///
-    /// Join order resolves to `[?a, ?x, ?b]`, so for the second pattern
-    /// `[?b :name ?x]` the entity variable (`?b`, level 2) sits at a *higher*
-    /// level than the value variable (`?x`, level 1). Before the fix to
-    /// `compile_pattern`, `participating_levels` was populated in pattern
-    /// order `[2, 1]` — descending. `build_slate_prefix` iterates until it
-    /// hits an out-of-range level and then breaks, so it broke on level 2
-    /// before ever appending `?x` at level 0 of its own key, producing an
-    /// AVE seek prefix of `[AVE][attr]` rather than `[AVE][attr][value]`.
-    /// The second pattern then proposed entities for *every* `:name`
-    /// assertion instead of just those sharing `?x`, and the join emitted
-    /// cross-product garbage like `(alice, bob)` and `(bob, alice)`.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_query_self_join_on_value_variable() {
         let node = Node::memory_node().await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -454,6 +454,55 @@ mod tests {
         );
     }
 
+    /// Regression: self-join on a value variable.
+    ///
+    /// Query: `[:find ?a ?b :where [?a :name ?x] [?b :name ?x]]`
+    ///
+    /// Join order resolves to `[?a, ?x, ?b]`, so for the second pattern
+    /// `[?b :name ?x]` the entity variable (`?b`, level 2) sits at a *higher*
+    /// level than the value variable (`?x`, level 1). Before the fix to
+    /// `compile_pattern`, `participating_levels` was populated in pattern
+    /// order `[2, 1]` — descending. `build_slate_prefix` iterates until it
+    /// hits an out-of-range level and then breaks, so it broke on level 2
+    /// before ever appending `?x` at level 0 of its own key, producing an
+    /// AVE seek prefix of `[AVE][attr]` rather than `[AVE][attr][value]`.
+    /// The second pattern then proposed entities for *every* `:name`
+    /// assertion instead of just those sharing `?x`, and the join emitted
+    /// cross-product garbage like `(alice, bob)` and `(bob, alice)`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_self_join_on_value_variable() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![
+            TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            },
+            TxOp::Add {
+                entity: "bob".into(),
+                attribute: kw!(:name),
+                value: "bob".into(),
+            },
+        ])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?a ?b :where [?a :name ?x] [?b :name ?x]]")
+            .await
+            .unwrap();
+
+        // Only same-entity pairs should match: (alice, alice) and (bob, bob).
+        assert_eq!(result.len(), 2, "expected 2 self-pairs, got {:?}", result);
+        for row in &result {
+            assert_eq!(row.len(), 2);
+            assert_eq!(row[0], row[1], "?a and ?b should be equal in {:?}", row);
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_query_entity_value_join() {
         let node = Node::memory_node().await;

--- a/src/query.rs
+++ b/src/query.rs
@@ -647,11 +647,13 @@ pub fn compile_pattern(
 ) -> Result<GenericPrefixExtender, Error> {
     let pat_vars = pattern_variables(pattern);
 
-    // Determine participating levels
-    let participating_levels: Vec<usize> = pat_vars
+    // Determine participating levels (sorted ascending — build_slate_prefix relies on
+    // ordered iteration to append already-bound components in index-key layout order).
+    let mut participating_levels: Vec<usize> = pat_vars
         .iter()
         .filter_map(|v| var_index.get(v).copied())
         .collect();
+    participating_levels.sort_unstable();
 
     // Determine index types for each level
     let index_types = determine_index_types(pattern, join_order, var_index, &participating_levels)?;


### PR DESCRIPTION
## Summary
Cherry-picks two commits from FiV0/triplox#171:
- `fa7b30b` fix: sort participating_levels in compile_pattern
- `3aa7922` test: regression for pattern self-join on value variable

## Test plan
- [ ] `cargo test` passes, including the new self-join regression test