### PR TITLE
Enable slatedb block and object-store caches

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -266,8 +266,17 @@ impl Node<FileLog> {
         secret_key: &str,
         region: &str,
     ) -> Result<Self, Error> {
-        let slate = remote_slate(endpoint, bucket, access_key, secret_key, region).await;
         std::fs::create_dir_all(log_path)?;
+        let cache_path = log_path.join("cache");
+        let slate = remote_slate(
+            endpoint,
+            bucket,
+            access_key,
+            secret_key,
+            region,
+            &cache_path,
+        )
+        .await;
         Self::from_slate_and_log(slate, &log_path.join("log")).await
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -276,7 +276,7 @@ impl Node<FileLog> {
             region,
             &cache_path,
         )
-        .await;
+        .await?;
         Self::from_slate_and_log(slate, &log_path.join("log")).await
     }
 }

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -2,14 +2,39 @@
 
 pub mod cdc;
 
-use slatedb::config::{DurabilityLevel, ReadOptions, ScanOptions, WriteOptions};
+use slatedb::config::{
+    DurabilityLevel, ObjectStoreCacheOptions, ReadOptions, ScanOptions, Settings, WriteOptions,
+};
 use object_store::aws::AmazonS3Builder;
+use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
+use slatedb::db_cache::{DbCache, SplitCache};
 use slatedb::object_store::local::LocalFileSystem;
 use slatedb::object_store::{memory::InMemory, ObjectStore};
 use slatedb::Db;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::util::random_string;
+
+pub const DEFAULT_BLOCK_CACHE_BYTES: u64 = 512 * 1024 * 1024;
+pub const DEFAULT_META_CACHE_BYTES: u64 = 128 * 1024 * 1024;
+
+pub fn default_db_cache() -> Arc<dyn DbCache> {
+    let block_cache = FoyerCache::new_with_opts(FoyerCacheOptions {
+        max_capacity: DEFAULT_BLOCK_CACHE_BYTES,
+        ..Default::default()
+    });
+    let meta_cache = FoyerCache::new_with_opts(FoyerCacheOptions {
+        max_capacity: DEFAULT_META_CACHE_BYTES,
+        ..Default::default()
+    });
+    Arc::new(
+        SplitCache::new()
+            .with_block_cache(Some(Arc::new(block_cache)))
+            .with_meta_cache(Some(Arc::new(meta_cache)))
+            .build(),
+    )
+}
 
 pub struct SlateComponents {
     pub db: Arc<Db>,
@@ -31,6 +56,7 @@ pub async fn in_memory_slate() -> SlateComponents {
     let path = format!("tmp/triplox-{}", random_string(10));
     let db = Arc::new(
         Db::builder(path.clone(), object_store.clone())
+            .with_db_cache(default_db_cache())
             .build()
             .await
             .unwrap(),
@@ -56,6 +82,7 @@ pub async fn local_slate(path: &str) -> SlateComponents {
     let slate_path = "triplox".to_string();
     let db = Arc::new(
         Db::builder(slate_path.clone(), object_store.clone())
+            .with_db_cache(default_db_cache())
             .build()
             .await
             .unwrap(),
@@ -81,6 +108,7 @@ pub async fn remote_slate(
     access_key: &str,
     secret_key: &str,
     region: &str,
+    cache_path: &Path,
 ) -> SlateComponents {
     let s3 = AmazonS3Builder::new()
         .with_endpoint(endpoint)
@@ -93,9 +121,19 @@ pub async fn remote_slate(
         .expect("failed to build S3 object store");
 
     let object_store: Arc<dyn ObjectStore> = Arc::new(s3);
+    std::fs::create_dir_all(cache_path).expect("failed to create object store cache directory");
+    let settings = Settings {
+        object_store_cache_options: ObjectStoreCacheOptions {
+            root_folder: Some(cache_path.to_path_buf()),
+            ..ObjectStoreCacheOptions::default()
+        },
+        ..Settings::default()
+    };
     // TODO: hardcoded path — reconsider when adding database creation functions
     let db = Arc::new(
         Db::builder("triplox", object_store.clone())
+            .with_settings(settings)
+            .with_db_cache(default_db_cache())
             .build()
             .await
             .unwrap(),
@@ -124,7 +162,7 @@ pub const DEFAULT_SCAN_OPTIONS: ScanOptions = ScanOptions {
     durability_filter: DurabilityLevel::Memory,
     dirty: false,
     read_ahead_bytes: 1,
-    cache_blocks: false,
+    cache_blocks: true,
     max_fetch_tasks: 1,
     order: slatedb::IterationOrder::Ascending,
 };

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use crate::util::random_string;
 
-pub const DEFAULT_BLOCK_CACHE_BYTES: u64 = 512 * 1024 * 1024;
-pub const DEFAULT_META_CACHE_BYTES: u64 = 128 * 1024 * 1024;
+pub const DEFAULT_BLOCK_CACHE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub const DEFAULT_META_CACHE_BYTES: u64 = 512 * 1024 * 1024;
 
 pub fn default_db_cache() -> Arc<dyn DbCache> {
     let block_cache = FoyerCache::new_with_opts(FoyerCacheOptions {

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -135,8 +135,7 @@ pub async fn remote_slate(
             .with_settings(settings)
             .with_db_cache(default_db_cache())
             .build()
-            .await
-            .unwrap(),
+            .await?,
     );
     let path = "triplox".to_string();
     let range_stats = Arc::new(slatedb_estimates::RangeStats::new(

--- a/src/slate/mod.rs
+++ b/src/slate/mod.rs
@@ -109,7 +109,7 @@ pub async fn remote_slate(
     secret_key: &str,
     region: &str,
     cache_path: &Path,
-) -> SlateComponents {
+) -> Result<SlateComponents, anyhow::Error> {
     let s3 = AmazonS3Builder::new()
         .with_endpoint(endpoint)
         .with_bucket_name(bucket)
@@ -121,7 +121,7 @@ pub async fn remote_slate(
         .expect("failed to build S3 object store");
 
     let object_store: Arc<dyn ObjectStore> = Arc::new(s3);
-    std::fs::create_dir_all(cache_path).expect("failed to create object store cache directory");
+    std::fs::create_dir_all(cache_path)?;
     let settings = Settings {
         object_store_cache_options: ObjectStoreCacheOptions {
             root_folder: Some(cache_path.to_path_buf()),
@@ -146,12 +146,12 @@ pub async fn remote_slate(
         None,
         None,
     ));
-    SlateComponents {
+    Ok(SlateComponents {
         db,
         path,
         object_store,
         range_stats,
-    }
+    })
 }
 
 pub const DEFAULT_WRITE_OPTIONS: WriteOptions = WriteOptions {


### PR DESCRIPTION
## Summary

- Turns on slatedb's in-memory block cache for scans (`DEFAULT_SCAN_OPTIONS.cache_blocks: false → true` in `src/slate/mod.rs`), so repeated scans of the same SST blocks stop round-tripping to the object store.
- Wires slatedb's disk-backed object-store part cache into `remote_slate`, rooted at `<log_path>/cache/`. Defaults to slatedb's 16 GiB cap, 4 MiB parts, `cache_puts: false`.
- Moves `SplitCache` construction out of slatedb and into triplox (`default_db_cache()` in `src/slate/mod.rs`) so the two knobs live in this repo. Sized 4× above slatedb's split-cache defaults (`DEFAULT_BLOCK_CACHE_BYTES = 2 GiB` vs. slatedb's 512 MiB; `DEFAULT_META_CACHE_BYTES = 512 MiB` vs. slatedb's 128 MiB) — bump there to retune.
- All three slate constructors (`in_memory_slate`, `local_slate`, `remote_slate`) now pass the same cache via `DbBuilder::with_db_cache`.

## Test plan

- [ ] `cargo test` passes
- [ ] Auctionmark ingestion against MinIO (PR #234) shows reduced S3 GETs once the warm-up phase completes — verify via MinIO request counters or `mc admin trace`
- [ ] `<log_path>/cache/` fills up on disk during ingestion and is preserved across triplox restarts (only wiped by `reset-remote-stack.sh`, which is triplox-log-only — the object-store cache lives on the local host, not in MinIO)
- [ ] Scans no longer show the previous re-read-from-S3 behavior in triplox tracing when replaying the same range twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)