### PR TITLE
ci: add manual Clojars SNAPSHOT deploy workflow

### DIFF
--- a/.github/workflows/clojars-deploy.yml
+++ b/.github/workflows/clojars-deploy.yml
@@ -1,0 +1,28 @@
+name: Clojars Deploy (SNAPSHOT)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Publish SNAPSHOT to Clojars
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: |
+          cd triplox-jvm && ./gradlew publishMavenPublicationToClojarsRepository \
+            -PtriploxVersion=0.1.0-alpha-SNAPSHOT \
+            -PclojarsUsername="$CLOJARS_USERNAME" \
+            -PclojarsPassword="$CLOJARS_PASSWORD"

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -56,7 +56,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "xyz.triplox"
             artifactId = "triplox"
-            version = "0.1.0-alpha"
+            version = (findProperty("triploxVersion") as String?) ?: "0.1.0-alpha"
 
             from(components["java"])
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch`-only GitHub Action that publishes `xyz.triplox/triplox` `0.1.0-alpha-SNAPSHOT` to Clojars
- Make publication version in `build.gradle.kts` overridable via `-PtriploxVersion` property (defaults to `0.1.0-alpha`)

## Setup required
Add these secrets in repo settings (Settings → Secrets → Actions):
- `CLOJARS_USERNAME`
- `CLOJARS_PASSWORD` (Clojars deploy token)

## Test plan
- [ ] Add secrets to GitHub repo
- [ ] Trigger workflow from Actions tab → "Clojars Deploy (SNAPSHOT)" → "Run workflow"
- [ ] Verify `xyz.triplox/triplox 0.1.0-alpha-SNAPSHOT` appears on Clojars

🤖 Generated with [Claude Code](https://claude.com/claude-code)