### PR TITLE
feat: implement lookup ref resolution in transaction pipeline

### DIFF
--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -73,4 +73,4 @@ Datom (i64 + DataType)                           fully concrete
 In the entity position we can use a strongly typed `EntityRef` (id, tempid, ident, lookup ref). The same thing doesn't
 work for value positions as things like `[:attr value]` could be considered a vector or a lookup-ref in Clojure and I didn't
 want to bring the schema to the client in non strongly typed languages. I think this is something to be revisited as it makes
-the Rust API look less convincing.
+the Rust API look less convincing. The other option is to use special syntax for lookup refs vs Clojure vectors.

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -68,36 +68,9 @@ DatomWithTempids (IdOrTempId + ValueWithTempIds) only TempId remains
 Datom (i64 + DataType)                           fully concrete
 ```
 
-## Key Types
+## User facing types
 
-### User-facing (src/ops.rs)
-
-- `EntityRef` — how to identify an entity: `Id(i64)`, `TempId(String)`, `Ident(Keyword)`, `LookupRef(Keyword, DataType)`
-- `TxOp` — transaction operation: `Put`, `Add`, `Retract`, `Delete`, `Erase`. Values are `DataType`; ref-typed attribute values are resolved server-side based on the schema.
-
-### Stage 1 — After expansion (src/tx.rs)
-
-- `EntityExpanded` — entity after ident resolution: `Id(i64)`, `TempId(String)`, or `LookupRef(i64, DataType)` (attribute entid resolved, value pending AVE lookup)
-- `ValueExpanded` — value after ident resolution: `Data(DataType)`, `TempRef(String)`, or `LookupRef(i64, DataType)`
-- `DatomExpanded` — datom-shaped tuple before lookup ref resolution
-
-### Stage 2 — After lookup ref resolution (src/tx.rs)
-
-- `IdOrTempId` — entity after lookup ref resolution: `Id(i64)` or `TempId(String)`
-- `ValueWithTempIds` — value after lookup ref resolution: `Data(DataType)` or `TempRef(String)`
-- `DatomWithTempids` — datom-shaped tuple before tempid allocation
-
-### Resolved (src/ops.rs)
-
-- `Datom` — fully resolved fact: `entity: i64`, `attribute: Keyword`, `value: DataType`, `op: DatomOp`
-- Note: `tx_eid` is not stored on Datom — passed separately to `write_index_entries`
-
-## Lookup Refs
-
-Lookup refs allow referring to an entity by an attribute-value pair instead of by ID.
-
-**Entity position**: Explicit via `EntityRef::LookupRef(keyword, value)`.
-
-**Value position** (ref-typed attributes only): Implicit via `DataType::Vector([Keyword, Value])` — a 2-element vector where the first element is a keyword. This follows the same implicit-resolution pattern as tempids (`String`) and idents (`Keyword`) in value position.
-
-Resolution is batched: all lookup refs across all datoms are collected, then resolved in one pass via AVE prefix scans.
+In the entity position we can use a strongly typed `EntityRef` (id, tempid, ident, lookup ref). The same thing doesn't
+work for value positions as things like `[:attr value]` could be considered a vector or a lookup-ref in Clojure and I didn't
+want to bring the schema to the client in non strongly typed languages. I think this is something to be revisited as it makes
+the Rust API look less convincing.

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -1,6 +1,6 @@
 # Triplox Transaction Pipeline
 
-Version 0.1
+Version 0.2
 
 ## Overview
 
@@ -13,36 +13,59 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 ```
 1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
    Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
+   Begin SlateDB transaction    txn = slatedb.begin(Snapshot)
                                 ↓
-2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) -> Vec<DatomWithTempids>
-   - TxOp::Put -> N DatomWithTempids (one per attr)
-   - TxOp::Add/Retract -> 1 DatomWithTempids
+2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) -> Vec<DatomExpanded>
+   - TxOp::Put -> N DatomExpanded (one per attr)
+   - TxOp::Add/Retract -> 1 DatomExpanded
    - Resolves EntityRef::Ident -> entid via schema.ident_map
-   - EntityRef::Id -> IdOrTempId::Id (passthrough)
-   - EntityRef::TempId -> IdOrTempId::TempId (deferred)
-   - EntityRef::LookupRef -> error (not yet supported)
+   - EntityRef::Id -> EntityExpanded::Id (passthrough)
+   - EntityRef::TempId -> EntityExpanded::TempId (deferred)
+   - EntityRef::LookupRef -> EntityExpanded::LookupRef (attr ident resolved to entid)
    - Put without :db/id key -> generates internal tempid (__auto_N)
+   - Ref-typed value DataType::Vector([Keyword, Value]) -> ValueExpanded::LookupRef
+   - Ref-typed value DataType::String -> ValueExpanded::TempRef
+   - Ref-typed value DataType::Keyword -> resolved ident -> ValueExpanded::Data(Long)
                                 ↓
-3. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm)
+3. Resolve lookup refs          tx::resolve_lookup_refs(datoms, &schema, &txn)
+   - Collects all unique (attr_entid, value) pairs from LookupRef variants
+   - Batch-resolves via AVE prefix scans (no I/O if no lookup refs)
+   - Converts DatomExpanded -> DatomWithTempids (eliminates LookupRef variants)
+   - Errors if any lookup ref has no matching entity
+                                ↓
+4. Resolve tempids              tx::resolve_tempids(datoms, &mut pending_pm)
    - Pre-scan: tempids with :db/ident -> DB_PARTITION, others -> USER_PARTITION
    - Allocate entids from PartitionMap (same tempid string -> same entid)
    - Map DatomWithTempids -> Datom (IdOrTempId->i64, ValueWithTempIds->DataType)
    Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
                                 ↓
-4. Validate + prepare           schema.validate_and_prepare(datoms) -> Result<SchemaUpdate>
+5. Cardinality resolution       finalize_datoms_for_commit (EAV scan for card-one auto-retract)
+                                ↓
+6. Validate                     schema.validate_datoms(datoms)
    - Type checking: value type matches attribute's value_type
    - Unknown attribute errors
-   - Witness pattern: split schema datoms, validate via AttributeBuilder
-   - Produces SchemaUpdate (pending delta) — errors abort before commit
+   - Detects schema changes
                                 ↓
-5. Cardinality resolution       (existing EAV scan for card-one auto-retract)
+7. Write indices + commit       write_index_entries(), txn.commit()
                                 ↓
-6. Write indices + commit       write_index_entries(), txn.commit()
-                                ↓
-7. Apply on success only:
+8. Apply on success only:
    - self.metadata.partition_map = pending_pm    (counter reservation committed)
    - self.metadata.schema.apply_schema_update(schema_update)  (infallible)
    - self.metadata.advance_generation()
+```
+
+## Type Pipeline
+
+Each stage narrows the types, eliminating one class of unresolved references:
+
+```
+TxOp (EntityRef + DataType)
+    ↓ expand_tx_ops (sync, schema-only)
+DatomExpanded (EntityExpanded + ValueExpanded)   may contain LookupRef + TempId
+    ↓ resolve_lookup_refs (async, AVE index)
+DatomWithTempids (IdOrTempId + ValueWithTempIds) only TempId remains
+    ↓ resolve_tempids (sync, partition map)
+Datom (i64 + DataType)                           fully concrete
 ```
 
 ## Key Types
@@ -52,13 +75,29 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 - `EntityRef` — how to identify an entity: `Id(i64)`, `TempId(String)`, `Ident(Keyword)`, `LookupRef(Keyword, DataType)`
 - `TxOp` — transaction operation: `Put`, `Add`, `Retract`, `Delete`, `Erase`. Values are `DataType`; ref-typed attribute values are resolved server-side based on the schema.
 
-### Intermediate (src/tx.rs)
+### Stage 1 — After expansion (src/tx.rs)
 
-- `IdOrTempId` — entity after ident resolution: `Id(i64)` or `TempId(String)`
-- `ValueWithTempIds` — value after ident resolution: `Data(DataType)` or `TempRef(String)`
+- `EntityExpanded` — entity after ident resolution: `Id(i64)`, `TempId(String)`, or `LookupRef(i64, DataType)` (attribute entid resolved, value pending AVE lookup)
+- `ValueExpanded` — value after ident resolution: `Data(DataType)`, `TempRef(String)`, or `LookupRef(i64, DataType)`
+- `DatomExpanded` — datom-shaped tuple before lookup ref resolution
+
+### Stage 2 — After lookup ref resolution (src/tx.rs)
+
+- `IdOrTempId` — entity after lookup ref resolution: `Id(i64)` or `TempId(String)`
+- `ValueWithTempIds` — value after lookup ref resolution: `Data(DataType)` or `TempRef(String)`
 - `DatomWithTempids` — datom-shaped tuple before tempid allocation
 
 ### Resolved (src/ops.rs)
 
 - `Datom` — fully resolved fact: `entity: i64`, `attribute: Keyword`, `value: DataType`, `op: DatomOp`
 - Note: `tx_eid` is not stored on Datom — passed separately to `write_index_entries`
+
+## Lookup Refs
+
+Lookup refs allow referring to an entity by an attribute-value pair instead of by ID.
+
+**Entity position**: Explicit via `EntityRef::LookupRef(keyword, value)`.
+
+**Value position** (ref-typed attributes only): Implicit via `DataType::Vector([Keyword, Value])` — a 2-element vector where the first element is a keyword. This follows the same implicit-resolution pattern as tempids (`String`) and idents (`Keyword`) in value position.
+
+Resolution is batched: all lookup refs across all datoms are collected, then resolved in one pass via AVE prefix scans.

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -1,6 +1,6 @@
 # Triplox Transaction Pipeline
 
-Version 0.2
+Version 0.1
 
 ## Overview
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -78,9 +78,14 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
+            // Same 3-stage pipeline as the indexer
+            let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();
             let expanded = tx::expand_tx_ops(&tx_ops, &bootstrap_schema).unwrap();
+            let with_tempids = tx::resolve_lookup_refs(expanded, &bootstrap_schema, &txn)
+                .await
+                .unwrap();
             let mut boot_pm = PartitionMap::new();
-            let datoms = tx::resolve_tempids(&expanded, &mut boot_pm).unwrap();
+            let datoms = tx::resolve_tempids(&with_tempids, &mut boot_pm).unwrap();
 
             // Validate against pre-built schema, then derive the bootstrap schema delta.
             let validation = bootstrap_schema.validate_datoms(&datoms).unwrap();
@@ -99,7 +104,6 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
                 "bootstrap attribute_map mismatch"
             );
 
-            let txn = slatedb.begin(IsolationLevel::Snapshot).await.unwrap();
             write_index_entries(&txn, &datoms, &bootstrap_schema, 0_i64).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -281,27 +281,32 @@ impl Indexer {
         let mut pending_pm = self.metadata.partition_map.clone();
         let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
 
-        // 2. Expand TxOps to DatomWithTempids (resolves idents via schema)
+        // Create txn early — needed for lookup ref resolution AND finalize
+        let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
+
+        // 2. Expand TxOps to DatomExpanded (resolves idents, keeps lookup refs + tempids)
         let expanded = tx::expand_tx_ops(&tx_ops, &self.metadata.schema)?;
 
-        // 3. Resolve tempids + build tx entity datoms
-        let mut datoms = tx::resolve_tempids(&expanded, &mut pending_pm)?;
+        // 3. Resolve lookup refs via AVE index → DatomWithTempids
+        let with_tempids = tx::resolve_lookup_refs(expanded, &self.metadata.schema, &txn).await?;
+
+        // 4. Resolve tempids + build tx entity datoms
+        let mut datoms = tx::resolve_tempids(&with_tempids, &mut pending_pm)?;
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
-        // 4. Finalize datoms (card-one rewrite) against current storage state
-        let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
+        // 5. Finalize datoms (card-one rewrite) against current storage state
         let datoms = self
             .finalize_datoms_for_commit(&txn, datoms)
             .await?;
 
-        // 5. General validation
+        // 6. General validation
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
 
-        // 6. Write indices + commit
+        // 7. Write indices + commit
         write_index_entries(&txn, &datoms, &self.metadata.schema, tx_eid)?;
         txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await?;
 
-        // 7. Apply on success only
+        // 8. Apply on success only
         self.metadata.partition_map = pending_pm;
         if validation.schema_changes_detected {
             let schema_update = self.metadata.schema.prepare_schema_update(&datoms)?;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -20,7 +20,7 @@ use crate::partition::{partition_entity_prefix, TX_PARTITION};
 use crate::schema::{Schema, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::transaction::TxKey;
-use crate::tx;
+use crate::tx::{self, first_live_key};
 use crate::util::concat_bytes;
 use edn::symbols::Keyword;
 
@@ -530,34 +530,6 @@ fn strip_atemporal_key<'a>(
         return Err(anyhow::anyhow!("Key too short"));
     }
     Ok(&key[1..])
-}
-
-/// Scan a prefix and return the first non-retracted entry's key, or None.
-/// The indexer processes transactions serially, so the first entry is always
-/// the most recent — if its op byte is RETRACT, the logical value is absent.
-pub(crate) async fn first_live_key(
-    txn: &slatedb::DbTransaction,
-    prefix: &[u8],
-) -> Result<Option<Bytes>, Error> {
-    let mut iter = txn
-        .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
-    match iter.next().await? {
-        Some(kv) => {
-            let key = &kv.key;
-            assert!(
-                key.len() >= codec::TX_EID_OP_SUFFIX,
-                "Key too short ({} bytes) to contain tx_eid + op suffix",
-                key.len()
-            );
-            if key[key.len() - 1] == codec::RETRACT {
-                Ok(None)
-            } else {
-                Ok(Some(kv.key))
-            }
-        }
-        None => Ok(None),
-    }
 }
 
 pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, i64, u8), Error> {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -362,28 +362,12 @@ impl Indexer {
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
             // Scan EAV prefix to find the current value for this (entity, attribute).
-            // The indexer processes transactions serially, so all existing entries
-            // have tx_eid < current. First entry is the most recent.
-            let mut iter = txn
-                .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
-                .await?;
-            let old_value: Option<DataType> = match iter.next().await? {
-                Some(kv) => {
-                    let key = &kv.key;
-                    assert!(
-                        key.len() >= codec::TX_EID_OP_SUFFIX,
-                        "Key too short ({} bytes) to contain tx_eid + op suffix",
-                        key.len()
-                    );
-                    let op = key[key.len() - 1];
-                    if op == codec::RETRACT {
-                        None
-                    } else {
-                        let value_bytes =
-                            &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
-                        let mut cursor = value_bytes;
-                        Some(decode_datatype(&mut cursor)?)
-                    }
+            let old_value: Option<DataType> = match first_live_key(txn, &eav_prefix).await? {
+                Some(key) => {
+                    let value_bytes =
+                        &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
+                    let mut cursor = value_bytes;
+                    Some(decode_datatype(&mut cursor)?)
                 }
                 None => None,
             };
@@ -546,6 +530,34 @@ fn strip_atemporal_key<'a>(
         return Err(anyhow::anyhow!("Key too short"));
     }
     Ok(&key[1..])
+}
+
+/// Scan a prefix and return the first non-retracted entry's key, or None.
+/// The indexer processes transactions serially, so the first entry is always
+/// the most recent — if its op byte is RETRACT, the logical value is absent.
+pub(crate) async fn first_live_key(
+    txn: &slatedb::DbTransaction,
+    prefix: &[u8],
+) -> Result<Option<Bytes>, Error> {
+    let mut iter = txn
+        .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    match iter.next().await? {
+        Some(kv) => {
+            let key = &kv.key;
+            assert!(
+                key.len() >= codec::TX_EID_OP_SUFFIX,
+                "Key too short ({} bytes) to contain tx_eid + op suffix",
+                key.len()
+            );
+            if key[key.len() - 1] == codec::RETRACT {
+                Ok(None)
+            } else {
+                Ok(Some(kv.key))
+            }
+        }
+        None => Ok(None),
+    }
 }
 
 pub fn eav_key_to_parts(key: Bytes) -> Result<(DataType, i64, DataType, i64, u8), Error> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1738,6 +1738,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_lookup_ref_in_put_db_id() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Create an entity with a known email
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Alice".into()),
+            (kw!(:email), "alice@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        // Use a lookup ref as :db/id in a Put to update the same entity
+        let result = node
+            .execute_tx(vec![TxOp::Put(
+                vec![
+                    (
+                        kw!(:db/id),
+                        DataType::Vector(vec![
+                            DataType::Keyword(kw!(:email)),
+                            DataType::String("alice@example.com".into()),
+                        ]),
+                    ),
+                    (kw!(:age), DataType::Long(30)),
+                ]
+                .into_iter()
+                .collect(),
+            )])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        // Verify :age was added to the same entity as :name
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][0], DataType::String("Alice".into()));
+        assert_eq!(result[0][1], DataType::Long(30));
+    }
+
+    #[tokio::test]
     async fn test_lookup_ref_not_found_errors() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -308,7 +308,7 @@ impl<L: TxLog> QueryNode for Node<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::{DataType, TxOp};
+    use crate::ops::{DataType, EntityRef, TxOp};
     use crate::schema::test_schema_tx;
     use crate::transaction::TransactionResult;
     use edn::kw;
@@ -1647,5 +1647,113 @@ mod tests {
         } else {
             panic!("Expected String for error, got {:?}", result[0][1]);
         }
+    }
+
+    // --- Lookup ref tests ---
+
+    #[tokio::test]
+    async fn test_lookup_ref_entity_position() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Create an entity with a known email
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Alice".into()),
+            (kw!(:email), "alice@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        // Use a lookup ref in entity position to add an attribute to the same entity
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::LookupRef(
+                    kw!(:email),
+                    DataType::String("alice@example.com".into()),
+                ),
+                attribute: kw!(:age),
+                value: DataType::Long(30),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        // Verify both :name and :age are on the same entity
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][0], DataType::String("Alice".into()));
+        assert_eq!(result[0][1], DataType::Long(30));
+    }
+
+    #[tokio::test]
+    async fn test_lookup_ref_value_position() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Create two entities
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Alice".into()),
+            (kw!(:email), "alice@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Bob".into()),
+            (kw!(:email), "bob@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        // Bob follows Alice, using a lookup ref in value position for the :follows ref attr
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::LookupRef(
+                    kw!(:email),
+                    DataType::String("bob@example.com".into()),
+                ),
+                attribute: kw!(:follows),
+                value: DataType::Vector(vec![
+                    DataType::Keyword(kw!(:email)),
+                    DataType::String("alice@example.com".into()),
+                ]),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        // Verify the follow relationship
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?follower ?followed :where [?e1 :name ?follower] [?e1 :follows ?e2] [?e2 :name ?followed]]")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][0], DataType::String("Bob".into()));
+        assert_eq!(result[0][1], DataType::String("Alice".into()));
+    }
+
+    #[tokio::test]
+    async fn test_lookup_ref_not_found_errors() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        // Try a lookup ref for a non-existent entity
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::LookupRef(
+                    kw!(:email),
+                    DataType::String("nobody@example.com".into()),
+                ),
+                attribute: kw!(:name),
+                value: "Ghost".into(),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxAborted(_, _)));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -865,11 +865,35 @@ mod tests {
     use crate::metadata::PartitionMap;
     use crate::tx;
 
+    /// Skip lookup ref resolution for tests that have no DB and no lookup refs.
+    fn expanded_to_tempids(datoms: Vec<tx::DatomExpanded>) -> Vec<tx::DatomWithTempids> {
+        datoms
+            .into_iter()
+            .map(|d| tx::DatomWithTempids {
+                entity: match d.entity {
+                    tx::EntityExpanded::Id(id) => tx::IdOrTempId::Id(id),
+                    tx::EntityExpanded::TempId(s) => tx::IdOrTempId::TempId(s),
+                    tx::EntityExpanded::LookupRef(_, _) => {
+                        panic!("test helper: unresolved lookup ref in entity position")
+                    }
+                },
+                attribute: d.attribute,
+                value: match d.value {
+                    tx::ValueExpanded::Data(dt) => tx::ValueWithTempIds::Data(dt),
+                    tx::ValueExpanded::TempRef(s) => tx::ValueWithTempIds::TempRef(s),
+                    tx::ValueExpanded::LookupRef(_, _) => {
+                        panic!("test helper: unresolved lookup ref in value position")
+                    }
+                },
+                op: d.op,
+            })
+            .collect()
+    }
+
     fn to_datoms(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
         let mut pm = PartitionMap::new();
         let expanded = tx::expand_tx_ops(ops, schema).unwrap();
-        let with_tempids: Vec<tx::DatomWithTempids> =
-            expanded.into_iter().map(Into::into).collect();
+        let with_tempids = expanded_to_tempids(expanded);
         tx::resolve_tempids(&with_tempids, &mut pm).unwrap()
     }
 
@@ -1060,8 +1084,7 @@ mod tests {
         let bootstrap = bootstrap_schema();
         let tx_ops = bootstrap_schema_tx();
         let expanded = tx::expand_tx_ops(&tx_ops, &bootstrap).unwrap();
-        let with_tempids: Vec<tx::DatomWithTempids> =
-            expanded.into_iter().map(Into::into).collect();
+        let with_tempids = expanded_to_tempids(expanded);
         let mut pm = PartitionMap::new();
         let datoms = tx::resolve_tempids(&with_tempids, &mut pm).unwrap();
         let validation = bootstrap.validate_datoms(&datoms).unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -335,7 +335,8 @@ impl<T> Default for AddRetractSet<T> {
     }
 }
 
-type AEVValidationMap<'a> = HashMap<(Entid, &'a Attribute), HashMap<Entid, AddRetractSet<DataType>>>;
+type AEVValidationMap<'a> =
+    HashMap<(Entid, &'a Attribute), HashMap<Entid, AddRetractSet<DataType>>>;
 
 #[derive(Debug)]
 enum ValidationConflict {
@@ -867,7 +868,9 @@ mod tests {
     fn to_datoms(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
         let mut pm = PartitionMap::new();
         let expanded = tx::expand_tx_ops(ops, schema).unwrap();
-        tx::resolve_tempids(&expanded, &mut pm).unwrap()
+        let with_tempids: Vec<tx::DatomWithTempids> =
+            expanded.into_iter().map(Into::into).collect();
+        tx::resolve_tempids(&with_tempids, &mut pm).unwrap()
     }
 
     fn bootstrapped_schema() -> Schema {
@@ -1057,8 +1060,10 @@ mod tests {
         let bootstrap = bootstrap_schema();
         let tx_ops = bootstrap_schema_tx();
         let expanded = tx::expand_tx_ops(&tx_ops, &bootstrap).unwrap();
+        let with_tempids: Vec<tx::DatomWithTempids> =
+            expanded.into_iter().map(Into::into).collect();
         let mut pm = PartitionMap::new();
-        let datoms = tx::resolve_tempids(&expanded, &mut pm).unwrap();
+        let datoms = tx::resolve_tempids(&with_tempids, &mut pm).unwrap();
         let validation = bootstrap.validate_datoms(&datoms).unwrap();
         assert!(validation.schema_changes_detected);
         let update = Schema::default().prepare_schema_update(&datoms).unwrap();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -5,12 +5,11 @@ use edn::kw;
 use edn::symbols::Keyword;
 
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
-use crate::indexer::ave_key_to_parts;
+use crate::indexer::{ave_key_to_parts, first_live_key};
 use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp};
 use crate::partition::{DB_PARTITION, USER_PARTITION};
 use crate::schema::{Schema, ValueType};
-use crate::slate::DEFAULT_SCAN_OPTIONS;
 use crate::util::concat_bytes;
 
 // ---------------------------------------------------------------------------
@@ -247,25 +246,16 @@ pub async fn resolve_lookup_refs(
         encode_datatype(value, &mut value_bytes);
         let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
 
-        let mut iter = txn
-            .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
-            .await?;
-
-        let resolved_eid = match iter.next().await? {
-            Some(kv) => {
-                let (_attribute, _value, entity_dt, _tx_eid, op) = ave_key_to_parts(kv.key)?;
-                // Most recent entry is a retraction — entity no longer has this value.
-                if op == codec::RETRACT {
-                    None
-                } else {
-                    match entity_dt {
-                        DataType::Long(eid) => Some(eid),
-                        other => {
-                            return Err(anyhow::anyhow!(
-                                "Expected Long entity ID in AVE key, got {:?}",
-                                other
-                            ));
-                        }
+        let resolved_eid = match first_live_key(txn, &ave_prefix).await? {
+            Some(key) => {
+                let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(key)?;
+                match entity_dt {
+                    DataType::Long(eid) => Some(eid),
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "Expected Long entity ID in AVE key, got {:?}",
+                            other
+                        ));
                     }
                 }
             }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,29 +1,94 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use edn::kw;
 use edn::symbols::Keyword;
 
+use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
+use crate::indexer::ave_key_to_parts;
 use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp};
 use crate::partition::{DB_PARTITION, USER_PARTITION};
 use crate::schema::{Schema, ValueType};
+use crate::slate::DEFAULT_SCAN_OPTIONS;
+use crate::util::concat_bytes;
 
-/// Entity reference after ident resolution: either a concrete ID or an unresolved tempid.
+// ---------------------------------------------------------------------------
+// Stage 1 types: after ident resolution, before lookup ref resolution.
+// May still contain LookupRef and TempId variants.
+// ---------------------------------------------------------------------------
+
+/// Entity reference after ident resolution, before lookup ref resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EntityExpanded {
+    Id(i64),
+    TempId(String),
+    LookupRef(i64, DataType), // (attribute_entid, value)
+}
+
+/// Value after ident resolution, before lookup ref resolution.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueExpanded {
+    Data(DataType),
+    TempRef(String),
+    LookupRef(i64, DataType), // (attribute_entid, value)
+}
+
+/// A datom after TxOp expansion and ident resolution, before lookup ref resolution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DatomExpanded {
+    pub entity: EntityExpanded,
+    pub attribute: Keyword,
+    pub value: ValueExpanded,
+    pub op: DatomOp,
+}
+
+/// Narrowing conversion from DatomExpanded to DatomWithTempids.
+/// Panics if any LookupRef variants remain — only use when lookup refs are known to be absent
+/// (e.g., in tests without a DB).
+impl From<DatomExpanded> for DatomWithTempids {
+    fn from(d: DatomExpanded) -> Self {
+        DatomWithTempids {
+            entity: match d.entity {
+                EntityExpanded::Id(id) => IdOrTempId::Id(id),
+                EntityExpanded::TempId(s) => IdOrTempId::TempId(s),
+                EntityExpanded::LookupRef(_, _) => {
+                    panic!("From<DatomExpanded>: unresolved lookup ref in entity position")
+                }
+            },
+            attribute: d.attribute,
+            value: match d.value {
+                ValueExpanded::Data(dt) => ValueWithTempIds::Data(dt),
+                ValueExpanded::TempRef(s) => ValueWithTempIds::TempRef(s),
+                ValueExpanded::LookupRef(_, _) => {
+                    panic!("From<DatomExpanded>: unresolved lookup ref in value position")
+                }
+            },
+            op: d.op,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2 types: after lookup ref resolution, before tempid allocation.
+// Only TempId variants remain.
+// ---------------------------------------------------------------------------
+
+/// Entity reference after lookup ref resolution: either a concrete ID or an unresolved tempid.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum IdOrTempId {
     Id(i64),
     TempId(String),
 }
 
-/// Value after ident resolution: either concrete data or a tempid reference.
+/// Value after lookup ref resolution: either concrete data or a tempid reference.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueWithTempIds {
     Data(DataType),
     TempRef(String),
 }
 
-/// A datom-shaped tuple after TxOp expansion and ident resolution, but before tempid allocation.
+/// A datom after lookup ref resolution, before tempid allocation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DatomWithTempids {
     pub entity: IdOrTempId,
@@ -32,33 +97,40 @@ pub struct DatomWithTempids {
     pub op: DatomOp,
 }
 
-/// Resolve an EntityRef to IdOrTempId, resolving idents via schema.
-fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<IdOrTempId> {
+/// Resolve an EntityRef to EntityExpanded, resolving idents via schema.
+/// Lookup refs have their attribute keyword resolved to an entid but remain as LookupRef.
+fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<EntityExpanded> {
     match eref {
-        EntityRef::Id(id) => Ok(IdOrTempId::Id(*id)),
-        EntityRef::TempId(s) => Ok(IdOrTempId::TempId(s.clone())),
+        EntityRef::Id(id) => Ok(EntityExpanded::Id(*id)),
+        EntityRef::TempId(s) => Ok(EntityExpanded::TempId(s.clone())),
         EntityRef::Ident(kw) => {
             let eid = schema
                 .ident_map
                 .get(kw)
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident: {}", kw))?;
-            Ok(IdOrTempId::Id(*eid))
+            Ok(EntityExpanded::Id(*eid))
         }
-        EntityRef::LookupRef(_, _) => Err(anyhow::anyhow!("Lookup refs not yet supported")),
+        EntityRef::LookupRef(kw, dt) => {
+            let attr_eid = schema
+                .ident_map
+                .get(kw)
+                .ok_or_else(|| anyhow::anyhow!("Unknown attribute in lookup ref: {}", kw))?;
+            Ok(EntityExpanded::LookupRef(*attr_eid, dt.clone()))
+        }
     }
 }
 
-/// Resolve a :db/id DataType value to IdOrTempId.
-fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<IdOrTempId> {
+/// Resolve a :db/id DataType value to EntityExpanded.
+fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<EntityExpanded> {
     match val {
-        DataType::Long(id) => Ok(IdOrTempId::Id(*id)),
-        DataType::String(s) => Ok(IdOrTempId::TempId(s.clone())),
+        DataType::Long(id) => Ok(EntityExpanded::Id(*id)),
+        DataType::String(s) => Ok(EntityExpanded::TempId(s.clone())),
         DataType::Keyword(kw) => {
             let eid = schema
                 .ident_map
                 .get(kw)
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident for :db/id: {}", kw))?;
-            Ok(IdOrTempId::Id(*eid))
+            Ok(EntityExpanded::Id(*eid))
         }
         other => Err(anyhow::anyhow!(
             ":db/id must be Long, String, or Keyword, got {:?}",
@@ -68,7 +140,8 @@ fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<IdOrTempId> {
 }
 
 /// Resolve a value using the schema to determine if the attribute is ref-typed.
-fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<ValueWithTempIds> {
+/// For ref-typed attributes, a 2-element vector [Keyword, Value] is treated as a lookup ref.
+fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<ValueExpanded> {
     let is_ref = schema
         .get_attribute(attr)
         .map(|(_, a)| a.value_type == ValueType::Ref)
@@ -76,14 +149,26 @@ fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<Valu
 
     if is_ref {
         match val {
-            DataType::Long(id) => Ok(ValueWithTempIds::Data(DataType::Long(*id))),
+            DataType::Long(id) => Ok(ValueExpanded::Data(DataType::Long(*id))),
             DataType::Keyword(kw) => {
                 let eid = schema.ident_map.get(kw).ok_or_else(|| {
                     anyhow::anyhow!("Unknown ident in ref value position: {}", kw)
                 })?;
-                Ok(ValueWithTempIds::Data(DataType::Long(*eid)))
+                Ok(ValueExpanded::Data(DataType::Long(*eid)))
             }
-            DataType::String(s) => Ok(ValueWithTempIds::TempRef(s.clone())),
+            DataType::String(s) => Ok(ValueExpanded::TempRef(s.clone())),
+            DataType::Vector(v) if v.len() == 2 => match (&v[0], &v[1]) {
+                (DataType::Keyword(kw), val) => {
+                    let attr_eid = schema.ident_map.get(kw).ok_or_else(|| {
+                        anyhow::anyhow!("Unknown attribute in lookup ref: {}", kw)
+                    })?;
+                    Ok(ValueExpanded::LookupRef(*attr_eid, val.clone()))
+                }
+                _ => Err(anyhow::anyhow!(
+                    "Lookup ref must be [Keyword, Value], got {:?}",
+                    v
+                )),
+            },
             other => Err(anyhow::anyhow!(
                 "Invalid value for ref-typed attribute {}: {:?}",
                 attr,
@@ -91,18 +176,19 @@ fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<Valu
             )),
         }
     } else {
-        Ok(ValueWithTempIds::Data(val.clone()))
+        Ok(ValueExpanded::Data(val.clone()))
     }
 }
 
-/// Expand TxOps into DatomWithTempids, resolving idents and ref-typed values via schema.
+/// Expand TxOps into DatomExpanded, resolving idents and ref-typed values via schema.
+/// Lookup refs and tempids pass through as-is for later resolution stages.
 ///
-/// - `Put(map)` -> N DatomWithTempids (one per non-`:db/id` attr). The `:db/id` key
+/// - `Put(map)` -> N DatomExpanded (one per non-`:db/id` attr). The `:db/id` key
 ///   identifies the entity (Long=ID, String=tempid, Keyword=ident). If absent, generates
 ///   an internal tempid.
-/// - `Add/Retract` -> 1 DatomWithTempids
+/// - `Add/Retract` -> 1 DatomExpanded
 /// - `Delete/Erase` -> panics (not yet implemented)
-pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempids>> {
+pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomExpanded>> {
     let db_id_kw = Keyword::namespaced("db", "id");
     let mut datoms = Vec::new();
     let mut auto_counter: u64 = 0;
@@ -115,11 +201,11 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     None => {
                         let tempid = format!("__auto_{}", auto_counter);
                         auto_counter += 1;
-                        IdOrTempId::TempId(tempid)
+                        EntityExpanded::TempId(tempid)
                     }
                 };
                 for (attr, value) in map.iter().filter(|(k, _)| *k != &db_id_kw) {
-                    datoms.push(DatomWithTempids {
+                    datoms.push(DatomExpanded {
                         entity: entity.clone(),
                         attribute: attr.clone(),
                         value: resolve_value(value, attr, schema)?,
@@ -132,7 +218,7 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                 attribute,
                 value,
             } => {
-                datoms.push(DatomWithTempids {
+                datoms.push(DatomExpanded {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_value(value, attribute, schema)?,
@@ -144,7 +230,7 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                 attribute,
                 value,
             } => {
-                datoms.push(DatomWithTempids {
+                datoms.push(DatomExpanded {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
                     value: resolve_value(value, attribute, schema)?,
@@ -157,6 +243,96 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
         }
     }
     Ok(datoms)
+}
+
+/// Batch-resolve all lookup refs via the AVE index.
+/// Converts DatomExpanded → DatomWithTempids, eliminating all LookupRef variants.
+/// If no lookup refs are present, this is a cheap conversion with no I/O.
+pub async fn resolve_lookup_refs(
+    datoms: Vec<DatomExpanded>,
+    schema: &Schema,
+    txn: &slatedb::DbTransaction,
+) -> Result<Vec<DatomWithTempids>> {
+    // Collect all unique (attr_entid, value) lookup ref pairs.
+    let mut lookup_refs: HashSet<(i64, DataType)> = HashSet::new();
+    for d in &datoms {
+        if let EntityExpanded::LookupRef(a, v) = &d.entity {
+            lookup_refs.insert((*a, v.clone()));
+        }
+        if let ValueExpanded::LookupRef(a, v) = &d.value {
+            lookup_refs.insert((*a, v.clone()));
+        }
+    }
+
+    // Batch resolve via AVE index.
+    let mut resolved_map: HashMap<(i64, DataType), i64> = HashMap::new();
+    for (attr_eid, value) in &lookup_refs {
+        let attr_bytes = encode_i64_bytes(*attr_eid);
+        let mut value_bytes = Vec::new();
+        encode_datatype(value, &mut value_bytes);
+        let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
+
+        let mut iter = txn
+            .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
+            .await?;
+
+        match iter.next().await? {
+            Some(kv) => {
+                let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
+                match entity_dt {
+                    DataType::Long(eid) => {
+                        resolved_map.insert((*attr_eid, value.clone()), eid);
+                    }
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "Expected Long entity ID in AVE key, got {:?}",
+                            other
+                        ));
+                    }
+                }
+            }
+            None => {
+                let attr_kw = schema
+                    .entid_map
+                    .get(attr_eid)
+                    .map(|kw| kw.to_string())
+                    .unwrap_or_else(|| attr_eid.to_string());
+                return Err(anyhow::anyhow!(
+                    "No entity found for lookup ref [{} {:?}]",
+                    attr_kw,
+                    value
+                ));
+            }
+        }
+    }
+
+    // Convert DatomExpanded → DatomWithTempids, replacing lookup refs with resolved IDs.
+    let mut result = Vec::with_capacity(datoms.len());
+    for d in datoms {
+        let entity = match d.entity {
+            EntityExpanded::Id(id) => IdOrTempId::Id(id),
+            EntityExpanded::TempId(s) => IdOrTempId::TempId(s),
+            EntityExpanded::LookupRef(a, v) => {
+                let eid = resolved_map[&(a, v)];
+                IdOrTempId::Id(eid)
+            }
+        };
+        let value = match d.value {
+            ValueExpanded::Data(dt) => ValueWithTempIds::Data(dt),
+            ValueExpanded::TempRef(s) => ValueWithTempIds::TempRef(s),
+            ValueExpanded::LookupRef(a, v) => {
+                let eid = resolved_map[&(a, v)];
+                ValueWithTempIds::Data(DataType::Long(eid))
+            }
+        };
+        result.push(DatomWithTempids {
+            entity,
+            attribute: d.attribute,
+            value,
+            op: d.op,
+        });
+    }
+    Ok(result)
 }
 
 /// Resolve tempids in DatomWithTempids to produce final Datoms.
@@ -257,7 +433,7 @@ mod tests {
         ])];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 2);
-        assert!(datoms.iter().all(|d| d.entity == IdOrTempId::Id(100)));
+        assert!(datoms.iter().all(|d| d.entity == EntityExpanded::Id(100)));
         assert!(datoms.iter().all(|d| d.op == DatomOp::Assert));
     }
 
@@ -269,10 +445,9 @@ mod tests {
         ];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 2);
-        // Different auto-tempids
         assert_ne!(datoms[0].entity, datoms[1].entity);
-        assert!(matches!(datoms[0].entity, IdOrTempId::TempId(_)));
-        assert!(matches!(datoms[1].entity, IdOrTempId::TempId(_)));
+        assert!(matches!(datoms[0].entity, EntityExpanded::TempId(_)));
+        assert!(matches!(datoms[1].entity, EntityExpanded::TempId(_)));
     }
 
     #[test]
@@ -295,11 +470,11 @@ mod tests {
         }];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 1);
-        assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
+        assert_eq!(datoms[0].entity, EntityExpanded::Id(200));
         assert_eq!(datoms[0].attribute, kw!(:name));
         assert_eq!(
             datoms[0].value,
-            ValueWithTempIds::Data(DataType::String("bob".to_string()))
+            ValueExpanded::Data(DataType::String("bob".to_string()))
         );
         assert_eq!(datoms[0].op, DatomOp::Assert);
     }
@@ -325,7 +500,7 @@ mod tests {
             value: DataType::Long(1),
         }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
-        assert_eq!(datoms[0].entity, IdOrTempId::Id(42));
+        assert_eq!(datoms[0].entity, EntityExpanded::Id(42));
     }
 
     #[test]
@@ -341,15 +516,33 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_lookup_ref_errors() {
+    fn test_expand_entity_lookup_ref() {
+        let schema = schema_with_ident(kw!(:email), 42);
         let ops = vec![TxOp::Add {
             entity: EntityRef::LookupRef(kw!(:email), DataType::String("a@b.com".into())),
             attribute: kw!(:name),
             value: DataType::Long(1),
         }];
+        let datoms = expand_tx_ops(&ops, &schema).unwrap();
+        assert_eq!(
+            datoms[0].entity,
+            EntityExpanded::LookupRef(42, DataType::String("a@b.com".into()))
+        );
+    }
+
+    #[test]
+    fn test_expand_entity_lookup_ref_unknown_attr_errors() {
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::LookupRef(kw!(:unknown/attr), DataType::String("a@b.com".into())),
+            attribute: kw!(:name),
+            value: DataType::Long(1),
+        }];
         let result = expand_tx_ops(&ops, &empty_schema());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Lookup refs"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown attribute in lookup ref"));
     }
 
     #[test]
@@ -363,7 +556,7 @@ mod tests {
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
         assert_eq!(
             datoms[0].value,
-            ValueWithTempIds::TempRef("friend".to_string())
+            ValueExpanded::TempRef("friend".to_string())
         );
     }
 
@@ -376,7 +569,7 @@ mod tests {
             value: DataType::Long(200),
         }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
-        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(200)));
+        assert_eq!(datoms[0].value, ValueExpanded::Data(DataType::Long(200)));
     }
 
     #[test]
@@ -390,7 +583,61 @@ mod tests {
             value: DataType::Keyword(kw!(:person/bob)),
         }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
-        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::Long(99)));
+        assert_eq!(datoms[0].value, ValueExpanded::Data(DataType::Long(99)));
+    }
+
+    #[test]
+    fn test_expand_value_lookup_ref() {
+        let mut schema = schema_with_ref_attr(kw!(:follows), 999);
+        schema.ident_map.insert(kw!(:email), 42);
+        schema.entid_map.insert(42, kw!(:email));
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Vector(vec![
+                DataType::Keyword(kw!(:email)),
+                DataType::String("a@b.com".into()),
+            ]),
+        }];
+        let datoms = expand_tx_ops(&ops, &schema).unwrap();
+        assert_eq!(
+            datoms[0].value,
+            ValueExpanded::LookupRef(42, DataType::String("a@b.com".into()))
+        );
+    }
+
+    #[test]
+    fn test_expand_value_lookup_ref_bad_shape_errors() {
+        let schema = schema_with_ref_attr(kw!(:follows), 999);
+        // Wrong length (3 elements)
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Vector(vec![
+                DataType::Keyword(kw!(:email)),
+                DataType::String("a".into()),
+                DataType::String("b".into()),
+            ]),
+        }];
+        let result = expand_tx_ops(&ops, &schema);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid value for ref-typed attribute"));
+
+        // Right length but first element is not keyword
+        let ops = vec![TxOp::Add {
+            entity: EntityRef::Id(100),
+            attribute: kw!(:follows),
+            value: DataType::Vector(vec![DataType::Long(1), DataType::String("a".into())]),
+        }];
+        let result = expand_tx_ops(&ops, &schema);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Lookup ref must be [Keyword, Value]"));
     }
 
     #[test]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -96,6 +96,9 @@ fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<EntityExpande
     }
 }
 
+// TODO: The code duplication in the two functions below seems off. The main difference is that
+// one deals with entity position and the other with value position. See also #198
+
 /// Resolve a :db/id DataType value to EntityExpanded.
 fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<EntityExpanded> {
     match val {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -43,32 +43,6 @@ pub struct DatomExpanded {
     pub op: DatomOp,
 }
 
-/// Narrowing conversion from DatomExpanded to DatomWithTempids.
-/// Panics if any LookupRef variants remain — only use when lookup refs are known to be absent
-/// (e.g., in tests without a DB).
-impl From<DatomExpanded> for DatomWithTempids {
-    fn from(d: DatomExpanded) -> Self {
-        DatomWithTempids {
-            entity: match d.entity {
-                EntityExpanded::Id(id) => IdOrTempId::Id(id),
-                EntityExpanded::TempId(s) => IdOrTempId::TempId(s),
-                EntityExpanded::LookupRef(_, _) => {
-                    panic!("From<DatomExpanded>: unresolved lookup ref in entity position")
-                }
-            },
-            attribute: d.attribute,
-            value: match d.value {
-                ValueExpanded::Data(dt) => ValueWithTempIds::Data(dt),
-                ValueExpanded::TempRef(s) => ValueWithTempIds::TempRef(s),
-                ValueExpanded::LookupRef(_, _) => {
-                    panic!("From<DatomExpanded>: unresolved lookup ref in value position")
-                }
-            },
-            op: d.op,
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Stage 2 types: after lookup ref resolution, before tempid allocation.
 // Only TempId variants remain.
@@ -248,6 +222,7 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomExpanded>
 /// Batch-resolve all lookup refs via the AVE index.
 /// Converts DatomExpanded → DatomWithTempids, eliminating all LookupRef variants.
 /// If no lookup refs are present, this is a cheap conversion with no I/O.
+// TODO(#62): validate that lookup ref attributes have :db/unique set.
 pub async fn resolve_lookup_refs(
     datoms: Vec<DatomExpanded>,
     schema: &Schema,
@@ -276,20 +251,30 @@ pub async fn resolve_lookup_refs(
             .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
             .await?;
 
-        match iter.next().await? {
+        let resolved_eid = match iter.next().await? {
             Some(kv) => {
-                let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
-                match entity_dt {
-                    DataType::Long(eid) => {
-                        resolved_map.insert((*attr_eid, value.clone()), eid);
-                    }
-                    other => {
-                        return Err(anyhow::anyhow!(
-                            "Expected Long entity ID in AVE key, got {:?}",
-                            other
-                        ));
+                let (_attribute, _value, entity_dt, _tx_eid, op) = ave_key_to_parts(kv.key)?;
+                // Most recent entry is a retraction — entity no longer has this value.
+                if op == codec::RETRACT {
+                    None
+                } else {
+                    match entity_dt {
+                        DataType::Long(eid) => Some(eid),
+                        other => {
+                            return Err(anyhow::anyhow!(
+                                "Expected Long entity ID in AVE key, got {:?}",
+                                other
+                            ));
+                        }
                     }
                 }
+            }
+            None => None,
+        };
+
+        match resolved_eid {
+            Some(eid) => {
+                resolved_map.insert((*attr_eid, value.clone()), eid);
             }
             None => {
                 let attr_kw = schema

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -108,8 +108,20 @@ fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<EntityExpanded> {
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident for :db/id: {}", kw))?;
             Ok(EntityExpanded::Id(*eid))
         }
+        DataType::Vector(v) if v.len() == 2 => match (&v[0], &v[1]) {
+            (DataType::Keyword(kw), val) => {
+                let attr_eid = schema.ident_map.get(kw).ok_or_else(|| {
+                    anyhow::anyhow!("Unknown attribute in :db/id lookup ref: {}", kw)
+                })?;
+                Ok(EntityExpanded::LookupRef(*attr_eid, val.clone()))
+            }
+            _ => Err(anyhow::anyhow!(
+                ":db/id lookup ref must be [Keyword, Value], got {:?}",
+                v
+            )),
+        },
         other => Err(anyhow::anyhow!(
-            ":db/id must be Long, String, or Keyword, got {:?}",
+            ":db/id must be Long, String, Keyword, or [Keyword, Value] lookup ref, got {:?}",
             other
         )),
     }
@@ -270,6 +282,7 @@ pub async fn resolve_lookup_refs(
     }
 
     // Batch resolve via AVE index.
+    // TODO(#196): parallelize AVE scans with try_join_all.
     let mut resolved_map: HashMap<(i64, DataType), i64> = HashMap::new();
     for (attr_eid, value) in &lookup_refs {
         let attr_bytes = encode_i64_bytes(*attr_eid);

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -4,12 +4,15 @@ use anyhow::Result;
 use edn::kw;
 use edn::symbols::Keyword;
 
+use bytes::Bytes;
+
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
-use crate::indexer::{ave_key_to_parts, first_live_key};
+use crate::indexer::ave_key_to_parts;
 use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp};
 use crate::partition::{DB_PARTITION, USER_PARTITION};
 use crate::schema::{Schema, ValueType};
+use crate::slate::DEFAULT_SCAN_OPTIONS;
 use crate::util::concat_bytes;
 
 // ---------------------------------------------------------------------------
@@ -216,6 +219,34 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomExpanded>
         }
     }
     Ok(datoms)
+}
+
+/// Scan a prefix and return the first non-retracted entry's key, or None.
+/// The first entry is the most recent (tx_eid is descending-encoded) — if
+/// its op byte is RETRACT, the logical value is absent.
+pub async fn first_live_key(
+    txn: &slatedb::DbTransaction,
+    prefix: &[u8],
+) -> Result<Option<Bytes>> {
+    let mut iter = txn
+        .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    match iter.next().await? {
+        Some(kv) => {
+            let key = &kv.key;
+            assert!(
+                key.len() >= codec::TX_EID_OP_SUFFIX,
+                "Key too short ({} bytes) to contain tx_eid + op suffix",
+                key.len()
+            );
+            if key[key.len() - 1] == codec::RETRACT {
+                Ok(None)
+            } else {
+                Ok(Some(kv.key))
+            }
+        }
+        None => Ok(None),
+    }
 }
 
 /// Batch-resolve all lookup refs via the AVE index.


### PR DESCRIPTION
## Summary

- Adds a new lookup ref resolution stage to the transaction pipeline, enabling entities to be referenced by attribute-value pairs (e.g., `EntityRef::LookupRef(:email, "alice@example.com")`) instead of by ID
- Introduces `DatomExpanded` / `EntityExpanded` / `ValueExpanded` intermediate types that carry `LookupRef` variants, resolved via AVE index before tempid resolution — compile-time safe at each pipeline boundary
- Supports lookup refs in value position for ref-typed attributes via `DataType::Vector([Keyword, Value])` (implicit, like existing String→tempid and Keyword→ident resolution)
- Moves SlateDB transaction creation earlier in `transact_tx_inner` so the AVE index is available during expansion
- Bootstrap uses the same 3-stage pipeline as the indexer

## Type pipeline

```
TxOp (EntityRef + DataType)
    ↓ expand_tx_ops (sync, schema-only)
DatomExpanded (EntityExpanded + ValueExpanded)   — may contain LookupRef + TempId
    ↓ resolve_lookup_refs (async, AVE index)
DatomWithTempids (IdOrTempId + ValueWithTempIds) — only TempId remains
    ↓ resolve_tempids (sync, partition map)
Datom (i64 + DataType)                           — fully concrete
```

## Test plan

- [x] All 416 existing + new tests pass (`cargo test`)
- [x] Entity-position lookup ref resolves to correct entity
- [x] Value-position lookup ref on ref-typed attribute resolves correctly
- [x] Missing lookup ref entity produces abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)