### PR TITLE
Batch lookup ref resolving

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -36,6 +36,9 @@ pub const AEV: u8 = 2;
 pub const AE: u8 = 3;
 pub const AV: u8 = 4;
 
+/// Exclusive upper bound for AVE-prefixed scans.
+pub const AVE_END: u8 = AEV;
+
 pub const STATS_INDEX: u8 = 128;
 pub const META_INDEX: u8 = 129;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1852,6 +1852,106 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_lookup_ref_batch_resolves_multiple_refs() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Alice".into()),
+            (kw!(:email), "alice@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Bob".into()),
+            (kw!(:email), "bob@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        let result = node
+            .execute_tx(vec![
+                TxOp::Add {
+                    entity: EntityRef::LookupRef(
+                        kw!(:email),
+                        DataType::String("bob@example.com".into()),
+                    ),
+                    attribute: kw!(:follows),
+                    value: DataType::Vector(vec![
+                        DataType::Keyword(kw!(:email)),
+                        DataType::String("alice@example.com".into()),
+                    ]),
+                },
+                TxOp::Add {
+                    entity: EntityRef::LookupRef(
+                        kw!(:email),
+                        DataType::String("alice@example.com".into()),
+                    ),
+                    attribute: kw!(:age),
+                    value: DataType::Long(30),
+                },
+            ])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(
+                "[:find ?follower ?followed ?age :where \
+                 [?e1 :name ?follower] [?e1 :follows ?e2] \
+                 [?e2 :name ?followed] [?e2 :age ?age]]",
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][0], DataType::String("Bob".into()));
+        assert_eq!(result[0][1], DataType::String("Alice".into()));
+        assert_eq!(result[0][2], DataType::Long(30));
+    }
+
+    #[tokio::test]
+    async fn test_lookup_ref_batch_deduplicates_repeated_ref() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:name), "Bob".into()),
+            (kw!(:email), "bob@example.com".into()),
+        ])])
+        .await
+        .unwrap();
+
+        let bob_lookup = DataType::String("bob@example.com".into());
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::LookupRef(kw!(:email), bob_lookup.clone()),
+                attribute: kw!(:follows),
+                value: DataType::Vector(vec![DataType::Keyword(kw!(:email)), bob_lookup]),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(
+                r#"[:find ?follower ?followed
+                   :where [?e1 :name ?follower] [?e1 :follows ?e2] [?e2 :name ?followed]]"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            vec![vec![
+                DataType::String("Bob".into()),
+                DataType::String("Bob".into())
+            ]]
+        );
+    }
+
+    #[tokio::test]
     async fn test_lookup_ref_in_put_db_id() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1856,17 +1856,16 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:name), "Alice".into()),
-            (kw!(:email), "alice@example.com".into()),
-        ])])
-        .await
-        .unwrap();
-
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:name), "Bob".into()),
-            (kw!(:email), "bob@example.com".into()),
-        ])])
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:name), "Alice".into()),
+                (kw!(:email), "alice@example.com".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:name), "Bob".into()),
+                (kw!(:email), "bob@example.com".into()),
+            ]),
+        ])
         .await
         .unwrap();
 
@@ -1899,9 +1898,8 @@ mod tests {
         let db = node.db().await.unwrap();
         let result = db
             .query(
-                "[:find ?follower ?followed ?age :where \
-                 [?e1 :name ?follower] [?e1 :follows ?e2] \
-                 [?e2 :name ?followed] [?e2 :age ?age]]",
+                r#"[:find ?follower ?followed ?age
+                   :where [?e1 :name ?follower] [?e1 :follows ?e2] [?e2 :name ?followed] [?e2 :age ?age]]"#,
             )
             .await
             .unwrap();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -264,6 +264,22 @@ pub async fn first_live_key(
     }
 }
 
+fn lookup_ref_ave_prefix(attr_eid: i64, value: &DataType) -> Vec<u8> {
+    let attr_bytes = encode_i64_bytes(attr_eid);
+    let mut value_bytes = Vec::new();
+    encode_datatype(value, &mut value_bytes);
+    concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes])
+}
+
+fn lookup_ref_not_found(schema: &Schema, attr_eid: i64, value: &DataType) -> anyhow::Error {
+    let attr_kw = schema
+        .entid_map
+        .get(&attr_eid)
+        .map(|kw| kw.to_string())
+        .unwrap_or_else(|| attr_eid.to_string());
+    anyhow::anyhow!("No entity found for lookup ref [{} {:?}]", attr_kw, value)
+}
+
 /// Batch-resolve all lookup refs via the AVE index.
 /// Converts DatomExpanded → DatomWithTempids, eliminating all LookupRef variants.
 /// If no lookup refs are present, this is a cheap conversion with no I/O.
@@ -353,22 +369,6 @@ pub async fn resolve_lookup_refs(
         });
     }
     Ok(result)
-}
-
-fn lookup_ref_ave_prefix(attr_eid: i64, value: &DataType) -> Vec<u8> {
-    let attr_bytes = encode_i64_bytes(attr_eid);
-    let mut value_bytes = Vec::new();
-    encode_datatype(value, &mut value_bytes);
-    concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes])
-}
-
-fn lookup_ref_not_found(schema: &Schema, attr_eid: i64, value: &DataType) -> anyhow::Error {
-    let attr_kw = schema
-        .entid_map
-        .get(&attr_eid)
-        .map(|kw| kw.to_string())
-        .unwrap_or_else(|| attr_eid.to_string());
-    anyhow::anyhow!("No entity found for lookup ref [{} {:?}]", attr_kw, value)
 }
 
 /// Resolve tempids in DatomWithTempids to produce final Datoms.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -305,7 +305,7 @@ pub async fn resolve_lookup_refs(
     if let Some(first_prefix) = lookup_refs.keys().next() {
         let mut iter = txn
             .scan_with_options(
-                first_prefix.clone()..vec![codec::AEV],
+                first_prefix.clone()..vec![codec::AVE_END],
                 &DEFAULT_SCAN_OPTIONS,
             )
             .await?;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use edn::kw;
@@ -273,57 +273,55 @@ pub async fn resolve_lookup_refs(
     schema: &Schema,
     txn: &slatedb::DbTransaction,
 ) -> Result<Vec<DatomWithTempids>> {
-    // Collect all unique (attr_entid, value) lookup ref pairs.
-    let mut lookup_refs: HashSet<(i64, DataType)> = HashSet::new();
+    // Collect all unique lookup refs keyed by their encoded AVE lookup prefix.
+    let mut lookup_refs: BTreeMap<Vec<u8>, (i64, DataType)> = BTreeMap::new();
     for d in &datoms {
         if let EntityExpanded::LookupRef(a, v) = &d.entity {
-            lookup_refs.insert((*a, v.clone()));
+            lookup_refs.insert(lookup_ref_ave_prefix(*a, v), (*a, v.clone()));
         }
         if let ValueExpanded::LookupRef(a, v) = &d.value {
-            lookup_refs.insert((*a, v.clone()));
+            lookup_refs.insert(lookup_ref_ave_prefix(*a, v), (*a, v.clone()));
         }
     }
 
-    // Batch resolve via AVE index.
-    // TODO(#196): parallelize AVE scans with try_join_all.
     let mut resolved_map: HashMap<(i64, DataType), i64> = HashMap::new();
-    for (attr_eid, value) in &lookup_refs {
-        let attr_bytes = encode_i64_bytes(*attr_eid);
-        let mut value_bytes = Vec::new();
-        encode_datatype(value, &mut value_bytes);
-        let ave_prefix = concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes]);
 
-        let resolved_eid = match first_live_key(txn, &ave_prefix).await? {
-            Some(key) => {
-                let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(key)?;
-                match entity_dt {
-                    DataType::Long(eid) => Some(eid),
-                    other => {
-                        return Err(anyhow::anyhow!(
-                            "Expected Long entity ID in AVE key, got {:?}",
-                            other
-                        ));
-                    }
+    if let Some(first_prefix) = lookup_refs.keys().next() {
+        let mut iter = txn
+            .scan_with_options(
+                first_prefix.clone()..vec![codec::AEV],
+                &DEFAULT_SCAN_OPTIONS,
+            )
+            .await?;
+
+        for (ave_prefix, (attr_eid, value)) in &lookup_refs {
+            iter.seek(ave_prefix).await?;
+
+            let key = match iter.next().await? {
+                Some(kv) if kv.key.starts_with(ave_prefix) => kv.key,
+                _ => return Err(lookup_ref_not_found(schema, *attr_eid, value)),
+            };
+
+            assert!(
+                key.len() >= codec::TX_EID_OP_SUFFIX,
+                "Key too short ({} bytes) to contain tx_eid + op suffix",
+                key.len()
+            );
+            if key[key.len() - 1] == codec::RETRACT {
+                return Err(lookup_ref_not_found(schema, *attr_eid, value));
+            }
+
+            let (_attribute, _value, entity_dt, _tx_eid, _op) = ave_key_to_parts(key)?;
+            match entity_dt {
+                DataType::Long(eid) => {
+                    resolved_map.insert((*attr_eid, value.clone()), eid);
                 }
-            }
-            None => None,
-        };
-
-        match resolved_eid {
-            Some(eid) => {
-                resolved_map.insert((*attr_eid, value.clone()), eid);
-            }
-            None => {
-                let attr_kw = schema
-                    .entid_map
-                    .get(attr_eid)
-                    .map(|kw| kw.to_string())
-                    .unwrap_or_else(|| attr_eid.to_string());
-                return Err(anyhow::anyhow!(
-                    "No entity found for lookup ref [{} {:?}]",
-                    attr_kw,
-                    value
-                ));
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "Expected Long entity ID in AVE key, got {:?}",
+                        other
+                    ));
+                }
             }
         }
     }
@@ -355,6 +353,22 @@ pub async fn resolve_lookup_refs(
         });
     }
     Ok(result)
+}
+
+fn lookup_ref_ave_prefix(attr_eid: i64, value: &DataType) -> Vec<u8> {
+    let attr_bytes = encode_i64_bytes(attr_eid);
+    let mut value_bytes = Vec::new();
+    encode_datatype(value, &mut value_bytes);
+    concat_bytes(&[&[codec::AVE], &attr_bytes, &value_bytes])
+}
+
+fn lookup_ref_not_found(schema: &Schema, attr_eid: i64, value: &DataType) -> anyhow::Error {
+    let attr_kw = schema
+        .entid_map
+        .get(&attr_eid)
+        .map(|kw| kw.to_string())
+        .unwrap_or_else(|| attr_eid.to_string());
+    anyhow::anyhow!("No entity found for lookup ref [{} {:?}]", attr_kw, value)
 }
 
 /// Resolve tempids in DatomWithTempids to produce final Datoms.


### PR DESCRIPTION
## Summary
- Batch lookup-ref resolution by collecting AVE prefixes in sorted order and scanning/seeking the AVE index once
- Preserve missing lookup-ref errors and retract handling
- Add tests for resolving multiple lookup refs in one transaction and deduplicating repeated refs

Fixes #241

## Test Plan
- cargo test lookup_ref
- cargo test