### PR TITLE
feat: add regexp_like predicate for regex matching (#214)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.11"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.13"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
@@ -3868,6 +3868,7 @@ dependencies = [
  "log",
  "object_store",
  "rand 0.9.2",
+ "regex",
  "reqwest",
  "rmp",
  "rmpv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,13 +2675,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.14",
  "regex-syntax 0.8.5",
 ]
 
@@ -2696,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ indexmap = "2.14.0"
 log = "0.4"
 object_store = { version = "0.12.3", features = ["aws"] }
 rand = "0.9"
-regex = "1"
+regex = "1.12.3"
 serde = { workspace = true, features = ["derive"] }
 # slatedb = { version = "0.12.0", features = ["wal_disable"] }
 slatedb = { git = "https://github.com/slatedb/slatedb", rev = "e4a31506e78878e313a001e0ade760ddbda59dba", features = ["wal_disable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ indexmap = "2.14.0"
 log = "0.4"
 object_store = { version = "0.12.3", features = ["aws"] }
 rand = "0.9"
+regex = "1"
 serde = { workspace = true, features = ["derive"] }
 # slatedb = { version = "0.12.0", features = ["wal_disable"] }
 slatedb = { git = "https://github.com/slatedb/slatedb", rev = "e4a31506e78878e313a001e0ade760ddbda59dba", features = ["wal_disable"] }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,6 +1,9 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use regex::Regex;
 
 use chrono::Datelike;
 
@@ -58,6 +61,20 @@ pub struct UnaryExpr {
     pub operand: Box<Expr>,
 }
 
+/// A regexp_like expression node. Compiles the pattern once at plan time.
+#[derive(Debug, Clone)]
+pub struct RegexpLikeExpr {
+    pub pattern_src: String,
+    pub pattern: Arc<Regex>,
+    pub subject: Box<Expr>,
+}
+
+impl PartialEq for RegexpLikeExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern_src == other.pattern_src && self.subject == other.subject
+    }
+}
+
 /// Expression tree (inspired by DataFusion's Expr enum).
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
@@ -69,6 +86,8 @@ pub enum Expr {
     BinaryExpr(BinaryExpr),
     /// A unary operation.
     UnaryExpr(UnaryExpr),
+    /// regexp_like predicate with a pre-compiled pattern.
+    RegexpLike(RegexpLikeExpr),
 }
 
 /// Collect all variables referenced in an expression, deduplicated, in first-appearance order.
@@ -93,6 +112,9 @@ fn collect_vars(expr: &Expr, seen: &mut HashSet<Variable>, vars: &mut Vec<Variab
         }
         Expr::UnaryExpr(UnaryExpr { operand, .. }) => {
             collect_vars(operand, seen, vars);
+        }
+        Expr::RegexpLike(RegexpLikeExpr { subject, .. }) => {
+            collect_vars(subject, seen, vars);
         }
     }
 }
@@ -128,6 +150,15 @@ pub fn evaluate<'a>(expr: &'a Expr, ctx: &'a EvalContext<'a>) -> Option<Cow<'a, 
         Expr::UnaryExpr(UnaryExpr { op, operand }) => {
             let v = evaluate(operand, ctx)?;
             eval_unary_op(op, &v).map(Cow::Owned)
+        }
+        Expr::RegexpLike(RegexpLikeExpr {
+            pattern, subject, ..
+        }) => {
+            let v = evaluate(subject, ctx)?;
+            match v.as_ref() {
+                DataType::String(s) => Some(Cow::Owned(DataType::Boolean(pattern.is_match(s)))),
+                _ => None,
+            }
         }
     }
 }
@@ -716,5 +747,92 @@ mod tests {
         let expr = unary(UnaryOp::Month, lit_string("2024-06-15"));
         let ctx = EvalContext::new(HashMap::new());
         assert_eq!(eval(&expr, &ctx), None);
+    }
+
+    // --- regexp_like tests ---
+
+    fn regexp_like(pattern: &str, subject: Expr) -> Expr {
+        Expr::RegexpLike(RegexpLikeExpr {
+            pattern_src: pattern.to_string(),
+            pattern: Arc::new(Regex::new(pattern).expect("valid regex")),
+            subject: Box::new(subject),
+        })
+    }
+
+    #[test]
+    fn test_regexp_like_match() {
+        let expr = regexp_like("^.*BRASS$", var("?ptype"));
+        let ptype = DataType::String("STANDARD POLISHED BRASS".to_string());
+        let ctx = EvalContext::new(HashMap::from([("?ptype".to_var(), &ptype)]));
+        assert_eq!(eval(&expr, &ctx), Some(DataType::Boolean(true)));
+    }
+
+    #[test]
+    fn test_regexp_like_no_match() {
+        let expr = regexp_like("^.*BRASS$", var("?ptype"));
+        let ptype = DataType::String("STANDARD POLISHED COPPER".to_string());
+        let ctx = EvalContext::new(HashMap::from([("?ptype".to_var(), &ptype)]));
+        assert_eq!(eval(&expr, &ctx), Some(DataType::Boolean(false)));
+    }
+
+    #[test]
+    fn test_regexp_like_substring() {
+        let expr = regexp_like(".*green.*", var("?name"));
+        let matches = DataType::String("forest green pine".to_string());
+        let misses = DataType::String("aqua blue".to_string());
+        let ctx_match = EvalContext::new(HashMap::from([("?name".to_var(), &matches)]));
+        let ctx_miss = EvalContext::new(HashMap::from([("?name".to_var(), &misses)]));
+        assert_eq!(eval(&expr, &ctx_match), Some(DataType::Boolean(true)));
+        assert_eq!(eval(&expr, &ctx_miss), Some(DataType::Boolean(false)));
+    }
+
+    #[test]
+    fn test_regexp_like_case_insensitive_inline_flag() {
+        let expr = regexp_like("(?i)^.*green.*", var("?name"));
+        let val = DataType::String("Forest GREEN pine".to_string());
+        let ctx = EvalContext::new(HashMap::from([("?name".to_var(), &val)]));
+        assert_eq!(eval(&expr, &ctx), Some(DataType::Boolean(true)));
+    }
+
+    #[test]
+    fn test_regexp_like_non_string_subject_drops() {
+        let expr = regexp_like(".*", var("?n"));
+        let n = DataType::Long(42);
+        let ctx = EvalContext::new(HashMap::from([("?n".to_var(), &n)]));
+        // Non-String subject -> None (row dropped). See issue #222.
+        assert_eq!(eval(&expr, &ctx), None);
+    }
+
+    #[test]
+    fn test_regexp_like_unbound_subject() {
+        let expr = regexp_like(".*", var("?missing"));
+        let ctx = EvalContext::new(HashMap::new());
+        assert_eq!(eval(&expr, &ctx), None);
+    }
+
+    #[test]
+    fn test_regexp_like_expr_variables() {
+        let expr = regexp_like("^foo", var("?name"));
+        assert_eq!(expr_variables(&expr), vec!["?name".to_var()]);
+    }
+
+    #[test]
+    fn test_regexp_like_evaluate_as_bool() {
+        let expr = regexp_like("^foo", var("?name"));
+        let hit = DataType::String("foobar".to_string());
+        let miss = DataType::String("bar".to_string());
+        let ctx_hit = EvalContext::new(HashMap::from([("?name".to_var(), &hit)]));
+        let ctx_miss = EvalContext::new(HashMap::from([("?name".to_var(), &miss)]));
+        assert!(evaluate_as_bool(&expr, &ctx_hit));
+        assert!(!evaluate_as_bool(&expr, &ctx_miss));
+    }
+
+    #[test]
+    fn test_regexp_like_partial_eq_by_pattern_src() {
+        let a = regexp_like("^foo", var("?x"));
+        let b = regexp_like("^foo", var("?x"));
+        let c = regexp_like("^bar", var("?x"));
+        assert_eq!(a, b);
+        assert_ne!(a, c);
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -19,7 +19,8 @@ use edn::query::{
 use crate::aggregate::{make_accumulator, Accumulator};
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple, SingleLevelExtender};
 use crate::codec::{Decode, Encode};
-use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr, UnaryExpr, UnaryOp};
+use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr, RegexpLikeExpr, UnaryExpr, UnaryOp};
+use regex::Regex;
 use crate::index::IndexType;
 use crate::iterator::generic_and_prefix_extender::GenericAndPrefixExtender;
 use crate::iterator::generic_fn_prefix_extender::GenericFnPrefixExtender;
@@ -247,8 +248,43 @@ fn convert_fn_arg(arg: &edn::query::FnArg) -> Result<Expr, Error> {
     }
 }
 
+/// Extract a literal string from a FnArg, for operators that require a literal pattern.
+fn fn_arg_as_text_literal<'a>(arg: &'a edn::query::FnArg) -> Option<&'a str> {
+    if let edn::query::FnArg::Constant(NonIntegerConstant::Text(s)) = arg {
+        Some(s.as_str())
+    } else {
+        None
+    }
+}
+
+/// Build a RegexpLike expression from the 2-arg `(regexp_like ?subject "pattern")` form.
+/// Pattern must be a string literal; compiled once at plan time.
+fn build_regexp_like(args: &[edn::query::FnArg]) -> Result<Expr, Error> {
+    if args.len() != 2 {
+        return Err(anyhow::anyhow!(
+            "regexp_like expects 2 args (subject, pattern), got {}",
+            args.len()
+        ));
+    }
+    let subject = convert_fn_arg(&args[0])?;
+    let pattern_src = fn_arg_as_text_literal(&args[1]).ok_or_else(|| {
+        anyhow::anyhow!("regexp_like requires a string literal as second argument (pattern)")
+    })?;
+    let pattern = Regex::new(pattern_src).map_err(|e| {
+        anyhow::anyhow!("invalid regex pattern for regexp_like `{}`: {}", pattern_src, e)
+    })?;
+    Ok(Expr::RegexpLike(RegexpLikeExpr {
+        pattern_src: pattern_src.to_string(),
+        pattern: Arc::new(pattern),
+        subject: Box::new(subject),
+    }))
+}
+
 pub(crate) fn convert_predicate(pred: &Predicate) -> Result<Expr, Error> {
     let op_name = pred.operator.0.as_str();
+    if op_name == "regexp_like" {
+        return build_regexp_like(&pred.args);
+    }
     let op = convert_binary_op(op_name)?;
     if pred.args.len() != 2 {
         return Err(anyhow::anyhow!(
@@ -268,6 +304,11 @@ pub(crate) fn convert_predicate(pred: &Predicate) -> Result<Expr, Error> {
 
 pub(crate) fn convert_where_fn(wf: &WhereFn) -> Result<FnExpr, Error> {
     let op_name = wf.operator.0.as_str();
+    if op_name == "regexp_like" {
+        return Err(anyhow::anyhow!(
+            "regexp_like is a predicate, not a binding function"
+        ));
+    }
     let expr = match wf.args.len() {
         1 => {
             let op = convert_unary_op(op_name)?;
@@ -1391,5 +1432,73 @@ mod tests {
         let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
         // ?name from :in should come first, then ?e from WHERE
         assert_eq!(order, vec!["?name".to_var(), "?e".to_var(),]);
+    }
+
+    // --- regexp_like query conversion tests ---
+
+    #[test]
+    fn test_regexp_like_valid_query() {
+        let parsed = parse_query(
+            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "^B")]]"#,
+        );
+        let result = validate_query(&parsed, &[]);
+        assert!(result.is_ok(), "expected ok, got {:?}", result);
+    }
+
+    #[test]
+    fn test_regexp_like_invalid_pattern_rejected_at_plan_time() {
+        let parsed = parse_query(
+            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "[")]]"#,
+        );
+        let result = validate_query(&parsed, &[]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("invalid regex pattern"),
+            "unexpected error: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_regexp_like_non_literal_pattern_rejected() {
+        // Pattern arg is a variable ?pat, not a string literal.
+        let parsed = parse_query(
+            r#"[:find ?name :where [?e :name ?name] [?e :pat ?pat] [(regexp_like ?name ?pat)]]"#,
+        );
+        let result = validate_query(&parsed, &[]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("string literal"),
+            "unexpected error: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_regexp_like_wrong_arity_rejected() {
+        let parsed = parse_query(
+            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name)]]"#,
+        );
+        let result = validate_query(&parsed, &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("expects 2 args"));
+    }
+
+    #[test]
+    fn test_regexp_like_binding_form_rejected() {
+        // regexp_like is predicate-only; binding form should be rejected.
+        let parsed = parse_query(
+            r#"[:find ?name ?hit :where [?e :name ?name] [(regexp_like ?name "^B") ?hit]]"#,
+        );
+        let result = validate_query(&parsed, &[]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("predicate, not a binding function"),
+            "unexpected error: {}",
+            msg
+        );
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,7 +20,6 @@ use crate::aggregate::{make_accumulator, Accumulator};
 use crate::algo::generic_join::{GenericJoin, PrefixExtender, ResultTuple, SingleLevelExtender};
 use crate::codec::{Decode, Encode};
 use crate::expr::{expr_variables, BinaryExpr, BinaryOp, Expr, RegexpLikeExpr, UnaryExpr, UnaryOp};
-use regex::Regex;
 use crate::index::IndexType;
 use crate::iterator::generic_and_prefix_extender::GenericAndPrefixExtender;
 use crate::iterator::generic_fn_prefix_extender::GenericFnPrefixExtender;
@@ -29,6 +28,7 @@ use crate::iterator::generic_or_prefix_extender::GenericOrPrefixExtender;
 use crate::iterator::generic_predicate_prefix_extender::GenericPredicatePrefixExtender;
 use crate::iterator::generic_prefix_extender::GenericPrefixExtender;
 use crate::ops::{DataType, QueryArg};
+use regex::Regex;
 
 /// Each inner Vec is a projected row of decoded DataType values.
 pub type QueryResult = Vec<Vec<DataType>>;
@@ -249,7 +249,7 @@ fn convert_fn_arg(arg: &edn::query::FnArg) -> Result<Expr, Error> {
 }
 
 /// Extract a literal string from a FnArg, for operators that require a literal pattern.
-fn fn_arg_as_text_literal<'a>(arg: &'a edn::query::FnArg) -> Option<&'a str> {
+fn fn_arg_as_text_literal(arg: &edn::query::FnArg) -> Option<&str> {
     if let edn::query::FnArg::Constant(NonIntegerConstant::Text(s)) = arg {
         Some(s.as_str())
     } else {
@@ -271,7 +271,11 @@ fn build_regexp_like(args: &[edn::query::FnArg]) -> Result<Expr, Error> {
         anyhow::anyhow!("regexp_like requires a string literal as second argument (pattern)")
     })?;
     let pattern = Regex::new(pattern_src).map_err(|e| {
-        anyhow::anyhow!("invalid regex pattern for regexp_like `{}`: {}", pattern_src, e)
+        anyhow::anyhow!(
+            "invalid regex pattern for regexp_like `{}`: {}",
+            pattern_src,
+            e
+        )
     })?;
     Ok(Expr::RegexpLike(RegexpLikeExpr {
         pattern_src: pattern_src.to_string(),
@@ -1197,6 +1201,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_validation::validate_query;
 
     /// Parse an EDN query string into a ParsedQuery.
     fn parse_query(input: &str) -> ParsedQuery {
@@ -1438,18 +1443,16 @@ mod tests {
 
     #[test]
     fn test_regexp_like_valid_query() {
-        let parsed = parse_query(
-            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "^B")]]"#,
-        );
+        let parsed =
+            parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "^B")]]"#);
         let result = validate_query(&parsed, &[]);
         assert!(result.is_ok(), "expected ok, got {:?}", result);
     }
 
     #[test]
     fn test_regexp_like_invalid_pattern_rejected_at_plan_time() {
-        let parsed = parse_query(
-            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "[")]]"#,
-        );
+        let parsed =
+            parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "[")]]"#);
         let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -1469,18 +1472,12 @@ mod tests {
         let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("string literal"),
-            "unexpected error: {}",
-            msg
-        );
+        assert!(msg.contains("string literal"), "unexpected error: {}", msg);
     }
 
     #[test]
     fn test_regexp_like_wrong_arity_rejected() {
-        let parsed = parse_query(
-            r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name)]]"#,
-        );
+        let parsed = parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name)]]"#);
         let result = validate_query(&parsed, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("expects 2 args"));

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -345,23 +345,22 @@
                           [?e2 :age ?age2]
                           [(<= ?age1 ?age2)]]})))))
 
-  ;; re-find tests commented out — see triplox-bwi for tracking
-  #_(testing "re-find predicate"
-      (is (= #{["Bob"] ["Dominic"]}
+  (testing "regexp_like predicate"
+    (is (= #{["Bob"] ["Dominic"]}
+           (q '{:find [?name]
+                :where [[?e :name ?name]
+                        [(regexp_like ?name "o")]]})))
+
+    (testing "No results"
+      (is (empty? (q '{:find [?name]
+                       :where [[?e :name ?name]
+                               [(regexp_like ?name "X")]]}))))
+
+    (testing "Not predicate"
+      (is (= #{["Ivan"]}
              (q '{:find [?name]
                   :where [[?e :name ?name]
-                          [(re-find #"o" ?name)]]})))
-
-      (testing "No results"
-        (is (empty? (q '{:find [?name]
-                         :where [[?e :name ?name]
-                                 [(re-find #"X" ?name)]]}))))
-
-      (testing "Not predicate"
-        (is (= #{["Ivan"]}
-               (q '{:find [?name]
-                    :where [[?e :name ?name]
-                            (not [(re-find #"o" ?name)])]})))))
+                          (not [(regexp_like ?name "o")])]})))))
 
   (testing "Entity variable"
     ;; Discover Ivan's entity ID, then use it in a predicate
@@ -386,30 +385,30 @@
                                    [(= 30 ?age)]]}))))))
 
 
-  ;; re-find tests commented out — see triplox-bwi
-  #_(testing "Several variables with re-find"
-      (is (= #{["Bob"]}
-             (q '{:find [?name]
-                  :where [[?e :name ?name]
-                          [?e :age ?age]
-                          [(= 40 ?age)]
-                          [(re-find #"o" ?name)]
-                          [(not= ?age ?name)]]})))
+  (testing "Several variables with regexp_like"
+    (is (= #{["Bob"]}
+           (q '{:find [?name]
+                :where [[?e :name ?name]
+                        [?e :age ?age]
+                        [(= 40 ?age)]
+                        [(regexp_like ?name "o")]
+                        [(not= ?age ?name)]]})))
 
-      (is (= #{[1001 "Ivanov"]}
+    (let [bob-id (ffirst (q '{:find [?e] :where [[?e :name "Bob"]]}))]
+      (is (= #{[bob-id "Ivanov"]}
              (q '{:find [?e ?last-name]
                   :where [[?e :last-name ?last-name]
                           [?e :age ?age]
-                          [(re-find #"ov$" ?last-name)]
-                          (not [(= ?age 30)])]})))
+                          [(regexp_like ?last-name "ov$")]
+                          (not [(= ?age 30)])]}))))
 
-      (testing "No results"
-        (is (= #{}
-               (q '{:find [?name]
-                    :where [[?e :name ?name]
-                            [?e :age ?age]
-                            [(re-find #"o" ?name)]
-                            [(= ?age ?name)]]})))))
+    (testing "No results"
+      (is (= #{}
+             (q '{:find [?name]
+                  :where [[?e :name ?name]
+                          [?e :age ?age]
+                          [(regexp_like ?name "o")]
+                          [(= ?age ?name)]]})))))
 
   (testing "Bind result to var"
     (is (= #{["Dominic" 25] ["Ivan" 15] ["Bob" 20]}

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -424,7 +424,7 @@
                           [?e :age ?real-age]
                           [(quot ?real-age 2) ?half-age]]}))))
 
-    ;; Commented out — requires negative number literals in expressions (triplox-qns)
+    ;; Commented out — requires negative number literals in expressions
     #_(testing "Binding more than once intersects result"
         (is (= #{["Ivan" 15]}
                (q '{:find [?name ?half-age]


### PR DESCRIPTION
## Summary

- Adds `regexp_like` as a 2-arg predicate: `[(regexp_like ?subject "pattern")]`
- SQL family naming + arg order (Postgres, DataFusion, Snowflake, Oracle). Plain-string patterns, no EDN parser change
- Patterns compile once at plan time via the `regex` crate; invalid/non-literal patterns rejected with a clear error
- Predicate-only in v1; binding form (`[(regexp_like ...) ?m]`) explicitly rejected. Inline flags (`(?i)`, `(?m)`, `(?s)`) cover case-insensitive needs
- Non-String subject follows the existing silent-drop convention (see #222); stricter error semantics land for free when that issue resolves
- Unblocks TPC-H Q2 / Q9 / Q13 / Q16 / Q20 / Q21. Reactivates the two previously `#_`-commented `re-find` integration tests in `query_test.clj`, rewritten against `regexp_like`

Closes #214.

## Test plan

- [x] `cargo test` — 416 lib + 20 integration tests green (13 new: 8 `src/expr.rs`, 5 `src/query.rs`)
- [x] `./gradlew integrationTest` with the dev server running — 23/23 pass, including the reactivated `regexp_like` blocks
- [ ] Spot-check TPC-H Q2 once sibling deps (`if` #215, `subs` #217) ship — not part of this PR