### PR TITLE
refactor: return SlateComponents from slate construction helpers

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_fresh() {
-        let slatedb = Arc::new(in_memory_slate().await);
+        let slatedb = Arc::new(in_memory_slate().await.db);
         let metadata = init_db(slatedb).await;
         // Bootstrap defines 7 schema attributes (3 core + 4 tx)
         assert_eq!(metadata.schema.len(), 7);
@@ -156,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_existing() {
-        let slatedb = Arc::new(in_memory_slate().await);
+        let slatedb = Arc::new(in_memory_slate().await.db);
         let metadata1 = init_db(slatedb.clone()).await;
         // Second call takes the existing-DB path (scan EAV for counters)
         let metadata2 = init_db(slatedb).await;
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_preserves_old_version() {
-        let slatedb = Arc::new(in_memory_slate().await);
+        let slatedb = Arc::new(in_memory_slate().await.db);
 
         // Write an older version directly (simulates existing DB without bootstrap indices)
         let key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_fresh() {
-        let slatedb = Arc::new(in_memory_slate().await.db);
+        let slatedb = in_memory_slate().await.db;
         let metadata = init_db(slatedb).await;
         // Bootstrap defines 7 schema attributes (3 core + 4 tx)
         assert_eq!(metadata.schema.len(), 7);
@@ -156,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_existing() {
-        let slatedb = Arc::new(in_memory_slate().await.db);
+        let slatedb = in_memory_slate().await.db;
         let metadata1 = init_db(slatedb.clone()).await;
         // Second call takes the existing-DB path (scan EAV for counters)
         let metadata2 = init_db(slatedb).await;
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_db_preserves_old_version() {
-        let slatedb = Arc::new(in_memory_slate().await.db);
+        let slatedb = in_memory_slate().await.db;
 
         // Write an older version directly (simulates existing DB without bootstrap indices)
         let key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -624,7 +624,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -672,7 +672,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_write_persisted() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 1,
@@ -709,7 +709,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_multi_attribute_document() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 1,
@@ -745,7 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 42,
@@ -769,7 +769,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_empty_db() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let snapshot = Arc::new(slate.snapshot().await?);
         let (tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 0, "Should return sentinel for empty DB");
@@ -779,7 +779,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_highest_wins() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         for i in 0..3 {
@@ -805,7 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 42,
@@ -831,7 +831,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let snapshot = Arc::new(slate.snapshot().await?);
         let tx_key = TxKey {
             tx_id: 999,
@@ -846,7 +846,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_already_indexed() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         let tx_key = TxKey {
@@ -868,7 +868,7 @@ mod tests {
     async fn test_await_tx_waits_for_future_tx() -> Result<(), Error> {
         use tokio::sync::RwLock;
 
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
         let tx_key_1 = TxKey {
@@ -897,7 +897,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let indexer = Indexer::new(
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
@@ -924,7 +924,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_ordering() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         for i in 0..2 {
@@ -959,7 +959,7 @@ mod tests {
     async fn test_await_tx_multiple_waiters() -> Result<(), Error> {
         use tokio::sync::RwLock;
 
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
         let tx_key = TxKey {
@@ -996,7 +996,7 @@ mod tests {
     // TODO(triplox-qj0): replace explicit entity IDs with query-based verification
     #[tokio::test]
     async fn test_retract_on_overwrite() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_value_no_retract() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -1163,8 +1163,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_schema_immutability_rejected_in_pipeline() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
-        let mut indexer = bootstrapped_indexer(slate).await;
+        let slate = in_memory_slate().await.db;
+        let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let (name_id, attr) = indexer
             .metadata()
             .schema
@@ -1219,7 +1219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cardinality_many_no_retract() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
@@ -1286,7 +1286,7 @@ mod tests {
     // We may want to switch to set semantics in the future.
     #[tokio::test]
     async fn test_cardinality_many_same_value() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await.db);
+        let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -624,7 +624,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -672,7 +672,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_write_persisted() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 1,
@@ -709,7 +709,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_multi_attribute_document() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 1,
@@ -745,7 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 42,
@@ -769,7 +769,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_empty_db() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let snapshot = Arc::new(slate.snapshot().await?);
         let (tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
         assert_eq!(latest.tx_id, 0, "Should return sentinel for empty DB");
@@ -779,7 +779,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_latest_tx_key_highest_wins() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         for i in 0..3 {
@@ -805,7 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let tx_key = TxKey {
             tx_id: 42,
@@ -831,7 +831,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let snapshot = Arc::new(slate.snapshot().await?);
         let tx_key = TxKey {
             tx_id: 999,
@@ -846,7 +846,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_already_indexed() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         let tx_key = TxKey {
@@ -868,7 +868,7 @@ mod tests {
     async fn test_await_tx_waits_for_future_tx() -> Result<(), Error> {
         use tokio::sync::RwLock;
 
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
         let tx_key_1 = TxKey {
@@ -897,7 +897,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_timeout() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let indexer = Indexer::new(
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
@@ -924,7 +924,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_await_tx_ordering() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         for i in 0..2 {
@@ -959,7 +959,7 @@ mod tests {
     async fn test_await_tx_multiple_waiters() -> Result<(), Error> {
         use tokio::sync::RwLock;
 
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
         let tx_key = TxKey {
@@ -996,7 +996,7 @@ mod tests {
     // TODO(triplox-qj0): replace explicit entity IDs with query-based verification
     #[tokio::test]
     async fn test_retract_on_overwrite() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_value_no_retract() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
         let name_id = indexer
             .metadata()
@@ -1219,7 +1219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cardinality_many_no_retract() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
@@ -1286,7 +1286,7 @@ mod tests {
     // We may want to switch to set semantics in the future.
     #[tokio::test]
     async fn test_cardinality_many_same_value() -> Result<(), Error> {
-        let slate = Arc::new(in_memory_slate().await);
+        let slate = Arc::new(in_memory_slate().await.db);
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn test_participates_in_level() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let snapshot = runtime.block_on(slate.snapshot()).unwrap();
 
         let extender = GenericPrefixExtender::new(
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_count_with_av_index() -> anyhow::Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Alice")))?;
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn test_propose_with_av_index() -> anyhow::Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Alice")))?;
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_multiple_index_types() -> anyhow::Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         // Insert into both AV and AVE indexes
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn test_intersect() -> anyhow::Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Alice")))?;
@@ -392,7 +392,7 @@ mod tests {
         // but make_extractor_fn computes position = pattern_level + 1 = 1,
         // which extracts the value (position 1) instead.
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         let value_bytes = Bytes::from(DataType::String("alice".to_string()).encode());
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn test_empty_results() -> anyhow::Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        let slate = runtime.block_on(in_memory_slate());
+        let slate = runtime.block_on(in_memory_slate()).db;
         let attr_name = 42i64;
 
         let snapshot = runtime.block_on(slate.snapshot()).unwrap();

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -245,7 +245,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_slate_iterator_basic() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let handle = Handle::current();
 
         slate.put(&make_key(PFX, b"aa"), b"").await;
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_slate_iterator_seek() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let handle = Handle::current();
 
         slate.put(&make_key(PFX, b"aa"), b"").await;
@@ -297,7 +297,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_slate_iterator_empty_prefix() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let handle = Handle::current();
 
         slate.put(&make_key(OTHER_PFX, b"aa"), b"").await;
@@ -316,7 +316,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_slate_iterator_count() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let handle = Handle::current();
 
         slate.put(&make_key(PFX, b"aa"), b"").await;

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -211,7 +211,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_single_version() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
 
         slate
@@ -235,7 +235,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_skips_future() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
         let t2 = 2000;
 
@@ -264,7 +264,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_before_all() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 2000;
 
         slate
@@ -289,7 +289,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_temporal_filter_multiple_logical_keys() {
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
         let t2 = 2000;
 
@@ -325,7 +325,7 @@ mod tests {
         // as-of T1: alice visible
         // as-of T2: alice hidden (retracted)
         // as-of T3: alice visible again (re-added)
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t0 = 500;
         let t1 = 1000;
         let t2 = 2000;
@@ -396,7 +396,7 @@ mod tests {
     async fn test_temporal_filter_seek() {
         // Three logical keys: alice, bob, charlie at T1.
         // Seek to "bob" should land on bob, then next gives charlie.
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
 
         slate
@@ -439,7 +439,7 @@ mod tests {
         // "alice" added at T1, retracted at T2. "bob" added at T1.
         // As-of T1: see alice and bob.
         // As-of T2: only bob (alice retracted).
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
         let t2 = 2000;
 
@@ -486,7 +486,7 @@ mod tests {
     async fn test_temporal_filter_retraction_then_re_add() {
         // "alice" added at T1, retracted at T2, re-added at T3.
         // As-of T2: not visible. As-of T3: visible again.
-        let slate = in_memory_slate().await;
+        let slate = in_memory_slate().await.db;
         let t1 = 1000;
         let t2 = 2000;
         let t3 = 3000;

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,7 +12,7 @@ use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
 use crate::query::{execute_query, validate_query, QueryResult};
 use crate::schema::IdentMap;
-use crate::slate::{in_memory_slate, local_slate};
+use crate::slate::{in_memory_slate, local_slate, SlateComponents};
 pub use crate::transaction::{TransactionResult, TxKey};
 use edn::query::ParsedQuery;
 use tokio::sync::RwLock;
@@ -157,17 +157,17 @@ impl Database for DB {
 pub struct Node<L: TxLog> {
     log: Arc<RwLock<L>>,
     indexer: Arc<tokio::sync::RwLock<Indexer>>,
-    slatedb: Arc<slatedb::Db>,
+    slate: SlateComponents,
     subscription: CancellationToken,
 }
 
 impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
-        let components = in_memory_slate().await;
-        let slatedb = Arc::new(components.db);
-        let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
+        let slate = in_memory_slate().await;
+        let db = slate.db.clone();
+        let metadata = crate::bootstrap::init_db(db.clone()).await;
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
-            slatedb.clone(),
+            db.clone(),
             metadata,
             None,
         )));
@@ -178,7 +178,7 @@ impl Node<MemoryLog> {
         Node {
             log,
             indexer,
-            slatedb,
+            slate,
             subscription,
         }
     }
@@ -191,13 +191,13 @@ impl Node<FileLog> {
         let db_path_str = db_path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
-        let components = local_slate(db_path_str).await;
-        let slatedb = Arc::new(components.db);
-        let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
+        let slate = local_slate(db_path_str).await;
+        let db = slate.db.clone();
+        let metadata = crate::bootstrap::init_db(db.clone()).await;
 
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
-        let snapshot = Arc::new(slatedb.snapshot().await?);
+        let snapshot = Arc::new(db.snapshot().await?);
         let (_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
         let latest_indexed_tx = if latest_indexed.tx_id > 0 {
             Some(latest_indexed)
@@ -206,7 +206,7 @@ impl Node<FileLog> {
         };
 
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
-            slatedb.clone(),
+            db.clone(),
             metadata,
             latest_indexed_tx,
         )));
@@ -240,7 +240,7 @@ impl Node<FileLog> {
         Ok(Node {
             log,
             indexer,
-            slatedb,
+            slate,
             subscription,
         })
     }
@@ -249,7 +249,7 @@ impl Node<FileLog> {
 impl<L: TxLog> Node<L> {
     pub async fn close(self) {
         self.subscription.cancel();
-        self.slatedb.close().await.unwrap();
+        self.slate.db.close().await.unwrap();
     }
 }
 
@@ -276,7 +276,7 @@ impl<L: TxLog> SubmitNode for Node<L> {
 impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
     async fn db(&self) -> Result<DB, Error> {
-        let snapshot = self.slatedb.snapshot().await?;
+        let snapshot = self.slate.db.snapshot().await?;
         let ident_map = self
             .indexer
             .read()
@@ -290,7 +290,7 @@ impl<L: TxLog> QueryNode for Node<L> {
     }
     // TODO we are currently not checking that snapshot contains TxKey
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
-        let snapshot = self.slatedb.snapshot().await?;
+        let snapshot = self.slate.db.snapshot().await?;
         let ident_map = self
             .indexer
             .read()

--- a/src/node.rs
+++ b/src/node.rs
@@ -163,7 +163,8 @@ pub struct Node<L: TxLog> {
 
 impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
-        let slatedb = Arc::new(in_memory_slate().await);
+        let components = in_memory_slate().await;
+        let slatedb = Arc::new(components.db);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slatedb.clone(),
@@ -190,7 +191,8 @@ impl Node<FileLog> {
         let db_path_str = db_path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("database path is not valid UTF-8: {:?}", db_path))?;
-        let slatedb = Arc::new(local_slate(db_path_str).await);
+        let components = local_slate(db_path_str).await;
+        let slatedb = Arc::new(components.db);
         let metadata = crate::bootstrap::init_db(slatedb.clone()).await;
 
         // Determine the latest already-indexed tx_id so we skip replaying it

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -10,18 +10,38 @@ use std::sync::Arc;
 
 use crate::util::random_string;
 
-pub async fn in_memory_slate() -> Db {
-    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-    Db::builder(format!("tmp/triplox-{}", random_string(10)), object_store)
-        .build()
-        .await
-        .unwrap()
+pub struct SlateComponents {
+    pub db: Db,
+    pub path: String,
+    pub object_store: Arc<dyn ObjectStore>,
 }
 
-pub async fn local_slate(path: &str) -> Db {
+pub async fn in_memory_slate() -> SlateComponents {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = format!("tmp/triplox-{}", random_string(10));
+    let db = Db::builder(path.clone(), object_store.clone())
+        .build()
+        .await
+        .unwrap();
+    SlateComponents {
+        db,
+        path,
+        object_store,
+    }
+}
+
+pub async fn local_slate(path: &str) -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> =
         Arc::new(LocalFileSystem::new_with_prefix(path).unwrap());
-    Db::builder("triplox", object_store).build().await.unwrap()
+    let db = Db::builder("triplox", object_store.clone())
+        .build()
+        .await
+        .unwrap();
+    SlateComponents {
+        db,
+        path: "triplox".to_string(),
+        object_store,
+    }
 }
 
 pub const DEFAULT_READ_OPTIONS: ReadOptions = ReadOptions {

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -16,6 +16,13 @@ pub struct SlateComponents {
     pub object_store: Arc<dyn ObjectStore>,
 }
 
+impl std::fmt::Debug for SlateComponents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlateComponents")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
 
 pub async fn in_memory_slate() -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -11,18 +11,21 @@ use std::sync::Arc;
 use crate::util::random_string;
 
 pub struct SlateComponents {
-    pub db: Db,
+    pub db: Arc<Db>,
     pub path: String,
     pub object_store: Arc<dyn ObjectStore>,
 }
 
+
 pub async fn in_memory_slate() -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let path = format!("tmp/triplox-{}", random_string(10));
-    let db = Db::builder(path.clone(), object_store.clone())
-        .build()
-        .await
-        .unwrap();
+    let db = Arc::new(
+        Db::builder(path.clone(), object_store.clone())
+            .build()
+            .await
+            .unwrap(),
+    );
     SlateComponents {
         db,
         path,
@@ -33,10 +36,12 @@ pub async fn in_memory_slate() -> SlateComponents {
 pub async fn local_slate(path: &str) -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> =
         Arc::new(LocalFileSystem::new_with_prefix(path).unwrap());
-    let db = Db::builder("triplox", object_store.clone())
-        .build()
-        .await
-        .unwrap();
+    let db = Arc::new(
+        Db::builder("triplox", object_store.clone())
+            .build()
+            .await
+            .unwrap(),
+    );
     SlateComponents {
         db,
         path: "triplox".to_string(),


### PR DESCRIPTION
## Summary
- Expose the path and object_store alongside the Db from `in_memory_slate()` and `local_slate()` so callers that need range statistics or SST access can reuse them without duplicating construction logic.

## Test plan
- [ ] Verify existing tests pass with the refactored return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)