### PR TITLE
refactor: simplify tx lookup in finalize_datoms_for_commit

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -291,7 +291,7 @@ impl Indexer {
         // 4. Finalize datoms (card-one rewrite) against current storage state
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
         let datoms = self
-            .finalize_datoms_for_commit(&txn, tx_eid, datoms)
+            .finalize_datoms_for_commit(&txn, datoms)
             .await?;
 
         // 5. General validation
@@ -328,7 +328,6 @@ impl Indexer {
     async fn finalize_datoms_for_commit(
         &self,
         txn: &slatedb::DbTransaction,
-        tx_eid: i64,
         datoms: Vec<Datom>,
     ) -> Result<Vec<Datom>, Error> {
         // For each Assert datom, scan EAV for the current value of (entity, attribute).

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,7 +12,6 @@ use edn::kw;
 use crate::codec::{
     self, decode_datatype, decode_i64, encode_datatype, encode_i64, encode_i64_bytes, Encode,
 };
-use crate::iterator::temporal_filter_iterator;
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;
@@ -336,7 +335,6 @@ impl Indexer {
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
-        let as_of_encoded = encode_i64_bytes(tx_eid);
         let mut resolved_datoms: HashSet<Datom> = HashSet::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
@@ -359,38 +357,32 @@ impl Indexer {
             let attr_id_bytes = encode_i64_bytes(attribute_id);
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
 
-            // Scan EAV prefix on the transaction to find the current value.
-            // Uses async scan directly because TemporalFilterIterator is sync-only.
-            // This duplicates the temporal resolution logic from advance_to_next_valid().
-            // TODO(#99): unify with TemporalFilterIterator once the iterator
-            // layer becomes fully async, eliminating this duplication.
+            // Scan EAV prefix to find the current value for this (entity, attribute).
+            // The indexer processes transactions serially, so all existing entries
+            // have tx_eid < current. First entry is the most recent.
             let mut iter = txn
                 .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
                 .await?;
-            let mut old_value: Option<DataType> = None;
-            while let Some(kv) = iter.next().await? {
-                let key = &kv.key;
-                assert!(
-                    key.len() >= codec::TX_EID_OP_SUFFIX,
-                    "Key too short ({} bytes) to contain tx_eid + op suffix",
-                    key.len()
-                );
-                match temporal_filter_iterator::resolve_temporal_key(key, &as_of_encoded) {
-                    Some(op) if op == codec::RETRACT => {
-                        old_value = None;
-                        break;
-                    }
-                    Some(_) => {
+            let old_value: Option<DataType> = match iter.next().await? {
+                Some(kv) => {
+                    let key = &kv.key;
+                    assert!(
+                        key.len() >= codec::TX_EID_OP_SUFFIX,
+                        "Key too short ({} bytes) to contain tx_eid + op suffix",
+                        key.len()
+                    );
+                    let op = key[key.len() - 1];
+                    if op == codec::RETRACT {
+                        None
+                    } else {
                         let value_bytes =
                             &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
                         let mut cursor = value_bytes;
-                        let value: DataType = decode_datatype(&mut cursor)?;
-                        old_value = Some(value);
-                        break;
+                        Some(decode_datatype(&mut cursor)?)
                     }
-                    None => {}
                 }
-            }
+                None => None,
+            };
 
             if let Some(old_value) = old_value {
                 if old_value == datom.value {

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -94,7 +94,7 @@ impl TemporalFilterIterator {
 
                     // Descending encoding: ts >= as_of_encoded means real_T <= as_of
                     let ts = &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH];
-                    if ts >= &self.as_of_encoded[..] {
+                    if ts >= self.as_of_encoded.as_slice() {
                         let op = key[key.len() - 1];
                         if op == codec::RETRACT {
                             if !self.seek_past_logical_key(&key)? {

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -29,27 +29,9 @@ pub(crate) struct TemporalFilterIterator {
 }
 
 /// Extract the logical key from a full key (everything except timestamp + op suffix).
-pub(crate) fn logical_key(key: &[u8]) -> &[u8] {
+#[inline]
+fn logical_key(key: &[u8]) -> &[u8] {
     &key[..key.len() - codec::TX_EID_OP_SUFFIX]
-}
-
-/// Extract the encoded tx_eid bytes from a full key.
-pub(crate) fn tx_eid_bytes(key: &[u8]) -> &[u8] {
-    &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH]
-}
-
-/// Resolve a temporal key against an as-of tx_eid.
-///
-/// Returns `Some(op_byte)` if the key's tx_eid <= as_of (i.e. it is the newest
-/// valid entry), or `None` if the entry is newer than as_of and should be skipped.
-pub(crate) fn resolve_temporal_key(key: &[u8], as_of_encoded: &[u8; 8]) -> Option<u8> {
-    let ts = tx_eid_bytes(key);
-    // Descending encoding: encoded_T >= as_of_encoded means real_T <= as_of
-    if ts >= &as_of_encoded[..] {
-        Some(key[key.len() - 1])
-    } else {
-        None
-    }
 }
 
 impl TemporalFilterIterator {
@@ -110,22 +92,21 @@ impl TemporalFilterIterator {
                         key.len()
                     );
 
-                    match resolve_temporal_key(&key, &self.as_of_encoded) {
-                        Some(op) if op == codec::RETRACT => {
+                    // Descending encoding: ts >= as_of_encoded means real_T <= as_of
+                    let ts = &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH];
+                    if ts >= &self.as_of_encoded[..] {
+                        let op = key[key.len() - 1];
+                        if op == codec::RETRACT {
                             if !self.seek_past_logical_key(&key)? {
                                 self.current_key = None;
                                 return Ok(());
                             }
                             continue;
                         }
-                        Some(_) => {
-                            self.current_key = Some(key);
-                            return Ok(());
-                        }
-                        None => {
-                            // Entry is newer than as_of — skip it, keep scanning.
-                        }
+                        self.current_key = Some(key);
+                        return Ok(());
                     }
+                    // Entry is newer than as_of — skip it, keep scanning.
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Simplify `finalize_datoms_for_commit` by removing unnecessary temporal resolution — the indexer processes transactions serially, so `tx_eid` is always at the head and there can never be entries newer than the current transaction
- Replace `while` loop + `resolve_temporal_key` with a single `match` on the first scan entry, reading the op byte directly
- Delete `resolve_temporal_key` and `tx_eid_bytes` from `temporal_filter_iterator.rs`, inlining the logic into `advance_to_next_valid`
- Make `logical_key` private with `#[inline]`

Net -27 lines.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 391 tests pass, including retraction tests (`test_retract_on_overwrite`, `test_same_value_no_retract`, `test_cardinality_many_no_retract`, temporal filter iterator tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)