### PR TITLE
feat: add year and month date extraction functions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
+use chrono::Datelike;
+
 use crate::ops::DataType;
 use edn::query::{ToVariable, Variable};
 
@@ -36,6 +38,9 @@ pub enum UnaryOp {
     Lower,
     Strlen,
     Str,
+    // Date/Time
+    Year,
+    Month,
 }
 
 /// A binary expression node (inspired by DataFusion's BinaryExpr).
@@ -250,6 +255,14 @@ fn eval_unary_op(op: &UnaryOp, val: &DataType) -> Option<DataType> {
             };
             Some(DataType::String(s))
         }
+        UnaryOp::Year => match val {
+            DataType::Instant(dt) => Some(DataType::Long(dt.year() as i64)),
+            _ => None,
+        },
+        UnaryOp::Month => match val {
+            DataType::Instant(dt) => Some(DataType::Long(dt.month() as i64)),
+            _ => None,
+        },
     }
 }
 
@@ -669,5 +682,39 @@ mod tests {
         let age = DataType::Long(25);
         let ctx = EvalContext::new(HashMap::from([("?age".to_var(), &age)]));
         assert_eq!(eval(&expr, &ctx), Some(DataType::Long(26)));
+    }
+
+    // --- Date/Time extraction tests ---
+
+    #[test]
+    fn test_year_from_instant() {
+        use chrono::TimeZone;
+        let dt = chrono::Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+        let expr = unary(UnaryOp::Year, Expr::Literal(DataType::Instant(dt)));
+        let ctx = EvalContext::new(HashMap::new());
+        assert_eq!(eval(&expr, &ctx), Some(DataType::Long(2024)));
+    }
+
+    #[test]
+    fn test_month_from_instant() {
+        use chrono::TimeZone;
+        let dt = chrono::Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+        let expr = unary(UnaryOp::Month, Expr::Literal(DataType::Instant(dt)));
+        let ctx = EvalContext::new(HashMap::new());
+        assert_eq!(eval(&expr, &ctx), Some(DataType::Long(6)));
+    }
+
+    #[test]
+    fn test_year_non_instant() {
+        let expr = unary(UnaryOp::Year, lit_long(42));
+        let ctx = EvalContext::new(HashMap::new());
+        assert_eq!(eval(&expr, &ctx), None);
+    }
+
+    #[test]
+    fn test_month_non_instant() {
+        let expr = unary(UnaryOp::Month, lit_string("2024-06-15"));
+        let ctx = EvalContext::new(HashMap::new());
+        assert_eq!(eval(&expr, &ctx), None);
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,7 +18,7 @@ use edn::query::{
 use crate::aggregate::{make_accumulator, Accumulator};
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple, SingleLevelExtender};
 use crate::codec::{Decode, Encode};
-use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr};
+use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr, UnaryExpr, UnaryOp};
 use crate::index::IndexType;
 use crate::iterator::generic_and_prefix_extender::GenericAndPrefixExtender;
 use crate::iterator::generic_fn_prefix_extender::GenericFnPrefixExtender;
@@ -218,6 +218,20 @@ fn convert_binary_op(name: &str) -> Result<BinaryOp, Error> {
     }
 }
 
+fn convert_unary_op(name: &str) -> Result<UnaryOp, Error> {
+    match name {
+        "not" => Ok(UnaryOp::Not),
+        "abs" => Ok(UnaryOp::Abs),
+        "upper" => Ok(UnaryOp::Upper),
+        "lower" => Ok(UnaryOp::Lower),
+        "strlen" => Ok(UnaryOp::Strlen),
+        "str" => Ok(UnaryOp::Str),
+        "year" => Ok(UnaryOp::Year),
+        "month" => Ok(UnaryOp::Month),
+        _ => Err(anyhow::anyhow!("Unsupported unary operator: {}", name)),
+    }
+}
+
 fn convert_fn_arg(arg: &edn::query::FnArg) -> Result<Expr, Error> {
     match arg {
         edn::query::FnArg::Variable(v) => Ok(Expr::Variable(v.clone())),
@@ -253,21 +267,33 @@ fn convert_predicate(pred: &Predicate) -> Result<Expr, Error> {
 
 fn convert_where_fn(wf: &WhereFn) -> Result<FnExpr, Error> {
     let op_name = wf.operator.0.as_str();
-    let op = convert_binary_op(op_name)?;
-    if wf.args.len() != 2 {
-        return Err(anyhow::anyhow!(
-            "WhereFn '{}' expects 2 args, got {}",
-            op_name,
-            wf.args.len()
-        ));
-    }
-    let left = convert_fn_arg(&wf.args[0])?;
-    let right = convert_fn_arg(&wf.args[1])?;
-    let expr = Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(left),
-        op,
-        right: Box::new(right),
-    });
+    let expr = match wf.args.len() {
+        1 => {
+            let op = convert_unary_op(op_name)?;
+            let operand = convert_fn_arg(&wf.args[0])?;
+            Expr::UnaryExpr(UnaryExpr {
+                op,
+                operand: Box::new(operand),
+            })
+        }
+        2 => {
+            let op = convert_binary_op(op_name)?;
+            let left = convert_fn_arg(&wf.args[0])?;
+            let right = convert_fn_arg(&wf.args[1])?;
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            })
+        }
+        n => {
+            return Err(anyhow::anyhow!(
+                "WhereFn '{}' has {} args, expected 1 or 2",
+                op_name,
+                n
+            ));
+        }
+    };
     let output = match &wf.binding {
         edn::query::Binding::BindScalar(v) => v.clone(),
         _ => return Err(anyhow::anyhow!("Only scalar binding supported")),

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use chrono::TimeZone;
 use edn::kw;
 use edn::symbols::Keyword;
 use triplox::client::ClientNode;
@@ -856,6 +857,53 @@ async fn test_upsert_with_resolved_entity_id() {
         result[0],
         vec![DataType::String("alice".to_string()), DataType::Long(31)]
     );
+
+    db.close().await.unwrap();
+    client.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_year_and_month_extraction() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+    define_schema_attr(&client, "birthday", "instant").await;
+
+    let dt = chrono::Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+    client
+        .execute_tx(vec![
+            TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            },
+            TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:birthday),
+                value: DataType::Instant(dt),
+            },
+        ])
+        .await
+        .unwrap();
+
+    let db = client.db().await.unwrap();
+
+    // Test year extraction
+    let result = db
+        .query("{:find [?y] :where [[?e :birthday ?d] [(year ?d) ?y]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], vec![DataType::Long(2024)]);
+
+    // Test month extraction
+    let result = db
+        .query("{:find [?m] :where [[?e :birthday ?d] [(month ?d) ?m]]}")
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], vec![DataType::Long(6)]);
 
     db.close().await.unwrap();
     client.close().await.unwrap();


### PR DESCRIPTION
## Summary
- Add `year` and `month` unary operators for extracting components from `Instant` values, returning `Long`
- Wire up unary op dispatch in `convert_where_fn` so 1-arg `WhereFn` clauses work in queries (this also enables existing unary ops like `abs`, `upper`, `lower`, `strlen`, `str` in queries)
- Query syntax: `[(year ?date) ?y]`, `[(month ?date) ?m]`

Closes #216 (year/month portion)

## Test plan
- [x] Unit tests for `Year`/`Month` evaluation from `Instant` values
- [x] Unit tests for type errors (non-`Instant` inputs return `None`)
- [x] Full `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)