### PR TITLE
style: add rustfmt.toml with use_small_heuristics = Max

### DIFF
--- a/edn/src/entities.rs
+++ b/edn/src/entities.rs
@@ -230,12 +230,7 @@ pub enum OpType {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub enum Entity<V> {
     // Like [:db/add|:db/retract e a v].
-    AddOrRetract {
-        op: OpType,
-        e: EntityPlace<V>,
-        a: AttributePlace,
-        v: ValuePlace<V>,
-    },
+    AddOrRetract { op: OpType, e: EntityPlace<V>, a: AttributePlace, v: ValuePlace<V> },
     // Like {:db/id "tempid" a1 v1 a2 v2}.
     MapNotation(MapNotation<V>),
 }

--- a/edn/src/intern_set.rs
+++ b/edn/src/intern_set.rs
@@ -54,9 +54,7 @@ where
     T: Eq + Hash,
 {
     pub fn new() -> InternSet<T> {
-        InternSet {
-            inner: HashSet::new(),
-        }
+        InternSet { inner: HashSet::new() }
     }
 
     /// Intern a value, providing a ref-counted handle to the interned value.

--- a/edn/src/matcher.rs
+++ b/edn/src/matcher.rs
@@ -64,9 +64,7 @@ struct Matcher<'a> {
 impl<'a> Matcher<'a> {
     /// Creates a Matcher instance.
     fn new() -> Matcher<'a> {
-        Matcher {
-            placeholders: RefCell::default(),
-        }
+        Matcher { placeholders: RefCell::default() }
     }
 
     /// Performs pattern matching between two EDN `Value` instances (`value`
@@ -104,10 +102,8 @@ impl<'a> Matcher<'a> {
                 }
                 (Set(v), Set(p)) => {
                     v.len() == p.len()
-                        && v.iter()
-                            .all(|a| p.iter().any(|b| self.match_internal::<T>(a, b)))
-                        && p.iter()
-                            .all(|b| v.iter().any(|a| self.match_internal::<T>(a, b)))
+                        && v.iter().all(|a| p.iter().any(|b| self.match_internal::<T>(a, b)))
+                        && p.iter().all(|b| v.iter().any(|a| self.match_internal::<T>(a, b)))
                 }
                 (Map(v), Map(p)) => {
                     v.len() == p.len()

--- a/edn/src/namespaceable_name.rs
+++ b/edn/src/namespaceable_name.rs
@@ -52,10 +52,7 @@ impl NamespaceableName {
         let n = name.into();
         assert!(!n.is_empty(), "Symbols and keywords cannot be unnamed.");
 
-        NamespaceableName {
-            components: n,
-            boundary: 0,
-        }
+        NamespaceableName { components: n, boundary: 0 }
     }
 
     #[inline]
@@ -70,10 +67,7 @@ impl NamespaceableName {
         // Note: These invariants are not required for safety. That is, if we
         // decide to allow these we can safely remove them.
         assert!(!n.is_empty(), "Symbols and keywords cannot be unnamed.");
-        assert!(
-            !ns.is_empty(),
-            "Symbols and keywords cannot have an empty non-null namespace."
-        );
+        assert!(!ns.is_empty(), "Symbols and keywords cannot have an empty non-null namespace.");
 
         let mut dest = String::with_capacity(n.len() + ns.len());
 
@@ -83,10 +77,7 @@ impl NamespaceableName {
 
         let boundary = ns.len();
 
-        NamespaceableName {
-            components: dest,
-            boundary,
-        }
+        NamespaceableName { components: dest, boundary }
     }
 
     fn new<N, T>(namespace: Option<N>, name: T) -> Self
@@ -146,10 +137,7 @@ impl NamespaceableName {
     #[inline]
     pub fn components(&self) -> (&str, &str) {
         if self.boundary > 0 {
-            (
-                &self.components[0..self.boundary],
-                &self.components[(self.boundary + 1)..],
-            )
+            (&self.components[0..self.boundary], &self.components[(self.boundary + 1)..])
         } else {
             (&self.components[0..0], &self.components)
         }
@@ -216,9 +204,7 @@ impl<'de> Deserialize<'de> for NamespaceableName {
         }
         if let Some(ns) = separated.namespace {
             if ns.is_empty() {
-                Err(de::Error::custom(
-                    "Empty but present namespace in keyword or symbol",
-                ))
+                Err(de::Error::custom("Empty but present namespace in keyword or symbol"))
             } else {
                 Ok(NamespaceableName::namespaced(ns, separated.name))
             }
@@ -289,29 +275,14 @@ mod test {
 
         let n6 = NamespaceableName::namespaced("z", "zz");
 
-        let mut arr = [
-            n5.clone(),
-            n6.clone(),
-            n0.clone(),
-            n3.clone(),
-            n2.clone(),
-            n1.clone(),
-            n4.clone(),
-        ];
+        let mut arr =
+            [n5.clone(), n6.clone(), n0.clone(), n3.clone(), n2.clone(), n1.clone(), n4.clone()];
 
         arr.sort();
 
         assert_eq!(
             arr,
-            [
-                n0.clone(),
-                n2.clone(),
-                n1.clone(),
-                n3.clone(),
-                n4.clone(),
-                n5.clone(),
-                n6.clone(),
-            ]
+            [n0.clone(), n2.clone(), n1.clone(), n3.clone(), n4.clone(), n5.clone(), n6.clone(),]
         );
     }
 }

--- a/edn/src/pretty_print.rs
+++ b/edn/src/pretty_print.rs
@@ -57,10 +57,7 @@ impl Value {
     {
         let open = open.into();
         let n = open.len();
-        let i = vs
-            .into_iter()
-            .map(|v| v.as_doc(allocator))
-            .intersperse_with(|| allocator.line());
+        let i = vs.into_iter().map(|v| v.as_doc(allocator)).intersperse_with(|| allocator.line());
         allocator
             .text(open)
             .append(allocator.concat(i).nest(n as isize))
@@ -86,19 +83,15 @@ impl Value {
                     .rev()
                     .map(|(k, v)| k.as_doc(pp).append(pp.space()).append(v.as_doc(pp)).group())
                     .intersperse_with(|| pp.line());
-                pp.text("{")
-                    .append(pp.concat(xs).nest(1))
-                    .append(pp.text("}"))
-                    .group()
+                pp.text("{").append(pp.concat(xs).nest(1)).append(pp.text("}")).group()
             }
             Value::NamespacedSymbol(ref v) => pp.text(v.namespace()).append("/").append(v.name()),
             Value::PlainSymbol(ref v) => pp.text(v.to_string()),
             Value::Keyword(ref v) => pp.text(v.to_string()),
             Value::Text(ref v) => pp.text("\"").append(v.as_str()).append("\""),
-            Value::Uuid(ref u) => pp
-                .text("#uuid \"")
-                .append(u.hyphenated().to_string())
-                .append("\""),
+            Value::Uuid(ref u) => {
+                pp.text("#uuid \"").append(u.hyphenated().to_string()).append("\"")
+            }
             Value::Instant(ref v) => pp
                 .text("#inst \"")
                 .append(v.to_rfc3339_opts(SecondsFormat::AutoSi, true))

--- a/edn/src/query.rs
+++ b/edn/src/query.rs
@@ -412,9 +412,9 @@ impl FromValue<PatternValuePlace> for PatternValuePlace {
             crate::SpannedValue::Float(x) => {
                 Some(PatternValuePlace::Constant(NonIntegerConstant::Float(x)))
             }
-            crate::SpannedValue::BigInteger(ref x) => Some(PatternValuePlace::Constant(
-                NonIntegerConstant::BigInteger(x.clone()),
-            )),
+            crate::SpannedValue::BigInteger(ref x) => {
+                Some(PatternValuePlace::Constant(NonIntegerConstant::BigInteger(x.clone())))
+            }
             crate::SpannedValue::Instant(x) => {
                 Some(PatternValuePlace::Constant(NonIntegerConstant::Instant(x)))
             }
@@ -499,10 +499,7 @@ pub struct NamedPullAttribute {
 
 impl From<PullConcreteAttribute> for NamedPullAttribute {
     fn from(a: PullConcreteAttribute) -> Self {
-        NamedPullAttribute {
-            attribute: a,
-            alias: None,
-        }
+        NamedPullAttribute { attribute: a, alias: None }
     }
 }
 
@@ -601,10 +598,7 @@ impl std::fmt::Display for Element {
             Element::Variable(var) => {
                 write!(f, "{}", var)
             }
-            &Element::Pull(Pull {
-                ref var,
-                ref patterns,
-            }) => {
+            &Element::Pull(Pull { ref var, ref patterns }) => {
                 write!(f, "(pull {} [ ", var)?;
                 for p in patterns.iter() {
                     write!(f, "{} ", p)?;
@@ -871,13 +865,7 @@ impl Pattern {
                 }
             }
         }
-        Some(Pattern {
-            source: src,
-            entity: e,
-            attribute: a,
-            value: v,
-            tx,
-        })
+        Some(Pattern { source: src, entity: e, attribute: a, value: v, tx })
     }
 }
 
@@ -962,10 +950,7 @@ pub struct NotJoin {
 
 impl NotJoin {
     pub fn new(unify_vars: UnifyVars, clauses: Vec<WhereClause>) -> NotJoin {
-        NotJoin {
-            unify_vars,
-            clauses,
-        }
+        NotJoin { unify_vars, clauses }
     }
 }
 
@@ -1082,11 +1067,7 @@ impl ParsedQuery {
 
 impl OrJoin {
     pub fn new(unify_vars: UnifyVars, clauses: Vec<OrWhereClause>) -> OrJoin {
-        OrJoin {
-            unify_vars,
-            clauses,
-            mentioned_vars: None,
-        }
+        OrJoin { unify_vars, clauses, mentioned_vars: None }
     }
 
     /// Return true if either the `OrJoin` is `UnifyVars::Implicit`, or if
@@ -1290,11 +1271,9 @@ impl std::fmt::Display for NonIntegerConstant {
                 }
                 write!(f, "\"")
             }
-            NonIntegerConstant::Instant(v) => write!(
-                f,
-                "#inst \"{}\"",
-                v.to_rfc3339_opts(SecondsFormat::AutoSi, true)
-            ),
+            NonIntegerConstant::Instant(v) => {
+                write!(f, "#inst \"{}\"", v.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+            }
             NonIntegerConstant::Uuid(ref u) => write!(f, "#uuid \"{}\"", u.hyphenated()),
         }
     }

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -165,10 +165,7 @@ pub struct NamespacedSymbol(NamespaceableName);
 /// Future: fast equality (interning?) for keywords.
 ///
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 pub struct Keyword(NamespaceableName);
 
 impl PlainSymbol {
@@ -216,10 +213,7 @@ impl NamespacedSymbol {
         T: AsRef<str>,
     {
         let r = namespace.as_ref();
-        assert!(
-            !r.is_empty(),
-            "Namespaced symbols cannot have an empty non-null namespace."
-        );
+        assert!(!r.is_empty(), "Namespaced symbols cannot have an empty non-null namespace.");
         NamespacedSymbol(NamespaceableName::namespaced(r, name))
     }
 
@@ -266,10 +260,7 @@ impl Keyword {
         T: AsRef<str>,
     {
         let r = namespace.as_ref();
-        assert!(
-            !r.is_empty(),
-            "Namespaced keywords cannot have an empty non-null namespace."
-        );
+        assert!(!r.is_empty(), "Namespaced keywords cannot have an empty non-null namespace.");
         Keyword(NamespaceableName::namespaced(r, name))
     }
 
@@ -424,9 +415,7 @@ impl FromStr for Keyword {
     /// assert!(Keyword::from_str(":foo/").is_err());
     /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s
-            .strip_prefix(':')
-            .ok_or(KeywordParseError::MissingColonPrefix)?;
+        let s = s.strip_prefix(':').ok_or(KeywordParseError::MissingColonPrefix)?;
         match s.split_once('/') {
             Some((ns, name)) => {
                 if ns.is_empty() {
@@ -479,10 +468,7 @@ fn test_kw_macro() {
     assert_eq!(kw!(:test/name), Keyword::namespaced("test", "name"));
     assert_eq!(kw!(:ns/_name), Keyword::namespaced("ns", "_name"));
     // Dotted namespace
-    assert_eq!(
-        kw!(:db.type/keyword),
-        Keyword::namespaced("db.type", "keyword")
-    );
+    assert_eq!(kw!(:db.type/keyword), Keyword::namespaced("db.type", "keyword"));
     // Plain
     assert_eq!(kw!(:name), Keyword::plain("name"));
     // Hyphenated

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -163,9 +163,7 @@ impl From<SpannedValue> for Value {
             }
             SpannedValue::Set(v) => Value::Set(v.into_iter().map(|x| x.without_spans()).collect()),
             SpannedValue::Map(v) => Value::Map(
-                v.into_iter()
-                    .map(|(x, y)| (x.without_spans(), y.without_spans()))
-                    .collect(),
+                v.into_iter().map(|(x, y)| (x.without_spans(), y.without_spans())).collect(),
             ),
         }
     }
@@ -536,11 +534,9 @@ macro_rules! def_common_value_display {
             $t::Nil => write!($f, "nil"),
             $t::Boolean(v) => write!($f, "{}", v),
             $t::Integer(v) => write!($f, "{}", v),
-            $t::Instant(v) => write!(
-                $f,
-                "#inst \"{}\"",
-                v.to_rfc3339_opts(SecondsFormat::AutoSi, true)
-            ),
+            $t::Instant(v) => {
+                write!($f, "#inst \"{}\"", v.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+            }
             $t::BigInteger(ref v) => write!($f, "{}N", v),
             // TODO: make sure float syntax is correct.
             $t::Float(ref v) => {
@@ -651,11 +647,8 @@ pub trait FromMicros {
 
 impl FromMicros for DateTime<Utc> {
     fn from_micros(ts: i64) -> Self {
-        DateTime::from_timestamp(
-            ts / 1_000_000,
-            ((ts % 1_000_000).unsigned_abs() as u32) * 1_000,
-        )
-        .unwrap()
+        DateTime::from_timestamp(ts / 1_000_000, ((ts % 1_000_000).unsigned_abs() as u32) * 1_000)
+            .unwrap()
     }
 }
 
@@ -717,18 +710,12 @@ mod test {
 
     #[test]
     fn test_value_from() {
-        assert_eq!(
-            Value::from_float(42f64),
-            Value::Float(OrderedFloat::from(42f64))
-        );
+        assert_eq!(Value::from_float(42f64), Value::Float(OrderedFloat::from(42f64)));
         assert_eq!(
             Value::from_ordered_float(OrderedFloat::from(42f64)),
             Value::Float(OrderedFloat::from(42f64))
         );
-        assert_eq!(
-            Value::from_bigint("42").unwrap(),
-            Value::BigInteger(BigInt::from(42))
-        );
+        assert_eq!(Value::from_bigint("42").unwrap(), Value::BigInteger(BigInt::from(42)));
     }
 
     #[test]
@@ -761,32 +748,17 @@ mod test {
 
         assert_eq!(string, data.to_string());
         assert_eq!(string, parse::value(&data.to_string()).unwrap().to_string());
-        assert_eq!(
-            string,
-            parse::value(&data.to_string())
-                .unwrap()
-                .without_spans()
-                .to_string()
-        );
+        assert_eq!(string, parse::value(&data.to_string()).unwrap().without_spans().to_string());
     }
 
     #[test]
     fn test_ord() {
         // TODO: Check we follow the equality rules at the bottom of https://github.com/edn-format/edn
         assert_eq!(Value::Nil.cmp(&Value::Nil), Ordering::Equal);
-        assert_eq!(
-            Value::Boolean(false).cmp(&Value::Boolean(true)),
-            Ordering::Greater
-        );
+        assert_eq!(Value::Boolean(false).cmp(&Value::Boolean(true)), Ordering::Greater);
         assert_eq!(Value::Integer(1).cmp(&Value::Integer(2)), Ordering::Greater);
-        assert_eq!(
-            Value::from_bigint("1").cmp(&Value::from_bigint("2")),
-            Ordering::Greater
-        );
-        assert_eq!(
-            Value::from_float(1f64).cmp(&Value::from_float(2f64)),
-            Ordering::Greater
-        );
+        assert_eq!(Value::from_bigint("1").cmp(&Value::from_bigint("2")), Ordering::Greater);
+        assert_eq!(Value::from_float(1f64).cmp(&Value::from_float(2f64)), Ordering::Greater);
         assert_eq!(
             Value::Text("1".to_string()).cmp(&Value::Text("2".to_string())),
             Ordering::Greater
@@ -807,22 +779,13 @@ mod test {
             Value::from_keyword(None, ":a").cmp(&Value::from_keyword(None, ":b")),
             Ordering::Greater
         );
-        assert_eq!(
-            Value::Vector(vec![]).cmp(&Value::Vector(vec![])),
-            Ordering::Equal
-        );
+        assert_eq!(Value::Vector(vec![]).cmp(&Value::Vector(vec![])), Ordering::Equal);
         assert_eq!(
             Value::List(LinkedList::new()).cmp(&Value::List(LinkedList::new())),
             Ordering::Equal
         );
-        assert_eq!(
-            Value::Set(BTreeSet::new()).cmp(&Value::Set(BTreeSet::new())),
-            Ordering::Equal
-        );
-        assert_eq!(
-            Value::Map(BTreeMap::new()).cmp(&Value::Map(BTreeMap::new())),
-            Ordering::Equal
-        );
+        assert_eq!(Value::Set(BTreeSet::new()).cmp(&Value::Set(BTreeSet::new())), Ordering::Equal);
+        assert_eq!(Value::Map(BTreeMap::new()).cmp(&Value::Map(BTreeMap::new())), Ordering::Equal);
     }
 
     #[test]

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -28,10 +28,7 @@ fn can_parse_predicates() {
     let s = "[:find [?x ...] :where [?x _ ?y] [(< ?y 10)]]";
     let p = parse_query(s).unwrap();
 
-    assert_eq!(
-        p.find_spec,
-        FindSpec::FindColl(Element::Variable("?x".to_var()))
-    );
+    assert_eq!(p.find_spec, FindSpec::FindColl(Element::Variable("?x".to_var())));
     assert_eq!(
         p.where_clauses,
         vec![
@@ -55,10 +52,7 @@ fn can_parse_simple_or() {
     let s = "[:find ?x . :where (or [?x _ 10] [?x _ 15])]";
     let p = parse_query(s).unwrap();
 
-    assert_eq!(
-        p.find_spec,
-        FindSpec::FindScalar(Element::Variable("?x".to_var()))
-    );
+    assert_eq!(p.find_spec, FindSpec::FindScalar(Element::Variable("?x".to_var())));
     assert_eq!(
         p.where_clauses,
         vec![WhereClause::OrJoin(OrJoin::new(
@@ -88,10 +82,7 @@ fn can_parse_unit_or_join() {
     let s = "[:find ?x . :where (or-join [?x] [?x _ 15])]";
     let p = parse_query(s).expect("to be able to parse find");
 
-    assert_eq!(
-        p.find_spec,
-        FindSpec::FindScalar(Element::Variable("?x".to_var()))
-    );
+    assert_eq!(p.find_spec, FindSpec::FindScalar(Element::Variable("?x".to_var())));
     assert_eq!(
         p.where_clauses,
         vec![WhereClause::OrJoin(OrJoin::new(
@@ -112,10 +103,7 @@ fn can_parse_simple_or_join() {
     let s = "[:find ?x . :where (or-join [?x] [?x _ 10] [?x _ -15])]";
     let p = parse_query(s).unwrap();
 
-    assert_eq!(
-        p.find_spec,
-        FindSpec::FindScalar(Element::Variable("?x".to_var()))
-    );
+    assert_eq!(p.find_spec, FindSpec::FindScalar(Element::Variable("?x".to_var())));
     assert_eq!(
         p.where_clauses,
         vec![WhereClause::OrJoin(OrJoin::new(
@@ -150,10 +138,7 @@ fn can_parse_simple_or_and_join() {
     let s = "[:find ?x . :where (or [?x _ 10] (and (or [?x :foo/bar ?y] [?x :foo/baz ?y]) [(< ?y 1)]))]";
     let p = parse_query(s).unwrap();
 
-    assert_eq!(
-        p.find_spec,
-        FindSpec::FindScalar(Element::Variable("?x".to_var()))
-    );
+    assert_eq!(p.find_spec, FindSpec::FindScalar(Element::Variable("?x".to_var())));
     assert_eq!(
         p.where_clauses,
         vec![WhereClause::OrJoin(OrJoin::new(
@@ -248,10 +233,7 @@ fn can_parse_limit() {
     assert_eq!(parse_query(onethousand).unwrap().limit, Limit::Fixed(1000));
 
     let variable_with_in = "[:find ?x :in ?limit :where [?x :foo/baz ?y] :limit ?limit]";
-    assert_eq!(
-        parse_query(variable_with_in).unwrap().limit,
-        Limit::Variable("?limit".to_var())
-    );
+    assert_eq!(parse_query(variable_with_in).unwrap().limit, Limit::Variable("?limit".to_var()));
 
     let variable_with_in_used = "[:find ?x :in ?limit :where [?x :foo/baz ?limit] :limit ?limit]";
     assert_eq!(
@@ -266,11 +248,7 @@ fn can_parse_uuid() {
         edn::Uuid::parse_str("4cb3f828-752d-497a-90c9-b1fd516d5644").expect("valid uuid");
     let s = "[:find ?x :where [?x :foo/baz #uuid \"4cb3f828-752d-497a-90c9-b1fd516d5644\"]]";
     assert_eq!(
-        parse_query(s)
-            .expect("parsed")
-            .where_clauses
-            .pop()
-            .expect("a where clause"),
+        parse_query(s).expect("parsed").where_clauses.pop().expect("a where clause"),
         WhereClause::Pattern(
             Pattern::new(
                 None,
@@ -295,11 +273,7 @@ fn can_parse_exotic_whitespace() {
    "4cb3f828-752d-497a-90c9-b1fd516d5644", ;testa
 ,],,  ,],;"#;
     assert_eq!(
-        parse_query(s)
-            .expect("parsed")
-            .where_clauses
-            .pop()
-            .expect("a where clause"),
+        parse_query(s).expect("parsed").where_clauses.pop().expect("a where clause"),
         WhereClause::Pattern(
             Pattern::new(
                 None,
@@ -322,10 +296,7 @@ fn assert_round_trip(input: &str) {
     let parsed = parse_query(input).expect("initial parse failed");
     let displayed = parsed.to_string();
     let reparsed = parse_query(&displayed).unwrap_or_else(|e| {
-        panic!(
-            "re-parse of Display output failed: {}\nDisplayed: {}",
-            e, displayed
-        )
+        panic!("re-parse of Display output failed: {}\nDisplayed: {}", e, displayed)
     });
     assert_eq!(
         parsed, reparsed,

--- a/edn/tests/serde_support.rs
+++ b/edn/tests/serde_support.rs
@@ -21,10 +21,7 @@ fn test_serialize_keyword() {
         &kw,
         &[
             Token::NewtypeStruct { name: "Keyword" },
-            Token::Struct {
-                name: "NamespaceableName",
-                len: 2,
-            },
+            Token::Struct { name: "NamespaceableName", len: 2 },
             Token::Str("namespace"),
             Token::Some,
             Token::BorrowedStr("foo"),

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -89,10 +89,7 @@ fn test_nil() {
 fn test_span_nil() {
     assert_eq!(
         parse::value("nil").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Nil,
-            span: Span(0, 3)
-        }
+        ValueAndSpan { inner: SpannedValue::Nil, span: Span(0, 3) }
     );
 }
 
@@ -114,10 +111,7 @@ fn test_nan() {
 fn test_span_nan() {
     assert_eq!(
         parse::value("#f NaN").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Float(OrderedFloat(f64::NAN)),
-            span: Span(0, 6)
-        }
+        ValueAndSpan { inner: SpannedValue::Float(OrderedFloat(f64::NAN)), span: Span(0, 6) }
     );
 }
 
@@ -131,32 +125,14 @@ fn test_infinity() {
     assert!(infinity("#f;x\n-Infinity").is_err());
     assert!(infinity("#f;x\n+Infinity").is_err());
 
-    assert_eq!(
-        infinity("#f -Infinity").unwrap(),
-        Float(OrderedFloat(f64::NEG_INFINITY))
-    );
-    assert_eq!(
-        infinity("#f +Infinity").unwrap(),
-        Float(OrderedFloat(f64::INFINITY))
-    );
+    assert_eq!(infinity("#f -Infinity").unwrap(), Float(OrderedFloat(f64::NEG_INFINITY)));
+    assert_eq!(infinity("#f +Infinity").unwrap(), Float(OrderedFloat(f64::INFINITY)));
 
-    assert_eq!(
-        infinity("#f\t -Infinity").unwrap(),
-        Float(OrderedFloat(f64::NEG_INFINITY))
-    );
-    assert_eq!(
-        infinity("#f\t +Infinity").unwrap(),
-        Float(OrderedFloat(f64::INFINITY))
-    );
+    assert_eq!(infinity("#f\t -Infinity").unwrap(), Float(OrderedFloat(f64::NEG_INFINITY)));
+    assert_eq!(infinity("#f\t +Infinity").unwrap(), Float(OrderedFloat(f64::INFINITY)));
 
-    assert_eq!(
-        infinity("#f,-Infinity").unwrap(),
-        Float(OrderedFloat(f64::NEG_INFINITY))
-    );
-    assert_eq!(
-        infinity("#f,+Infinity").unwrap(),
-        Float(OrderedFloat(f64::INFINITY))
-    );
+    assert_eq!(infinity("#f,-Infinity").unwrap(), Float(OrderedFloat(f64::NEG_INFINITY)));
+    assert_eq!(infinity("#f,+Infinity").unwrap(), Float(OrderedFloat(f64::INFINITY)));
 
     assert!(infinity("true").is_err());
 }
@@ -172,10 +148,7 @@ fn test_span_infinity() {
     );
     assert_eq!(
         parse::value("#f +Infinity").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Float(OrderedFloat(f64::INFINITY)),
-            span: Span(0, 12)
-        }
+        ValueAndSpan { inner: SpannedValue::Float(OrderedFloat(f64::INFINITY)), span: Span(0, 12) }
     );
 }
 
@@ -193,18 +166,12 @@ fn test_boolean() {
 fn test_span_boolean() {
     assert_eq!(
         parse::value("true").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Boolean(true),
-            span: Span(0, 4)
-        }
+        ValueAndSpan { inner: SpannedValue::Boolean(true), span: Span(0, 4) }
     );
 
     assert_eq!(
         parse::value("false").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Boolean(false),
-            span: Span(0, 5)
-        }
+        ValueAndSpan { inner: SpannedValue::Boolean(false), span: Span(0, 5) }
     );
 }
 
@@ -262,31 +229,19 @@ fn test_octalinteger() {
 fn test_span_integer() {
     assert_eq!(
         parse::value("42").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Integer(42),
-            span: Span(0, 2)
-        }
+        ValueAndSpan { inner: SpannedValue::Integer(42), span: Span(0, 2) }
     );
     assert_eq!(
         parse::value("0xabc111").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Integer(11256081),
-            span: Span(0, 8)
-        }
+        ValueAndSpan { inner: SpannedValue::Integer(11256081), span: Span(0, 8) }
     );
     assert_eq!(
         parse::value("2r111").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Integer(7),
-            span: Span(0, 5)
-        }
+        ValueAndSpan { inner: SpannedValue::Integer(7), span: Span(0, 5) }
     );
     assert_eq!(
         parse::value("011").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Integer(9),
-            span: Span(0, 3)
-        }
+        ValueAndSpan { inner: SpannedValue::Integer(9), span: Span(0, 3) }
     );
 }
 
@@ -334,10 +289,7 @@ fn test_bigint() {
     assert_eq!(bigint("0N").unwrap(), BigInteger(Zero::zero()));
     assert_eq!(bigint("1N").unwrap(), BigInteger(One::one()));
     assert_eq!(bigint("9223372036854775807N").unwrap(), BigInteger(max_i64));
-    assert_eq!(
-        bigint("85070591730234615847396907784232501249N").unwrap(),
-        BigInteger(bigger)
-    );
+    assert_eq!(bigint("85070591730234615847396907784232501249N").unwrap(), BigInteger(bigger));
 
     assert!(bigint("nil").is_err());
 }
@@ -349,10 +301,7 @@ fn test_span_bigint() {
 
     assert_eq!(
         parse::value("85070591730234615847396907784232501249N").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::BigInteger(bigger),
-            span: Span(0, 39)
-        }
+        ValueAndSpan { inner: SpannedValue::BigInteger(bigger), span: Span(0, 39) }
     );
 }
 
@@ -374,10 +323,7 @@ fn test_float() {
 fn test_span_float() {
     assert_eq!(
         parse::value("42.0").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Float(OrderedFloat(42f64)),
-            span: Span(0, 4)
-        }
+        ValueAndSpan { inner: SpannedValue::Float(OrderedFloat(42f64)), span: Span(0, 4) }
     );
 }
 
@@ -385,10 +331,7 @@ fn test_span_float() {
 fn test_text() {
     use self::Value::*;
 
-    assert_eq!(
-        text("\"hello world\"").unwrap(),
-        Text("hello world".to_string())
-    );
+    assert_eq!(text("\"hello world\"").unwrap(), Text("hello world".to_string()));
     assert_eq!(text("\"\"").unwrap(), Text("".to_string()));
 
     assert!(text("\"").is_err());
@@ -409,10 +352,7 @@ fn test_text() {
 fn test_span_text() {
     assert_eq!(
         parse::value("\"hello world\"").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Text("hello world".to_string()),
-            span: Span(0, 13)
-        }
+        ValueAndSpan { inner: SpannedValue::Text("hello world".to_string()), span: Span(0, 13) }
     );
 }
 
@@ -423,23 +363,11 @@ fn test_symbol() {
     assert_eq!(symbol("...").unwrap(), s_plain("..."));
 
     assert_eq!(symbol("hello/world").unwrap(), s_ns("hello", "world"));
-    assert_eq!(
-        symbol("foo-bar/baz-boz").unwrap(),
-        s_ns("foo-bar", "baz-boz")
-    );
+    assert_eq!(symbol("foo-bar/baz-boz").unwrap(), s_ns("foo-bar", "baz-boz"));
 
-    assert_eq!(
-        symbol("foo-bar/baz_boz").unwrap(),
-        s_ns("foo-bar", "baz_boz")
-    );
-    assert_eq!(
-        symbol("foo_bar/baz-boz").unwrap(),
-        s_ns("foo_bar", "baz-boz")
-    );
-    assert_eq!(
-        symbol("foo_bar/baz_boz").unwrap(),
-        s_ns("foo_bar", "baz_boz")
-    );
+    assert_eq!(symbol("foo-bar/baz_boz").unwrap(), s_ns("foo-bar", "baz_boz"));
+    assert_eq!(symbol("foo_bar/baz-boz").unwrap(), s_ns("foo_bar", "baz-boz"));
+    assert_eq!(symbol("foo_bar/baz_boz").unwrap(), s_ns("foo_bar", "baz_boz"));
 
     assert_eq!(symbol("symbol").unwrap(), s_plain("symbol"));
     assert_eq!(symbol("hello").unwrap(), s_plain("hello"));
@@ -451,40 +379,22 @@ fn test_symbol() {
 fn test_span_symbol() {
     assert_eq!(
         parse::value("hello").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_symbol(None, "hello"),
-            span: Span(0, 5)
-        }
+        ValueAndSpan { inner: SpannedValue::from_symbol(None, "hello"), span: Span(0, 5) }
     );
     assert_eq!(
         parse::value("hello/world").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_symbol("hello", "world"),
-            span: Span(0, 11)
-        }
+        ValueAndSpan { inner: SpannedValue::from_symbol("hello", "world"), span: Span(0, 11) }
     );
 }
 
 #[test]
 fn test_keyword() {
     assert_eq!(keyword(":hello/world").unwrap(), k_ns("hello", "world"));
-    assert_eq!(
-        keyword(":foo-bar/baz-boz").unwrap(),
-        k_ns("foo-bar", "baz-boz")
-    );
+    assert_eq!(keyword(":foo-bar/baz-boz").unwrap(), k_ns("foo-bar", "baz-boz"));
 
-    assert_eq!(
-        keyword(":foo-bar/baz_boz").unwrap(),
-        k_ns("foo-bar", "baz_boz")
-    );
-    assert_eq!(
-        keyword(":foo_bar/baz-boz").unwrap(),
-        k_ns("foo_bar", "baz-boz")
-    );
-    assert_eq!(
-        keyword(":foo_bar/baz_boz").unwrap(),
-        k_ns("foo_bar", "baz_boz")
-    );
+    assert_eq!(keyword(":foo-bar/baz_boz").unwrap(), k_ns("foo-bar", "baz_boz"));
+    assert_eq!(keyword(":foo_bar/baz-boz").unwrap(), k_ns("foo_bar", "baz-boz"));
+    assert_eq!(keyword(":foo_bar/baz_boz").unwrap(), k_ns("foo_bar", "baz_boz"));
 
     assert_eq!(keyword(":symbol").unwrap(), k_plain("symbol"));
     assert_eq!(keyword(":hello").unwrap(), k_plain("hello"));
@@ -494,31 +404,19 @@ fn test_keyword() {
     assert!(keyword(":").is_err());
     assert!(keyword(":foo/").is_err());
 
-    assert_eq!(
-        keyword(":foo*!_?$%&=<>-+").unwrap(),
-        k_plain("foo*!_?$%&=<>-+")
-    );
-    assert_eq!(
-        keyword(":foo/bar*!_?$%&=<>-+").unwrap(),
-        k_ns("foo", "bar*!_?$%&=<>-+")
-    );
+    assert_eq!(keyword(":foo*!_?$%&=<>-+").unwrap(), k_plain("foo*!_?$%&=<>-+"));
+    assert_eq!(keyword(":foo/bar*!_?$%&=<>-+").unwrap(), k_ns("foo", "bar*!_?$%&=<>-+"));
 }
 
 #[test]
 fn test_span_keyword() {
     assert_eq!(
         parse::value(":hello").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_keyword(None, "hello"),
-            span: Span(0, 6)
-        }
+        ValueAndSpan { inner: SpannedValue::from_keyword(None, "hello"), span: Span(0, 6) }
     );
     assert_eq!(
         parse::value(":hello/world").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_keyword("hello", "world"),
-            span: Span(0, 12)
-        }
+        ValueAndSpan { inner: SpannedValue::from_keyword("hello", "world"), span: Span(0, 12) }
     );
 }
 
@@ -535,32 +433,17 @@ fn test_value() {
     assert_eq!(value("0xabc111").unwrap(), Integer(11256081));
     assert_eq!(value("2r111").unwrap(), Integer(7));
     assert_eq!(value("011").unwrap(), Integer(9));
-    assert_eq!(
-        value("85070591730234615847396907784232501249N").unwrap(),
-        BigInteger(bigger)
-    );
+    assert_eq!(value("85070591730234615847396907784232501249N").unwrap(), BigInteger(bigger));
     assert_eq!(value("111.222").unwrap(), Float(OrderedFloat(111.222f64)));
-    assert_eq!(
-        value("\"hello world\"").unwrap(),
-        Text("hello world".to_string())
-    );
+    assert_eq!(value("\"hello world\"").unwrap(), Text("hello world".to_string()));
     assert_eq!(value("$").unwrap(), s_plain("$"));
     assert_eq!(value(".").unwrap(), s_plain("."));
     assert_eq!(value("$symbol").unwrap(), s_plain("$symbol"));
     assert_eq!(value(":hello").unwrap(), k_plain("hello"));
     assert_eq!(value("[1]").unwrap(), Vector(vec![Integer(1)]));
-    assert_eq!(
-        value("(1)").unwrap(),
-        List(LinkedList::from_iter(vec![Integer(1)]))
-    );
-    assert_eq!(
-        value("#{1}").unwrap(),
-        Set(BTreeSet::from_iter(vec![Integer(1)]))
-    );
-    assert_eq!(
-        value("{1 2}").unwrap(),
-        Map(BTreeMap::from_iter(vec![(Integer(1), Integer(2))]))
-    );
+    assert_eq!(value("(1)").unwrap(), List(LinkedList::from_iter(vec![Integer(1)])));
+    assert_eq!(value("#{1}").unwrap(), Set(BTreeSet::from_iter(vec![Integer(1)])));
+    assert_eq!(value("{1 2}").unwrap(), Map(BTreeMap::from_iter(vec![(Integer(1), Integer(2))])));
     assert_eq!(
         value("#uuid \"e43c6f3e-3123-49b7-8098-9b47a7bc0fa4\"").unwrap(),
         Uuid(uuid::Uuid::parse_str("e43c6f3e-3123-49b7-8098-9b47a7bc0fa4").unwrap())
@@ -586,73 +469,43 @@ fn test_span_value() {
 
     assert_eq!(
         parse::value("nil").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Nil,
-            span: Span(0, 3)
-        }
+        ValueAndSpan { inner: SpannedValue::Nil, span: Span(0, 3) }
     );
     assert_eq!(
         parse::value("true").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Boolean(true),
-            span: Span(0, 4)
-        }
+        ValueAndSpan { inner: SpannedValue::Boolean(true), span: Span(0, 4) }
     );
     assert_eq!(
         parse::value("1").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Integer(1i64),
-            span: Span(0, 1)
-        }
+        ValueAndSpan { inner: SpannedValue::Integer(1i64), span: Span(0, 1) }
     );
     assert_eq!(
         parse::value("85070591730234615847396907784232501249N").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::BigInteger(bigger),
-            span: Span(0, 39)
-        }
+        ValueAndSpan { inner: SpannedValue::BigInteger(bigger), span: Span(0, 39) }
     );
     assert_eq!(
         parse::value("111.222").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Float(OrderedFloat(111.222f64)),
-            span: Span(0, 7)
-        }
+        ValueAndSpan { inner: SpannedValue::Float(OrderedFloat(111.222f64)), span: Span(0, 7) }
     );
     assert_eq!(
         parse::value("\"hello world\"").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::Text("hello world".to_string()),
-            span: Span(0, 13)
-        }
+        ValueAndSpan { inner: SpannedValue::Text("hello world".to_string()), span: Span(0, 13) }
     );
     assert_eq!(
         parse::value("$").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_symbol(None, "$"),
-            span: Span(0, 1)
-        }
+        ValueAndSpan { inner: SpannedValue::from_symbol(None, "$"), span: Span(0, 1) }
     );
     assert_eq!(
         parse::value(".").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_symbol(None, "."),
-            span: Span(0, 1)
-        }
+        ValueAndSpan { inner: SpannedValue::from_symbol(None, "."), span: Span(0, 1) }
     );
     assert_eq!(
         parse::value("$symbol").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_symbol(None, "$symbol"),
-            span: Span(0, 7)
-        }
+        ValueAndSpan { inner: SpannedValue::from_symbol(None, "$symbol"), span: Span(0, 7) }
     );
     assert_eq!(
         parse::value(":hello").unwrap(),
-        ValueAndSpan {
-            inner: SpannedValue::from_keyword(None, "hello"),
-            span: Span(0, 6)
-        }
+        ValueAndSpan { inner: SpannedValue::from_keyword(None, "hello"), span: Span(0, 6) }
     );
     assert_eq!(
         parse::value("[1]").unwrap(),
@@ -688,14 +541,8 @@ fn test_span_value() {
         parse::value("{1 2}").unwrap(),
         ValueAndSpan {
             inner: SpannedValue::Map(BTreeMap::from_iter(vec![(
-                ValueAndSpan {
-                    inner: SpannedValue::Integer(1),
-                    span: Span(1, 2)
-                },
-                ValueAndSpan {
-                    inner: SpannedValue::Integer(2),
-                    span: Span(3, 4)
-                }
+                ValueAndSpan { inner: SpannedValue::Integer(1), span: Span(1, 2) },
+                ValueAndSpan { inner: SpannedValue::Integer(2), span: Span(3, 4) }
             )])),
             span: Span(0, 5)
         }
@@ -734,12 +581,8 @@ fn test_vector() {
     assert_eq!(vector(test).unwrap(), value);
 
     let test = "[1 2 3.4 85070591730234615847396907784232501249N]";
-    let value = Vector(vec![
-        Integer(1),
-        Integer(2),
-        Float(OrderedFloat(3.4f64)),
-        BigInteger(bigger),
-    ]);
+    let value =
+        Vector(vec![Integer(1), Integer(2), Float(OrderedFloat(3.4f64)), BigInteger(bigger)]);
     assert_eq!(vector(test).unwrap(), value);
 
     let test = "[1 0 nil \"nil\"]";
@@ -747,11 +590,7 @@ fn test_vector() {
     assert_eq!(vector(test).unwrap(), value);
 
     let test = "[1 [0 nil] \"nil\"]";
-    let value = Vector(vec![
-        Integer(1),
-        Vector(vec![Integer(0), Nil]),
-        Text("nil".to_string()),
-    ]);
+    let value = Vector(vec![Integer(1), Vector(vec![Integer(0), Nil]), Text("nil".to_string())]);
     assert_eq!(vector(test).unwrap(), value);
 
     assert!(vector("[").is_err());
@@ -789,20 +628,13 @@ fn test_list() {
     assert_eq!(list(test).unwrap(), value);
 
     let test = "(1 2 3.4)";
-    let value = List(LinkedList::from_iter(vec![
-        Integer(1),
-        Integer(2),
-        Float(OrderedFloat(3.4f64)),
-    ]));
+    let value =
+        List(LinkedList::from_iter(vec![Integer(1), Integer(2), Float(OrderedFloat(3.4f64))]));
     assert_eq!(list(test).unwrap(), value);
 
     let test = "(1 0 nil \"nil\")";
-    let value = List(LinkedList::from_iter(vec![
-        Integer(1),
-        Integer(0),
-        Nil,
-        Text("nil".to_string()),
-    ]));
+    let value =
+        List(LinkedList::from_iter(vec![Integer(1), Integer(0), Nil, Text("nil".to_string())]));
     assert_eq!(list(test).unwrap(), value);
 
     let test = "(1 (0 nil) \"nil\")";
@@ -852,20 +684,12 @@ fn test_set() {
     assert_eq!(set(test).unwrap(), value);
 
     let test = "#{3.4 2 1}";
-    let value = Set(BTreeSet::from_iter(vec![
-        Integer(1),
-        Integer(2),
-        Float(OrderedFloat(3.4f64)),
-    ]));
+    let value = Set(BTreeSet::from_iter(vec![Integer(1), Integer(2), Float(OrderedFloat(3.4f64))]));
     assert_eq!(set(test).unwrap(), value);
 
     let test = "#{1 0 nil \"nil\"}";
-    let value = Set(BTreeSet::from_iter(vec![
-        Nil,
-        Integer(0),
-        Integer(1),
-        Text("nil".to_string()),
-    ]));
+    let value =
+        Set(BTreeSet::from_iter(vec![Nil, Integer(0), Integer(1), Text("nil".to_string())]));
     assert_eq!(set(test).unwrap(), value);
 
     let test = "#{1 #{0 nil} \"nil\"}";
@@ -895,31 +719,21 @@ fn test_map() {
     assert_eq!(map(test).unwrap(), value);
 
     let test = "{\"a\" 1}";
-    let value = Map(BTreeMap::from_iter(vec![(
-        Text("a".to_string()),
-        Integer(1),
-    )]));
+    let value = Map(BTreeMap::from_iter(vec![(Text("a".to_string()), Integer(1))]));
     assert_eq!(map(test).unwrap(), value);
 
     let test = "{ \"a\" 1 }";
-    let value = Map(BTreeMap::from_iter(vec![(
-        Text("a".to_string()),
-        Integer(1),
-    )]));
+    let value = Map(BTreeMap::from_iter(vec![(Text("a".to_string()), Integer(1))]));
     assert_eq!(map(test).unwrap(), value);
 
     let test = "{nil 1, \"b\" 2}";
-    let value = Map(BTreeMap::from_iter(vec![
-        (Nil, Integer(1)),
-        (Text("b".to_string()), Integer(2)),
-    ]));
+    let value =
+        Map(BTreeMap::from_iter(vec![(Nil, Integer(1)), (Text("b".to_string()), Integer(2))]));
     assert_eq!(map(test).unwrap(), value);
 
     let test = "{ nil 1 \"b\" 2 }";
-    let value = Map(BTreeMap::from_iter(vec![
-        (Nil, Integer(1)),
-        (Text("b".to_string()), Integer(2)),
-    ]));
+    let value =
+        Map(BTreeMap::from_iter(vec![(Nil, Integer(1)), (Text("b".to_string()), Integer(2))]));
     assert_eq!(map(test).unwrap(), value);
 
     let test = "{nil 1, \"b\" 2, \"a\" 3}";
@@ -945,17 +759,11 @@ fn test_map() {
             s_plain("$b"),
             Map(BTreeMap::from_iter(vec![
                 (k_ns("b", "a"), Nil),
-                (
-                    k_ns("b", "b"),
-                    Set(BTreeSet::from_iter(vec![Nil, Integer(5)])),
-                ),
+                (k_ns("b", "b"), Set(BTreeSet::from_iter(vec![Nil, Integer(5)]))),
             ])),
         ),
         (s_plain("c"), Vector(vec![Integer(1), Integer(2)])),
-        (
-            s_plain("d"),
-            List(LinkedList::from_iter(vec![Integer(3), Integer(4)])),
-        ),
+        (s_plain("d"), List(LinkedList::from_iter(vec![Integer(3), Integer(4)]))),
     ]));
     assert_eq!(map(test).unwrap(), value);
 
@@ -996,19 +804,11 @@ fn test_query_active_sessions() {
             s_plain("?reason"),
             s_plain("?tx"),
         ]),
-        Vector(vec![
-            s_plain("?tx"),
-            k_ns("db", "txInstant"),
-            s_plain("?ts"),
-        ]),
+        Vector(vec![s_plain("?tx"), k_ns("db", "txInstant"), s_plain("?ts")]),
         List(LinkedList::from_iter(vec![
             s_plain("not-join"),
             Vector(vec![s_plain("?id")]),
-            Vector(vec![
-                s_plain("?id"),
-                k_ns("session", "endReason"),
-                s_plain("_"),
-            ]),
+            Vector(vec![s_plain("?id"), k_ns("session", "endReason"), s_plain("_")]),
         ])),
     ]);
     assert_eq!(value(test).unwrap(), reply);
@@ -1040,11 +840,7 @@ fn test_query_ended_sessions() {
             s_plain("?endReason"),
             s_plain("?tx"),
         ]),
-        Vector(vec![
-            s_plain("?tx"),
-            k_ns("db", "txInstant"),
-            s_plain("?ts"),
-        ]),
+        Vector(vec![s_plain("?tx"), k_ns("db", "txInstant"), s_plain("?ts")]),
     ]);
     assert_eq!(value(test).unwrap(), reply);
 }
@@ -1062,11 +858,7 @@ fn test_query_starred_pages() {
 
     let reply = Vector(vec![
         k_plain("find"),
-        Vector(vec![
-            s_plain("?url"),
-            s_plain("?title"),
-            s_plain("?starredOn"),
-        ]),
+        Vector(vec![s_plain("?url"), s_plain("?title"), s_plain("?starredOn")]),
         k_plain("in"),
         List(LinkedList::from_iter(vec![
             s_plain("if"),
@@ -1104,16 +896,8 @@ fn test_query_saved_pages() {
         k_plain("in"),
         s_plain("$"),
         k_plain("where"),
-        Vector(vec![
-            s_plain("?save"),
-            k_ns("save", "page"),
-            s_plain("?page"),
-        ]),
-        Vector(vec![
-            s_plain("?save"),
-            k_ns("save", "savedAt"),
-            s_plain("?instant"),
-        ]),
+        Vector(vec![s_plain("?save"), k_ns("save", "page"), s_plain("?page")]),
+        Vector(vec![s_plain("?save"), k_ns("save", "savedAt"), s_plain("?instant")]),
         Vector(vec![s_plain("?page"), k_ns("page", "url"), s_plain("?url")]),
         Vector(vec![
             List(LinkedList::from_iter(vec![
@@ -1175,10 +959,7 @@ fn test_query_pages_matching_string_1() {
                     s_plain("list"),
                     s_plain("fulltext"),
                     s_plain("$"),
-                    Set(BTreeSet::from_iter(vec![
-                        k_ns("page", "url"),
-                        k_ns("page", "title"),
-                    ])),
+                    Set(BTreeSet::from_iter(vec![k_ns("page", "url"), k_ns("page", "title")])),
                     s_plain("string"),
                 ])),
                 Vector(vec![Vector(vec![s_plain("?page")])]),
@@ -1238,11 +1019,7 @@ fn test_query_pages_matching_string_2() {
 
     let reply = Vector(vec![
         k_plain("find"),
-        Vector(vec![
-            s_plain("?url"),
-            s_plain("?title"),
-            s_plain("?excerpt"),
-        ]),
+        Vector(vec![s_plain("?url"), s_plain("?title"), s_plain("?excerpt")]),
         k_plain("in"),
         Vector(vec![s_plain("$")]),
         k_plain("where"),
@@ -1261,11 +1038,7 @@ fn test_query_pages_matching_string_2() {
                 ])),
                 Vector(vec![Vector(vec![s_plain("?save")])]),
             ]),
-            Vector(vec![
-                s_plain("?save"),
-                k_ns("save", "page"),
-                s_plain("?page"),
-            ]),
+            Vector(vec![s_plain("?save"), k_ns("save", "page"), s_plain("?page")]),
             Vector(vec![s_plain("?page"), k_ns("page", "url"), s_plain("?url")]),
             Vector(vec![
                 List(LinkedList::from_iter(vec![
@@ -1313,10 +1086,7 @@ fn test_query_visited() {
         Vector(vec![
             s_plain("?url"),
             s_plain("?title"),
-            List(LinkedList::from_iter(vec![
-                s_plain("max"),
-                s_plain("?time"),
-            ])),
+            List(LinkedList::from_iter(vec![s_plain("max"), s_plain("?time")])),
         ]),
         k_plain("in"),
         List(LinkedList::from_iter(vec![
@@ -1509,10 +1279,7 @@ fn test_is_and_as_type_helper_functions() {
         Value::Vector(vec![Value::Integer(1)]),
         Value::List(LinkedList::from_iter(vec![])),
         Value::Set(BTreeSet::from_iter(vec![])),
-        Value::Map(BTreeMap::from_iter(vec![(
-            Value::Text("a".to_string()),
-            Value::Integer(1),
-        )])),
+        Value::Map(BTreeMap::from_iter(vec![(Value::Text("a".to_string()), Value::Integer(1))])),
     ];
 
     for (i, value) in values.iter().enumerate() {
@@ -1536,14 +1303,7 @@ fn test_is_and_as_type_helper_functions() {
         assert_eq!(values.len(), is_result.len());
 
         for (j, result) in is_result.iter().enumerate() {
-            assert_eq!(
-                j == i,
-                *result,
-                "Expected {} = {} to equal {}",
-                j,
-                i,
-                result
-            );
+            assert_eq!(j == i, *result, "Expected {} = {} to equal {}", j, i, result);
         }
 
         if i == 0 {
@@ -1560,24 +1320,14 @@ fn test_is_and_as_type_helper_functions() {
         def_test_as_type!(value, as_big_integer, i == 3, &max_i64 * &max_i64);
         def_test_as_type!(value, as_ordered_float, i == 4, OrderedFloat(22.22f64));
         def_test_as_type!(value, as_text, i == 5, "hello world".to_string());
-        def_test_as_type!(
-            value,
-            as_symbol,
-            i == 6,
-            symbols::PlainSymbol::plain("$symbol")
-        );
+        def_test_as_type!(value, as_symbol, i == 6, symbols::PlainSymbol::plain("$symbol"));
         def_test_as_type!(
             value,
             as_namespaced_symbol,
             i == 7,
             symbols::NamespacedSymbol::namespaced("$ns", "$symbol")
         );
-        def_test_as_type!(
-            value,
-            as_plain_keyword,
-            i == 8,
-            symbols::Keyword::plain("hello")
-        );
+        def_test_as_type!(value, as_plain_keyword, i == 8, symbols::Keyword::plain("hello"));
         def_test_as_type!(
             value,
             as_namespaced_keyword,
@@ -1601,24 +1351,14 @@ fn test_is_and_as_type_helper_functions() {
         def_test_into_type!(value, into_big_integer, i == 3, &max_i64 * &max_i64);
         def_test_into_type!(value, into_ordered_float, i == 4, OrderedFloat(22.22f64));
         def_test_into_type!(value, into_text, i == 5, "hello world".to_string());
-        def_test_into_type!(
-            value,
-            into_symbol,
-            i == 6,
-            symbols::PlainSymbol::plain("$symbol")
-        );
+        def_test_into_type!(value, into_symbol, i == 6, symbols::PlainSymbol::plain("$symbol"));
         def_test_into_type!(
             value,
             into_namespaced_symbol,
             i == 7,
             symbols::NamespacedSymbol::namespaced("$ns", "$symbol")
         );
-        def_test_into_type!(
-            value,
-            into_plain_keyword,
-            i == 8,
-            symbols::Keyword::plain("hello")
-        );
+        def_test_into_type!(value, into_plain_keyword, i == 8, symbols::Keyword::plain("hello"));
         def_test_into_type!(
             value,
             into_namespaced_keyword,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -13,10 +13,7 @@ fn datatype_to_f64(dt: &DataType) -> Result<f64> {
         DataType::Double(n) => Ok(*n),
         DataType::Float(n) => Ok(*n as f64),
         DataType::BigInt(n) => Ok(*n as f64),
-        other => Err(anyhow!(
-            "cannot convert {:?} to numeric for aggregation",
-            other
-        )),
+        other => Err(anyhow!("cannot convert {:?} to numeric for aggregation", other)),
     }
 }
 
@@ -79,9 +76,7 @@ impl Accumulator for SumAccumulator {
                 self.accum = Some(NumericAccum::Double(*n));
             }
             (Some(NumericAccum::Long(acc)), DataType::Long(n)) => {
-                *acc = acc
-                    .checked_add(*n)
-                    .ok_or_else(|| anyhow!("integer overflow in sum"))?;
+                *acc = acc.checked_add(*n).ok_or_else(|| anyhow!("integer overflow in sum"))?;
             }
             (Some(NumericAccum::Long(acc)), DataType::Double(n)) => {
                 self.accum = Some(NumericAccum::Double(*acc as f64 + n));
@@ -113,10 +108,7 @@ impl Accumulator for SumAccumulator {
                 }
             }
             (_, other) => {
-                return Err(anyhow!(
-                    "sum: cannot aggregate non-numeric value {:?}",
-                    other
-                ));
+                return Err(anyhow!("sum: cannot aggregate non-numeric value {:?}", other));
             }
         }
         Ok(())
@@ -172,9 +164,7 @@ impl Accumulator for MinAccumulator {
     }
 
     fn finalize(&self) -> Result<DataType> {
-        self.current
-            .clone()
-            .ok_or_else(|| anyhow!("min: no values accumulated"))
+        self.current.clone().ok_or_else(|| anyhow!("min: no values accumulated"))
     }
 }
 
@@ -199,18 +189,14 @@ impl Accumulator for MaxAccumulator {
     }
 
     fn finalize(&self) -> Result<DataType> {
-        self.current
-            .clone()
-            .ok_or_else(|| anyhow!("max: no values accumulated"))
+        self.current.clone().ok_or_else(|| anyhow!("max: no values accumulated"))
     }
 }
 
 pub(crate) fn make_accumulator(func: &AggregateFunc) -> Box<dyn Accumulator> {
     match func {
         AggregateFunc::Count => Box::new(CountAccumulator { count: 0 }),
-        AggregateFunc::CountDistinct => Box::new(CountDistinctAccumulator {
-            seen: HashSet::new(),
-        }),
+        AggregateFunc::CountDistinct => Box::new(CountDistinctAccumulator { seen: HashSet::new() }),
         AggregateFunc::Sum => Box::new(SumAccumulator { accum: None }),
         AggregateFunc::Avg => Box::new(AvgAccumulator { sum: 0.0, count: 0 }),
         AggregateFunc::Min => Box::new(MinAccumulator { current: None }),

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -38,10 +38,7 @@ impl SingleLevelExtender {
     pub fn new(values: Vec<Bytes>, participates_in: usize) -> Self {
         let mut values = values;
         values.sort();
-        Self {
-            values,
-            participates_in,
-        }
+        Self { values, participates_in }
     }
 }
 
@@ -56,11 +53,7 @@ impl PrefixExtender for SingleLevelExtender {
 
     fn intersect(&self, _prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
         let value_set: HashSet<_> = self.values.iter().collect();
-        extensions
-            .iter()
-            .filter(|ext| value_set.contains(ext))
-            .cloned()
-            .collect()
+        extensions.iter().filter(|ext| value_set.contains(ext)).cloned().collect()
     }
 
     fn participates_in_level(&self, level: usize) -> bool {
@@ -134,11 +127,7 @@ impl FromPrefixExtender {
             participating_levels
         );
         let level_set = participating_levels.iter().cloned().collect();
-        Self {
-            participating_levels,
-            level_set,
-            partial_prefix,
-        }
+        Self { participating_levels, level_set, partial_prefix }
     }
 
     fn is_prefix_matching(&self, prefix: &Prefix) -> bool {
@@ -218,11 +207,7 @@ impl FromPrefixesExtender {
             participating_levels
         );
         let level_set = participating_levels.iter().cloned().collect();
-        Self {
-            participating_levels,
-            level_set,
-            partial_prefixes,
-        }
+        Self { participating_levels, level_set, partial_prefixes }
     }
 
     fn matching_prefixes(&self, prefix: &Prefix) -> Vec<&Prefix> {
@@ -273,16 +258,9 @@ impl PrefixExtender for FromPrefixesExtender {
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
         let idx = self.next_level_index(prefix);
-        let valid_extensions: HashSet<_> = self
-            .matching_prefixes(prefix)
-            .into_iter()
-            .filter_map(|p| p.get(idx))
-            .collect();
-        extensions
-            .iter()
-            .filter(|ext| valid_extensions.contains(ext))
-            .cloned()
-            .collect()
+        let valid_extensions: HashSet<_> =
+            self.matching_prefixes(prefix).into_iter().filter_map(|p| p.get(idx)).collect();
+        extensions.iter().filter(|ext| valid_extensions.contains(ext)).cloned().collect()
     }
 
     fn participates_in_level(&self, level: usize) -> bool {
@@ -299,10 +277,7 @@ pub struct GenericSingleJoin<'a> {
 impl<'a> GenericSingleJoin<'a> {
     pub fn new(extenders: Vec<&'a dyn PrefixExtender>, prefixes: Vec<Prefix>) -> Self {
         assert!(!extenders.is_empty(), "At least one extender is required");
-        Self {
-            extenders,
-            prefixes,
-        }
+        Self { extenders, prefixes }
     }
 
     pub fn join(&self) -> Vec<Prefix> {
@@ -349,19 +324,12 @@ pub struct PrefixAndExtensionsExtender {
 impl PrefixAndExtensionsExtender {
     pub fn new(fixed_prefix: Prefix, fixed_extensions: Vec<Extension>) -> Self {
         let extension_set = fixed_extensions.iter().cloned().collect();
-        Self {
-            fixed_prefix,
-            fixed_extensions,
-            extension_set,
-        }
+        Self { fixed_prefix, fixed_extensions, extension_set }
     }
 
     fn is_prefix_matching(&self, prefix: &Prefix) -> bool {
         prefix.len() <= self.fixed_prefix.len()
-            && prefix
-                .iter()
-                .zip(self.fixed_prefix.iter())
-                .all(|(a, b)| a == b)
+            && prefix.iter().zip(self.fixed_prefix.iter()).all(|(a, b)| a == b)
     }
 }
 
@@ -400,11 +368,7 @@ impl PrefixExtender for PrefixAndExtensionsExtender {
                     vec![]
                 }
             } else {
-                extensions
-                    .iter()
-                    .filter(|ext| self.extension_set.contains(*ext))
-                    .cloned()
-                    .collect()
+                extensions.iter().filter(|ext| self.extension_set.contains(*ext)).cloned().collect()
             }
         } else {
             vec![]
@@ -502,11 +466,8 @@ mod tests {
         // Second level: multiples of 6 and 12
         let multiples_of_six = SingleLevelExtender::new(vec![bi(6), bi(12)], 1);
 
-        let extenders: Vec<&dyn PrefixExtender> = vec![
-            &even_extender,
-            &divisible_by_three_extender,
-            &multiples_of_six,
-        ];
+        let extenders: Vec<&dyn PrefixExtender> =
+            vec![&even_extender, &divisible_by_three_extender, &multiples_of_six];
 
         let join = GenericJoin::new(extenders, 2);
         let result = join.join();
@@ -579,34 +540,19 @@ mod tests {
         let extender = FromPrefixExtender::new(vec![0, 2], vec![b("x"), b("y")]);
 
         // Empty prefix, extensions contain the expected value
-        assert_eq!(
-            extender.intersect(&vec![], &[b("x"), b("a"), b("b")]),
-            vec![b("x")]
-        );
+        assert_eq!(extender.intersect(&vec![], &[b("x"), b("a"), b("b")]), vec![b("x")]);
 
         // Empty prefix, extensions don't contain the expected value
-        assert_eq!(
-            extender.intersect(&vec![], &[b("a"), b("b"), b("c")]),
-            Vec::<Bytes>::new()
-        );
+        assert_eq!(extender.intersect(&vec![], &[b("a"), b("b"), b("c")]), Vec::<Bytes>::new());
 
         // Matching prefix at level 0, extensions contain expected value "y"
-        assert_eq!(
-            extender.intersect(&vec![b("x")], &[b("y"), b("z")]),
-            vec![b("y")]
-        );
+        assert_eq!(extender.intersect(&vec![b("x")], &[b("y"), b("z")]), vec![b("y")]);
 
         // Matching prefix at level 0, extensions don't contain expected value
-        assert_eq!(
-            extender.intersect(&vec![b("x")], &[b("a"), b("b")]),
-            Vec::<Bytes>::new()
-        );
+        assert_eq!(extender.intersect(&vec![b("x")], &[b("a"), b("b")]), Vec::<Bytes>::new());
 
         // Non-matching prefix
-        assert_eq!(
-            extender.intersect(&vec![b("wrong")], &[b("x"), b("y")]),
-            Vec::<Bytes>::new()
-        );
+        assert_eq!(extender.intersect(&vec![b("wrong")], &[b("x"), b("y")]), Vec::<Bytes>::new());
     }
 
     #[test]
@@ -623,12 +569,8 @@ mod tests {
         // This extender constrains: level 0 = 2, level 2 = "x"
         let constraint_extender = FromPrefixExtender::new(vec![0, 2], vec![bi(2), b("x")]);
 
-        let extenders: Vec<&dyn PrefixExtender> = vec![
-            &level0_extender,
-            &level1_extender,
-            &level2_extender,
-            &constraint_extender,
-        ];
+        let extenders: Vec<&dyn PrefixExtender> =
+            vec![&level0_extender, &level1_extender, &level2_extender, &constraint_extender];
 
         let join = GenericJoin::new(extenders, 3);
         let result = join.join();
@@ -705,31 +647,19 @@ mod tests {
             FromPrefixesExtender::new(vec![0, 2], vec![vec![b("a"), b("b")], vec![b("x"), b("y")]]);
 
         // Empty prefix, extensions contain both expected values
-        assert_eq!(
-            extender.intersect(&vec![], &[b("a"), b("x"), b("z")]),
-            vec![b("a"), b("x")]
-        );
+        assert_eq!(extender.intersect(&vec![], &[b("a"), b("x"), b("z")]), vec![b("a"), b("x")]);
 
         // Empty prefix, extensions contain only one expected value
         assert_eq!(extender.intersect(&vec![], &[b("a"), b("z")]), vec![b("a")]);
 
         // Empty prefix, extensions don't contain expected values
-        assert_eq!(
-            extender.intersect(&vec![], &[b("z"), b("w")]),
-            Vec::<Bytes>::new()
-        );
+        assert_eq!(extender.intersect(&vec![], &[b("z"), b("w")]), Vec::<Bytes>::new());
 
         // Matching prefix at level 0 for first prefix
-        assert_eq!(
-            extender.intersect(&vec![b("a")], &[b("b"), b("y"), b("z")]),
-            vec![b("b")]
-        );
+        assert_eq!(extender.intersect(&vec![b("a")], &[b("b"), b("y"), b("z")]), vec![b("b")]);
 
         // Matching prefix at level 0 for second prefix
-        assert_eq!(
-            extender.intersect(&vec![b("x")], &[b("b"), b("y"), b("z")]),
-            vec![b("y")]
-        );
+        assert_eq!(extender.intersect(&vec![b("x")], &[b("b"), b("y"), b("z")]), vec![b("y")]);
 
         // Non-matching prefix
         assert_eq!(
@@ -771,31 +701,13 @@ mod tests {
         let multi_extender = FromPrefixesExtender::new(vec![0, 1], vec![vec![b("a"), b("b")]]);
 
         // Both should behave identically
-        assert_eq!(
-            single_extender.count(&vec![]),
-            multi_extender.count(&vec![])
-        );
-        assert_eq!(
-            single_extender.count(&vec![b("a")]),
-            multi_extender.count(&vec![b("a")])
-        );
-        assert_eq!(
-            single_extender.count(&vec![b("z")]),
-            multi_extender.count(&vec![b("z")])
-        );
+        assert_eq!(single_extender.count(&vec![]), multi_extender.count(&vec![]));
+        assert_eq!(single_extender.count(&vec![b("a")]), multi_extender.count(&vec![b("a")]));
+        assert_eq!(single_extender.count(&vec![b("z")]), multi_extender.count(&vec![b("z")]));
 
-        assert_eq!(
-            single_extender.propose(&vec![]),
-            multi_extender.propose(&vec![])
-        );
-        assert_eq!(
-            single_extender.propose(&vec![b("a")]),
-            multi_extender.propose(&vec![b("a")])
-        );
-        assert_eq!(
-            single_extender.propose(&vec![b("z")]),
-            multi_extender.propose(&vec![b("z")])
-        );
+        assert_eq!(single_extender.propose(&vec![]), multi_extender.propose(&vec![]));
+        assert_eq!(single_extender.propose(&vec![b("a")]), multi_extender.propose(&vec![b("a")]));
+        assert_eq!(single_extender.propose(&vec![b("z")]), multi_extender.propose(&vec![b("z")]));
 
         assert_eq!(
             single_extender.intersect(&vec![], &[b("a"), b("b"), b("c")]),

--- a/src/algo/leapfrog.rs
+++ b/src/algo/leapfrog.rs
@@ -58,11 +58,7 @@ pub struct SingleLevelIndex {
 impl SingleLevelIndex {
     pub fn new(mut values: Vec<Bytes>, participating_level: usize) -> Self {
         values.sort();
-        Self {
-            values,
-            current_index: 0,
-            participating_level,
-        }
+        Self { values, current_index: 0, participating_level }
     }
 }
 
@@ -128,11 +124,7 @@ pub struct TupleIndex {
 
 impl TupleIndex {
     pub fn new(tuple: ResultTuple) -> Self {
-        Self {
-            tuple,
-            current_level: 0,
-            past_value: false,
-        }
+        Self { tuple, current_level: 0, past_value: false }
     }
 }
 
@@ -201,10 +193,7 @@ pub struct LeapfrogSingleJoin<'a> {
 impl<'a> LeapfrogSingleJoin<'a> {
     pub fn new(iterators: Vec<&'a mut dyn LeapfrogIndex>) -> Self {
         assert!(!iterators.is_empty(), "Must have at least one iterator");
-        Self {
-            iterators,
-            current_iterator_index: 0,
-        }
+        Self { iterators, current_iterator_index: 0 }
     }
 
     pub fn next(&mut self) {
@@ -294,12 +283,7 @@ impl LeapfrogJoin {
             })
             .collect();
 
-        Self {
-            indexes,
-            levels,
-            filter_indexes,
-            participants,
-        }
+        Self { indexes, levels, filter_indexes, participants }
     }
 
     pub fn join(&mut self) -> Vec<ResultTuple> {
@@ -312,11 +296,7 @@ impl LeapfrogJoin {
 
         while current_level >= 0 {
             let level = current_level as usize;
-            assert_eq!(
-                level,
-                candidate_tuple.len(),
-                "Level should always match candidate size"
-            );
+            assert_eq!(level, candidate_tuple.len(), "Level should always match candidate size");
 
             // Perform single join search at current level
             let found = self.search_at_level(level, &mut candidate_tuple);
@@ -460,11 +440,7 @@ mod tests {
         impl MultiLevelIndex {
             fn new(level_data: Vec<Vec<Bytes>>) -> Self {
                 let num_levels = level_data.len();
-                Self {
-                    level_data,
-                    current_level: 0,
-                    index_per_level: vec![0; num_levels],
-                }
+                Self { level_data, current_level: 0, index_per_level: vec![0; num_levels] }
             }
         }
 
@@ -724,10 +700,7 @@ mod tests {
 
     impl NotLeapfrogIndex {
         fn new(indexes: Vec<Box<dyn LeapfrogIndex>>, participation_level: usize) -> Self {
-            Self {
-                indexes,
-                participation_level,
-            }
+            Self { indexes, participation_level }
         }
     }
 
@@ -763,10 +736,7 @@ mod tests {
 
     impl SimpleNotFilter {
         fn new(excluded_values: Vec<Bytes>, participation_level: usize) -> Self {
-            Self {
-                excluded_values,
-                participation_level,
-            }
+            Self { excluded_values, participation_level }
         }
     }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -63,11 +63,7 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> PartitionMap {
 pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
     let version_key = concat_bytes(&[&[codec::META_INDEX], META_KEY_VERSION]);
 
-    match slatedb
-        .get(&version_key)
-        .await
-        .expect("Failed to read version from META_INDEX")
-    {
+    match slatedb.get(&version_key).await.expect("Failed to read version from META_INDEX") {
         Some(_bytes) => {
             // Existing DB — load schema from indices, derive counters from EAV scan
             let schema = load_schema_from_indices(slatedb.clone()).await;
@@ -104,9 +100,7 @@ pub async fn init_db(slatedb: Arc<Db>) -> Metadata {
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             txn.put(&version_key, version.as_bytes()).unwrap();
-            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS)
-                .await
-                .unwrap();
+            txn.commit_with_options(&DEFAULT_WRITE_OPTIONS).await.unwrap();
 
             // Derive counters from the just-written index
             let pm = scan_partition_counters(&slatedb).await;
@@ -130,28 +124,16 @@ mod tests {
         assert_eq!(metadata.schema.len(), 7);
         assert!(metadata.schema.get_attribute(&kw!(:db/ident)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/valueType)).is_some());
-        assert!(metadata
-            .schema
-            .get_attribute(&kw!(:db/cardinality))
-            .is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/cardinality)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txInstant)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txId)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txResult)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db.tx/error)).is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
-        assert_eq!(
-            metadata.partition_map[&DB_PARTITION],
-            DB_PARTITION_COUNTER_FLOOR
-        );
+        assert_eq!(metadata.partition_map[&DB_PARTITION], DB_PARTITION_COUNTER_FLOOR);
         // Enum entities are in ident_map but not attribute_map
-        assert!(metadata
-            .schema
-            .ident_map
-            .contains_key(&kw!(:db.type/string)));
-        assert!(metadata
-            .schema
-            .get_attribute(&kw!(:db.type/string))
-            .is_none());
+        assert!(metadata.schema.ident_map.contains_key(&kw!(:db.type/string)));
+        assert!(metadata.schema.get_attribute(&kw!(:db.type/string)).is_none());
     }
 
     #[tokio::test]
@@ -162,10 +144,7 @@ mod tests {
         let metadata2 = init_db(slatedb).await;
         assert_eq!(metadata1.schema.len(), metadata2.schema.len());
         assert_eq!(metadata1.schema.len(), 7);
-        assert_eq!(
-            metadata1.partition_map[&DB_PARTITION],
-            metadata2.partition_map[&DB_PARTITION]
-        );
+        assert_eq!(metadata1.partition_map[&DB_PARTITION], metadata2.partition_map[&DB_PARTITION]);
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,15 +65,11 @@ impl ClientNode {
         // Expect ReadyForQuery
         let msg = read_backend_message(&mut reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
         match msg {
-            BackendMessage::ReadyForQuery {
-                status: STATUS_IDLE,
-            } => {}
+            BackendMessage::ReadyForQuery { status: STATUS_IDLE } => {}
             other => bail!("Expected ReadyForQuery, got {:?}", other),
         }
 
-        Ok(ClientNode {
-            conn: Arc::new(Mutex::new(ConnectionInner { reader, writer })),
-        })
+        Ok(ClientNode { conn: Arc::new(Mutex::new(ConnectionInner { reader, writer })) })
     }
 
     async fn open_db(&self, tx_key: Option<TxKey>) -> Result<ClientDb> {
@@ -82,11 +78,8 @@ impl ClientNode {
             None => (None, None),
             Some(tk) => (Some(tk.tx_id), Some(tk.system_time.timestamp_micros())),
         };
-        write_frontend_message(
-            &mut conn.writer,
-            &FrontendMessage::OpenDb { tx_id, system_time },
-        )
-        .await?;
+        write_frontend_message(&mut conn.writer, &FrontendMessage::OpenDb { tx_id, system_time })
+            .await?;
         conn.writer.flush().await?;
 
         // Expect DbOpened
@@ -107,11 +100,7 @@ impl ClientNode {
             other => bail!("Expected ReadyForQuery, got {:?}", other),
         }
 
-        Ok(ClientDb {
-            db_id,
-            tx_id,
-            conn: self.conn.clone(),
-        })
+        Ok(ClientDb { db_id, tx_id, conn: self.conn.clone() })
     }
 
     /// Gracefully close the connection.
@@ -128,10 +117,7 @@ impl SubmitNode for ClientNode {
         let mut conn = self.conn.lock().await;
         write_frontend_message(
             &mut conn.writer,
-            &FrontendMessage::Execute {
-                ops,
-                await_indexing: false,
-            },
+            &FrontendMessage::Execute { ops, await_indexing: false },
         )
         .await?;
         conn.writer.flush().await?;
@@ -140,10 +126,7 @@ impl SubmitNode for ClientNode {
         let tx_key = match msg {
             BackendMessage::TxKey { tx_id, system_time } => {
                 let dt = crate::protocol::micros_to_datetime(system_time)?;
-                TxKey {
-                    tx_id,
-                    system_time: dt,
-                }
+                TxKey { tx_id, system_time: dt }
             }
             BackendMessage::ErrorResponse { message, .. } => {
                 // TODO: fatal errors may not be followed by ReadyForQuery
@@ -167,27 +150,16 @@ impl SubmitNode for ClientNode {
         let mut conn = self.conn.lock().await;
         write_frontend_message(
             &mut conn.writer,
-            &FrontendMessage::Execute {
-                ops,
-                await_indexing: true,
-            },
+            &FrontendMessage::Execute { ops, await_indexing: true },
         )
         .await?;
         conn.writer.flush().await?;
 
         let msg = read_backend_message(&mut conn.reader, DEFAULT_MAX_MESSAGE_SIZE).await?;
         let result = match msg {
-            BackendMessage::TxResult {
-                status,
-                tx_id,
-                system_time,
-                error_message,
-            } => {
+            BackendMessage::TxResult { status, tx_id, system_time, error_message } => {
                 let dt = crate::protocol::micros_to_datetime(system_time)?;
-                let tx_key = TxKey {
-                    tx_id,
-                    system_time: dt,
-                };
+                let tx_key = TxKey { tx_id, system_time: dt };
                 if status == 0 {
                     TransactionResult::TxCommited(tx_key)
                 } else {
@@ -252,11 +224,7 @@ impl ClientDb {
         let mut conn = self.conn.lock().await;
         write_frontend_message(
             &mut conn.writer,
-            &FrontendMessage::Query {
-                query_string: edn.to_string(),
-                db_id: self.db_id,
-                args,
-            },
+            &FrontendMessage::Query { query_string: edn.to_string(), db_id: self.db_id, args },
         )
         .await?;
         conn.writer.flush().await?;
@@ -292,11 +260,8 @@ impl ClientDb {
     /// Release this DB handle on the server.
     pub async fn close(self) -> Result<()> {
         let mut conn = self.conn.lock().await;
-        write_frontend_message(
-            &mut conn.writer,
-            &FrontendMessage::CloseDb { db_id: self.db_id },
-        )
-        .await?;
+        write_frontend_message(&mut conn.writer, &FrontendMessage::CloseDb { db_id: self.db_id })
+            .await?;
         conn.writer.flush().await?;
 
         // Expect DbClosed

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -88,14 +88,8 @@ mod tests {
         };
 
         assert_eq!(clock.now(), base_instant);
-        assert_eq!(
-            clock.now(),
-            base_instant + std::time::Duration::from_secs(1)
-        );
-        assert_eq!(
-            clock.now(),
-            base_instant + std::time::Duration::from_secs(2)
-        );
+        assert_eq!(clock.now(), base_instant + std::time::Duration::from_secs(1));
+        assert_eq!(clock.now(), base_instant + std::time::Duration::from_secs(2));
     }
 
     #[test]
@@ -117,13 +111,7 @@ mod tests {
         }));
 
         assert_eq!(clock.now(), base_instant);
-        assert_eq!(
-            clock.now(),
-            base_instant + std::time::Duration::from_secs(1)
-        );
-        assert_eq!(
-            clock.now(),
-            base_instant + std::time::Duration::from_secs(2)
-        );
+        assert_eq!(clock.now(), base_instant + std::time::Duration::from_secs(1));
+        assert_eq!(clock.now(), base_instant + std::time::Duration::from_secs(2));
     }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -82,9 +82,7 @@ impl From<String> for DecodeError {
 
 impl From<&str> for DecodeError {
     fn from(message: &str) -> Self {
-        DecodeError {
-            message: message.to_string(),
-        }
+        DecodeError { message: message.to_string() }
     }
 }
 
@@ -159,11 +157,7 @@ pub fn decode_u64(cursor: &mut &[u8]) -> Result<u64, DecodeError> {
 pub fn encode_f64(value: f64, buf: &mut Vec<u8>) {
     let bits = value.to_bits();
     let sign_mask: u64 = 0x8000_0000_0000_0000;
-    let sortable = if bits & sign_mask != 0 {
-        !bits
-    } else {
-        bits ^ sign_mask
-    };
+    let sortable = if bits & sign_mask != 0 { !bits } else { bits ^ sign_mask };
     buf.extend_from_slice(&sortable.to_be_bytes());
 }
 
@@ -175,22 +169,14 @@ pub fn decode_f64(cursor: &mut &[u8]) -> Result<f64, DecodeError> {
     *cursor = &cursor[8..];
     let sortable = u64::from_be_bytes(bytes);
     let sign_mask: u64 = 0x8000_0000_0000_0000;
-    let bits = if sortable & sign_mask != 0 {
-        sortable ^ sign_mask
-    } else {
-        !sortable
-    };
+    let bits = if sortable & sign_mask != 0 { sortable ^ sign_mask } else { !sortable };
     Ok(f64::from_bits(bits))
 }
 
 pub fn encode_f32(value: f32, buf: &mut Vec<u8>) {
     let bits = value.to_bits();
     let sign_mask: u32 = 0x8000_0000;
-    let sortable = if bits & sign_mask != 0 {
-        !bits
-    } else {
-        bits ^ sign_mask
-    };
+    let sortable = if bits & sign_mask != 0 { !bits } else { bits ^ sign_mask };
     buf.extend_from_slice(&sortable.to_be_bytes());
 }
 
@@ -202,11 +188,7 @@ pub fn decode_f32(cursor: &mut &[u8]) -> Result<f32, DecodeError> {
     *cursor = &cursor[4..];
     let sortable = u32::from_be_bytes(bytes);
     let sign_mask: u32 = 0x8000_0000;
-    let bits = if sortable & sign_mask != 0 {
-        sortable ^ sign_mask
-    } else {
-        !sortable
-    };
+    let bits = if sortable & sign_mask != 0 { sortable ^ sign_mask } else { !sortable };
     Ok(f32::from_bits(bits))
 }
 
@@ -537,11 +519,9 @@ impl Decode for DataType {
         let mut cursor = buf;
         let result = decode_datatype(&mut cursor)?;
         if !cursor.is_empty() {
-            return Err(format!(
-                "trailing bytes after decode: {} bytes remaining",
-                cursor.len()
-            )
-            .into());
+            return Err(
+                format!("trailing bytes after decode: {} bytes remaining", cursor.len()).into()
+            );
         }
         Ok(result)
     }
@@ -562,17 +542,11 @@ mod tests {
     #[test]
     fn i64_encoding_table() {
         let cases: Vec<(i64, Vec<u8>)> = vec![
-            (
-                i64::MIN,
-                vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-            ),
+            (i64::MIN, vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
             (-1, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
             (0, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
             (1, vec![0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE]),
-            (
-                i64::MAX,
-                vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-            ),
+            (i64::MAX, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         ];
         for (value, expected) in cases {
             let mut buf = Vec::new();
@@ -634,15 +608,7 @@ mod tests {
 
     #[test]
     fn roundtrip_f64() {
-        for &v in &[
-            f64::NEG_INFINITY,
-            -1.5,
-            -0.0,
-            0.0,
-            1.5,
-            f64::INFINITY,
-            f64::NAN,
-        ] {
+        for &v in &[f64::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f64::INFINITY, f64::NAN] {
             let mut buf = Vec::new();
             encode_f64(v, &mut buf);
             let mut cursor = buf.as_slice();
@@ -650,12 +616,7 @@ mod tests {
             if v.is_nan() {
                 assert!(decoded.is_nan());
             } else {
-                assert_eq!(
-                    decoded.to_bits(),
-                    v.to_bits(),
-                    "f64 {} round-trip failed",
-                    v
-                );
+                assert_eq!(decoded.to_bits(), v.to_bits(), "f64 {} round-trip failed", v);
             }
             assert!(cursor.is_empty());
         }
@@ -663,15 +624,7 @@ mod tests {
 
     #[test]
     fn roundtrip_f32() {
-        for &v in &[
-            f32::NEG_INFINITY,
-            -1.5,
-            -0.0,
-            0.0,
-            1.5,
-            f32::INFINITY,
-            f32::NAN,
-        ] {
+        for &v in &[f32::NEG_INFINITY, -1.5, -0.0, 0.0, 1.5, f32::INFINITY, f32::NAN] {
             let mut buf = Vec::new();
             encode_f32(v, &mut buf);
             let mut cursor = buf.as_slice();
@@ -679,12 +632,7 @@ mod tests {
             if v.is_nan() {
                 assert!(decoded.is_nan());
             } else {
-                assert_eq!(
-                    decoded.to_bits(),
-                    v.to_bits(),
-                    "f32 {} round-trip failed",
-                    v
-                );
+                assert_eq!(decoded.to_bits(), v.to_bits(), "f32 {} round-trip failed", v);
             }
             assert!(cursor.is_empty());
         }
@@ -829,10 +777,7 @@ mod tests {
     #[test]
     fn roundtrip_datatype_nested_composite() {
         let nested = DataType::Vector(vec![
-            DataType::Tuple(vec![
-                DataType::Long(1),
-                DataType::String("inner".to_string()),
-            ]),
+            DataType::Tuple(vec![DataType::Long(1), DataType::String("inner".to_string())]),
             DataType::Map({
                 let mut m = BTreeMap::new();
                 m.insert("k".to_string(), DataType::Boolean(true));
@@ -854,12 +799,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_i64(window[0], &mut a_buf);
             encode_i64(window[1], &mut b_buf);
-            assert!(
-                a_buf > b_buf,
-                "{} should encode after {}",
-                window[0],
-                window[1]
-            );
+            assert!(a_buf > b_buf, "{} should encode after {}", window[0], window[1]);
         }
     }
 
@@ -898,12 +838,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_f64(window[0], &mut a_buf);
             encode_f64(window[1], &mut b_buf);
-            assert!(
-                a_buf <= b_buf,
-                "{} should encode <= {}",
-                window[0],
-                window[1]
-            );
+            assert!(a_buf <= b_buf, "{} should encode <= {}", window[0], window[1]);
         }
     }
 
@@ -936,12 +871,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_string(window[0], &mut a_buf);
             encode_string(window[1], &mut b_buf);
-            assert!(
-                a_buf < b_buf,
-                "{:?} should encode before {:?}",
-                window[0],
-                window[1]
-            );
+            assert!(a_buf < b_buf, "{:?} should encode before {:?}", window[0], window[1]);
         }
     }
 
@@ -954,12 +884,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_bytes(&window[0], &mut a_buf);
             encode_bytes(&window[1], &mut b_buf);
-            assert!(
-                a_buf < b_buf,
-                "{:?} should encode before {:?}",
-                window[0],
-                window[1]
-            );
+            assert!(a_buf < b_buf, "{:?} should encode before {:?}", window[0], window[1]);
         }
     }
 
@@ -977,12 +902,7 @@ mod tests {
             let mut b_buf = Vec::new();
             encode_keyword(&window[0], &mut a_buf);
             encode_keyword(&window[1], &mut b_buf);
-            assert!(
-                a_buf < b_buf,
-                "{:?} should encode before {:?}",
-                window[0],
-                window[1]
-            );
+            assert!(a_buf < b_buf, "{:?} should encode before {:?}", window[0], window[1]);
         }
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -129,31 +129,24 @@ pub fn evaluate<'a>(expr: &'a Expr, ctx: &'a EvalContext<'a>) -> Option<Cow<'a, 
 
 /// Entry point for predicate evaluation — returns true/false directly.
 pub fn evaluate_as_bool(expr: &Expr, ctx: &EvalContext) -> bool {
-    matches!(
-        evaluate(expr, ctx).as_deref(),
-        Some(DataType::Boolean(true))
-    )
+    matches!(evaluate(expr, ctx).as_deref(), Some(DataType::Boolean(true)))
 }
 
 fn eval_binary_op(left: &DataType, op: &BinaryOp, right: &DataType) -> Option<DataType> {
     match op {
-        BinaryOp::Lt => Some(DataType::Boolean(
-            left.partial_compare(right).ok()? == Ordering::Less,
-        )),
+        BinaryOp::Lt => {
+            Some(DataType::Boolean(left.partial_compare(right).ok()? == Ordering::Less))
+        }
         BinaryOp::LtEq => {
             let ord = left.partial_compare(right).ok()?;
-            Some(DataType::Boolean(
-                ord == Ordering::Less || ord == Ordering::Equal,
-            ))
+            Some(DataType::Boolean(ord == Ordering::Less || ord == Ordering::Equal))
         }
-        BinaryOp::Gt => Some(DataType::Boolean(
-            left.partial_compare(right).ok()? == Ordering::Greater,
-        )),
+        BinaryOp::Gt => {
+            Some(DataType::Boolean(left.partial_compare(right).ok()? == Ordering::Greater))
+        }
         BinaryOp::GtEq => {
             let ord = left.partial_compare(right).ok()?;
-            Some(DataType::Boolean(
-                ord == Ordering::Greater || ord == Ordering::Equal,
-            ))
+            Some(DataType::Boolean(ord == Ordering::Greater || ord == Ordering::Equal))
         }
         BinaryOp::Eq => Some(DataType::Boolean(left == right)),
         BinaryOp::NotEq => Some(DataType::Boolean(left != right)),
@@ -275,18 +268,11 @@ mod tests {
     }
 
     fn binary(left: Expr, op: BinaryOp, right: Expr) -> Expr {
-        Expr::BinaryExpr(BinaryExpr {
-            left: Box::new(left),
-            op,
-            right: Box::new(right),
-        })
+        Expr::BinaryExpr(BinaryExpr { left: Box::new(left), op, right: Box::new(right) })
     }
 
     fn unary(op: UnaryOp, operand: Expr) -> Expr {
-        Expr::UnaryExpr(UnaryExpr {
-            op,
-            operand: Box::new(operand),
-        })
+        Expr::UnaryExpr(UnaryExpr { op, operand: Box::new(operand) })
     }
 
     #[test]
@@ -343,14 +329,10 @@ mod tests {
 
         let five = DataType::Long(5);
         let ten = DataType::Long(10);
-        let ctx_same = EvalContext::new(HashMap::from([
-            ("?a".to_var(), &five),
-            ("?b".to_var(), &five),
-        ]));
-        let ctx_diff = EvalContext::new(HashMap::from([
-            ("?a".to_var(), &five),
-            ("?b".to_var(), &ten),
-        ]));
+        let ctx_same =
+            EvalContext::new(HashMap::from([("?a".to_var(), &five), ("?b".to_var(), &five)]));
+        let ctx_diff =
+            EvalContext::new(HashMap::from([("?a".to_var(), &five), ("?b".to_var(), &ten)]));
         assert_eq!(eval(&expr_eq, &ctx_same), Some(DataType::Boolean(true)));
         assert_eq!(eval(&expr_eq, &ctx_diff), Some(DataType::Boolean(false)));
         assert_eq!(eval(&expr_neq, &ctx_same), Some(DataType::Boolean(false)));
@@ -402,11 +384,8 @@ mod tests {
 
     #[test]
     fn test_evaluate_incompatible_types() {
-        let expr = binary(
-            Expr::Literal(DataType::String("hello".into())),
-            BinaryOp::Lt,
-            lit_long(10),
-        );
+        let expr =
+            binary(Expr::Literal(DataType::String("hello".into())), BinaryOp::Lt, lit_long(10));
         let ctx = EvalContext::new(HashMap::new());
         assert_eq!(eval(&expr, &ctx), None);
     }
@@ -546,10 +525,7 @@ mod tests {
     fn test_concat() {
         let expr = binary(lit_string("hello"), BinaryOp::Concat, lit_string(" world"));
         let ctx = EvalContext::new(HashMap::new());
-        assert_eq!(
-            eval(&expr, &ctx),
-            Some(DataType::String("hello world".to_string()))
-        );
+        assert_eq!(eval(&expr, &ctx), Some(DataType::String("hello world".to_string())));
     }
 
     #[test]
@@ -593,20 +569,14 @@ mod tests {
     fn test_upper() {
         let expr = unary(UnaryOp::Upper, lit_string("hello"));
         let ctx = EvalContext::new(HashMap::new());
-        assert_eq!(
-            eval(&expr, &ctx),
-            Some(DataType::String("HELLO".to_string()))
-        );
+        assert_eq!(eval(&expr, &ctx), Some(DataType::String("HELLO".to_string())));
     }
 
     #[test]
     fn test_lower() {
         let expr = unary(UnaryOp::Lower, lit_string("HELLO"));
         let ctx = EvalContext::new(HashMap::new());
-        assert_eq!(
-            eval(&expr, &ctx),
-            Some(DataType::String("hello".to_string()))
-        );
+        assert_eq!(eval(&expr, &ctx), Some(DataType::String("hello".to_string())));
     }
 
     #[test]
@@ -634,30 +604,21 @@ mod tests {
     fn test_str_from_double() {
         let expr = unary(UnaryOp::Str, lit_double(3.15));
         let ctx = EvalContext::new(HashMap::new());
-        assert_eq!(
-            eval(&expr, &ctx),
-            Some(DataType::String("3.15".to_string()))
-        );
+        assert_eq!(eval(&expr, &ctx), Some(DataType::String("3.15".to_string())));
     }
 
     #[test]
     fn test_str_from_bool() {
         let expr = unary(UnaryOp::Str, lit_bool(true));
         let ctx = EvalContext::new(HashMap::new());
-        assert_eq!(
-            eval(&expr, &ctx),
-            Some(DataType::String("true".to_string()))
-        );
+        assert_eq!(eval(&expr, &ctx), Some(DataType::String("true".to_string())));
     }
 
     #[test]
     fn test_nested_arithmetic() {
         // (+ (* ?x 2) 10)
-        let expr = binary(
-            binary(var("?x"), BinaryOp::Mul, lit_long(2)),
-            BinaryOp::Add,
-            lit_long(10),
-        );
+        let expr =
+            binary(binary(var("?x"), BinaryOp::Mul, lit_long(2)), BinaryOp::Add, lit_long(10));
         let x = DataType::Long(5);
         let ctx = EvalContext::new(HashMap::from([("?x".to_var(), &x)]));
         assert_eq!(eval(&expr, &ctx), Some(DataType::Long(20)));

--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -17,18 +17,10 @@ pub struct FileLog {
 impl FileLog {
     #[allow(unused)]
     pub fn new(path: &Path, clock: Box<dyn SystemTimeSource>) -> io::Result<Self> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)?;
+        let file =
+            OpenOptions::new().read(true).write(true).create(true).truncate(false).open(path)?;
 
-        Ok(FileLog {
-            file: BufWriter::new(file),
-            tx_sender: broadcast::channel(1024).0,
-            clock,
-        })
+        Ok(FileLog { file: BufWriter::new(file), tx_sender: broadcast::channel(1024).0, clock })
     }
 
     fn current_offset(&mut self) -> io::Result<i64> {
@@ -76,13 +68,7 @@ impl TxLogWriter for FileLog {
     async fn append_tx(&mut self, record: Vec<u8>) -> TxKey {
         let tx_id = self.current_offset().unwrap();
 
-        let record = Record {
-            tx_key: TxKey {
-                tx_id,
-                system_time: self.clock.now(),
-            },
-            record,
-        };
+        let record = Record { tx_key: TxKey { tx_id, system_time: self.clock.now() }, record };
 
         // Serialize and write the record
         bincode::serialize_into(&mut self.file, &record).unwrap();
@@ -127,9 +113,7 @@ mod tests {
             st_from_unix_epoch(400),
         ]);
 
-        let log = Arc::new(RwLock::new(
-            FileLog::new(&file_path, Box::new(clock)).unwrap(),
-        ));
+        let log = Arc::new(RwLock::new(FileLog::new(&file_path, Box::new(clock)).unwrap()));
         let token = subscribe(log.clone(), None, subscriber.clone()).await;
 
         {
@@ -183,9 +167,7 @@ mod tests {
 
         let clock = MockClock::new(vec![st_from_unix_epoch(0), st_from_unix_epoch(100)]);
 
-        let log = Arc::new(RwLock::new(
-            FileLog::new(&file_path, Box::new(clock)).unwrap(),
-        ));
+        let log = Arc::new(RwLock::new(FileLog::new(&file_path, Box::new(clock)).unwrap()));
 
         // Write one transaction
         {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -120,9 +120,7 @@ pub async fn latest_tx_key_from_snapshot(
     snapshot: &Arc<slatedb::DbSnapshot>,
 ) -> Result<(i64, TxKey)> {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = snapshot
-        .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
+    let mut iter = snapshot.scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     let mut first_eid: Option<i64> = None;
     let mut tx_id: Option<i64> = None;
     let mut system_time: Option<crate::clock::Instant> = None;
@@ -149,20 +147,8 @@ pub async fn latest_tx_key_from_snapshot(
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok((
-            eid,
-            TxKey {
-                tx_id: tid,
-                system_time: st,
-            },
-        )),
-        _ => Ok((
-            0,
-            TxKey {
-                tx_id: 0,
-                system_time: crate::clock::st_from_unix_epoch(0),
-            },
-        )),
+        (Some(eid), Some(tid), Some(st)) => Ok((eid, TxKey { tx_id: tid, system_time: st })),
+        _ => Ok((0, TxKey { tx_id: 0, system_time: crate::clock::st_from_unix_epoch(0) })),
     }
 }
 
@@ -174,9 +160,7 @@ pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxK
     let mut value_bytes = Vec::new();
     codec::encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_bytes);
     let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
-    let mut iter = snapshot
-        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
+    let mut iter = snapshot.scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS).await?;
     match iter.next().await? {
         Some(kv) => {
             let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(kv.key)?;
@@ -201,11 +185,7 @@ fn build_tx_entity_datoms(
     error: Option<String>,
 ) -> Vec<Datom> {
     let st = tx_key.system_time;
-    let result_eid = if committed {
-        DB_TX_COMMITTED
-    } else {
-        DB_TX_ABORTED
-    };
+    let result_eid = if committed { DB_TX_COMMITTED } else { DB_TX_ABORTED };
     let mut datoms = vec![
         Datom {
             entity: tx_eid,
@@ -240,12 +220,7 @@ fn build_tx_entity_datoms(
 impl Indexer {
     pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: Option<TxKey>) -> Self {
         let (tx_completion_sender, _) = broadcast::channel(1024);
-        Indexer {
-            slatedb,
-            metadata,
-            latest_indexed_tx,
-            tx_completion_sender,
-        }
+        Indexer { slatedb, metadata, latest_indexed_tx, tx_completion_sender }
     }
 
     pub fn metadata(&self) -> &Metadata {
@@ -262,10 +237,7 @@ impl Indexer {
             Ok(tx_key) => Ok(tx_key),
             Err(e) => {
                 if let Err(abort_err) = self.write_aborted_tx(tx_key, e.to_string()).await {
-                    error!(
-                        "Failed to write aborted tx entity for {}: {}",
-                        tx_key.tx_id, abort_err
-                    );
+                    error!("Failed to write aborted tx entity for {}: {}", tx_key.tx_id, abort_err);
                 }
                 Err(e)
             }
@@ -290,9 +262,7 @@ impl Indexer {
 
         // 4. Finalize datoms (card-one rewrite) against current storage state
         let txn = self.slatedb.begin(IsolationLevel::Snapshot).await?;
-        let datoms = self
-            .finalize_datoms_for_commit(&txn, datoms)
-            .await?;
+        let datoms = self.finalize_datoms_for_commit(&txn, datoms).await?;
 
         // 5. General validation
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
@@ -315,11 +285,7 @@ impl Indexer {
         self.latest_indexed_tx = Some(tx_key);
 
         if let Err(e) = self.tx_completion_sender.send((tx_key, Ok(()))) {
-            trace!(
-                "No receivers for indexed transaction {}: {}",
-                tx_key.tx_id,
-                e
-            );
+            trace!("No receivers for indexed transaction {}: {}", tx_key.tx_id, e);
         }
 
         Ok(tx_key)
@@ -359,9 +325,7 @@ impl Indexer {
             // Scan EAV prefix to find the current value for this (entity, attribute).
             // The indexer processes transactions serially, so all existing entries
             // have tx_eid < current. First entry is the most recent.
-            let mut iter = txn
-                .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
-                .await?;
+            let mut iter = txn.scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS).await?;
             let old_value: Option<DataType> = match iter.next().await? {
                 Some(kv) => {
                     let key = &kv.key;
@@ -414,10 +378,7 @@ impl Indexer {
     /// waiter.await_tx(tx_key).await?;
     /// ```
     pub(crate) fn tx_waiter(&self) -> TxWaiter {
-        TxWaiter {
-            latest_tx: self.latest_indexed_tx,
-            rx: self.tx_completion_sender.subscribe(),
-        }
+        TxWaiter { latest_tx: self.latest_indexed_tx, rx: self.tx_completion_sender.subscribe() }
     }
 
     /// Write an aborted transaction entity (no user data) when transact_tx fails.
@@ -488,13 +449,8 @@ impl Subscriber for Indexer {
             Ok(ops) => ops,
             Err(e) => {
                 let err = anyhow::anyhow!("Failed to deserialize TxOps: {}", e);
-                warn!(
-                    "Transaction {} deserialization failed: {}",
-                    record.tx_key.tx_id, err
-                );
-                let _ = self
-                    .tx_completion_sender
-                    .send((record.tx_key, Err(Arc::new(err))));
+                warn!("Transaction {} deserialization failed: {}", record.tx_key.tx_id, err);
+                let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(err))));
                 return;
             }
         };
@@ -502,9 +458,7 @@ impl Subscriber for Indexer {
         // the subscriber should propagate the error notification via tx_completion_sender.
         if let Err(e) = self.transact_tx(record.tx_key, tx_ops).await {
             warn!("Transaction {} failed: {}", record.tx_key.tx_id, e);
-            let _ = self
-                .tx_completion_sender
-                .send((record.tx_key, Err(Arc::new(e))));
+            let _ = self.tx_completion_sender.send((record.tx_key, Err(Arc::new(e))));
         }
     }
 }
@@ -602,14 +556,8 @@ mod tests {
     async fn bootstrapped_indexer(slate: Arc<Db>) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate.clone()).await;
         let mut indexer = Indexer::new(slate, metadata, None);
-        let tx_key_0 = TxKey {
-            tx_id: 0,
-            system_time: st_from_unix_epoch(1),
-        };
-        indexer
-            .transact_tx(tx_key_0, test_schema_tx())
-            .await
-            .unwrap();
+        let tx_key_0 = TxKey { tx_id: 0, system_time: st_from_unix_epoch(1) };
+        indexer.transact_tx(tx_key_0, test_schema_tx()).await.unwrap();
         indexer
     }
 
@@ -617,31 +565,18 @@ mod tests {
     async fn test_indexer() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
-        let tx_ops = vec![TxOp::Add {
-            entity: "alan".into(),
-            attribute: kw!(:name),
-            value: "alan".into(),
-        }];
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
+        let tx_ops =
+            vec![TxOp::Add { entity: "alan".into(), attribute: kw!(:name), value: "alan".into() }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // The entity was auto-assigned an ID in USER_PARTITION
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
 
         // Find the EAV entry for the user entity (skip bootstrap/schema entries)
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
             let (entity_id, attribute, value, _timestamp, suffix) =
@@ -665,24 +600,16 @@ mod tests {
     async fn test_indexer_write_persisted() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let tx_ops = vec![TxOp::Add {
-            entity: "alan".into(),
-            attribute: kw!(:name),
-            value: "alan".into(),
-        }];
+        let tx_ops =
+            vec![TxOp::Add { entity: "alan".into(), attribute: kw!(:name), value: "alan".into() }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Verify an EAV entry in USER_PARTITION exists
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut found = false;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
@@ -702,24 +629,16 @@ mod tests {
     async fn test_indexer_multi_attribute_document() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
 
-        let tx_ops = vec![TxOp::put(vec![
-            (kw!(:name), "alan".into()),
-            (kw!(:age), 30_i64.into()),
-        ])];
+        let tx_ops = vec![TxOp::put(vec![(kw!(:name), "alan".into()), (kw!(:age), 30_i64.into())])];
 
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
         // Count EAV entries in USER_PARTITION (should be 2: name + age)
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await.unwrap();
         let mut eav_count = 0;
         while let Some(kv) = iter.next().await? {
             let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
@@ -738,10 +657,7 @@ mod tests {
     async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 42,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
 
         let tx_ops = vec![TxOp::Add {
             entity: "alice".into(),
@@ -775,10 +691,7 @@ mod tests {
 
         for i in 0..3 {
             let tx_id = i + 1;
-            let tx_key = TxKey {
-                tx_id,
-                system_time: st_from_unix_epoch(tx_id as u64 * 100),
-            };
+            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
             let tx_ops = vec![TxOp::Add {
                 entity: format!("user{}", i).into(),
                 attribute: kw!(:name),
@@ -798,10 +711,7 @@ mod tests {
     async fn test_tx_eid_for_tx_key_found() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let tx_key = TxKey {
-            tx_id: 42,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 42, system_time: st_from_unix_epoch(1000) };
 
         let tx_ops = vec![TxOp::Add {
             entity: "alice".into(),
@@ -824,10 +734,7 @@ mod tests {
     async fn test_tx_eid_for_tx_key_not_found() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let snapshot = Arc::new(slate.snapshot().await?);
-        let tx_key = TxKey {
-            tx_id: 999,
-            system_time: st_from_unix_epoch(1000),
-        };
+        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(1000) };
 
         let result = tx_eid_for_tx_key(&snapshot, &tx_key).await;
         assert!(result.is_err(), "Should fail for non-existent tx_id");
@@ -840,10 +747,7 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
-        let tx_key = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(2),
-        };
+        let tx_key = TxKey { tx_id: 1, system_time: st_from_unix_epoch(2) };
         let tx_ops = vec![TxOp::Add {
             entity: "alice".into(),
             attribute: kw!(:name),
@@ -862,10 +766,7 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key_1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(200) };
 
         // Subscribe BEFORE transacting to avoid race
         let waiter = indexer.read().await.tx_waiter();
@@ -895,10 +796,7 @@ mod tests {
             None,
         );
 
-        let tx_key = TxKey {
-            tx_id: 999,
-            system_time: st_from_unix_epoch(999),
-        };
+        let tx_key = TxKey { tx_id: 999, system_time: st_from_unix_epoch(999) };
 
         let result = tokio::time::timeout(
             std::time::Duration::from_millis(100),
@@ -906,10 +804,7 @@ mod tests {
         )
         .await;
 
-        assert!(
-            result.is_err(),
-            "Should timeout waiting for non-existent tx"
-        );
+        assert!(result.is_err(), "Should timeout waiting for non-existent tx");
         Ok(())
     }
 
@@ -920,10 +815,7 @@ mod tests {
 
         for i in 0..2 {
             let tx_id = i + 1;
-            let tx_key = TxKey {
-                tx_id,
-                system_time: st_from_unix_epoch(tx_id as u64 * 100),
-            };
+            let tx_key = TxKey { tx_id, system_time: st_from_unix_epoch(tx_id as u64 * 100) };
             let tx_ops = vec![TxOp::Add {
                 entity: format!("user{}", i).into(),
                 attribute: kw!(:name),
@@ -932,15 +824,9 @@ mod tests {
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let tx_key_1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx_key_1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         indexer.tx_waiter().await_tx(tx_key_1).await?;
-        let tx_key_2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx_key_2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         indexer.tx_waiter().await_tx(tx_key_2).await?;
 
         Ok(())
@@ -953,10 +839,7 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(slate.clone()).await));
 
-        let tx_key = TxKey {
-            tx_id: 5,
-            system_time: st_from_unix_epoch(500),
-        };
+        let tx_key = TxKey { tx_id: 5, system_time: st_from_unix_epoch(500) };
 
         // Subscribe multiple waiters BEFORE transacting
         let waiters: Vec<_> = {
@@ -989,18 +872,10 @@ mod tests {
     async fn test_retract_on_overwrite() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops = vec![TxOp::Add {
             entity: "alice".into(),
             attribute: kw!(:name),
@@ -1011,9 +886,8 @@ mod tests {
         // Find the auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
@@ -1026,10 +900,7 @@ mod tests {
         assert!(entity_id >= user_base, "Should have found user entity");
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         indexer
             .transact_tx(
                 tx2,
@@ -1042,9 +913,8 @@ mod tests {
             .await?;
 
         // Scan EAV for entity — expect: alice ADD, alice RETRACT, bob ADD
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut alice_add = false;
         let mut alice_retract = false;
         let mut bob_add = false;
@@ -1078,18 +948,10 @@ mod tests {
     async fn test_same_value_no_retract() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
+        let name_id = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap().0;
 
         // First tx: assert name="alice" for a new entity
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops = vec![TxOp::Add {
             entity: "alice".into(),
             attribute: kw!(:name),
@@ -1100,9 +962,8 @@ mod tests {
         // Find auto-assigned entity ID
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
@@ -1114,10 +975,7 @@ mod tests {
         }
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         indexer
             .transact_tx(
                 tx2,
@@ -1130,9 +988,8 @@ mod tests {
             .await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -1156,17 +1013,10 @@ mod tests {
     async fn test_schema_immutability_rejected_in_pipeline() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
-        let (name_id, attr) = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap();
+        let (name_id, attr) = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap();
         assert_eq!(attr.value_type, crate::schema::ValueType::String);
 
-        let tx = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let err = indexer
             .transact_tx(
                 tx,
@@ -1181,11 +1031,7 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("Cannot modify schema entity"));
-        let (_name_id, attr) = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap();
+        let (_name_id, attr) = indexer.metadata().schema.get_attribute(&kw!(:name)).unwrap();
         assert_eq!(attr.value_type, crate::schema::ValueType::String);
 
         Ok(())
@@ -1194,9 +1040,8 @@ mod tests {
     /// Find the first user-partition entity ID by scanning the EAV index.
     async fn find_first_user_entity(slate: &Arc<slatedb::Db>) -> Result<i64, Error> {
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         while let Some(kv) = iter.next().await? {
             let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
             if let DataType::Long(id) = eid {
@@ -1214,10 +1059,7 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
             entity: "tagged".into(),
             attribute: kw!(:tags),
@@ -1227,18 +1069,10 @@ mod tests {
 
         // Discover auto-assigned entity ID
         let entity_id = find_first_user_entity(&slate).await?;
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
             entity: EntityRef::Id(entity_id),
             attribute: kw!(:tags),
@@ -1247,9 +1081,8 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs, 0 RETRACTs
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         let mut retract_count = 0;
         while let Some(kv) = iter.next().await? {
@@ -1264,10 +1097,7 @@ mod tests {
             }
         }
         assert_eq!(add_count, 2, "Expected 2 ADD entries for cardinality-many");
-        assert_eq!(
-            retract_count, 0,
-            "Expected no RETRACT entries for cardinality-many"
-        );
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries for cardinality-many");
 
         Ok(())
     }
@@ -1281,10 +1111,7 @@ mod tests {
         let mut indexer = bootstrapped_indexer(slate.clone()).await;
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
+        let tx1 = TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) };
         let tx_ops1 = vec![TxOp::Add {
             entity: "tagged".into(),
             attribute: kw!(:tags),
@@ -1294,18 +1121,10 @@ mod tests {
 
         // Discover auto-assigned entity ID
         let entity_id = find_first_user_entity(&slate).await?;
-        let tags_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:tags))
-            .unwrap()
-            .0;
+        let tags_id = indexer.metadata().schema.get_attribute(&kw!(:tags)).unwrap().0;
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
+        let tx2 = TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) };
         let tx_ops2 = vec![TxOp::Add {
             entity: EntityRef::Id(entity_id),
             attribute: kw!(:tags),
@@ -1314,9 +1133,8 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs (both written)
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
+        let mut iter =
+            slate.scan_prefix_with_options(&[codec::EAV], &ScanOptions::default()).await?;
         let mut add_count = 0;
         while let Some(kv) = iter.next().await? {
             let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
@@ -1327,10 +1145,7 @@ mod tests {
                 add_count += 1;
             }
         }
-        assert_eq!(
-            add_count, 2,
-            "Expected 2 ADD entries for same value on cardinality-many"
-        );
+        assert_eq!(add_count, 2, "Expected 2 ADD entries for same value on cardinality-many");
 
         Ok(())
     }

--- a/src/iterator/generic_and_prefix_extender.rs
+++ b/src/iterator/generic_and_prefix_extender.rs
@@ -12,10 +12,7 @@ pub struct GenericAndPrefixExtender {
 
 impl GenericAndPrefixExtender {
     pub fn new(children: Vec<Box<dyn PrefixExtender>>) -> Self {
-        assert!(
-            !children.is_empty(),
-            "AND extender requires at least one child"
-        );
+        assert!(!children.is_empty(), "AND extender requires at least one child");
         Self { children }
     }
 }
@@ -33,22 +30,16 @@ impl PrefixExtender for GenericAndPrefixExtender {
 
     fn propose(&self, prefix: &Prefix) -> Vec<Extension> {
         let next_level = prefix.len();
-        let participating: Vec<_> = self
-            .children
-            .iter()
-            .filter(|c| c.participates_in_level(next_level))
-            .collect();
+        let participating: Vec<_> =
+            self.children.iter().filter(|c| c.participates_in_level(next_level)).collect();
 
         if participating.is_empty() {
             return vec![];
         }
 
         // Propose from the child with the smallest count
-        let (min_idx, _) = participating
-            .iter()
-            .enumerate()
-            .min_by_key(|(_, c)| c.count(prefix))
-            .unwrap();
+        let (min_idx, _) =
+            participating.iter().enumerate().min_by_key(|(_, c)| c.count(prefix)).unwrap();
 
         let mut extensions = participating[min_idx].propose(prefix);
 
@@ -67,11 +58,8 @@ impl PrefixExtender for GenericAndPrefixExtender {
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
         let next_level = prefix.len();
-        let mut participating: Vec<_> = self
-            .children
-            .iter()
-            .filter(|c| c.participates_in_level(next_level))
-            .collect();
+        let mut participating: Vec<_> =
+            self.children.iter().filter(|c| c.participates_in_level(next_level)).collect();
 
         // Sort by count so we intersect with the smallest first (fail fast)
         participating.sort_by_key(|c| c.count(prefix));

--- a/src/iterator/generic_fn_prefix_extender.rs
+++ b/src/iterator/generic_fn_prefix_extender.rs
@@ -28,11 +28,7 @@ pub struct GenericFnPrefixExtender {
 
 impl GenericFnPrefixExtender {
     pub fn new(expr: Expr, prefix_vars: Vec<(Variable, usize)>, output_level: usize) -> Self {
-        Self {
-            expr,
-            prefix_vars,
-            output_level,
-        }
+        Self { expr, prefix_vars, output_level }
     }
 
     /// Evaluate the expression against the given prefix, returning the serialized result.
@@ -46,10 +42,8 @@ impl GenericFnPrefixExtender {
             })
             .collect();
 
-        let bindings: HashMap<Variable, &DataType> = prefix_values
-            .iter()
-            .map(|(var, dt)| (var.clone(), dt))
-            .collect();
+        let bindings: HashMap<Variable, &DataType> =
+            prefix_values.iter().map(|(var, dt)| (var.clone(), dt)).collect();
 
         let ctx = EvalContext::new(bindings);
         let result = evaluate(&self.expr, &ctx)?;
@@ -71,11 +65,7 @@ impl PrefixExtender for GenericFnPrefixExtender {
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
         match self.compute(prefix) {
-            Some(result) => extensions
-                .iter()
-                .filter(|ext| **ext == result)
-                .cloned()
-                .collect(),
+            Some(result) => extensions.iter().filter(|ext| **ext == result).cloned().collect(),
             None => vec![],
         }
     }
@@ -169,10 +159,7 @@ mod tests {
             2, // output at level 2
         );
 
-        let prefix = vec![
-            serialize(&DataType::Long(10)),
-            serialize(&DataType::Long(20)),
-        ];
+        let prefix = vec![serialize(&DataType::Long(10)), serialize(&DataType::Long(20))];
         let result = ext.propose(&prefix);
         assert_eq!(result.len(), 1);
         assert_eq!(DataType::decode(&result[0]).unwrap(), DataType::Long(30));
@@ -226,10 +213,7 @@ mod tests {
         let ext = GenericFnPrefixExtender::new(expr, vec![("?x".to_var(), 0)], 1);
 
         let prefix = vec![serialize(&DataType::Long(25))];
-        let extensions = vec![
-            serialize(&DataType::Long(30)),
-            serialize(&DataType::Long(40)),
-        ];
+        let extensions = vec![serialize(&DataType::Long(30)), serialize(&DataType::Long(40))];
 
         let result = ext.intersect(&prefix, &extensions);
         assert!(result.is_empty());

--- a/src/iterator/generic_not_prefix_extender.rs
+++ b/src/iterator/generic_not_prefix_extender.rs
@@ -40,17 +40,10 @@ impl PrefixExtender for GenericNotPrefixExtender {
         all_extenders.push(&pinning_extender);
 
         let inner_join = GenericJoin::new(all_extenders, prefix.len() + 1);
-        let extensions_to_remove: HashSet<Extension> = inner_join
-            .join()
-            .into_iter()
-            .filter_map(|tuple| tuple.last().cloned())
-            .collect();
+        let extensions_to_remove: HashSet<Extension> =
+            inner_join.join().into_iter().filter_map(|tuple| tuple.last().cloned()).collect();
 
-        extensions
-            .iter()
-            .filter(|ext| !extensions_to_remove.contains(*ext))
-            .cloned()
-            .collect()
+        extensions.iter().filter(|ext| !extensions_to_remove.contains(*ext)).cloned().collect()
     }
 
     fn participates_in_level(&self, level: usize) -> bool {
@@ -93,10 +86,8 @@ mod tests {
     #[test]
     fn test_intersect_removes_matching_extensions() {
         // NOT child: values divisible by 3 at level 1
-        let div3_extender: Box<dyn PrefixExtender> = Box::new(SingleLevelExtender::new(
-            vec![bi(3), bi(6), bi(9), bi(12)],
-            1,
-        ));
+        let div3_extender: Box<dyn PrefixExtender> =
+            Box::new(SingleLevelExtender::new(vec![bi(3), bi(6), bi(9), bi(12)], 1));
 
         let not_ext = GenericNotPrefixExtender::new(vec![div3_extender], 1);
 
@@ -121,14 +112,10 @@ mod tests {
     fn test_intersect_with_two_children_conjunction() {
         // NOT with two children: even numbers at level 0, divisible by 3 at level 1
         // NOT removes extensions where BOTH conditions are met (conjunction inside NOT)
-        let even_extender: Box<dyn PrefixExtender> = Box::new(SingleLevelExtender::new(
-            vec![bi(2), bi(4), bi(6), bi(8), bi(10)],
-            0,
-        ));
-        let div3_extender: Box<dyn PrefixExtender> = Box::new(SingleLevelExtender::new(
-            vec![bi(3), bi(6), bi(9), bi(12)],
-            1,
-        ));
+        let even_extender: Box<dyn PrefixExtender> =
+            Box::new(SingleLevelExtender::new(vec![bi(2), bi(4), bi(6), bi(8), bi(10)], 0));
+        let div3_extender: Box<dyn PrefixExtender> =
+            Box::new(SingleLevelExtender::new(vec![bi(3), bi(6), bi(9), bi(12)], 1));
 
         let not_ext = GenericNotPrefixExtender::new(vec![even_extender, div3_extender], 1);
 

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -13,10 +13,7 @@ pub struct GenericOrPrefixExtender {
 
 impl GenericOrPrefixExtender {
     pub fn new(children: Vec<Box<dyn PrefixExtender>>) -> Self {
-        assert!(
-            !children.is_empty(),
-            "OR extender requires at least one child"
-        );
+        assert!(!children.is_empty(), "OR extender requires at least one child");
         Self { children }
     }
 }
@@ -27,22 +24,16 @@ impl PrefixExtender for GenericOrPrefixExtender {
     }
 
     fn propose(&self, prefix: &Prefix) -> Vec<Extension> {
-        let mut all: Vec<Extension> = self
-            .children
-            .iter()
-            .flat_map(|c| c.propose(prefix))
-            .collect();
+        let mut all: Vec<Extension> =
+            self.children.iter().flat_map(|c| c.propose(prefix)).collect();
         all.sort();
         all.dedup();
         all
     }
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
-        let mut all: Vec<Extension> = self
-            .children
-            .iter()
-            .flat_map(|c| c.intersect(prefix, extensions))
-            .collect();
+        let mut all: Vec<Extension> =
+            self.children.iter().flat_map(|c| c.intersect(prefix, extensions)).collect();
         all.sort();
         all.dedup();
         all

--- a/src/iterator/generic_predicate_prefix_extender.rs
+++ b/src/iterator/generic_predicate_prefix_extender.rs
@@ -31,12 +31,7 @@ impl GenericPredicatePrefixExtender {
         extension_var: Variable,
         level: usize,
     ) -> Self {
-        Self {
-            expr,
-            prefix_vars,
-            extension_var,
-            level,
-        }
+        Self { expr, prefix_vars, extension_var, level }
     }
 }
 
@@ -65,10 +60,8 @@ impl PrefixExtender for GenericPredicatePrefixExtender {
             .filter(|ext| {
                 let ext_val = DataType::decode(ext).expect("failed to decode extension value");
 
-                let mut bindings: HashMap<Variable, &DataType> = prefix_values
-                    .iter()
-                    .map(|(var, dt)| (var.clone(), dt))
-                    .collect();
+                let mut bindings: HashMap<Variable, &DataType> =
+                    prefix_values.iter().map(|(var, dt)| (var.clone(), dt)).collect();
                 bindings.insert(self.extension_var.clone(), &ext_val);
 
                 let ctx = EvalContext::new(bindings);

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -56,10 +56,7 @@ impl GenericPrefixExtender {
 
     /// Get the pattern-internal level (how many of this pattern's variables we've already bound)
     fn pattern_level(&self, join_prefix: &Prefix) -> usize {
-        self.participating_levels
-            .iter()
-            .filter(|&&level| level < join_prefix.len())
-            .count()
+        self.participating_levels.iter().filter(|&&level| level < join_prefix.len()).count()
     }
 
     /// Build SlateDB key prefix from join prefix
@@ -159,8 +156,7 @@ impl PrefixExtender for GenericPrefixExtender {
         let mut extensions = Vec::new();
         while let Ok(Some(extension)) = iter.get_value() {
             extensions.push(extension);
-            iter.next()
-                .unwrap_or_else(|e| panic!("Failed to advance iterator: {}", e));
+            iter.next().unwrap_or_else(|e| panic!("Failed to advance iterator: {}", e));
         }
 
         extensions
@@ -177,8 +173,7 @@ impl PrefixExtender for GenericPrefixExtender {
 
         let mut result = Vec::new();
         for ext in extensions {
-            iter.seek(ext.clone())
-                .unwrap_or_else(|e| panic!("Failed to seek iterator: {}", e));
+            iter.seek(ext.clone()).unwrap_or_else(|e| panic!("Failed to seek iterator: {}", e));
             if !iter.has_next() {
                 break;
             }
@@ -369,11 +364,8 @@ mod tests {
             2000_i64,
         );
 
-        let candidates = vec![
-            encode_string("Alice"),
-            encode_string("Bob"),
-            encode_string("Charlie"),
-        ];
+        let candidates =
+            vec![encode_string("Alice"), encode_string("Bob"), encode_string("Charlie")];
 
         let filtered = extender.intersect(&vec![], &candidates);
         assert_eq!(filtered.len(), 2);
@@ -442,10 +434,7 @@ mod tests {
 
         // Note: estimate_key_count may return non-zero even for empty ranges
         assert_eq!(extender.propose(&vec![]), Vec::<Bytes>::new());
-        assert_eq!(
-            extender.intersect(&vec![], &[encode_string("Alice")]),
-            Vec::<Bytes>::new()
-        );
+        assert_eq!(extender.intersect(&vec![], &[encode_string("Alice")]), Vec::<Bytes>::new());
 
         Ok(())
     }

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -38,13 +38,7 @@ impl SlateIterator {
         if let Some(next_key) = handle.block_on(iterator.next())? {
             current_key = Some(next_key.key.clone());
         }
-        Ok(Self {
-            inner: iterator,
-            current_key,
-            prefix: prefix_bytes,
-            handle,
-            extractor,
-        })
+        Ok(Self { inner: iterator, current_key, prefix: prefix_bytes, handle, extractor })
     }
 }
 

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -93,7 +93,8 @@ impl TemporalFilterIterator {
                     );
 
                     // Descending encoding: ts >= as_of_encoded means real_T <= as_of
-                    let ts = &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH];
+                    let ts =
+                        &key[key.len() - codec::TX_EID_OP_SUFFIX..key.len() - codec::OP_LENGTH];
                     if ts >= self.as_of_encoded.as_slice() {
                         let op = key[key.len() - 1];
                         if op == codec::RETRACT {
@@ -195,9 +196,7 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let t1 = 1000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
         let handle = tokio::runtime::Handle::current();
@@ -221,12 +220,8 @@ mod tests {
         let t2 = 2000;
 
         // Two versions of "alice" at t1 and t2
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t2, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
         let handle = tokio::runtime::Handle::current();
@@ -248,9 +243,7 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let t1 = 2000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
         let handle = tokio::runtime::Handle::current();
@@ -274,9 +267,7 @@ mod tests {
         let t1 = 1000;
         let t2 = 2000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t2, codec::ADD), b"").await;
 
@@ -312,15 +303,9 @@ mod tests {
         let t2 = 2000;
         let t3 = 3000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t3, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
+        slate.put(&make_key(PFX, b"alice", t3, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
 
@@ -380,13 +365,9 @@ mod tests {
         let slate = in_memory_slate().await.db;
         let t1 = 1000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
-        slate
-            .put(&make_key(PFX, b"charlie", t1, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"charlie", t1, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
         let handle = tokio::runtime::Handle::current();
@@ -424,12 +405,8 @@ mod tests {
         let t1 = 1000;
         let t2 = 2000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
@@ -472,15 +449,9 @@ mod tests {
         let t2 = 2000;
         let t3 = 3000;
 
-        slate
-            .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"")
-            .await;
-        slate
-            .put(&make_key(PFX, b"alice", t3, codec::ADD), b"")
-            .await;
+        slate.put(&make_key(PFX, b"alice", t1, codec::ADD), b"").await;
+        slate.put(&make_key(PFX, b"alice", t2, codec::RETRACT), b"").await;
+        slate.put(&make_key(PFX, b"alice", t3, codec::ADD), b"").await;
 
         let snapshot = slate.snapshot().await.unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,7 @@ use triplox::node::Node;
 use triplox::server::{DevServer, Server};
 
 fn load_config() -> Result<Config> {
-    let path = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "config/triplox.toml".to_string());
+    let path = std::env::args().nth(1).unwrap_or_else(|| "config/triplox.toml".to_string());
     let contents = std::fs::read_to_string(&path)
         .with_context(|| format!("Failed to read config file: {}", path))?;
     let config: Config = toml::from_str(&contents)

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -20,11 +20,7 @@ pub struct MemoryLog {
 
 impl MemoryLog {
     pub fn new(clock: Box<dyn SystemTimeSource>) -> Self {
-        MemoryLog {
-            txs: vec![],
-            tx_sender: broadcast::channel(1024).0,
-            clock,
-        }
+        MemoryLog { txs: vec![], tx_sender: broadcast::channel(1024).0, clock }
     }
 }
 
@@ -49,20 +45,14 @@ impl TxLogReader for MemoryLog {
 impl TxLogWriter for MemoryLog {
     async fn append_tx(&mut self, record: Vec<u8>) -> TxKey {
         let record = Record {
-            tx_key: TxKey {
-                tx_id: self.txs.len() as i64,
-                system_time: self.clock.now(),
-            },
+            tx_key: TxKey { tx_id: self.txs.len() as i64, system_time: self.clock.now() },
             record,
         };
         let tx_key = record.tx_key;
         self.txs.push(record.clone());
         // TODO: verify if warning on no receivers is idiomatic Rust broadcast channel pattern
         if let Err(e) = self.tx_sender.send(record) {
-            warn!(
-                "Failed to send record from memory log to subscribers: {}",
-                e
-            );
+            warn!("Failed to send record from memory log to subscribers: {}", e);
         }
         tx_key
     }
@@ -111,30 +101,21 @@ mod tests {
         assert_eq!(
             subscriber.records[0],
             Record {
-                tx_key: TxKey {
-                    tx_id: 0,
-                    system_time: st_from_unix_epoch(0)
-                },
+                tx_key: TxKey { tx_id: 0, system_time: st_from_unix_epoch(0) },
                 record: vec![1, 2, 3]
             }
         );
         assert_eq!(
             subscriber.records[1],
             Record {
-                tx_key: TxKey {
-                    tx_id: 1,
-                    system_time: st_from_unix_epoch(100)
-                },
+                tx_key: TxKey { tx_id: 1, system_time: st_from_unix_epoch(100) },
                 record: vec![4, 5, 6]
             }
         );
         assert_eq!(
             subscriber.records[2],
             Record {
-                tx_key: TxKey {
-                    tx_id: 2,
-                    system_time: st_from_unix_epoch(200)
-                },
+                tx_key: TxKey { tx_id: 2, system_time: st_from_unix_epoch(200) },
                 record: vec![7, 8, 9]
             }
         );

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -71,11 +71,7 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn new(schema: Schema, partition_map: PartitionMap) -> Self {
-        Self {
-            generation: 0,
-            partition_map,
-            schema,
-        }
+        Self { generation: 0, partition_map, schema }
     }
 
     pub fn advance_generation(&mut self) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,8 +43,7 @@ impl IntoQuery for &ParsedQuery {
 
 impl IntoQuery for &str {
     fn into_query(self) -> Result<ParsedQuery, Error> {
-        self.parse()
-            .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))
+        self.parse().map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))
     }
 }
 
@@ -89,13 +88,7 @@ impl DB {
         tx_key: TxKey,
         tx_eid: i64,
     ) -> Self {
-        Self {
-            snapshot,
-            ident_map,
-            handle,
-            tx_key,
-            tx_eid,
-        }
+        Self { snapshot, ident_map, handle, tx_key, tx_eid }
     }
 
     /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxKey.
@@ -105,13 +98,7 @@ impl DB {
         handle: Handle,
     ) -> Result<Self, Error> {
         let (tx_eid, tx_key) = crate::indexer::latest_tx_key_from_snapshot(&snapshot).await?;
-        Ok(Self {
-            snapshot,
-            ident_map,
-            handle,
-            tx_key,
-            tx_eid,
-        })
+        Ok(Self { snapshot, ident_map, handle, tx_key, tx_eid })
     }
 
     pub fn tx_key(&self) -> &TxKey {
@@ -166,21 +153,12 @@ impl Node<MemoryLog> {
         let slate = in_memory_slate().await;
         let db = slate.db.clone();
         let metadata = crate::bootstrap::init_db(db.clone()).await;
-        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
-            db.clone(),
-            metadata,
-            None,
-        )));
+        let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(db.clone(), metadata, None)));
         let log = Arc::new(RwLock::new(MemoryLog::new(Box::new(clock::SystemClock))));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
 
-        Node {
-            log,
-            indexer,
-            slate,
-            subscription,
-        }
+        Node { log, indexer, slate, subscription }
     }
 }
 
@@ -199,11 +177,7 @@ impl Node<FileLog> {
         // and restore the indexer's in-memory state for TxWaiter fast-path.
         let snapshot = Arc::new(db.snapshot().await?);
         let (_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
-        let latest_indexed_tx = if latest_indexed.tx_id > 0 {
-            Some(latest_indexed)
-        } else {
-            None
-        };
+        let latest_indexed_tx = if latest_indexed.tx_id > 0 { Some(latest_indexed) } else { None };
 
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             db.clone(),
@@ -237,12 +211,7 @@ impl Node<FileLog> {
             waiter.await_tx(tx_key).await?;
         }
 
-        Ok(Node {
-            log,
-            indexer,
-            slate,
-            subscription,
-        })
+        Ok(Node { log, indexer, slate, subscription })
     }
 }
 
@@ -277,28 +246,14 @@ impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
     async fn db(&self) -> Result<DB, Error> {
         let snapshot = self.slate.db.snapshot().await?;
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
         DB::from_latest_snapshot(snapshot, ident_map, handle).await
     }
     // TODO we are currently not checking that snapshot contains TxKey
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
         let snapshot = self.slate.db.snapshot().await?;
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let ident_map = self.indexer.read().await.metadata().schema.ident_map.clone();
         let handle = Handle::current();
         let tx_eid = crate::indexer::tx_eid_for_tx_key(&snapshot, &tx_key).await?;
         Ok(DB::new(snapshot, ident_map, handle, tx_key, tx_eid))
@@ -325,11 +280,8 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        let tx_ops = vec![TxOp::Add {
-            entity: "bob".into(),
-            attribute: kw!(:name),
-            value: "bob".into(),
-        }];
+        let tx_ops =
+            vec![TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() }];
 
         let waiter = node.indexer.read().await.tx_waiter();
 
@@ -338,17 +290,11 @@ mod tests {
         assert_eq!(tx_key.tx_id, 1);
 
         // Wait for indexer to process the transaction
-        waiter
-            .await_tx(tx_key)
-            .await
-            .expect("Transaction should be indexed");
+        waiter.await_tx(tx_key).await.expect("Transaction should be indexed");
 
         // Verify data is queryable after async indexing
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(result, vec![vec![DataType::String("bob".to_string())]]);
     }
 
@@ -367,15 +313,9 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query(r#"[:find ?email :where [?e :email ?email]]"#)
-            .await
-            .unwrap();
+        let result = db.query(r#"[:find ?email :where [?e :email ?email]]"#).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("test@example.com".to_string())]
-        );
+        assert_eq!(result[0], vec![DataType::String("test@example.com".to_string())]);
     }
 
     // End-to-end query tests
@@ -401,10 +341,7 @@ mod tests {
         .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("alice".to_string())]));
@@ -432,10 +369,7 @@ mod tests {
         .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query(r#"[:find ?e :where [?e :name "alice"]]"#)
-            .await
-            .unwrap();
+        let result = db.query(r#"[:find ?e :where [?e :name "alice"]]"#).await.unwrap();
 
         assert_eq!(result.len(), 1);
     }
@@ -460,16 +394,11 @@ mod tests {
         .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
-            .await
-            .unwrap();
+        let result =
+            db.query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("alice".to_string()), DataType::Long(30)]
-        );
+        assert_eq!(result[0], vec![DataType::String("alice".to_string()), DataType::Long(30)]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -478,25 +407,14 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![
-            TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            },
-            TxOp::Add {
-                entity: "bob".into(),
-                attribute: kw!(:name),
-                value: "bob".into(),
-            },
+            TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "alice".into() },
+            TxOp::Add { entity: "bob".into(), attribute: kw!(:name), value: "bob".into() },
         ])
         .await
         .unwrap();
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?a ?b :where [?a :name ?x] [?b :name ?x]]")
-            .await
-            .unwrap();
+        let result = db.query("[:find ?a ?b :where [?a :name ?x] [?b :name ?x]]").await.unwrap();
 
         // Only same-entity pairs should match: (alice, alice) and (bob, bob).
         assert_eq!(result.len(), 2, "expected 2 self-pairs, got {:?}", result);
@@ -533,10 +451,7 @@ mod tests {
         .unwrap();
 
         // Bind ?name to "Petr": only Petr's row should match.
-        let result = db
-            .query_with_args(&parsed, &[QueryArg::Scalar("Petr".into())])
-            .await
-            .unwrap();
+        let result = db.query_with_args(&parsed, &[QueryArg::Scalar("Petr".into())]).await.unwrap();
         assert_eq!(
             result,
             vec![vec![
@@ -546,10 +461,7 @@ mod tests {
         );
 
         // Bind ?name to "Ivan": only Ivan's row.
-        let result = db
-            .query_with_args(&parsed, &[QueryArg::Scalar("Ivan".into())])
-            .await
-            .unwrap();
+        let result = db.query_with_args(&parsed, &[QueryArg::Scalar("Ivan".into())]).await.unwrap();
         assert_eq!(
             result,
             vec![vec![
@@ -559,10 +471,7 @@ mod tests {
         );
 
         // A name with no match yields no rows.
-        let result = db
-            .query_with_args(&parsed, &[QueryArg::Scalar("Bob".into())])
-            .await
-            .unwrap();
+        let result = db.query_with_args(&parsed, &[QueryArg::Scalar("Bob".into())]).await.unwrap();
         assert!(result.is_empty());
 
         // Multiple scalar bindings: constrain on both name and email.
@@ -573,10 +482,7 @@ mod tests {
         let result = db
             .query_with_args(
                 &parsed,
-                &[
-                    QueryArg::Scalar("Petr".into()),
-                    QueryArg::Scalar("petr@example.com".into()),
-                ],
+                &[QueryArg::Scalar("Petr".into()), QueryArg::Scalar("petr@example.com".into())],
             )
             .await
             .unwrap();
@@ -586,10 +492,7 @@ mod tests {
         let result = db
             .query_with_args(
                 &parsed,
-                &[
-                    QueryArg::Scalar("Petr".into()),
-                    QueryArg::Scalar("ivan@example.com".into()),
-                ],
+                &[QueryArg::Scalar("Petr".into()), QueryArg::Scalar("ivan@example.com".into())],
             )
             .await
             .unwrap();
@@ -626,10 +529,8 @@ mod tests {
         .unwrap();
 
         // Variable limit resolved to 2.
-        let result = db
-            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(2))])
-            .await
-            .unwrap();
+        let result =
+            db.query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(2))]).await.unwrap();
         assert_eq!(
             result,
             vec![
@@ -639,33 +540,18 @@ mod tests {
         );
 
         // Zero limit yields an empty result.
-        let result = db
-            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(0))])
-            .await
-            .unwrap();
+        let result =
+            db.query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(0))]).await.unwrap();
         assert!(result.is_empty());
 
         // Non-Long binding for a variable limit is rejected.
-        let err = db
-            .query_with_args(&parsed, &[QueryArg::Scalar("two".into())])
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("must be bound to a Long"),
-            "unexpected error: {}",
-            err
-        );
+        let err = db.query_with_args(&parsed, &[QueryArg::Scalar("two".into())]).await.unwrap_err();
+        assert!(err.to_string().contains("must be bound to a Long"), "unexpected error: {}", err);
 
         // Negative limit is rejected.
-        let err = db
-            .query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(-1))])
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("non-negative"),
-            "unexpected error: {}",
-            err
-        );
+        let err =
+            db.query_with_args(&parsed, &[QueryArg::Scalar(DataType::Long(-1))]).await.unwrap_err();
+        assert!(err.to_string().contains("non-negative"), "unexpected error: {}", err);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -768,14 +654,8 @@ mod tests {
         let result = db.query(r#"[:find ?name ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :name ?name] [?e :age ?age]]"#).await.unwrap();
 
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&vec![
-            DataType::String("alice".to_string()),
-            DataType::Long(30)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("bob".to_string()),
-            DataType::Long(25)
-        ]));
+        assert!(result.contains(&vec![DataType::String("alice".to_string()), DataType::Long(30)]));
+        assert!(result.contains(&vec![DataType::String("bob".to_string()), DataType::Long(25)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -846,19 +726,13 @@ mod tests {
 
         // db_as_of(tx_key1): should only see alice
         let db1 = node.db_as_of(tx_key1).await.unwrap();
-        let result1 = db1
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result1 = db1.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(result1.len(), 1);
         assert_eq!(result1[0], vec![DataType::String("alice".to_string())]);
 
         // db_as_of(tx_key2): should see both
         let db2 = node.db_as_of(tx_key2).await.unwrap();
-        let result2 = db2
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result2 = db2.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(result2.len(), 2);
         assert!(result2.contains(&vec![DataType::String("alice".to_string())]));
         assert!(result2.contains(&vec![DataType::String("bob".to_string())]));
@@ -884,10 +758,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
-        let results = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let results = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
@@ -897,10 +768,7 @@ mod tests {
         let node = Node::local_node(&root_path).await.unwrap();
 
         let db = node.db().await.unwrap();
-        let results = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let results = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
@@ -915,10 +783,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let db = node.db().await.unwrap();
-        let results = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let results = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.contains(&vec![DataType::String("alice".to_string())]));
         assert!(results.contains(&vec![DataType::String("bob".to_string())]));
@@ -963,10 +828,7 @@ mod tests {
         let result =
             tokio::time::timeout(std::time::Duration::from_secs(2), waiter.await_tx(tx_key)).await;
 
-        assert!(
-            result.is_ok(),
-            "tx_waiter should not timeout for an already-indexed tx"
-        );
+        assert!(result.is_ok(), "tx_waiter should not timeout for an already-indexed tx");
         result.unwrap().expect("await_tx should succeed");
 
         node.close().await;
@@ -1002,24 +864,14 @@ mod tests {
 
         // db_as_of pinned to first tx should only see alice
         let db = node.db_as_of(tx_key1).await.unwrap();
-        let results = db
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
-        assert_eq!(
-            results.len(),
-            1,
-            "basis-pinned DB should only see alice, got {:?}",
-            results
-        );
+        let results = db.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
+        assert_eq!(results.len(), 1, "basis-pinned DB should only see alice, got {:?}", results);
         assert_eq!(results[0], vec![DataType::String("alice".to_string())]);
 
         // latest db should see both
         let db_latest = node.db().await.unwrap();
-        let results_latest = db_latest
-            .query("[:find ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let results_latest =
+            db_latest.query("[:find ?name :where [?e :name ?name]]").await.unwrap();
         assert_eq!(results_latest.len(), 2);
 
         node.close().await;
@@ -1040,10 +892,7 @@ mod tests {
 
         // Discover the auto-assigned entity ID
         let db = node.db().await.unwrap();
-        let result = db
-            .query(r#"[:find ?e :where [?e :name "alice"]]"#)
-            .await
-            .unwrap();
+        let result = db.query(r#"[:find ?e :where [?e :name "alice"]]"#).await.unwrap();
         assert_eq!(result.len(), 1);
         let entity_id = match &result[0][0] {
             DataType::Long(id) => *id,
@@ -1061,15 +910,10 @@ mod tests {
 
         // Verify: alice should now have age 31 (cardinality-one retracted 30)
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]")
-            .await
-            .unwrap();
+        let result =
+            db.query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]").await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("alice".to_string()), DataType::Long(31)]
-        );
+        assert_eq!(result[0], vec![DataType::String("alice".to_string()), DataType::Long(31)]);
 
         node.close().await;
     }
@@ -1151,10 +995,8 @@ mod tests {
         insert_three_people(&node).await;
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#)
-            .await
-            .unwrap();
+        let result =
+            db.query(r#"[:find ?e :where [?e :name ?name] [(= "Ivan" ?name)]]"#).await.unwrap();
         assert_eq!(result.len(), 1);
     }
 
@@ -1183,18 +1025,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![
-            DataType::String("Ivan".to_string()),
-            DataType::Long(15)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Bob".to_string()),
-            DataType::Long(20)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Dominic".to_string()),
-            DataType::Long(25)
-        ]));
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(20)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(25)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1206,10 +1039,7 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query("[:find ?name ?half :where [?e :name ?name] [?e :age ?age] [(/ ?age 2) ?half] [(> ?half 20)]]").await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            vec![DataType::String("Dominic".to_string()), DataType::Long(25)]
-        );
+        assert_eq!(result[0], vec![DataType::String("Dominic".to_string()), DataType::Long(25)]);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1221,18 +1051,9 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db.query("[:find ?name ?result :where [?e :name ?name] [?e :age ?age] [(- ?age 15) ?result]]").await.unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&vec![
-            DataType::String("Ivan".to_string()),
-            DataType::Long(15)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Bob".to_string()),
-            DataType::Long(25)
-        ]));
-        assert!(result.contains(&vec![
-            DataType::String("Dominic".to_string()),
-            DataType::Long(35)
-        ]));
+        assert!(result.contains(&vec![DataType::String("Ivan".to_string()), DataType::Long(15)]));
+        assert!(result.contains(&vec![DataType::String("Bob".to_string()), DataType::Long(25)]));
+        assert!(result.contains(&vec![DataType::String("Dominic".to_string()), DataType::Long(35)]));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1242,10 +1063,8 @@ mod tests {
         insert_three_people(&node).await;
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]")
-            .await
-            .unwrap();
+        let result =
+            db.query("[:find ?name :where [?e :name ?name] (not [?e :age 50])]").await.unwrap();
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
         assert!(result.contains(&vec![DataType::String("Bob".to_string())]));
@@ -1259,24 +1078,14 @@ mod tests {
         // Define "sex" attribute with keyword value type
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)).into(),
-            ),
-            (
-                kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
         ])])
         .await
         .unwrap();
 
-        let people = vec![
-            ("Ivan", "male"),
-            ("Ivana", "female"),
-            ("Petr", "male"),
-            ("Doris", "female"),
-        ];
+        let people =
+            vec![("Ivan", "male"), ("Ivana", "female"), ("Petr", "male"), ("Doris", "female")];
         for (name, sex) in people {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
@@ -1289,10 +1098,8 @@ mod tests {
         // find ?name where [?e :sex :male] [?e :name ?name]
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name :where [?e :sex :male] [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result =
+            db.query("[:find ?name :where [?e :sex :male] [?e :name ?name]]").await.unwrap();
 
         // Only Ivan and Petr are male
         assert_eq!(result.len(), 2);
@@ -1309,24 +1116,14 @@ mod tests {
 
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)).into(),
-            ),
-            (
-                kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
         ])])
         .await
         .unwrap();
 
-        let people = vec![
-            ("Ivan", "male"),
-            ("Petr", "male"),
-            ("Doris", "female"),
-            ("Jane", "female"),
-        ];
+        let people =
+            vec![("Ivan", "male"), ("Petr", "male"), ("Doris", "female"), ("Jane", "female")];
         for (name, sex) in people {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
@@ -1339,10 +1136,8 @@ mod tests {
         // Same clause order as Clojure: name first (binds ?e), sex filter second
 
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?name :where [?e :name ?name] [?e :sex :male]]")
-            .await
-            .unwrap();
+        let result =
+            db.query("[:find ?name :where [?e :name ?name] [?e :sex :male]]").await.unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
@@ -1359,14 +1154,8 @@ mod tests {
         // Define "last-name" attribute
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:last-name)).into()),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/string)).into(),
-            ),
-            (
-                kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string)).into()),
+            (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one)).into()),
         ])])
         .await
         .unwrap();
@@ -1389,10 +1178,7 @@ mod tests {
 
         // Discover the entity ID for "Ivannotov"
         let db = node.db().await.unwrap();
-        let ids = db
-            .query(r#"[:find ?e :where [?e :last-name "Ivannotov"]]"#)
-            .await
-            .unwrap();
+        let ids = db.query(r#"[:find ?e :where [?e :last-name "Ivannotov"]]"#).await.unwrap();
         assert_eq!(ids.len(), 1);
         let entity_id = match &ids[0][0] {
             DataType::Long(id) => *id,
@@ -1400,10 +1186,8 @@ mod tests {
         };
 
         // Use literal entity ID in entity position of a query
-        let result = db
-            .query(format!("[:find ?ln :where [{entity_id} :last-name ?ln]]"))
-            .await
-            .unwrap();
+        let result =
+            db.query(format!("[:find ?ln :where [{entity_id} :last-name ?ln]]")).await.unwrap();
 
         // Should return exactly one row: "Ivannotov"
         assert_eq!(result.len(), 1);
@@ -1484,10 +1268,7 @@ mod tests {
 
         // Discover the auto-assigned entity ID
         let db = node.db().await.unwrap();
-        let result = db
-            .query(r#"[:find ?e :where [?e :tags "rust"]]"#)
-            .await
-            .unwrap();
+        let result = db.query(r#"[:find ?e :where [?e :tags "rust"]]"#).await.unwrap();
         assert_eq!(result.len(), 1);
         let entity_id = match &result[0][0] {
             DataType::Long(id) => *id,
@@ -1505,10 +1286,8 @@ mod tests {
 
         // Query: find all tags for the entity
         let db = node.db().await.unwrap();
-        let result = db
-            .query(format!("[:find ?tag :where [{entity_id} :tags ?tag]]"))
-            .await
-            .unwrap();
+        let result =
+            db.query(format!("[:find ?tag :where [{entity_id} :tags ?tag]]")).await.unwrap();
 
         assert_eq!(result.len(), 2, "Expected both tags, got {:?}", result);
         assert!(result.contains(&vec![DataType::String("rust".to_string())]));
@@ -1555,10 +1334,7 @@ mod tests {
 
         // Query all (entity, name) pairs and verify contiguous counter values
         let db = node.db().await.unwrap();
-        let result = db
-            .query("[:find ?e ?name :where [?e :name ?name]]")
-            .await
-            .unwrap();
+        let result = db.query("[:find ?e ?name :where [?e :name ?name]]").await.unwrap();
 
         assert_eq!(result.len(), 2);
         let mut eids: Vec<i64> = result

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -191,16 +191,8 @@ impl From<&str> for DataType {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum TxOp {
     Put(BTreeMap<Keyword, DataType>),
-    Add {
-        entity: EntityRef,
-        attribute: Keyword,
-        value: DataType,
-    },
-    Retract {
-        entity: EntityRef,
-        attribute: Keyword,
-        value: DataType,
-    },
+    Add { entity: EntityRef, attribute: Keyword, value: DataType },
+    Retract { entity: EntityRef, attribute: Keyword, value: DataType },
     Delete(EntityRef),
     Erase(EntityRef),
 }
@@ -248,41 +240,23 @@ mod tests {
     #[test]
     fn test_partial_compare_same_type() {
         use std::cmp::Ordering;
+        assert_eq!(DataType::Long(1).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Less);
+        assert_eq!(DataType::Long(2).partial_compare(&DataType::Long(2)).unwrap(), Ordering::Equal);
         assert_eq!(
-            DataType::Long(1)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            DataType::Long(2)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            DataType::Long(3)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
+            DataType::Long(3).partial_compare(&DataType::Long(2)).unwrap(),
             Ordering::Greater
         );
 
         assert_eq!(
-            DataType::String("a".into())
-                .partial_compare(&DataType::String("b".into()))
-                .unwrap(),
+            DataType::String("a".into()).partial_compare(&DataType::String("b".into())).unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Boolean(false)
-                .partial_compare(&DataType::Boolean(true))
-                .unwrap(),
+            DataType::Boolean(false).partial_compare(&DataType::Boolean(true)).unwrap(),
             Ordering::Less,
         );
         assert_eq!(
-            DataType::Double(1.5)
-                .partial_compare(&DataType::Double(2.5))
-                .unwrap(),
+            DataType::Double(1.5).partial_compare(&DataType::Double(2.5)).unwrap(),
             Ordering::Less,
         );
     }
@@ -291,124 +265,79 @@ mod tests {
     fn test_partial_compare_cross_numeric() {
         use std::cmp::Ordering;
         assert_eq!(
-            DataType::Long(10)
-                .partial_compare(&DataType::BigInt(20))
-                .unwrap(),
+            DataType::Long(10).partial_compare(&DataType::BigInt(20)).unwrap(),
             Ordering::Less
         );
         assert_eq!(
-            DataType::BigInt(20)
-                .partial_compare(&DataType::Long(10))
-                .unwrap(),
+            DataType::BigInt(20).partial_compare(&DataType::Long(10)).unwrap(),
             Ordering::Greater
         );
         assert_eq!(
-            DataType::Long(5)
-                .partial_compare(&DataType::Double(5.0))
-                .unwrap(),
+            DataType::Long(5).partial_compare(&DataType::Double(5.0)).unwrap(),
             Ordering::Equal
         );
         assert_eq!(
-            DataType::Double(3.0)
-                .partial_compare(&DataType::Long(4))
-                .unwrap(),
+            DataType::Double(3.0).partial_compare(&DataType::Long(4)).unwrap(),
             Ordering::Less
         );
 
         // Float cross-numeric
         assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::Long(2))
-                .unwrap(),
+            DataType::Float(1.0).partial_compare(&DataType::Long(2)).unwrap(),
             Ordering::Less
         );
         assert_eq!(
-            DataType::Long(2)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
+            DataType::Long(2).partial_compare(&DataType::Float(1.0)).unwrap(),
             Ordering::Greater
         );
         assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::Double(1.0))
-                .unwrap(),
+            DataType::Float(1.0).partial_compare(&DataType::Double(1.0)).unwrap(),
             Ordering::Equal
         );
         assert_eq!(
-            DataType::Double(2.0)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
+            DataType::Double(2.0).partial_compare(&DataType::Float(1.0)).unwrap(),
             Ordering::Greater
         );
         assert_eq!(
-            DataType::Float(1.0)
-                .partial_compare(&DataType::BigInt(2))
-                .unwrap(),
+            DataType::Float(1.0).partial_compare(&DataType::BigInt(2)).unwrap(),
             Ordering::Less
         );
         assert_eq!(
-            DataType::BigInt(2)
-                .partial_compare(&DataType::Float(1.0))
-                .unwrap(),
+            DataType::BigInt(2).partial_compare(&DataType::Float(1.0)).unwrap(),
             Ordering::Greater
         );
         assert_eq!(
-            DataType::BigInt(1)
-                .partial_compare(&DataType::Double(2.0))
-                .unwrap(),
+            DataType::BigInt(1).partial_compare(&DataType::Double(2.0)).unwrap(),
             Ordering::Less
         );
         assert_eq!(
-            DataType::Double(2.0)
-                .partial_compare(&DataType::BigInt(1))
-                .unwrap(),
+            DataType::Double(2.0).partial_compare(&DataType::BigInt(1)).unwrap(),
             Ordering::Greater
         );
     }
 
     #[test]
     fn test_partial_compare_incompatible() {
-        assert!(DataType::Long(1)
-            .partial_compare(&DataType::String("a".into()))
-            .is_err());
-        assert!(DataType::Boolean(true)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
+        assert!(DataType::Long(1).partial_compare(&DataType::String("a".into())).is_err());
+        assert!(DataType::Boolean(true).partial_compare(&DataType::Long(1)).is_err());
     }
 
     #[test]
     fn test_partial_compare_nan() {
         // Same-type NaN
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::Double(1.0))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Float(1.0))
-            .is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Float(1.0)).is_err());
         // Cross-type NaN
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::Double(1.0))
-            .is_err());
-        assert!(DataType::Float(f32::NAN)
-            .partial_compare(&DataType::BigInt(1))
-            .is_err());
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::Long(1))
-            .is_err());
-        assert!(DataType::Double(f64::NAN)
-            .partial_compare(&DataType::BigInt(1))
-            .is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::Double(1.0)).is_err());
+        assert!(DataType::Float(f32::NAN).partial_compare(&DataType::BigInt(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::Long(1)).is_err());
+        assert!(DataType::Double(f64::NAN).partial_compare(&DataType::BigInt(1)).is_err());
     }
 
     #[test]
     fn test_op_put_bincode() {
-        let op = TxOp::put(vec![
-            (kw!(:string), "string_value".into()),
-            (kw!(:int), 1i64.into()),
-        ]);
+        let op = TxOp::put(vec![(kw!(:string), "string_value".into()), (kw!(:int), 1i64.into())]);
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
@@ -457,13 +386,7 @@ mod tests {
     #[test]
     fn test_entity_ref_from_impls() {
         assert_eq!(EntityRef::from(42_i64), EntityRef::Id(42));
-        assert_eq!(
-            EntityRef::from(kw!(:person/name)),
-            EntityRef::Ident(kw!(:person/name))
-        );
-        assert_eq!(
-            EntityRef::from("temp-1"),
-            EntityRef::TempId("temp-1".to_string())
-        );
+        assert_eq!(EntityRef::from(kw!(:person/name)), EntityRef::Ident(kw!(:person/name)));
+        assert_eq!(EntityRef::from("temp-1"), EntityRef::TempId("temp-1".to_string()));
     }
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -43,10 +43,7 @@ pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
 /// For partition 0, the result equals the counter (small, readable IDs).
 pub fn make_entity_id(partition: u32, counter: i64) -> i64 {
     assert!(partition < (1 << 20), "partition must fit in 20 bits");
-    assert!(
-        (0..=COUNTER_MASK).contains(&counter),
-        "counter must fit in 42 bits"
-    );
+    assert!((0..=COUNTER_MASK).contains(&counter), "counter must fit in 42 bits");
     ((partition as i64) << COUNTER_BITS) | counter
 }
 
@@ -79,10 +76,7 @@ mod tests {
 
     #[test]
     fn test_bootstrap_ids_in_db_partition() {
-        assert_eq!(
-            make_entity_id(DB_PARTITION, crate::schema::DB_IDENT),
-            crate::schema::DB_IDENT
-        );
+        assert_eq!(make_entity_id(DB_PARTITION, crate::schema::DB_IDENT), crate::schema::DB_IDENT);
         assert_eq!(
             make_entity_id(DB_PARTITION, crate::schema::DB_VALUE_TYPE),
             crate::schema::DB_VALUE_TYPE

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -187,32 +187,12 @@ pub struct ColumnDescription {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FrontendMessage {
-    Startup {
-        version_major: u16,
-        version_minor: u16,
-        params: BTreeMap<String, String>,
-    },
-    OpenDb {
-        tx_id: Option<i64>,
-        system_time: Option<i64>,
-    },
-    CloseDb {
-        db_id: u32,
-    },
-    Query {
-        query_string: String,
-        db_id: u32,
-        args: Vec<QueryArg>,
-    },
-    Execute {
-        ops: Vec<TxOp>,
-        await_indexing: bool,
-    },
-    Subscribe {
-        query_string: String,
-        db_id: u32,
-        args: Vec<QueryArg>,
-    },
+    Startup { version_major: u16, version_minor: u16, params: BTreeMap<String, String> },
+    OpenDb { tx_id: Option<i64>, system_time: Option<i64> },
+    CloseDb { db_id: u32 },
+    Query { query_string: String, db_id: u32, args: Vec<QueryArg> },
+    Execute { ops: Vec<TxOp>, await_indexing: bool },
+    Subscribe { query_string: String, db_id: u32, args: Vec<QueryArg> },
     Unsubscribe,
     Terminate,
 }
@@ -312,20 +292,14 @@ fn encode_f64(buf: &mut Vec<u8>, v: f64) {
 /// message-size limit before encoding, which is well below `u32::MAX` (~4 GB).
 fn encode_string(buf: &mut Vec<u8>, s: &str) {
     let bytes = s.as_bytes();
-    encode_u32(
-        buf,
-        u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"),
-    );
+    encode_u32(buf, u32::try_from(bytes.len()).expect("string exceeds u32::MAX bytes"));
     buf.extend_from_slice(bytes);
 }
 
 /// # Panics
 /// Panics if `b` exceeds `u32::MAX` bytes. Unreachable — see [`encode_string`].
 fn encode_bytes(buf: &mut Vec<u8>, b: &[u8]) {
-    encode_u32(
-        buf,
-        u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"),
-    );
+    encode_u32(buf, u32::try_from(b.len()).expect("byte array exceeds u32::MAX bytes"));
     buf.extend_from_slice(b);
 }
 
@@ -464,21 +438,13 @@ fn encode_tx_op(buf: &mut Vec<u8>, op: &TxOp) {
             encode_u8(buf, TXOP_PUT);
             encode_keyword_datatype_map(buf, map);
         }
-        TxOp::Add {
-            entity,
-            attribute,
-            value,
-        } => {
+        TxOp::Add { entity, attribute, value } => {
             encode_u8(buf, TXOP_ADD);
             encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
             encode_data_type(buf, value);
         }
-        TxOp::Retract {
-            entity,
-            attribute,
-            value,
-        } => {
+        TxOp::Retract { entity, attribute, value } => {
             encode_u8(buf, TXOP_RETRACT);
             encode_entity_ref(buf, entity);
             encode_string(buf, &attribute.to_string());
@@ -554,11 +520,7 @@ impl<'a> Cursor<'a> {
 
     fn read_bytes(&mut self, n: usize) -> Result<&'a [u8]> {
         if self.pos + n > self.data.len() {
-            bail!(
-                "Unexpected end of message: need {} bytes, have {}",
-                n,
-                self.remaining()
-            );
+            bail!("Unexpected end of message: need {} bytes, have {}", n, self.remaining());
         }
         let slice = &self.data[self.pos..self.pos + n];
         self.pos += n;
@@ -654,11 +616,7 @@ impl<'a> Cursor<'a> {
     fn read_string_map(&mut self) -> Result<BTreeMap<String, String>> {
         let count = self.read_u32()? as usize;
         if count > self.remaining() {
-            bail!(
-                "String map count {} exceeds remaining bytes {}",
-                count,
-                self.remaining()
-            );
+            bail!("String map count {} exceeds remaining bytes {}", count, self.remaining());
         }
         let mut map = BTreeMap::new();
         for _ in 0..count {
@@ -705,11 +663,7 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
 fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Vec<DataType> count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Vec<DataType> count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut vec = Vec::with_capacity(count);
     for _ in 0..count {
@@ -721,11 +675,7 @@ fn decode_data_type_vec(cursor: &mut Cursor) -> Result<Vec<DataType>> {
 fn decode_data_type_map(cursor: &mut Cursor) -> Result<BTreeMap<String, DataType>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Map count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Map count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut map = BTreeMap::new();
     for _ in 0..count {
@@ -788,21 +738,13 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
             let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_data_type(cursor)?;
-            Ok(TxOp::Add {
-                entity,
-                attribute,
-                value,
-            })
+            Ok(TxOp::Add { entity, attribute, value })
         }
         TXOP_RETRACT => {
             let entity = decode_entity_ref(cursor)?;
             let attribute = Keyword::from_str(&cursor.read_string()?)?;
             let value = decode_data_type(cursor)?;
-            Ok(TxOp::Retract {
-                entity,
-                attribute,
-                value,
-            })
+            Ok(TxOp::Retract { entity, attribute, value })
         }
         TXOP_DELETE => Ok(TxOp::Delete(decode_entity_ref(cursor)?)),
         TXOP_ERASE => Ok(TxOp::Erase(decode_entity_ref(cursor)?)),
@@ -813,11 +755,7 @@ fn decode_tx_op(cursor: &mut Cursor) -> Result<TxOp> {
 fn decode_tx_ops(cursor: &mut Cursor) -> Result<Vec<TxOp>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Vec<TxOp> count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Vec<TxOp> count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut ops = Vec::with_capacity(count);
     for _ in 0..count {
@@ -854,11 +792,7 @@ fn decode_query_arg(cursor: &mut Cursor) -> Result<QueryArg> {
 fn decode_query_args(cursor: &mut Cursor) -> Result<Vec<QueryArg>> {
     let count = cursor.read_u32()? as usize;
     if count > cursor.remaining() {
-        bail!(
-            "Vec<QueryArg> count {} exceeds remaining bytes {}",
-            count,
-            cursor.remaining()
-        );
+        bail!("Vec<QueryArg> count {} exceeds remaining bytes {}", count, cursor.remaining());
     }
     let mut args = Vec::with_capacity(count);
     for _ in 0..count {
@@ -873,11 +807,7 @@ fn decode_query_args(cursor: &mut Cursor) -> Result<Vec<QueryArg>> {
 
 fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
     match msg {
-        FrontendMessage::Startup {
-            version_major,
-            version_minor,
-            params,
-        } => {
+        FrontendMessage::Startup { version_major, version_minor, params } => {
             encode_u16(buf, *version_major);
             encode_u16(buf, *version_minor);
             encode_string_map(buf, params);
@@ -889,27 +819,16 @@ fn encode_frontend_payload(buf: &mut Vec<u8>, msg: &FrontendMessage) {
         FrontendMessage::CloseDb { db_id } => {
             encode_u32(buf, *db_id);
         }
-        FrontendMessage::Query {
-            query_string,
-            db_id,
-            args,
-        } => {
+        FrontendMessage::Query { query_string, db_id, args } => {
             encode_string(buf, query_string);
             encode_u32(buf, *db_id);
             encode_query_args(buf, args);
         }
-        FrontendMessage::Execute {
-            ops,
-            await_indexing,
-        } => {
+        FrontendMessage::Execute { ops, await_indexing } => {
             encode_tx_ops(buf, ops);
             encode_bool(buf, *await_indexing);
         }
-        FrontendMessage::Subscribe {
-            query_string,
-            db_id,
-            args,
-        } => {
+        FrontendMessage::Subscribe { query_string, db_id, args } => {
             encode_string(buf, query_string);
             encode_u32(buf, *db_id);
             encode_query_args(buf, args);
@@ -951,12 +870,7 @@ fn encode_backend_payload(buf: &mut Vec<u8>, msg: &BackendMessage) {
             encode_i64(buf, *tx_id);
             encode_i64(buf, *system_time);
         }
-        BackendMessage::TxResult {
-            status,
-            tx_id,
-            system_time,
-            error_message,
-        } => {
+        BackendMessage::TxResult { status, tx_id, system_time, error_message } => {
             encode_u8(buf, *status);
             encode_i64(buf, *tx_id);
             encode_i64(buf, *system_time);
@@ -964,13 +878,7 @@ fn encode_backend_payload(buf: &mut Vec<u8>, msg: &BackendMessage) {
         }
         BackendMessage::UnsubscribeComplete => {}
         BackendMessage::Heartbeat => {}
-        BackendMessage::ErrorResponse {
-            severity,
-            code,
-            message,
-            detail,
-            hint,
-        } => {
+        BackendMessage::ErrorResponse { severity, code, message, detail, hint } => {
             encode_u8(buf, *severity);
             encode_u16(buf, *code);
             encode_string(buf, message);
@@ -990,9 +898,7 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
             tx_id: cursor.read_option_i64()?,
             system_time: cursor.read_option_i64()?,
         }),
-        MSG_CLOSE_DB => Ok(FrontendMessage::CloseDb {
-            db_id: cursor.read_u32()?,
-        }),
+        MSG_CLOSE_DB => Ok(FrontendMessage::CloseDb { db_id: cursor.read_u32()? }),
         MSG_QUERY => Ok(FrontendMessage::Query {
             query_string: cursor.read_string()?,
             db_id: cursor.read_u32()?,
@@ -1001,10 +907,7 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
         MSG_EXECUTE => {
             let ops = decode_tx_ops(cursor)?;
             let await_indexing = cursor.read_bool()?;
-            Ok(FrontendMessage::Execute {
-                ops,
-                await_indexing,
-            })
+            Ok(FrontendMessage::Execute { ops, await_indexing })
         }
         MSG_SUBSCRIBE => Ok(FrontendMessage::Subscribe {
             query_string: cursor.read_string()?,
@@ -1019,16 +922,13 @@ fn decode_frontend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<Frontend
 
 fn decode_backend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<BackendMessage> {
     match msg_type {
-        MSG_AUTHENTICATION_OK => Ok(BackendMessage::AuthenticationOk {
-            server_version: cursor.read_string()?,
-        }),
-        MSG_DB_OPENED => Ok(BackendMessage::DbOpened {
-            db_id: cursor.read_u32()?,
-            tx_id: cursor.read_i64()?,
-        }),
-        MSG_DB_CLOSED => Ok(BackendMessage::DbClosed {
-            db_id: cursor.read_u32()?,
-        }),
+        MSG_AUTHENTICATION_OK => {
+            Ok(BackendMessage::AuthenticationOk { server_version: cursor.read_string()? })
+        }
+        MSG_DB_OPENED => {
+            Ok(BackendMessage::DbOpened { db_id: cursor.read_u32()?, tx_id: cursor.read_i64()? })
+        }
+        MSG_DB_CLOSED => Ok(BackendMessage::DbClosed { db_id: cursor.read_u32()? }),
         MSG_ROW_DESCRIPTION => {
             let count = cursor.read_u32()? as usize;
             if count > cursor.remaining() {
@@ -1051,16 +951,13 @@ fn decode_backend_payload(msg_type: u8, cursor: &mut Cursor) -> Result<BackendMe
             let values = decode_data_type_vec(cursor)?;
             Ok(BackendMessage::DataRow { values })
         }
-        MSG_DATA_BATCH_COMPLETE => Ok(BackendMessage::DataBatchComplete {
-            tx_id: cursor.read_i64()?,
-        }),
-        MSG_READY_FOR_QUERY => Ok(BackendMessage::ReadyForQuery {
-            status: cursor.read_u8()?,
-        }),
-        MSG_TX_KEY => Ok(BackendMessage::TxKey {
-            tx_id: cursor.read_i64()?,
-            system_time: cursor.read_i64()?,
-        }),
+        MSG_DATA_BATCH_COMPLETE => {
+            Ok(BackendMessage::DataBatchComplete { tx_id: cursor.read_i64()? })
+        }
+        MSG_READY_FOR_QUERY => Ok(BackendMessage::ReadyForQuery { status: cursor.read_u8()? }),
+        MSG_TX_KEY => {
+            Ok(BackendMessage::TxKey { tx_id: cursor.read_i64()?, system_time: cursor.read_i64()? })
+        }
         MSG_TX_RESULT => Ok(BackendMessage::TxResult {
             status: cursor.read_u8()?,
             tx_id: cursor.read_i64()?,
@@ -1108,11 +1005,7 @@ pub async fn read_frontend_message<R: AsyncRead + Unpin>(
         let version_major = cursor.read_u16()?;
         let version_minor = cursor.read_u16()?;
         let params = cursor.read_string_map()?;
-        Ok(FrontendMessage::Startup {
-            version_major,
-            version_minor,
-            params,
-        })
+        Ok(FrontendMessage::Startup { version_major, version_minor, params })
     } else {
         let msg_type = reader.read_u8().await?;
         let length = reader.read_u32().await?;
@@ -1250,9 +1143,7 @@ mod tests {
 
         let is_startup = matches!(msg, FrontendMessage::Startup { .. });
         let mut cursor = &buf[..];
-        read_frontend_message(&mut cursor, is_startup, DEFAULT_MAX_MESSAGE_SIZE)
-            .await
-            .unwrap()
+        read_frontend_message(&mut cursor, is_startup, DEFAULT_MAX_MESSAGE_SIZE).await.unwrap()
     }
 
     // Helper: encode a backend message to bytes and decode it back.
@@ -1261,9 +1152,7 @@ mod tests {
         write_backend_message(&mut buf, msg).await.unwrap();
 
         let mut cursor = &buf[..];
-        read_backend_message(&mut cursor, DEFAULT_MAX_MESSAGE_SIZE)
-            .await
-            .unwrap()
+        read_backend_message(&mut cursor, DEFAULT_MAX_MESSAGE_SIZE).await.unwrap()
     }
 
     // -- DataType round-trip tests --
@@ -1283,14 +1172,8 @@ mod tests {
 
     #[test]
     fn test_data_type_boolean() {
-        assert_eq!(
-            roundtrip_data_type(&DataType::Boolean(true)),
-            DataType::Boolean(true)
-        );
-        assert_eq!(
-            roundtrip_data_type(&DataType::Boolean(false)),
-            DataType::Boolean(false)
-        );
+        assert_eq!(roundtrip_data_type(&DataType::Boolean(true)), DataType::Boolean(true));
+        assert_eq!(roundtrip_data_type(&DataType::Boolean(false)), DataType::Boolean(false));
     }
 
     #[test]
@@ -1384,10 +1267,7 @@ mod tests {
         inner_map.insert("x".to_string(), DataType::Long(1));
         let dt = DataType::Vector(vec![
             DataType::Map(inner_map),
-            DataType::Tuple(vec![
-                DataType::String("hello".to_string()),
-                DataType::Boolean(false),
-            ]),
+            DataType::Tuple(vec![DataType::String("hello".to_string()), DataType::Boolean(false)]),
         ]);
         assert_eq!(roundtrip_data_type(&dt), dt);
     }
@@ -1502,26 +1382,16 @@ mod tests {
     async fn test_startup_roundtrip() {
         let mut params = BTreeMap::new();
         params.insert("client_name".to_string(), "test-client".to_string());
-        let msg = FrontendMessage::Startup {
-            version_major: 0,
-            version_minor: 1,
-            params,
-        };
+        let msg = FrontendMessage::Startup { version_major: 0, version_minor: 1, params };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
     }
 
     #[tokio::test]
     async fn test_open_db_roundtrip() {
-        let msg = FrontendMessage::OpenDb {
-            tx_id: Some(42),
-            system_time: Some(1700000000000000),
-        };
+        let msg = FrontendMessage::OpenDb { tx_id: Some(42), system_time: Some(1700000000000000) };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
 
-        let msg = FrontendMessage::OpenDb {
-            tx_id: None,
-            system_time: None,
-        };
+        let msg = FrontendMessage::OpenDb { tx_id: None, system_time: None };
         assert_eq!(roundtrip_frontend(&msg).await, msg);
     }
 
@@ -1587,18 +1457,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_authentication_ok_roundtrip() {
-        let msg = BackendMessage::AuthenticationOk {
-            server_version: "triplox 0.1.0".to_string(),
-        };
+        let msg = BackendMessage::AuthenticationOk { server_version: "triplox 0.1.0".to_string() };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }
 
     #[tokio::test]
     async fn test_db_opened_roundtrip() {
-        let msg = BackendMessage::DbOpened {
-            db_id: 5,
-            tx_id: 42,
-        };
+        let msg = BackendMessage::DbOpened { db_id: 5, tx_id: 42 };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }
 
@@ -1612,14 +1477,8 @@ mod tests {
     async fn test_row_description_roundtrip() {
         let msg = BackendMessage::RowDescription {
             columns: vec![
-                ColumnDescription {
-                    name: "?e".to_string(),
-                    data_type: TAG_LONG,
-                },
-                ColumnDescription {
-                    name: "?name".to_string(),
-                    data_type: TAG_STRING,
-                },
+                ColumnDescription { name: "?e".to_string(), data_type: TAG_LONG },
+                ColumnDescription { name: "?name".to_string(), data_type: TAG_STRING },
             ],
         };
         assert_eq!(roundtrip_backend(&msg).await, msg);
@@ -1641,23 +1500,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_ready_for_query_roundtrip() {
-        let msg = BackendMessage::ReadyForQuery {
-            status: STATUS_IDLE,
-        };
+        let msg = BackendMessage::ReadyForQuery { status: STATUS_IDLE };
         assert_eq!(roundtrip_backend(&msg).await, msg);
 
-        let msg = BackendMessage::ReadyForQuery {
-            status: STATUS_SUBSCRIBED,
-        };
+        let msg = BackendMessage::ReadyForQuery { status: STATUS_SUBSCRIBED };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }
 
     #[tokio::test]
     async fn test_tx_key_roundtrip() {
-        let msg = BackendMessage::TxKey {
-            tx_id: 42,
-            system_time: 1700000000000000,
-        };
+        let msg = BackendMessage::TxKey { tx_id: 42, system_time: 1700000000000000 };
         assert_eq!(roundtrip_backend(&msg).await, msg);
     }
 
@@ -1693,10 +1545,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_heartbeat_roundtrip() {
-        assert_eq!(
-            roundtrip_backend(&BackendMessage::Heartbeat).await,
-            BackendMessage::Heartbeat
-        );
+        assert_eq!(roundtrip_backend(&BackendMessage::Heartbeat).await, BackendMessage::Heartbeat);
     }
 
     #[tokio::test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -170,10 +170,7 @@ fn is_value_variable(place: &PatternValuePlace) -> bool {
 
 /// Check if a PatternNonValuePlace is a constant (Entid or Ident).
 fn is_non_value_constant(place: &PatternNonValuePlace) -> bool {
-    matches!(
-        place,
-        PatternNonValuePlace::Entid(_) | PatternNonValuePlace::Ident(_)
-    )
+    matches!(place, PatternNonValuePlace::Entid(_) | PatternNonValuePlace::Ident(_))
 }
 
 /// Check if a PatternValuePlace is a constant.
@@ -244,30 +241,18 @@ fn convert_predicate(pred: &EdnPredicate) -> Result<Expr, Error> {
     }
     let left = convert_fn_arg(&pred.args[0])?;
     let right = convert_fn_arg(&pred.args[1])?;
-    Ok(Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(left),
-        op,
-        right: Box::new(right),
-    }))
+    Ok(Expr::BinaryExpr(BinaryExpr { left: Box::new(left), op, right: Box::new(right) }))
 }
 
 fn convert_where_fn(wf: &EdnWhereFn) -> Result<FnExpr, Error> {
     let op_name = wf.operator.0.as_str();
     let op = convert_binary_op(op_name)?;
     if wf.args.len() != 2 {
-        return Err(anyhow::anyhow!(
-            "WhereFn '{}' expects 2 args, got {}",
-            op_name,
-            wf.args.len()
-        ));
+        return Err(anyhow::anyhow!("WhereFn '{}' expects 2 args, got {}", op_name, wf.args.len()));
     }
     let left = convert_fn_arg(&wf.args[0])?;
     let right = convert_fn_arg(&wf.args[1])?;
-    let expr = Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(left),
-        op,
-        right: Box::new(right),
-    });
+    let expr = Expr::BinaryExpr(BinaryExpr { left: Box::new(left), op, right: Box::new(right) });
     let output = match &wf.binding {
         edn::query::Binding::BindScalar(v) => v.clone(),
         _ => return Err(anyhow::anyhow!("Only scalar binding supported")),
@@ -283,10 +268,9 @@ fn convert_where_fn(wf: &EdnWhereFn) -> Result<FnExpr, Error> {
 fn collect_variables_from_or_branch(branch: &OrWhereClause) -> Vec<Variable> {
     match branch {
         OrWhereClause::Clause(clause) => collect_variables_from_clause(clause),
-        OrWhereClause::And(children) => children
-            .iter()
-            .flat_map(collect_variables_from_clause)
-            .collect(),
+        OrWhereClause::And(children) => {
+            children.iter().flat_map(collect_variables_from_clause).collect()
+        }
     }
 }
 
@@ -299,10 +283,7 @@ fn collect_variables_from_clause(clause: &WhereClause) -> Vec<Variable> {
         WhereClause::OrJoin(oj) => {
             // All branches must have the same free variables (validated in execute_query).
             // Extract from the first branch only.
-            oj.clauses
-                .first()
-                .map(collect_variables_from_or_branch)
-                .unwrap_or_default()
+            oj.clauses.first().map(collect_variables_from_or_branch).unwrap_or_default()
         }
         WhereClause::WhereFn(wf) => {
             // The output variable is the one contributed.
@@ -339,11 +320,7 @@ pub fn query_variable_order(in_vars: &[Variable], where_clauses: &[WhereClause])
     let reordered: Vec<&WhereClause> = where_clauses
         .iter()
         .filter(|c| !matches!(c, WhereClause::WhereFn(_)))
-        .chain(
-            where_clauses
-                .iter()
-                .filter(|c| matches!(c, WhereClause::WhereFn(_))),
-        )
+        .chain(where_clauses.iter().filter(|c| matches!(c, WhereClause::WhereFn(_))))
         .collect();
 
     for clause in reordered {
@@ -434,10 +411,7 @@ fn validate_fn_clauses(
         if let WhereClause::WhereFn(wf) = clause {
             let fn_expr = convert_where_fn(wf)?;
             let output_pos = var_index.get(&fn_expr.output).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Function output variable {} not in join order",
-                    fn_expr.output
-                )
+                anyhow::anyhow!("Function output variable {} not in join order", fn_expr.output)
             })?;
             for var in fn_expr.input_variables() {
                 let input_pos = var_index.get(&var).ok_or_else(|| {
@@ -466,9 +440,7 @@ fn compile_predicate(
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     let vars = expr_variables(expr);
     if vars.is_empty() {
-        return Err(anyhow::anyhow!(
-            "Predicate expression must reference at least one variable"
-        ));
+        return Err(anyhow::anyhow!("Predicate expression must reference at least one variable"));
     }
 
     // Find each variable's join level
@@ -483,11 +455,7 @@ fn compile_predicate(
         .collect::<Result<_, Error>>()?;
 
     // The variable with the highest join level is the extension variable
-    let (ext_idx, _) = var_levels
-        .iter()
-        .enumerate()
-        .max_by_key(|(_, (_, level))| *level)
-        .unwrap();
+    let (ext_idx, _) = var_levels.iter().enumerate().max_by_key(|(_, (_, level))| *level).unwrap();
 
     let (extension_var, level) = var_levels.remove(ext_idx);
     let prefix_vars = var_levels;
@@ -519,17 +487,10 @@ fn compile_fn_expr(
         .collect::<Result<_, Error>>()?;
 
     let output_level = var_index.get(&fn_expr.output).copied().ok_or_else(|| {
-        anyhow::anyhow!(
-            "FnExpr output variable {} not in join order",
-            fn_expr.output
-        )
+        anyhow::anyhow!("FnExpr output variable {} not in join order", fn_expr.output)
     })?;
 
-    Ok(Box::new(GenericFnPrefixExtender::new(
-        fn_expr.expr.clone(),
-        prefix_vars,
-        output_level,
-    )))
+    Ok(Box::new(GenericFnPrefixExtender::new(fn_expr.expr.clone(), prefix_vars, output_level)))
 }
 
 /// Determine the index type for a single-variable pattern using Pattern directly.
@@ -539,13 +500,8 @@ fn pattern_index_type(pattern: &Pattern, join_order: &[Variable]) -> Result<Inde
     let value = &pattern.value;
 
     // Attribute must be constant (Ident or Entid)
-    if matches!(
-        attribute,
-        PatternNonValuePlace::Placeholder | PatternNonValuePlace::Variable(_)
-    ) {
-        return Err(anyhow::anyhow!(
-            "Attribute position must be a keyword or entid"
-        ));
+    if matches!(attribute, PatternNonValuePlace::Placeholder | PatternNonValuePlace::Variable(_)) {
+        return Err(anyhow::anyhow!("Attribute position must be a keyword or entid"));
     }
 
     match (entity, value) {
@@ -606,9 +562,7 @@ fn determine_index_types(
     } else if pat_vars.is_empty() {
         Ok(vec![])
     } else {
-        Err(anyhow::anyhow!(
-            "Patterns with more than 2 variables not supported"
-        ))
+        Err(anyhow::anyhow!("Patterns with more than 2 variables not supported"))
     }
 }
 
@@ -655,10 +609,8 @@ pub fn compile_pattern(
 
     // Determine participating levels (sorted ascending — build_slate_prefix relies on
     // ordered iteration to append already-bound components in index-key layout order).
-    let mut participating_levels: Vec<usize> = pat_vars
-        .iter()
-        .filter_map(|v| var_index.get(v).copied())
-        .collect();
+    let mut participating_levels: Vec<usize> =
+        pat_vars.iter().filter_map(|v| var_index.get(v).copied()).collect();
     participating_levels.sort_unstable();
 
     // Determine index types for each level
@@ -769,11 +721,7 @@ fn compile_find_plan(
         }
     }
 
-    Ok(FindPlan {
-        group_key_indices,
-        projections,
-        has_aggregates,
-    })
+    Ok(FindPlan { group_key_indices, projections, has_aggregates })
 }
 
 /// Project join results without aggregation.
@@ -904,14 +852,12 @@ fn validate_or_branches(branches: &[OrWhereClause]) -> Result<(), Error> {
         return Err(anyhow::anyhow!("OR clause must have at least one branch"));
     }
 
-    let first_vars: HashSet<Variable> = collect_variables_from_or_branch(&branches[0])
-        .into_iter()
-        .collect();
+    let first_vars: HashSet<Variable> =
+        collect_variables_from_or_branch(&branches[0]).into_iter().collect();
 
     for (i, branch) in branches.iter().enumerate().skip(1) {
-        let branch_vars: HashSet<Variable> = collect_variables_from_or_branch(branch)
-            .into_iter()
-            .collect();
+        let branch_vars: HashSet<Variable> =
+            collect_variables_from_or_branch(branch).into_iter().collect();
         if branch_vars != first_vars {
             return Err(anyhow::anyhow!(
                 "OR branch {} has different free variables {:?} than branch 0 {:?}",
@@ -955,12 +901,9 @@ fn resolve_order_columns(
     orders
         .iter()
         .map(|Order(dir, var)| {
-            var_positions
-                .get(var)
-                .map(|&idx| (idx, dir.clone()))
-                .ok_or_else(|| {
-                    anyhow::anyhow!("ORDER BY variable {} is not in the :find clause", var)
-                })
+            var_positions.get(var).map(|&idx| (idx, dir.clone())).ok_or_else(|| {
+                anyhow::anyhow!("ORDER BY variable {} is not in the :find clause", var)
+            })
         })
         .collect()
 }
@@ -1102,9 +1045,9 @@ fn compile_or_branch(
     as_of: i64,
 ) -> Result<Box<dyn PrefixExtender>, Error> {
     match branch {
-        OrWhereClause::Clause(clause) => compile_where_clause(
-            clause, join_order, var_index, slate, handle, ident_map, as_of,
-        ),
+        OrWhereClause::Clause(clause) => {
+            compile_where_clause(clause, join_order, var_index, slate, handle, ident_map, as_of)
+        }
         OrWhereClause::And(children) => {
             let extenders: Vec<Box<dyn PrefixExtender>> = children
                 .iter()
@@ -1170,10 +1113,7 @@ fn compile_where_clause(
             let fn_expr = convert_where_fn(wf)?;
             compile_fn_expr(&fn_expr, var_index)
         }
-        _ => Err(anyhow::anyhow!(
-            "Unsupported where clause type: {:?}",
-            clause
-        )),
+        _ => Err(anyhow::anyhow!("Unsupported where clause type: {:?}", clause)),
     }
 }
 
@@ -1221,10 +1161,8 @@ pub fn execute_query(
             unreachable!("validate_query ensures only scalar bindings reach execute_query");
         };
         let encoded = dt.encode();
-        extenders.push(Box::new(SingleLevelExtender::new(
-            vec![bytes::Bytes::from(encoded)],
-            level,
-        )));
+        extenders
+            .push(Box::new(SingleLevelExtender::new(vec![bytes::Bytes::from(encoded)], level)));
     }
 
     // 3. Compile WHERE patterns into extenders
@@ -1278,10 +1216,7 @@ mod tests {
     fn test_query_variable_order_multiple_patterns() {
         let parsed = parse_query("[:find ?e ?name ?age :where [?e :name ?name] [?e :age ?age]]");
         let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
-        assert_eq!(
-            order,
-            vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
-        );
+        assert_eq!(order, vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]);
     }
 
     #[test]
@@ -1327,10 +1262,7 @@ mod tests {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#);
         let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("at least one variable"));
+        assert!(result.unwrap_err().to_string().contains("at least one variable"));
     }
 
     #[test]
@@ -1338,10 +1270,7 @@ mod tests {
         let parsed =
             parse_query("[:find ?e ?next_age :where [?e :age ?age] [(+ ?age 1) ?next_age]]");
         let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
-        assert_eq!(
-            order,
-            vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
-        );
+        assert_eq!(order, vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]);
     }
 
     #[test]
@@ -1378,10 +1307,7 @@ mod tests {
         let parsed =
             parse_query("[:find ?e ?next_age :where [(+ ?age 1) ?next_age] [?e :age ?age]]");
         let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
-        assert_eq!(
-            order,
-            vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
-        );
+        assert_eq!(order, vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]);
     }
 
     #[test]
@@ -1389,10 +1315,7 @@ mod tests {
         let parsed =
             parse_query("[:find ?e ?name ?age :where (or (and [?e :name ?name] [?e :age ?age]))]");
         let order = query_variable_order(&parsed.in_vars, &parsed.where_clauses);
-        assert_eq!(
-            order,
-            vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
-        );
+        assert_eq!(order, vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]);
     }
 
     #[test]
@@ -1429,25 +1352,18 @@ mod tests {
 
     fn make_find_rel(vars: &[&str]) -> FindSpec {
         FindSpec::FindRel(
-            vars.iter()
-                .map(|name| Element::Variable(Variable::from_valid_name(name)))
-                .collect(),
+            vars.iter().map(|name| Element::Variable(Variable::from_valid_name(name))).collect(),
         )
     }
 
     fn rows(data: Vec<Vec<i64>>) -> QueryResult {
-        data.into_iter()
-            .map(|row| row.into_iter().map(DataType::from).collect())
-            .collect()
+        data.into_iter().map(|row| row.into_iter().map(DataType::from).collect()).collect()
     }
 
     #[test]
     fn test_apply_order_ascending() {
         let find = make_find_rel(&["?a"]);
-        let order = Some(vec![Order(
-            Direction::Ascending,
-            Variable::from_valid_name("?a"),
-        )]);
+        let order = Some(vec![Order(Direction::Ascending, Variable::from_valid_name("?a"))]);
         let result = apply_order_and_limit(
             rows(vec![vec![3], vec![1], vec![2]]),
             &order,
@@ -1461,10 +1377,7 @@ mod tests {
     #[test]
     fn test_apply_order_descending() {
         let find = make_find_rel(&["?a"]);
-        let order = Some(vec![Order(
-            Direction::Descending,
-            Variable::from_valid_name("?a"),
-        )]);
+        let order = Some(vec![Order(Direction::Descending, Variable::from_valid_name("?a"))]);
         let result = apply_order_and_limit(
             rows(vec![vec![1], vec![3], vec![2]]),
             &order,
@@ -1484,10 +1397,7 @@ mod tests {
         ]);
         let input = rows(vec![vec![1, 10], vec![2, 20], vec![1, 30], vec![2, 10]]);
         let result = apply_order_and_limit(input, &order, &Limit::None, &find).unwrap();
-        assert_eq!(
-            result,
-            rows(vec![vec![1, 30], vec![1, 10], vec![2, 20], vec![2, 10]])
-        );
+        assert_eq!(result, rows(vec![vec![1, 30], vec![1, 10], vec![2, 20], vec![2, 10]]));
     }
 
     #[test]
@@ -1523,10 +1433,7 @@ mod tests {
     #[test]
     fn test_apply_order_then_limit() {
         let find = make_find_rel(&["?a"]);
-        let order = Some(vec![Order(
-            Direction::Ascending,
-            Variable::from_valid_name("?a"),
-        )]);
+        let order = Some(vec![Order(Direction::Ascending, Variable::from_valid_name("?a"))]);
         let result = apply_order_and_limit(
             rows(vec![vec![5], vec![3], vec![1], vec![4], vec![2]]),
             &order,
@@ -1541,11 +1448,7 @@ mod tests {
     fn test_validate_order_var_not_in_find() {
         let parsed = parse_query("[:find ?e :where [?e :name ?name] :order [?name :asc]]");
         let err = validate_query(&parsed, &[]).unwrap_err();
-        assert!(
-            err.to_string().contains("ORDER BY variable"),
-            "unexpected error: {}",
-            err
-        );
+        assert!(err.to_string().contains("ORDER BY variable"), "unexpected error: {}", err);
     }
 
     #[test]
@@ -1553,11 +1456,7 @@ mod tests {
         // Variable limit without :in binding should fail
         let parsed = parse_query("[:find ?e :where [?e :name ?name] :limit ?limit]");
         let err = validate_query(&parsed, &[]).unwrap_err();
-        assert!(
-            err.to_string().contains("not bound in :in clause"),
-            "unexpected error: {}",
-            err
-        );
+        assert!(err.to_string().contains("not bound in :in clause"), "unexpected error: {}", err);
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -90,37 +90,13 @@ static V1_IDENTS: LazyLock<Vec<(Keyword, i64)>> = LazyLock::new(|| {
 /// (ident, value_type_ident, cardinality_ident)
 static V1_ATTRIBUTES: LazyLock<Vec<(Keyword, Keyword, Keyword)>> = LazyLock::new(|| {
     vec![
-        (
-            kw!(:db/ident),
-            kw!(:db.type/keyword),
-            kw!(:db.cardinality/one),
-        ),
-        (
-            kw!(:db/valueType),
-            kw!(:db.type/ref),
-            kw!(:db.cardinality/one),
-        ),
-        (
-            kw!(:db/cardinality),
-            kw!(:db.type/ref),
-            kw!(:db.cardinality/one),
-        ),
-        (
-            kw!(:db/txInstant),
-            kw!(:db.type/instant),
-            kw!(:db.cardinality/one),
-        ),
+        (kw!(:db/ident), kw!(:db.type/keyword), kw!(:db.cardinality/one)),
+        (kw!(:db/valueType), kw!(:db.type/ref), kw!(:db.cardinality/one)),
+        (kw!(:db/cardinality), kw!(:db.type/ref), kw!(:db.cardinality/one)),
+        (kw!(:db/txInstant), kw!(:db.type/instant), kw!(:db.cardinality/one)),
         (kw!(:db/txId), kw!(:db.type/long), kw!(:db.cardinality/one)),
-        (
-            kw!(:db/txResult),
-            kw!(:db.type/ref),
-            kw!(:db.cardinality/one),
-        ),
-        (
-            kw!(:db.tx/error),
-            kw!(:db.type/string),
-            kw!(:db.cardinality/one),
-        ),
+        (kw!(:db/txResult), kw!(:db.type/ref), kw!(:db.cardinality/one)),
+        (kw!(:db.tx/error), kw!(:db.type/string), kw!(:db.cardinality/one)),
     ]
 });
 
@@ -281,14 +257,10 @@ impl AttributeBuilder {
     /// Validate that all required fields are present for a new attribute.
     pub fn validate_install_attribute(&self) -> Result<()> {
         if self.value_type.is_none() {
-            return Err(anyhow::anyhow!(
-                "db/valueType is required for schema attribute"
-            ));
+            return Err(anyhow::anyhow!("db/valueType is required for schema attribute"));
         }
         if self.multival.is_none() {
-            return Err(anyhow::anyhow!(
-                "db/cardinality is required for schema attribute"
-            ));
+            return Err(anyhow::anyhow!("db/cardinality is required for schema attribute"));
         }
         Ok(())
     }
@@ -328,40 +300,22 @@ struct AddRetractSet<T> {
 
 impl<T> Default for AddRetractSet<T> {
     fn default() -> Self {
-        Self {
-            adds: HashSet::new(),
-            retracts: HashSet::new(),
-        }
+        Self { adds: HashSet::new(), retracts: HashSet::new() }
     }
 }
 
-type AEVValidationMap<'a> = HashMap<(Entid, &'a Attribute), HashMap<Entid, AddRetractSet<DataType>>>;
+type AEVValidationMap<'a> =
+    HashMap<(Entid, &'a Attribute), HashMap<Entid, AddRetractSet<DataType>>>;
 
 #[derive(Debug)]
 enum ValidationConflict {
-    TypeMismatch {
-        entity: Entid,
-        attribute: Keyword,
-        value: DataType,
-        expected: ValueType,
-    },
-    AddRetractConflict {
-        entity: Entid,
-        attribute: Keyword,
-        values: Vec<DataType>,
-    },
-    CardinalityOneAddConflict {
-        entity: Entid,
-        attribute: Keyword,
-        values: Vec<DataType>,
-    },
+    TypeMismatch { entity: Entid, attribute: Keyword, value: DataType, expected: ValueType },
+    AddRetractConflict { entity: Entid, attribute: Keyword, values: Vec<DataType> },
+    CardinalityOneAddConflict { entity: Entid, attribute: Keyword, values: Vec<DataType> },
 }
 
 fn is_schema_attribute(attribute: &Keyword) -> bool {
-    matches!(
-        attribute.components(),
-        ("db", "ident" | "valueType" | "cardinality")
-    )
+    matches!(attribute.components(), ("db", "ident" | "valueType" | "cardinality"))
 }
 
 /// The schema: bidirectional ident/entid maps + attribute definitions.
@@ -428,9 +382,7 @@ impl Schema {
             });
         }
 
-        Ok(ValidationReport {
-            schema_changes_detected,
-        })
+        Ok(ValidationReport { schema_changes_detected })
     }
 
     /// Build a pre-validated schema delta from finalized transaction datoms.
@@ -477,9 +429,7 @@ impl Schema {
                         builders.entry(datom.entity).or_default().value_type = Some(vt);
                     }
                     _ => {
-                        return Err(anyhow::anyhow!(
-                            "db/valueType must be a Ref (Long entity ID)"
-                        ))
+                        return Err(anyhow::anyhow!("db/valueType must be a Ref (Long entity ID)"))
                     }
                 },
                 ("db", "cardinality") => match &datom.value {
@@ -511,10 +461,7 @@ impl Schema {
             attribute_updates.push((entity_id, builder.build()));
         }
 
-        Ok(SchemaUpdate {
-            idents: ident_updates,
-            attributes: attribute_updates,
-        })
+        Ok(SchemaUpdate { idents: ident_updates, attributes: attribute_updates })
     }
 
     fn build_aev_validation_map(&self, datoms: &[Datom]) -> Result<(AEVValidationMap<'_>, bool)> {
@@ -530,11 +477,8 @@ impl Schema {
                 schema_changes_detected = true;
             }
 
-            let entry = aev
-                .entry((attribute_id, attr))
-                .or_default()
-                .entry(datom.entity)
-                .or_default();
+            let entry =
+                aev.entry((attribute_id, attr)).or_default().entry(datom.entity).or_default();
 
             match datom.op {
                 DatomOp::Assert => {
@@ -552,11 +496,8 @@ impl Schema {
     fn type_mismatches(&self, aev: &AEVValidationMap<'_>) -> Vec<ValidationConflict> {
         let mut conflicts = Vec::new();
         for ((attribute_id, attribute), evs) in aev {
-            let attribute_ident = self
-                .entid_map
-                .get(attribute_id)
-                .cloned()
-                .unwrap_or_else(|| kw!(:db/unknown));
+            let attribute_ident =
+                self.entid_map.get(attribute_id).cloned().unwrap_or_else(|| kw!(:db/unknown));
             for (entity, values) in evs {
                 for value in values.adds.iter().chain(values.retracts.iter()) {
                     if !attribute.value_type.matches(value) {
@@ -579,17 +520,10 @@ impl Schema {
             if attribute.multival {
                 continue;
             }
-            let attribute_ident = self
-                .entid_map
-                .get(attribute_id)
-                .cloned()
-                .unwrap_or_else(|| kw!(:db/unknown));
+            let attribute_ident =
+                self.entid_map.get(attribute_id).cloned().unwrap_or_else(|| kw!(:db/unknown));
             for (entity, values) in evs {
-                let overlap: Vec<_> = values
-                    .adds
-                    .intersection(&values.retracts)
-                    .cloned()
-                    .collect();
+                let overlap: Vec<_> = values.adds.intersection(&values.retracts).cloned().collect();
                 if !overlap.is_empty() {
                     conflicts.push(ValidationConflict::AddRetractConflict {
                         entity: *entity,
@@ -608,11 +542,8 @@ impl Schema {
             if attribute.multival {
                 continue;
             }
-            let attribute_ident = self
-                .entid_map
-                .get(attribute_id)
-                .cloned()
-                .unwrap_or_else(|| kw!(:db/unknown));
+            let attribute_ident =
+                self.entid_map.get(attribute_id).cloned().unwrap_or_else(|| kw!(:db/unknown));
             for (entity, values) in evs {
                 if values.adds.len() > 1 {
                     conflicts.push(ValidationConflict::CardinalityOneAddConflict {
@@ -658,18 +589,10 @@ pub fn bootstrap_schema() -> Schema {
     }
 
     for (ident, vt_ident, card_ident) in V1_ATTRIBUTES.iter() {
-        let eid = *schema
-            .ident_map
-            .get(ident)
-            .expect("V1_ATTRIBUTES ident not in V1_IDENTS");
-        let vt_id = *schema
-            .ident_map
-            .get(vt_ident)
-            .expect("value type ident not in V1_IDENTS");
-        let card_id = *schema
-            .ident_map
-            .get(card_ident)
-            .expect("cardinality ident not in V1_IDENTS");
+        let eid = *schema.ident_map.get(ident).expect("V1_ATTRIBUTES ident not in V1_IDENTS");
+        let vt_id = *schema.ident_map.get(vt_ident).expect("value type ident not in V1_IDENTS");
+        let card_id =
+            *schema.ident_map.get(card_ident).expect("cardinality ident not in V1_IDENTS");
         schema.attribute_map.insert(
             eid,
             Attribute {
@@ -725,10 +648,7 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 fn schema_attribute_with_cardinality(ident: Keyword, value_type: &str, cardinality: &str) -> TxOp {
     TxOp::put(vec![
         (kw!(:db/ident), DataType::Keyword(ident)),
-        (
-            kw!(:db/valueType),
-            DataType::Keyword(Keyword::namespaced("db.type", value_type)),
-        ),
+        (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type))),
         (
             kw!(:db/cardinality),
             DataType::Keyword(Keyword::namespaced("db.cardinality", cardinality)),
@@ -760,22 +680,14 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
     let handle = Handle::current();
 
     // Query 1: all entities with db/ident (populates ident_map/entid_map)
-    let ident_query: ParsedQuery = "[:find ?e ?ident :where [?e :db/ident ?ident]]"
-        .parse()
-        .expect("Ident query parse failed");
+    let ident_query: ParsedQuery =
+        "[:find ?e ?ident :where [?e :db/ident ?ident]]".parse().expect("Ident query parse failed");
 
     let snap_clone = snapshot.clone();
     let handle_clone = handle.clone();
     let ident_map_clone = bootstrap_ident_map.clone();
     let ident_results = tokio::task::spawn_blocking(move || {
-        execute_query(
-            &ident_query,
-            &[],
-            snap_clone,
-            handle_clone,
-            &ident_map_clone,
-            i64::MAX,
-        )
+        execute_query(&ident_query, &[], snap_clone, handle_clone, &ident_map_clone, i64::MAX)
     })
     .await
     .expect("Ident query task failed")
@@ -787,14 +699,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
         .expect("Attribute query parse failed");
 
     let attr_results = tokio::task::spawn_blocking(move || {
-        execute_query(
-            &attr_query,
-            &[],
-            snapshot,
-            handle,
-            &bootstrap_ident_map,
-            i64::MAX,
-        )
+        execute_query(&attr_query, &[], snapshot, handle, &bootstrap_ident_map, i64::MAX)
     })
     .await
     .expect("Attribute query task failed")
@@ -835,10 +740,7 @@ pub async fn load_schema_from_indices(slatedb: Arc<slatedb::Db>) -> Schema {
 
         schema.attribute_map.insert(
             entity_id,
-            Attribute {
-                value_type,
-                multival: cardinality == Cardinality::Many,
-            },
+            Attribute { value_type, multival: cardinality == Cardinality::Many },
         );
     }
 
@@ -929,11 +831,8 @@ mod tests {
     #[test]
     fn test_validate_datoms_valid() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "Alice".into(),
-        }];
+        let ops =
+            [TxOp::Add { entity: "alice".into(), attribute: kw!(:name), value: "Alice".into() }];
         let validation = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap();
         assert!(!validation.schema_changes_detected);
     }
@@ -946,23 +845,16 @@ mod tests {
             attribute: kw!(:person/age),
             value: 30_i64.into(),
         }];
-        let err = schema
-            .validate_datoms(&to_datoms(&ops, &schema))
-            .unwrap_err();
+        let err = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("Unknown attribute: :person/age"));
     }
 
     #[test]
     fn test_validate_datoms_type_mismatch() {
         let schema = bootstrapped_schema_with_person_name();
-        let ops = [TxOp::Add {
-            entity: "person".into(),
-            attribute: kw!(:name),
-            value: 42_i64.into(),
-        }];
-        let err = schema
-            .validate_datoms(&to_datoms(&ops, &schema))
-            .unwrap_err();
+        let ops =
+            [TxOp::Add { entity: "person".into(), attribute: kw!(:name), value: 42_i64.into() }];
+        let err = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("Type mismatch"));
     }
 
@@ -1004,14 +896,8 @@ mod tests {
 
     #[test]
     fn test_value_type_from_entity_id() {
-        assert_eq!(
-            ValueType::from_entity_id(DB_TYPE_REF).unwrap(),
-            ValueType::Ref
-        );
-        assert_eq!(
-            ValueType::from_entity_id(DB_TYPE_STRING).unwrap(),
-            ValueType::String
-        );
+        assert_eq!(ValueType::from_entity_id(DB_TYPE_REF).unwrap(), ValueType::Ref);
+        assert_eq!(ValueType::from_entity_id(DB_TYPE_STRING).unwrap(), ValueType::String);
         assert!(ValueType::from_entity_id(9999).is_err());
     }
 
@@ -1039,14 +925,8 @@ mod tests {
 
     #[test]
     fn test_cardinality_from_entity_id() {
-        assert_eq!(
-            Cardinality::from_entity_id(DB_CARDINALITY_ONE).unwrap(),
-            Cardinality::One
-        );
-        assert_eq!(
-            Cardinality::from_entity_id(DB_CARDINALITY_MANY).unwrap(),
-            Cardinality::Many
-        );
+        assert_eq!(Cardinality::from_entity_id(DB_CARDINALITY_ONE).unwrap(), Cardinality::One);
+        assert_eq!(Cardinality::from_entity_id(DB_CARDINALITY_MANY).unwrap(), Cardinality::Many);
         assert!(Cardinality::from_entity_id(9999).is_err());
     }
 
@@ -1106,11 +986,7 @@ mod tests {
     #[test]
     fn test_prepare_schema_update_parses_cardinality_many() {
         let schema = bootstrapped_schema();
-        let ops = [schema_attribute_with_cardinality(
-            kw!(:tags),
-            "string",
-            "many",
-        )];
+        let ops = [schema_attribute_with_cardinality(kw!(:tags), "string", "many")];
         let datoms = to_datoms(&ops, &schema);
         let validation = schema.validate_datoms(&datoms).unwrap();
         assert!(validation.schema_changes_detected);
@@ -1151,20 +1027,14 @@ mod tests {
     fn test_validate_datoms_rejects_add_retract_conflict() {
         let schema = bootstrapped_schema_with_person_name();
         let ops = [
-            TxOp::Add {
-                entity: EntityRef::Id(200),
-                attribute: kw!(:name),
-                value: "Alice".into(),
-            },
+            TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:name), value: "Alice".into() },
             TxOp::Retract {
                 entity: EntityRef::Id(200),
                 attribute: kw!(:name),
                 value: "Alice".into(),
             },
         ];
-        let err = schema
-            .validate_datoms(&to_datoms(&ops, &schema))
-            .unwrap_err();
+        let err = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("both assert and retract"));
     }
 
@@ -1172,41 +1042,23 @@ mod tests {
     fn test_validate_datoms_rejects_cardinality_one_conflict() {
         let schema = bootstrapped_schema_with_person_name();
         let ops = [
-            TxOp::Add {
-                entity: EntityRef::Id(200),
-                attribute: kw!(:name),
-                value: "Alice".into(),
-            },
-            TxOp::Add {
-                entity: EntityRef::Id(200),
-                attribute: kw!(:name),
-                value: "Bob".into(),
-            },
+            TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:name), value: "Alice".into() },
+            TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:name), value: "Bob".into() },
         ];
-        let err = schema
-            .validate_datoms(&to_datoms(&ops, &schema))
-            .unwrap_err();
+        let err = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap_err();
         assert!(err.to_string().contains("multiple values"));
     }
 
     #[test]
     fn test_validate_datoms_allows_add_retract_overlap_for_cardinality_many() {
         let mut schema = bootstrapped_schema();
-        let ops = [schema_attribute_with_cardinality(
-            kw!(:tags),
-            "string",
-            "many",
-        )];
+        let ops = [schema_attribute_with_cardinality(kw!(:tags), "string", "many")];
         let datoms = to_datoms(&ops, &schema);
         let update = schema.prepare_schema_update(&datoms).unwrap();
         schema.apply_schema_update(update);
 
         let ops = [
-            TxOp::Add {
-                entity: EntityRef::Id(200),
-                attribute: kw!(:tags),
-                value: "rust".into(),
-            },
+            TxOp::Add { entity: EntityRef::Id(200), attribute: kw!(:tags), value: "rust".into() },
             TxOp::Retract {
                 entity: EntityRef::Id(200),
                 attribute: kw!(:tags),

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,10 +40,7 @@ struct DbCache {
 
 impl DbCache {
     fn new(max_open: usize) -> Self {
-        DbCache {
-            entries: RwLock::new(HashMap::new()),
-            max_open,
-        }
+        DbCache { entries: RwLock::new(HashMap::new()), max_open }
     }
 
     /// Get or create a DB snapshot for the given tx_id.
@@ -83,13 +80,7 @@ impl DbCache {
         if entries.len() >= self.max_open {
             bail!("Too many open DB snapshots (max {})", self.max_open);
         }
-        entries.insert(
-            tx_id,
-            DbCacheEntry {
-                db: arc_db.clone(),
-                refcount: 1,
-            },
-        );
+        entries.insert(tx_id, DbCacheEntry { db: arc_db.clone(), refcount: 1 });
         Ok(arc_db)
     }
 
@@ -121,11 +112,7 @@ struct ConnectionState {
 
 impl ConnectionState {
     fn new() -> Self {
-        ConnectionState {
-            handles: HashMap::new(),
-            dbs: HashMap::new(),
-            next_db_id: 1,
-        }
+        ConnectionState { handles: HashMap::new(), dbs: HashMap::new(), next_db_id: 1 }
     }
 
     fn allocate_handle(&mut self, tx_id: i64, db: Arc<DB>) -> Result<u32> {
@@ -164,10 +151,7 @@ pub struct Server<L: TxLog> {
 
 impl<L: TxLog + 'static> Server<L> {
     pub fn new(node: Arc<Node<L>>, max_open_dbs: usize) -> Self {
-        Server {
-            node,
-            db_cache: Arc::new(DbCache::new(max_open_dbs)),
-        }
+        Server { node, db_cache: Arc::new(DbCache::new(max_open_dbs)) }
     }
 
     /// Start listening on the given address.
@@ -187,21 +171,17 @@ impl<L: TxLog + 'static> Server<L> {
     pub async fn listen_on(&self, listener: TcpListener, token: CancellationToken) -> Result<()> {
         let node = self.node.clone();
         let db_cache = self.db_cache.clone();
-        accept_loop(
-            listener,
-            token,
-            |stream, peer_addr, conn_token, connections| {
-                let node = node.clone();
-                let db_cache = db_cache.clone();
-                connections.spawn(async move {
-                    if let Err(e) = handle_connection(stream, node, db_cache, conn_token).await {
-                        warn!("Connection from {} closed with error: {}", peer_addr, e);
-                    } else {
-                        info!("Connection from {} closed cleanly", peer_addr);
-                    }
-                });
-            },
-        )
+        accept_loop(listener, token, |stream, peer_addr, conn_token, connections| {
+            let node = node.clone();
+            let db_cache = db_cache.clone();
+            connections.spawn(async move {
+                if let Err(e) = handle_connection(stream, node, db_cache, conn_token).await {
+                    warn!("Connection from {} closed with error: {}", peer_addr, e);
+                } else {
+                    info!("Connection from {} closed cleanly", peer_addr);
+                }
+            });
+        })
         .await
     }
 }
@@ -226,29 +206,24 @@ impl DevServer {
 
     pub async fn listen_on(&self, listener: TcpListener, token: CancellationToken) -> Result<()> {
         let max_open_dbs = self.max_open_dbs;
-        accept_loop(
-            listener,
-            token,
-            move |stream, peer_addr, conn_token, connections| {
-                connections.spawn(async move {
-                    let node = Arc::new(Node::memory_node().await);
-                    let db_cache = Arc::new(DbCache::new(max_open_dbs));
-                    if let Err(e) =
-                        handle_connection(stream, node.clone(), db_cache, conn_token).await
-                    {
-                        warn!("Connection from {} closed with error: {}", peer_addr, e);
-                    } else {
-                        info!("Connection from {} closed cleanly", peer_addr);
-                    }
-                    // This should never fail: handle_connection only borrows the Arc,
-                    // so refcount is 1 after it returns.
-                    let node = Arc::try_unwrap(node).unwrap_or_else(|_| {
-                        panic!("dev node Arc should have refcount 1 after connection close")
-                    });
-                    node.close().await;
+        accept_loop(listener, token, move |stream, peer_addr, conn_token, connections| {
+            connections.spawn(async move {
+                let node = Arc::new(Node::memory_node().await);
+                let db_cache = Arc::new(DbCache::new(max_open_dbs));
+                if let Err(e) = handle_connection(stream, node.clone(), db_cache, conn_token).await
+                {
+                    warn!("Connection from {} closed with error: {}", peer_addr, e);
+                } else {
+                    info!("Connection from {} closed cleanly", peer_addr);
+                }
+                // This should never fail: handle_connection only borrows the Arc,
+                // so refcount is 1 after it returns.
+                let node = Arc::try_unwrap(node).unwrap_or_else(|_| {
+                    panic!("dev node Arc should have refcount 1 after connection close")
                 });
-            },
-        )
+                node.close().await;
+            });
+        })
         .await
     }
 }
@@ -335,11 +310,7 @@ async fn handle_connection<L: TxLog + 'static>(
     // handshake doesn't block shutdown until the drain timeout expires.
     let startup = read_frontend_message(&mut reader, true, DEFAULT_MAX_MESSAGE_SIZE).await?;
     match startup {
-        FrontendMessage::Startup {
-            version_major,
-            version_minor,
-            ..
-        } => {
+        FrontendMessage::Startup { version_major, version_minor, .. } => {
             if version_major != PROTOCOL_VERSION_MAJOR {
                 write_backend_message(
                     &mut writer,
@@ -453,11 +424,7 @@ async fn handle_connection<L: TxLog + 'static>(
                 ready_for_query_flush(&mut writer).await?;
             }
 
-            FrontendMessage::Query {
-                query_string,
-                db_id,
-                args,
-            } => {
+            FrontendMessage::Query { query_string, db_id, args } => {
                 match handle_query(&conn_state, &query_string, db_id, &args).await {
                     Ok((result, find_vars)) => {
                         // Send RowDescription
@@ -490,10 +457,7 @@ async fn handle_connection<L: TxLog + 'static>(
                 ready_for_query_flush(&mut writer).await?;
             }
 
-            FrontendMessage::Execute {
-                ops,
-                await_indexing,
-            } => {
+            FrontendMessage::Execute { ops, await_indexing } => {
                 match handle_execute(&node, ops, await_indexing).await {
                     Ok(tx_result_msg) => {
                         write_backend_message(&mut writer, &tx_result_msg).await?;
@@ -579,15 +543,11 @@ async fn handle_open_db<L: TxLog + 'static>(
         }
         (Some(tid), Some(st)) => {
             let system_time = crate::protocol::micros_to_datetime(st)?;
-            let tx_key = crate::transaction::TxKey {
-                tx_id: tid,
-                system_time,
-            };
+            let tx_key = crate::transaction::TxKey { tx_id: tid, system_time };
             let tx_id = tx_key.tx_id;
             let node = node.clone();
-            let arc_db = db_cache
-                .acquire(tx_id, || async move { node.db_as_of(tx_key).await })
-                .await?;
+            let arc_db =
+                db_cache.acquire(tx_id, || async move { node.db_as_of(tx_key).await }).await?;
             (arc_db, tx_id)
         }
         _ => bail!("OpenDb requires both tx_id and system_time, or neither"),
@@ -603,9 +563,8 @@ async fn handle_query(
     db_id: u32,
     args: &[crate::ops::QueryArg],
 ) -> Result<(QueryResult, Vec<String>)> {
-    let db = conn_state
-        .get_db(db_id)
-        .ok_or_else(|| anyhow::anyhow!("Invalid DB handle: {}", db_id))?;
+    let db =
+        conn_state.get_db(db_id).ok_or_else(|| anyhow::anyhow!("Invalid DB handle: {}", db_id))?;
 
     let parsed = query_string.into_query()?;
 
@@ -651,13 +610,7 @@ async fn handle_execute<L: TxLog + 'static>(
 
 /// Send ReadyForQuery(Idle) and flush the writer.
 async fn ready_for_query_flush<W: tokio::io::AsyncWrite + Unpin>(writer: &mut W) -> Result<()> {
-    write_backend_message(
-        writer,
-        &BackendMessage::ReadyForQuery {
-            status: STATUS_IDLE,
-        },
-    )
-    .await?;
+    write_backend_message(writer, &BackendMessage::ReadyForQuery { status: STATUS_IDLE }).await?;
     writer.flush().await?;
     Ok(())
 }
@@ -678,13 +631,7 @@ async fn write_error_response<W: tokio::io::AsyncWrite + Unpin>(
     let message = err.to_string();
     write_backend_message(
         writer,
-        &BackendMessage::ErrorResponse {
-            severity,
-            code,
-            message,
-            detail: None,
-            hint: None,
-        },
+        &BackendMessage::ErrorResponse { severity, code, message, detail: None, hint: None },
     )
     .await?;
     Ok(())

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -121,11 +121,8 @@ impl CdcStream {
 
             // No more files — poll for new WAL files (after the one we already processed).
             loop {
-                let new_files: VecDeque<WalFile> = self
-                    .wal_reader
-                    .list((self.cursor.wal_id + 1)..)
-                    .await?
-                    .into();
+                let new_files: VecDeque<WalFile> =
+                    self.wal_reader.list((self.cursor.wal_id + 1)..).await?.into();
 
                 if !new_files.is_empty() {
                     self.wal_files = new_files;
@@ -171,9 +168,7 @@ mod tests {
     }
 
     fn flush_opts() -> FlushOptions {
-        FlushOptions {
-            flush_type: FlushType::Wal,
-        }
+        FlushOptions { flush_type: FlushType::Wal }
     }
 
     #[tokio::test]
@@ -182,14 +177,10 @@ mod tests {
         let wal_reader = WalReader::new("/test_empty", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel(); // cancel immediately so next_transaction returns None
-        let mut stream = CdcStream::new(
-            wal_reader,
-            CdcCursor::default(),
-            Duration::from_millis(10),
-            cancel,
-        )
-        .await
-        .unwrap();
+        let mut stream =
+            CdcStream::new(wal_reader, CdcCursor::default(), Duration::from_millis(10), cancel)
+                .await
+                .unwrap();
 
         let result = stream.next_transaction().await.unwrap();
         assert!(result.is_none());
@@ -207,14 +198,10 @@ mod tests {
         let wal_reader = WalReader::new("/test_single", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let mut stream = CdcStream::new(
-            wal_reader,
-            CdcCursor::default(),
-            Duration::from_millis(10),
-            cancel,
-        )
-        .await
-        .unwrap();
+        let mut stream =
+            CdcStream::new(wal_reader, CdcCursor::default(), Duration::from_millis(10), cancel)
+                .await
+                .unwrap();
 
         // Collect all entries across transactions.
         let mut all_entries = Vec::new();
@@ -254,14 +241,10 @@ mod tests {
         let wal_reader = WalReader::new("/test_multi", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let mut stream = CdcStream::new(
-            wal_reader,
-            CdcCursor::default(),
-            Duration::from_millis(10),
-            cancel,
-        )
-        .await
-        .unwrap();
+        let mut stream =
+            CdcStream::new(wal_reader, CdcCursor::default(), Duration::from_millis(10), cancel)
+                .await
+                .unwrap();
 
         let mut txs = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
@@ -291,14 +274,10 @@ mod tests {
         let wal_reader = WalReader::new("/test_filter", object_store.clone());
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let mut stream = CdcStream::new(
-            wal_reader,
-            CdcCursor::default(),
-            Duration::from_millis(10),
-            cancel,
-        )
-        .await
-        .unwrap();
+        let mut stream =
+            CdcStream::new(wal_reader, CdcCursor::default(), Duration::from_millis(10), cancel)
+                .await
+                .unwrap();
 
         let tx1 = stream.next_transaction().await.unwrap().unwrap();
 
@@ -308,10 +287,7 @@ mod tests {
         cancel2.cancel();
         let mut stream2 = CdcStream::new(
             wal_reader2,
-            CdcCursor {
-                wal_id: 0,
-                last_seq: tx1.seq,
-            },
+            CdcCursor { wal_id: 0, last_seq: tx1.seq },
             Duration::from_millis(10),
             cancel2,
         )
@@ -337,14 +313,10 @@ mod tests {
         let cancel = CancellationToken::new();
         // Cancel immediately so we don't block after consuming available data.
         cancel.cancel();
-        let mut stream = CdcStream::new(
-            wal_reader,
-            CdcCursor::default(),
-            Duration::from_millis(10),
-            cancel,
-        )
-        .await
-        .unwrap();
+        let mut stream =
+            CdcStream::new(wal_reader, CdcCursor::default(), Duration::from_millis(10), cancel)
+                .await
+                .unwrap();
 
         // Collect all entries across transactions.
         let mut all_entries = Vec::new();
@@ -353,9 +325,8 @@ mod tests {
         }
 
         // Should have a tombstone entry.
-        let has_tombstone = all_entries
-            .iter()
-            .any(|e| matches!(e.value, ValueDeletable::Tombstone));
+        let has_tombstone =
+            all_entries.iter().any(|e| matches!(e.value, ValueDeletable::Tombstone));
         assert!(has_tombstone);
         db.close().await.unwrap();
     }
@@ -372,10 +343,7 @@ mod tests {
         cancel.cancel();
         let mut stream = CdcStream::new(
             wal_reader,
-            CdcCursor {
-                wal_id: 0,
-                last_seq: u64::MAX - 1,
-            },
+            CdcCursor { wal_id: 0, last_seq: u64::MAX - 1 },
             Duration::from_millis(10),
             cancel,
         )
@@ -409,10 +377,7 @@ mod tests {
         cancel.cancel();
         let mut stream = CdcStream::new(
             wal_reader,
-            CdcCursor {
-                wal_id: 0,
-                last_seq: snap_seq,
-            },
+            CdcCursor { wal_id: 0, last_seq: snap_seq },
             Duration::from_millis(10),
             cancel,
         )
@@ -448,10 +413,7 @@ mod tests {
         cancel.cancel();
         let mut stream = CdcStream::new(
             wal_reader,
-            CdcCursor {
-                wal_id: 0,
-                last_seq: snap_seq,
-            },
+            CdcCursor { wal_id: 0, last_seq: snap_seq },
             Duration::from_millis(10),
             cancel,
         )
@@ -460,12 +422,7 @@ mod tests {
 
         let mut txs = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
-            assert!(
-                tx.seq > snap_seq,
-                "tx.seq {} should be > snapshot seq {}",
-                tx.seq,
-                snap_seq
-            );
+            assert!(tx.seq > snap_seq, "tx.seq {} should be > snapshot seq {}", tx.seq, snap_seq);
             txs.push(tx);
         }
         assert!(
@@ -495,10 +452,7 @@ mod tests {
         cancel.cancel();
         let mut stream = CdcStream::new(
             wal_reader,
-            CdcCursor {
-                wal_id: 0,
-                last_seq: snap_seq,
-            },
+            CdcCursor { wal_id: 0, last_seq: snap_seq },
             Duration::from_millis(10),
             cancel,
         )
@@ -507,19 +461,10 @@ mod tests {
 
         let mut txs = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
-            assert!(
-                tx.seq > snap_seq,
-                "tx.seq {} should be > snapshot seq {}",
-                tx.seq,
-                snap_seq
-            );
+            assert!(tx.seq > snap_seq, "tx.seq {} should be > snapshot seq {}", tx.seq, snap_seq);
             txs.push(tx);
         }
-        assert!(
-            txs.len() >= 2,
-            "expected at least 2 transactions, got {}",
-            txs.len()
-        );
+        assert!(txs.len() >= 2, "expected at least 2 transactions, got {}", txs.len());
         db.close().await.unwrap();
     }
 
@@ -540,10 +485,7 @@ mod tests {
             let cancel_clone = cancel.clone();
             let mut stream = CdcStream::new(
                 wal_reader,
-                CdcCursor {
-                    wal_id: 0,
-                    last_seq: snap_seq,
-                },
+                CdcCursor { wal_id: 0, last_seq: snap_seq },
                 Duration::from_millis(10),
                 cancel,
             )
@@ -572,11 +514,7 @@ mod tests {
                 );
                 txs.push(tx);
             }
-            assert!(
-                txs.len() >= 2,
-                "expected at least 2 live transactions, got {}",
-                txs.len()
-            );
+            assert!(txs.len() >= 2, "expected at least 2 live transactions, got {}", txs.len());
         })
         .await
         .expect("test_cdc_after_snapshot_live_streaming timed out");
@@ -604,10 +542,7 @@ mod tests {
             let cancel_clone = cancel.clone();
             let mut stream = CdcStream::new(
                 wal_reader,
-                CdcCursor {
-                    wal_id: 0,
-                    last_seq: snap_seq,
-                },
+                CdcCursor { wal_id: 0, last_seq: snap_seq },
                 Duration::from_millis(10),
                 cancel,
             )

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -18,47 +18,25 @@ pub struct SlateComponents {
 
 impl std::fmt::Debug for SlateComponents {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SlateComponents")
-            .field("path", &self.path)
-            .finish_non_exhaustive()
+        f.debug_struct("SlateComponents").field("path", &self.path).finish_non_exhaustive()
     }
 }
 
 pub async fn in_memory_slate() -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let path = format!("tmp/triplox-{}", random_string(10));
-    let db = Arc::new(
-        Db::builder(path.clone(), object_store.clone())
-            .build()
-            .await
-            .unwrap(),
-    );
-    SlateComponents {
-        db,
-        path,
-        object_store,
-    }
+    let db = Arc::new(Db::builder(path.clone(), object_store.clone()).build().await.unwrap());
+    SlateComponents { db, path, object_store }
 }
 
 pub async fn local_slate(path: &str) -> SlateComponents {
     let object_store: Arc<dyn ObjectStore> =
         Arc::new(LocalFileSystem::new_with_prefix(path).unwrap());
-    let db = Arc::new(
-        Db::builder("triplox", object_store.clone())
-            .build()
-            .await
-            .unwrap(),
-    );
-    SlateComponents {
-        db,
-        path: "triplox".to_string(),
-        object_store,
-    }
+    let db = Arc::new(Db::builder("triplox", object_store.clone()).build().await.unwrap());
+    SlateComponents { db, path: "triplox".to_string(), object_store }
 }
 
-pub const DEFAULT_WRITE_OPTIONS: WriteOptions = WriteOptions {
-    await_durable: false,
-};
+pub const DEFAULT_WRITE_OPTIONS: WriteOptions = WriteOptions { await_durable: false };
 
 pub const DEFAULT_SCAN_OPTIONS: ScanOptions = ScanOptions {
     durability_filter: DurabilityLevel::Memory,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -38,10 +38,8 @@ fn resolve_entity_ref(eref: &EntityRef, schema: &Schema) -> Result<IdOrTempId> {
         EntityRef::Id(id) => Ok(IdOrTempId::Id(*id)),
         EntityRef::TempId(s) => Ok(IdOrTempId::TempId(s.clone())),
         EntityRef::Ident(kw) => {
-            let eid = schema
-                .ident_map
-                .get(kw)
-                .ok_or_else(|| anyhow::anyhow!("Unknown ident: {}", kw))?;
+            let eid =
+                schema.ident_map.get(kw).ok_or_else(|| anyhow::anyhow!("Unknown ident: {}", kw))?;
             Ok(IdOrTempId::Id(*eid))
         }
         EntityRef::LookupRef(_, _) => Err(anyhow::anyhow!("Lookup refs not yet supported")),
@@ -60,19 +58,14 @@ fn resolve_db_id(val: &DataType, schema: &Schema) -> Result<IdOrTempId> {
                 .ok_or_else(|| anyhow::anyhow!("Unknown ident for :db/id: {}", kw))?;
             Ok(IdOrTempId::Id(*eid))
         }
-        other => Err(anyhow::anyhow!(
-            ":db/id must be Long, String, or Keyword, got {:?}",
-            other
-        )),
+        other => Err(anyhow::anyhow!(":db/id must be Long, String, or Keyword, got {:?}", other)),
     }
 }
 
 /// Resolve a value using the schema to determine if the attribute is ref-typed.
 fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<ValueWithTempIds> {
-    let is_ref = schema
-        .get_attribute(attr)
-        .map(|(_, a)| a.value_type == ValueType::Ref)
-        .unwrap_or(false);
+    let is_ref =
+        schema.get_attribute(attr).map(|(_, a)| a.value_type == ValueType::Ref).unwrap_or(false);
 
     if is_ref {
         match val {
@@ -84,11 +77,9 @@ fn resolve_value(val: &DataType, attr: &Keyword, schema: &Schema) -> Result<Valu
                 Ok(ValueWithTempIds::Data(DataType::Long(*eid)))
             }
             DataType::String(s) => Ok(ValueWithTempIds::TempRef(s.clone())),
-            other => Err(anyhow::anyhow!(
-                "Invalid value for ref-typed attribute {}: {:?}",
-                attr,
-                other
-            )),
+            other => {
+                Err(anyhow::anyhow!("Invalid value for ref-typed attribute {}: {:?}", attr, other))
+            }
         }
     } else {
         Ok(ValueWithTempIds::Data(val.clone()))
@@ -127,11 +118,7 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     });
                 }
             }
-            TxOp::Add {
-                entity,
-                attribute,
-                value,
-            } => {
+            TxOp::Add { entity, attribute, value } => {
                 datoms.push(DatomWithTempids {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
@@ -139,11 +126,7 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomWithTempi
                     op: DatomOp::Assert,
                 });
             }
-            TxOp::Retract {
-                entity,
-                attribute,
-                value,
-            } => {
+            TxOp::Retract { entity, attribute, value } => {
                 datoms.push(DatomWithTempids {
                     entity: resolve_entity_ref(entity, schema)?,
                     attribute: attribute.clone(),
@@ -206,12 +189,7 @@ pub fn resolve_tempids(
             ValueWithTempIds::Data(data) => data.clone(),
             ValueWithTempIds::TempRef(s) => DataType::Long(*tempid_map.get(s.as_str()).unwrap()),
         };
-        resolved.push(Datom {
-            entity,
-            attribute: d.attribute.clone(),
-            value,
-            op: d.op,
-        });
+        resolved.push(Datom { entity, attribute: d.attribute.clone(), value, op: d.op });
     }
     Ok(resolved)
 }
@@ -236,13 +214,9 @@ mod tests {
         use crate::schema::Attribute;
         let mut schema = Schema::default();
         schema.ident_map.insert(attr_kw, attr_eid);
-        schema.attribute_map.insert(
-            attr_eid,
-            Attribute {
-                value_type: ValueType::Ref,
-                multival: false,
-            },
-        );
+        schema
+            .attribute_map
+            .insert(attr_eid, Attribute { value_type: ValueType::Ref, multival: false });
         schema
     }
 
@@ -277,10 +251,7 @@ mod tests {
 
     #[test]
     fn test_expand_put_attrs_share_entity() {
-        let ops = vec![TxOp::put(vec![
-            (kw!(:name), "alice".into()),
-            (kw!(:age), 30_i64.into()),
-        ])];
+        let ops = vec![TxOp::put(vec![(kw!(:name), "alice".into()), (kw!(:age), 30_i64.into())])];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 2);
         assert_eq!(datoms[0].entity, datoms[1].entity);
@@ -297,10 +268,7 @@ mod tests {
         assert_eq!(datoms.len(), 1);
         assert_eq!(datoms[0].entity, IdOrTempId::Id(200));
         assert_eq!(datoms[0].attribute, kw!(:name));
-        assert_eq!(
-            datoms[0].value,
-            ValueWithTempIds::Data(DataType::String("bob".to_string()))
-        );
+        assert_eq!(datoms[0].value, ValueWithTempIds::Data(DataType::String("bob".to_string())));
         assert_eq!(datoms[0].op, DatomOp::Assert);
     }
 
@@ -361,10 +329,7 @@ mod tests {
             value: DataType::String("friend".to_string()),
         }];
         let datoms = expand_tx_ops(&ops, &schema).unwrap();
-        assert_eq!(
-            datoms[0].value,
-            ValueWithTempIds::TempRef("friend".to_string())
-        );
+        assert_eq!(datoms[0].value, ValueWithTempIds::TempRef("friend".to_string()));
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -99,10 +99,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
 
         let (start, end) = match index {
             IndexType::EAV => match position {
-                0 => (
-                    codec::CODEC_LENGTH,
-                    codec::CODEC_LENGTH + codec::ENTITY_LENGTH,
-                ),
+                0 => (codec::CODEC_LENGTH, codec::CODEC_LENGTH + codec::ENTITY_LENGTH),
                 1 => (
                     codec::CODEC_LENGTH + codec::ENTITY_LENGTH,
                     codec::CODEC_LENGTH + codec::ENTITY_LENGTH + codec::ATTRIBUTE_LENGTH,
@@ -113,10 +110,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
             },
             IndexType::AVE => match position {
-                0 => (
-                    codec::CODEC_LENGTH,
-                    codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                ),
+                0 => (codec::CODEC_LENGTH, codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH),
                 1 => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
                     total_length - codec::ENTITY_LENGTH - codec::TX_EID_OP_SUFFIX,
@@ -127,10 +121,7 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
                 ),
             },
             IndexType::AEV => match position {
-                0 => (
-                    codec::CODEC_LENGTH,
-                    codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                ),
+                0 => (codec::CODEC_LENGTH, codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH),
                 1 => (
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
                     codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH + codec::ENTITY_LENGTH,
@@ -142,17 +133,11 @@ pub fn make_extractor<T: GetSlice + AsRef<[u8]>>(
             },
             // AE/AV are atemporal — no T+op suffix
             IndexType::AE => match position {
-                0 => (
-                    codec::CODEC_LENGTH,
-                    codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                ),
+                0 => (codec::CODEC_LENGTH, codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH),
                 1.. => (codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH, total_length),
             },
             IndexType::AV => match position {
-                0 => (
-                    codec::CODEC_LENGTH,
-                    codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH,
-                ),
+                0 => (codec::CODEC_LENGTH, codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH),
                 1.. => (codec::CODEC_LENGTH + codec::ATTRIBUTE_LENGTH, total_length),
             },
         };


### PR DESCRIPTION
## Summary

- Adds `rustfmt.toml` with `use_small_heuristics = "Max"` to keep function calls on a single line when they fit within `max_width` (100 chars)
- Reformats existing code accordingly

## Test plan

- [x] `cargo fmt --check` passes
- [x] No functional changes — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)