### PR TITLE
perf: reuse buffers in write_index_entries (closes #69)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -39,65 +39,72 @@ pub(crate) fn write_index_entries(
     tx_eid: i64,
 ) -> Result<(), Error> {
     let tx_eid_bytes = encode_i64_bytes(tx_eid);
+    let mut key_buf: Vec<u8> = Vec::with_capacity(64);
+    let mut value_buf: Vec<u8> = Vec::with_capacity(32);
 
     for datom in datoms {
-        // TODO: entity IDs encoded as DataType::Long to match value-position encoding.
-        // Revisit with schema/custom encoding.
-        let entity_id = DataType::Long(datom.entity).encode();
         let attribute_id = schema
             .get_attribute(&datom.attribute)
             .map(|(eid, _)| eid)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
-        let attribute = encode_i64_bytes(attribute_id);
-        let mut value = Vec::new();
-        encode_datatype(&datom.value, &mut value);
+        let attr_bytes = encode_i64_bytes(attribute_id);
+        // Entity IDs are stored in value-position encoding (DataType::Long),
+        // which for i64 is just the same big-endian bytes as encode_i64_bytes.
+        let entity_bytes = DataType::Long(datom.entity).encode();
+
+        value_buf.clear();
+        encode_datatype(&datom.value, &mut value_buf);
+        let value = value_buf.as_slice();
+
         let op_byte = match datom.op {
             DatomOp::Assert => codec::ADD,
             DatomOp::Retract => codec::RETRACT,
         };
 
-        // Temporal indices include tx_eid + op
-        // TODO(#69): concat_bytes allocates intermediate Vecs per component;
-        // encoding directly into a single buffer would be faster.
-        txn.put(
-            concat_bytes(&[
-                &[codec::EAV],
-                &entity_id,
-                &attribute,
-                &value,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
-        txn.put(
-            concat_bytes(&[
-                &[codec::AVE],
-                &attribute,
-                &value,
-                &entity_id,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
-        txn.put(
-            concat_bytes(&[
-                &[codec::AEV],
-                &attribute,
-                &entity_id,
-                &value,
-                &tx_eid_bytes,
-                &[op_byte],
-            ]),
-            [],
-        )?;
+        // EAV
+        key_buf.clear();
+        key_buf.push(codec::EAV);
+        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(&attr_bytes);
+        key_buf.extend_from_slice(value);
+        key_buf.extend_from_slice(&tx_eid_bytes);
+        key_buf.push(op_byte);
+        txn.put(&key_buf, [])?;
+
+        // AVE
+        key_buf.clear();
+        key_buf.push(codec::AVE);
+        key_buf.extend_from_slice(&attr_bytes);
+        key_buf.extend_from_slice(value);
+        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(&tx_eid_bytes);
+        key_buf.push(op_byte);
+        txn.put(&key_buf, [])?;
+
+        // AEV
+        key_buf.clear();
+        key_buf.push(codec::AEV);
+        key_buf.extend_from_slice(&attr_bytes);
+        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(value);
+        key_buf.extend_from_slice(&tx_eid_bytes);
+        key_buf.push(op_byte);
+        txn.put(&key_buf, [])?;
 
         // AE and AV are atemporal, purely additive indices.
         // Retractions are not written to AE/AV.
         if datom.op == DatomOp::Assert {
-            txn.put(concat_bytes(&[&[codec::AE], &attribute, &entity_id]), [])?;
-            txn.put(concat_bytes(&[&[codec::AV], &attribute, &value]), [])?;
+            key_buf.clear();
+            key_buf.push(codec::AE);
+            key_buf.extend_from_slice(&attr_bytes);
+            key_buf.extend_from_slice(&entity_bytes);
+            txn.put(&key_buf, [])?;
+
+            key_buf.clear();
+            key_buf.push(codec::AV);
+            key_buf.extend_from_slice(&attr_bytes);
+            key_buf.extend_from_slice(value);
+            txn.put(&key_buf, [])?;
         }
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -41,6 +41,8 @@ pub(crate) fn write_index_entries(
     let tx_eid_bytes = encode_i64_bytes(tx_eid);
     let mut key_buf: Vec<u8> = Vec::with_capacity(64);
     let mut value_buf: Vec<u8> = Vec::with_capacity(32);
+    // DataType::Long encodes as 1 type-tag byte + 8 big-endian bytes.
+    let mut entity_buf: Vec<u8> = Vec::with_capacity(9);
 
     for datom in datoms {
         let attribute_id = schema
@@ -48,9 +50,11 @@ pub(crate) fn write_index_entries(
             .map(|(eid, _)| eid)
             .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
         let attr_bytes = encode_i64_bytes(attribute_id);
-        // Entity IDs are stored in value-position encoding (DataType::Long),
-        // which for i64 is just the same big-endian bytes as encode_i64_bytes.
-        let entity_bytes = DataType::Long(datom.entity).encode();
+        // Entity IDs use value-position encoding (DataType::Long) so they can
+        // share the value slot in EAV/AVE/AEV keys.
+        entity_buf.clear();
+        encode_datatype(&DataType::Long(datom.entity), &mut entity_buf);
+        let entity_bytes = entity_buf.as_slice();
 
         value_buf.clear();
         encode_datatype(&datom.value, &mut value_buf);
@@ -64,7 +68,7 @@ pub(crate) fn write_index_entries(
         // EAV
         key_buf.clear();
         key_buf.push(codec::EAV);
-        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(entity_bytes);
         key_buf.extend_from_slice(&attr_bytes);
         key_buf.extend_from_slice(value);
         key_buf.extend_from_slice(&tx_eid_bytes);
@@ -76,7 +80,7 @@ pub(crate) fn write_index_entries(
         key_buf.push(codec::AVE);
         key_buf.extend_from_slice(&attr_bytes);
         key_buf.extend_from_slice(value);
-        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(entity_bytes);
         key_buf.extend_from_slice(&tx_eid_bytes);
         key_buf.push(op_byte);
         txn.put(&key_buf, [])?;
@@ -85,7 +89,7 @@ pub(crate) fn write_index_entries(
         key_buf.clear();
         key_buf.push(codec::AEV);
         key_buf.extend_from_slice(&attr_bytes);
-        key_buf.extend_from_slice(&entity_bytes);
+        key_buf.extend_from_slice(entity_bytes);
         key_buf.extend_from_slice(value);
         key_buf.extend_from_slice(&tx_eid_bytes);
         key_buf.push(op_byte);
@@ -97,7 +101,7 @@ pub(crate) fn write_index_entries(
             key_buf.clear();
             key_buf.push(codec::AE);
             key_buf.extend_from_slice(&attr_bytes);
-            key_buf.extend_from_slice(&entity_bytes);
+            key_buf.extend_from_slice(entity_bytes);
             txn.put(&key_buf, [])?;
 
             key_buf.clear();


### PR DESCRIPTION
## Summary

- Replaces the per-put `concat_bytes` calls in `write_index_entries` with a single reused `Vec<u8>` key buffer (and a reused value buffer), both sized up front.
- `DbTransaction::put` takes `AsRef<[u8]>` and copies into its own batch, so borrowing the buffer by reference is enough — we never hand off ownership, and the buffer's capacity survives every iteration.
- Motivated by the samply profile: `concat_bytes` appeared on 2% of stacks under `write_index_entries`, and `malloc`/`free`/`realloc` accounted for ~6% of worker self-time. This change removes 5–7 heap allocations per datom (plus the reallocs `concat_bytes` incurs starting from `Vec::new()`).

## Test plan

- [x] `cargo test` — all 406 unit tests and 21 integration tests pass; indexer-specific tests unchanged
- [ ] Re-record a samply profile of auctionmark ingest against this branch and confirm `concat_bytes` / `write_index_entries` drop on the flamegraph
- [ ] Confirm overall malloc/free self-time decreases proportionally

Addresses TODO(#69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)