### PR TITLE
Swap rustfs for MinIO in docker compose stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@ target/
 .git/
 .idea/
 .claude/
+docker/data/
 *.md
 !docker/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .clj-kondo/
 .cpcache/
 .nrepl-port
+
+docker/data/

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,25 @@ docker run -p 5490:5490 \
   triplox:latest
 ```
 
-### Remote mode (S3-compatible with RustFS)
+### Remote mode (S3-compatible with MinIO)
+
+#### First-time setup
+
+MinIO data lives on a loopback ext4 image on disk (MinIO's sanity check treats
+btrfs as corrupt, so a plain bind mount to a btrfs host FS won't work). Create
+and mount the image once, then re-run after each reboot:
+
+```bash
+./docker/scripts/setup-minio-disk.sh
+```
+
+This creates a 50G sparse image at `docker/data/minio.img`, formats it ext4,
+and mounts it at `docker/data/minio/`. Override the size with
+`MINIO_IMG_SIZE=100G ./docker/scripts/setup-minio-disk.sh`.
+
+To unmount later: `sudo umount docker/data/minio`.
+
+#### Starting the stack
 
 Using docker-compose:
 
@@ -36,8 +54,22 @@ docker compose -f docker/docker-compose.yml up --build
 ```
 
 This starts:
-- **RustFS** on port 9000 (S3 API) and 9001 (console)
-- **Triplox** on port 5490 with SlateDB backed by RustFS
+- **MinIO** on port 9000 (S3 API) and 9001 (console)
+- **Triplox** on port 5490 with SlateDB backed by MinIO
+
+#### Resetting the stack
+
+Wipe all MinIO data and the triplox local log, and bring everything back to a
+clean slate:
+
+```bash
+./docker/scripts/reset-remote-stack.sh
+```
+
+This runs `docker compose down -v` (removing the `triplox-log` named volume)
+and clears the contents of `docker/data/minio/` (keeping the ext4 mount). It
+does not unmount or delete the loopback image. After it finishes, re-run
+`docker compose -f docker/docker-compose.yml up --build`.
 
 ### Custom config
 

--- a/docker/config/triplox-remote.toml
+++ b/docker/config/triplox-remote.toml
@@ -1,6 +1,6 @@
 [storage]
 type = "remote"
-endpoint = "http://rustfs:9000"
+endpoint = "http://minio:9000"
 bucket = "triplox"
 access_key = "triplox"
 secret_key = "triplox123"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,19 +1,18 @@
 services:
-  rustfs:
-    image: rustfs/rustfs:1.0.0-alpha.93
+  minio:
+    image: minio/minio:latest
     command: server /data --console-address ":9001"
     # Dev-only credentials — do not use in production
     environment:
-      RUSTFS_ROOT_USER: triplox
-      RUSTFS_ROOT_PASSWORD: triplox123
+      MINIO_ROOT_USER: triplox
+      MINIO_ROOT_PASSWORD: triplox123
     ports:
       - "9000:9000"
       - "9001:9001"
-    tmpfs:
-      - /data:mode=1777
-      - /logs:mode=1777
+    volumes:
+      - ./data/minio:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/health/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -21,13 +20,13 @@ services:
   createbucket:
     image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
-      rustfs:
+      minio:
         condition: service_healthy
     entrypoint: /bin/sh
     command: >
       -c "
-      mc alias set myrustfs http://rustfs:9000 triplox triplox123 &&
-      mc mb --ignore-existing myrustfs/triplox
+      mc alias set myminio http://minio:9000 triplox triplox123 &&
+      mc mb --ignore-existing myminio/triplox
       "
 
   triplox:

--- a/docker/scripts/reset-remote-stack.sh
+++ b/docker/scripts/reset-remote-stack.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+COMPOSE_FILE="$REPO_ROOT/docker/docker-compose.yml"
+MINIO_MNT="$REPO_ROOT/docker/data/minio"
+
+echo "Stopping stack and removing named volumes (triplox-log)"
+docker compose -f "$COMPOSE_FILE" down -v
+
+if mountpoint -q "$MINIO_MNT"; then
+    echo "Wiping minio data under $MINIO_MNT"
+    find "$MINIO_MNT" -mindepth 1 -maxdepth 1 ! -name 'lost+found' -exec rm -rf {} +
+else
+    echo "Skipping minio wipe — $MINIO_MNT is not mounted"
+fi
+
+echo "Done. Bring the stack back up with:"
+echo "  docker compose -f docker/docker-compose.yml up --build"

--- a/docker/scripts/setup-minio-disk.sh
+++ b/docker/scripts/setup-minio-disk.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+IMG="$REPO_ROOT/docker/data/minio.img"
+MNT="$REPO_ROOT/docker/data/minio"
+SIZE="${MINIO_IMG_SIZE:-50G}"
+
+mkdir -p "$(dirname "$IMG")"
+
+if [ ! -e "$IMG" ]; then
+    echo "Creating $SIZE sparse ext4 image at $IMG"
+    truncate -s "$SIZE" "$IMG"
+    mkfs.ext4 -q "$IMG"
+fi
+
+mkdir -p "$MNT"
+
+if mountpoint -q "$MNT"; then
+    echo "$MNT already mounted"
+    df -h "$MNT" | tail -n 1
+    exit 0
+fi
+
+echo "Mounting $IMG at $MNT (sudo required)"
+sudo mount -o loop "$IMG" "$MNT"
+sudo chown "$(id -u):$(id -g)" "$MNT"
+chmod 1777 "$MNT"
+
+df -h "$MNT" | tail -n 1


### PR DESCRIPTION
## Summary

- Replaces the `rustfs` service in `docker/docker-compose.yml` with `minio/minio:latest` after rustfs 1.0.0-alpha.93 reproducibly truncated SlateDB's multipart SST uploads and then returned `FileCorrupt` on the resulting short objects during auctionmark ingestion.
- Backs the MinIO data volume with a loopback ext4 image (`docker/data/minio.img` → `docker/data/minio/`) so MinIO's inherited btrfs sanity check is satisfied on this btrfs host without forcing the data into size-limited tmpfs.
- Adds two helper scripts and README coverage for first-time setup and clean resets.

## Test plan

- [ ] `./docker/scripts/setup-minio-disk.sh` creates and mounts the 50G ext4 image on a fresh checkout
- [ ] `docker compose -f docker/docker-compose.yml up --build` brings the stack up; MinIO passes its own health check and triplox reports remote storage ready
- [ ] Auctionmark ingestion from the `auctionmark` worktree completes without `FileCorrupt` / `IncompleteBody` retries
- [ ] `docker compose exec minio df -h /data` shows ~50G ext4 inside the container
- [ ] `./docker/scripts/reset-remote-stack.sh` wipes the `triplox-log` volume and `docker/data/minio/` contents without unmounting the image, and a subsequent `up --build` starts cleanly
- [ ] `docker compose -f docker/docker-compose.yml down && up` (without `-v`) preserves MinIO data on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)