### PR TITLE
Batch old value lookups

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -36,6 +36,9 @@ pub const AEV: u8 = 2;
 pub const AE: u8 = 3;
 pub const AV: u8 = 4;
 
+/// Exclusive upper bound for EAV-prefixed scans.
+pub const EAV_END: u8 = AVE;
+
 /// Exclusive upper bound for AVE-prefixed scans.
 pub const AVE_END: u8 = AEV;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -36,12 +36,6 @@ pub const AEV: u8 = 2;
 pub const AE: u8 = 3;
 pub const AV: u8 = 4;
 
-/// Exclusive upper bound for EAV-prefixed scans.
-pub const EAV_END: u8 = AVE;
-
-/// Exclusive upper bound for AVE-prefixed scans.
-pub const AVE_END: u8 = AEV;
-
 pub const STATS_INDEX: u8 = 128;
 pub const META_INDEX: u8 = 129;
 
@@ -50,6 +44,10 @@ pub const RETRACT: u8 = 1;
 
 /// Suffix length: tx_eid (8 bytes) + op (1 byte), used for end-of-key extraction.
 pub const TX_EID_OP_SUFFIX: usize = TX_EID_LENGTH + OP_LENGTH;
+
+/// Exclusive upper bounds for covering indexes scans
+pub const AVE_END: u8 = AEV;
+pub const EAV_END: u8 = AVE;
 
 // TODO move this to lazy_static
 pub fn index_type_to_prefix(index_type: IndexType) -> Result<u8, Error> {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -381,24 +381,28 @@ impl Indexer {
                 )
                 .await?;
 
+            let mut last_returned = Bytes::new();
             for (eav_prefix, (entity, attribute_id)) in &eav_prefixes {
-                iter.seek(eav_prefix).await?;
+                if last_returned.as_ref() < eav_prefix.as_slice() {
+                    iter.seek(eav_prefix).await?;
+                    let Some(kv) = iter.next().await? else {
+                        // Prefixes are sorted, so no later prefix can match once the range is exhausted.
+                        break;
+                    };
+                    last_returned = kv.key;
+                }
 
-                if let Some(kv) = iter.next().await? {
-                    let key = &kv.key;
-                    if key.starts_with(eav_prefix) {
-                        assert!(
-                            key.len() >= codec::TX_EID_OP_SUFFIX,
-                            "Key too short ({} bytes) to contain tx_eid + op suffix",
-                            key.len()
-                        );
-                        if key[key.len() - 1] != codec::RETRACT {
-                            let value_bytes =
-                                &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
-                            let mut cursor = value_bytes;
-                            old_values
-                                .insert((*entity, *attribute_id), decode_datatype(&mut cursor)?);
-                        }
+                if last_returned.starts_with(eav_prefix) {
+                    assert!(
+                        last_returned.len() >= codec::TX_EID_OP_SUFFIX,
+                        "Key too short ({} bytes) to contain tx_eid + op suffix",
+                        last_returned.len()
+                    );
+                    if last_returned[last_returned.len() - 1] != codec::RETRACT {
+                        let value_bytes = &last_returned
+                            [eav_prefix.len()..last_returned.len() - codec::TX_EID_OP_SUFFIX];
+                        let mut cursor = value_bytes;
+                        old_values.insert((*entity, *attribute_id), decode_datatype(&mut cursor)?);
                     }
                 }
             }
@@ -1374,6 +1378,98 @@ mod tests {
         assert!(seen.contains(&(bob_eid, "bob".to_string(), codec::ADD)));
         assert!(seen.contains(&(bob_eid, "bob".to_string(), codec::RETRACT)));
         assert!(seen.contains(&(bob_eid, "robert".to_string(), codec::ADD)));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_batch_old_value_scan_handles_missing_prefix() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let slate = components.db.clone();
+        let mut indexer = bootstrapped_indexer(&components).await;
+
+        let mut attrs = vec![
+            (
+                kw!(:name),
+                DataType::String("old-name".to_string()),
+                DataType::String("new-name".to_string()),
+                DataType::String("missing-name".to_string()),
+            ),
+            (
+                kw!(:age),
+                DataType::Long(1),
+                DataType::Long(2),
+                DataType::Long(3),
+            ),
+            (
+                kw!(:email),
+                DataType::String("old@example.com".to_string()),
+                DataType::String("new@example.com".to_string()),
+                DataType::String("missing@example.com".to_string()),
+            ),
+        ];
+        attrs.sort_by_key(|(attr, _, _, _)| {
+            indexer.metadata().schema.get_attribute(attr).unwrap().0
+        });
+        let (missing_attr, _, _, missing_value) = attrs.first().unwrap().clone();
+        let (existing_attr, old_value, new_value, _) = attrs.last().unwrap().clone();
+
+        indexer
+            .transact_tx(
+                TxKey {
+                    tx_id: 1,
+                    system_time: st_from_unix_epoch(100),
+                },
+                vec![TxOp::Add {
+                    entity: "entity".into(),
+                    attribute: existing_attr.clone(),
+                    value: old_value.clone(),
+                }],
+            )
+            .await?;
+
+        let entity_id = find_first_user_entity(&slate).await?;
+
+        indexer
+            .transact_tx(
+                TxKey {
+                    tx_id: 2,
+                    system_time: st_from_unix_epoch(200),
+                },
+                vec![
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: missing_attr,
+                        value: missing_value,
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: existing_attr.clone(),
+                        value: new_value.clone(),
+                    },
+                ],
+            )
+            .await?;
+
+        let existing_attr_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&existing_attr)
+            .unwrap()
+            .0;
+        let mut seen = std::collections::HashSet::new();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, attribute, value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if eid == DataType::Long(entity_id) && attribute == existing_attr_id {
+                seen.insert((value, op));
+            }
+        }
+
+        assert!(seen.contains(&(old_value, codec::RETRACT)));
+        assert!(seen.contains(&(new_value, codec::ADD)));
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1263,6 +1263,7 @@ mod tests {
         panic!("No user-partition entity found in EAV index");
     }
 
+    // TODO move this test to a proper node level test once we support historic queries
     #[tokio::test]
     async fn test_retract_on_multiple_overwrites() -> Result<(), Error> {
         let components = in_memory_slate().await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use log::{error, trace, warn};
 use slatedb::Db;
 use slatedb::IsolationLevel;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -20,7 +20,7 @@ use crate::partition::{partition_entity_prefix, TX_PARTITION};
 use crate::schema::{Schema, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::transaction::TxKey;
-use crate::tx::{self, first_live_key};
+use crate::tx;
 use crate::util::concat_bytes;
 use edn::symbols::Keyword;
 
@@ -306,9 +306,7 @@ impl Indexer {
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
         // 5. Finalize datoms (card-one rewrite) against current storage state
-        let datoms = self
-            .finalize_datoms_for_commit(&txn, datoms)
-            .await?;
+        let datoms = self.finalize_datoms_for_commit(&txn, datoms).await?;
 
         // 6. General validation
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
@@ -350,6 +348,63 @@ impl Indexer {
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
+        let mut eav_prefixes: BTreeMap<Vec<u8>, (i64, Keyword)> = BTreeMap::new();
+        for datom in &datoms {
+            if datom.op != DatomOp::Assert {
+                continue;
+            }
+
+            let (attribute_id, attr) = self
+                .metadata
+                .schema
+                .get_attribute(&datom.attribute)
+                .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+
+            if attr.multival || !self.metadata.partition_map.contains_entid(datom.entity) {
+                continue;
+            }
+
+            let entity_id_bytes = DataType::Long(datom.entity).encode();
+            let attr_id_bytes = encode_i64_bytes(attribute_id);
+            let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
+            eav_prefixes.insert(eav_prefix, (datom.entity, datom.attribute.clone()));
+        }
+
+        let mut old_values: HashMap<(i64, Keyword), DataType> =
+            HashMap::with_capacity(eav_prefixes.len());
+        if let Some(first_prefix) = eav_prefixes.keys().next() {
+            let mut iter = txn
+                .scan_with_options(
+                    first_prefix.clone()..vec![codec::EAV_END],
+                    &DEFAULT_SCAN_OPTIONS,
+                )
+                .await?;
+
+            for (eav_prefix, (entity, attribute)) in &eav_prefixes {
+                iter.seek(eav_prefix).await?;
+
+                if let Some(kv) = iter.next().await? {
+                    let key = &kv.key;
+                    if key.starts_with(eav_prefix) {
+                        assert!(
+                            key.len() >= codec::TX_EID_OP_SUFFIX,
+                            "Key too short ({} bytes) to contain tx_eid + op suffix",
+                            key.len()
+                        );
+                        if key[key.len() - 1] != codec::RETRACT {
+                            let value_bytes =
+                                &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
+                            let mut cursor = value_bytes;
+                            old_values.insert(
+                                (*entity, attribute.clone()),
+                                decode_datatype(&mut cursor)?,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         let mut resolved_datoms: HashSet<Datom> = HashSet::with_capacity(datoms.len());
         for datom in datoms {
             if datom.op != DatomOp::Assert {
@@ -357,7 +412,7 @@ impl Indexer {
                 continue;
             }
 
-            let (attribute_id, attr) = self
+            let (_attribute_id, attr) = self
                 .metadata
                 .schema
                 .get_attribute(&datom.attribute)
@@ -368,29 +423,14 @@ impl Indexer {
                 continue;
             }
 
-            let entity_id_bytes = DataType::Long(datom.entity).encode();
-            let attr_id_bytes = encode_i64_bytes(attribute_id);
-            let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
-
-            // Scan EAV prefix to find the current value for this (entity, attribute).
-            let old_value: Option<DataType> = match first_live_key(txn, &eav_prefix).await? {
-                Some(key) => {
-                    let value_bytes =
-                        &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
-                    let mut cursor = value_bytes;
-                    Some(decode_datatype(&mut cursor)?)
-                }
-                None => None,
-            };
-
-            if let Some(old_value) = old_value {
-                if old_value == datom.value {
+            if let Some(old_value) = old_values.get(&(datom.entity, datom.attribute.clone())) {
+                if old_value == &datom.value {
                     continue;
                 }
                 resolved_datoms.insert(Datom {
                     entity: datom.entity,
                     attribute: datom.attribute.clone(),
-                    value: old_value,
+                    value: old_value.clone(),
                     op: DatomOp::Retract,
                 });
             }
@@ -1219,6 +1259,122 @@ mod tests {
             }
         }
         panic!("No user-partition entity found in EAV index");
+    }
+
+    async fn find_user_entities_by_name(
+        slate: &Arc<slatedb::Db>,
+        name_id: i64,
+    ) -> Result<std::collections::HashMap<String, i64>, Error> {
+        let mut entities = std::collections::HashMap::new();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, attribute, value, _ts, op) = eav_key_to_parts(kv.key)?;
+            let DataType::Long(entity_id) = eid else {
+                continue;
+            };
+            if crate::partition::extract_partition(entity_id) != crate::partition::USER_PARTITION {
+                continue;
+            }
+            if attribute != name_id || op != codec::ADD {
+                continue;
+            }
+            if let DataType::String(name) = value {
+                entities.insert(name, entity_id);
+            }
+        }
+        Ok(entities)
+    }
+
+    #[tokio::test]
+    async fn test_retract_on_multiple_overwrites() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let slate = components.db.clone();
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
+        indexer
+            .transact_tx(
+                tx1,
+                vec![
+                    TxOp::Add {
+                        entity: "alice".into(),
+                        attribute: kw!(:name),
+                        value: "alice".into(),
+                    },
+                    TxOp::Add {
+                        entity: "bob".into(),
+                        attribute: kw!(:name),
+                        value: "bob".into(),
+                    },
+                ],
+            )
+            .await?;
+
+        let entities = find_user_entities_by_name(&slate, name_id).await?;
+        let alice_eid = entities["alice"];
+        let bob_eid = entities["bob"];
+
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        indexer
+            .transact_tx(
+                tx2,
+                vec![
+                    TxOp::Add {
+                        entity: EntityRef::Id(alice_eid),
+                        attribute: kw!(:name),
+                        value: "alicia".into(),
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(bob_eid),
+                        attribute: kw!(:name),
+                        value: "robert".into(),
+                    },
+                ],
+            )
+            .await?;
+
+        let mut seen = std::collections::HashSet::new();
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, attribute, value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if attribute != name_id {
+                continue;
+            }
+            let DataType::Long(entity_id) = eid else {
+                continue;
+            };
+            let DataType::String(name) = value else {
+                continue;
+            };
+            if entity_id == alice_eid || entity_id == bob_eid {
+                seen.insert((entity_id, name, op));
+            }
+        }
+
+        assert!(seen.contains(&(alice_eid, "alice".to_string(), codec::ADD)));
+        assert!(seen.contains(&(alice_eid, "alice".to_string(), codec::RETRACT)));
+        assert!(seen.contains(&(alice_eid, "alicia".to_string(), codec::ADD)));
+        assert!(seen.contains(&(bob_eid, "bob".to_string(), codec::ADD)));
+        assert!(seen.contains(&(bob_eid, "bob".to_string(), codec::RETRACT)));
+        assert!(seen.contains(&(bob_eid, "robert".to_string(), codec::ADD)));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -633,8 +633,10 @@ mod tests {
     use super::*;
     use crate::clock::{st_from_unix_epoch, Instant};
     use crate::ops::{DataType, EntityRef};
+    use crate::query::execute_query;
     use crate::schema::{test_schema_tx, DB_CARDINALITY_ONE, DB_TYPE_LONG};
     use crate::slate::{in_memory_slate, SlateComponents};
+    use edn::query::ParsedQuery;
 
     /// Create an indexer with bootstrap schema and test attributes already transacted.
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
@@ -1261,32 +1263,6 @@ mod tests {
         panic!("No user-partition entity found in EAV index");
     }
 
-    async fn find_user_entities_by_name(
-        slate: &Arc<slatedb::Db>,
-        name_id: i64,
-    ) -> Result<std::collections::HashMap<String, i64>, Error> {
-        let mut entities = std::collections::HashMap::new();
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, attribute, value, _ts, op) = eav_key_to_parts(kv.key)?;
-            let DataType::Long(entity_id) = eid else {
-                continue;
-            };
-            if crate::partition::extract_partition(entity_id) != crate::partition::USER_PARTITION {
-                continue;
-            }
-            if attribute != name_id || op != codec::ADD {
-                continue;
-            }
-            if let DataType::String(name) = value {
-                entities.insert(name, entity_id);
-            }
-        }
-        Ok(entities)
-    }
-
     #[tokio::test]
     async fn test_retract_on_multiple_overwrites() -> Result<(), Error> {
         let components = in_memory_slate().await;
@@ -1321,9 +1297,34 @@ mod tests {
             )
             .await?;
 
-        let entities = find_user_entities_by_name(&slate, name_id).await?;
-        let alice_eid = entities["alice"];
-        let bob_eid = entities["bob"];
+        let query: ParsedQuery = r#"[:find ?e ?name :where [?e :name ?name]]"#.parse()?;
+        let snapshot = slate.snapshot().await?;
+        let handle = tokio::runtime::Handle::current();
+        let ident_map = indexer.metadata().schema.ident_map.clone();
+        let range_stats = components.range_stats.clone();
+        let rows = tokio::task::spawn_blocking(move || {
+            execute_query(
+                &query,
+                &[],
+                snapshot,
+                handle,
+                &ident_map,
+                i64::MAX,
+                range_stats,
+            )
+        })
+        .await??;
+
+        let mut entities = std::collections::HashMap::new();
+        for row in rows {
+            if let [DataType::Long(eid), DataType::String(name)] = row.as_slice() {
+                if name == "alice" || name == "bob" {
+                    entities.insert(name.clone(), *eid);
+                }
+            }
+        }
+        let alice_eid = *entities.get("alice").expect("alice entity should exist");
+        let bob_eid = *entities.get("bob").expect("bob entity should exist");
 
         let tx2 = TxKey {
             tx_id: 2,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -15,14 +15,13 @@ use crate::codec::{
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;
-use crate::ops::{Datom, DatomOp, TxOp};
+use crate::ops::{Datom, DatomOp, Entid, TxOp};
 use crate::partition::{partition_entity_prefix, TX_PARTITION};
 use crate::schema::{Schema, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::transaction::TxKey;
 use crate::tx;
 use crate::util::concat_bytes;
-use edn::symbols::Keyword;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
@@ -348,7 +347,7 @@ impl Indexer {
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
-        let mut eav_prefixes: BTreeMap<Vec<u8>, (i64, Keyword)> = BTreeMap::new();
+        let mut eav_prefixes: BTreeMap<Vec<u8>, (Entid, Entid)> = BTreeMap::new();
         for datom in &datoms {
             if datom.op != DatomOp::Assert {
                 continue;
@@ -368,10 +367,11 @@ impl Indexer {
             let entity_id_bytes = DataType::Long(datom.entity).encode();
             let attr_id_bytes = encode_i64_bytes(attribute_id);
             let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_id_bytes, &attr_id_bytes]);
-            eav_prefixes.insert(eav_prefix, (datom.entity, datom.attribute.clone()));
+            eav_prefixes.insert(eav_prefix, (datom.entity, attribute_id));
         }
 
-        let mut old_values: HashMap<(i64, Keyword), DataType> =
+        // uses entity entid and attribute entid
+        let mut old_values: HashMap<(Entid, Entid), DataType> =
             HashMap::with_capacity(eav_prefixes.len());
         if let Some(first_prefix) = eav_prefixes.keys().next() {
             let mut iter = txn
@@ -381,7 +381,7 @@ impl Indexer {
                 )
                 .await?;
 
-            for (eav_prefix, (entity, attribute)) in &eav_prefixes {
+            for (eav_prefix, (entity, attribute_id)) in &eav_prefixes {
                 iter.seek(eav_prefix).await?;
 
                 if let Some(kv) = iter.next().await? {
@@ -396,10 +396,8 @@ impl Indexer {
                             let value_bytes =
                                 &key[eav_prefix.len()..key.len() - codec::TX_EID_OP_SUFFIX];
                             let mut cursor = value_bytes;
-                            old_values.insert(
-                                (*entity, attribute.clone()),
-                                decode_datatype(&mut cursor)?,
-                            );
+                            old_values
+                                .insert((*entity, *attribute_id), decode_datatype(&mut cursor)?);
                         }
                     }
                 }
@@ -413,7 +411,7 @@ impl Indexer {
                 continue;
             }
 
-            let (_attribute_id, attr) = self
+            let (attribute_id, attr) = self
                 .metadata
                 .schema
                 .get_attribute(&datom.attribute)
@@ -424,7 +422,7 @@ impl Indexer {
                 continue;
             }
 
-            if let Some(old_value) = old_values.get(&(datom.entity, datom.attribute.clone())) {
+            if let Some(old_value) = old_values.get(&(datom.entity, attribute_id)) {
                 if old_value == &datom.value {
                     continue;
                 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -344,7 +344,7 @@ impl Indexer {
         txn: &slatedb::DbTransaction,
         datoms: Vec<Datom>,
     ) -> Result<Vec<Datom>, Error> {
-        // For each Assert datom, scan EAV for the current value of (entity, attribute).
+        // Batch resolve all cardinality one assertion old values via an EAV scan
         // If the old value equals the new value, drop the datom (no-op).
         // If the old value differs, add a Retract datom for the old value.
         // Collect into HashSet to deduplicate explicit + auto-generated retractions.
@@ -354,6 +354,7 @@ impl Indexer {
                 continue;
             }
 
+            // TODO: this attribute lookup is done twice. Here and in the final loop. Refactor
             let (attribute_id, attr) = self
                 .metadata
                 .schema

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1382,6 +1382,9 @@ mod tests {
         Ok(())
     }
 
+    // Regression: a batched-scan prefix with no entries must not swallow the
+    // next prefix's first key. Sorting by attribute_id ensures the missing
+    // prefix sorts first so the seek-past-missing path is exercised.
     #[tokio::test]
     async fn test_batch_old_value_scan_handles_missing_prefix() -> Result<(), Error> {
         let components = in_memory_slate().await;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -4,8 +4,6 @@ use anyhow::Result;
 use edn::kw;
 use edn::symbols::Keyword;
 
-use bytes::Bytes;
-
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
 use crate::indexer::ave_key_to_parts;
 use crate::metadata::PartitionMap;
@@ -234,34 +232,6 @@ pub fn expand_tx_ops(ops: &[TxOp], schema: &Schema) -> Result<Vec<DatomExpanded>
         }
     }
     Ok(datoms)
-}
-
-/// Scan a prefix and return the first non-retracted entry's key, or None.
-/// The first entry is the most recent (tx_eid is descending-encoded) — if
-/// its op byte is RETRACT, the logical value is absent.
-pub async fn first_live_key(
-    txn: &slatedb::DbTransaction,
-    prefix: &[u8],
-) -> Result<Option<Bytes>> {
-    let mut iter = txn
-        .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
-    match iter.next().await? {
-        Some(kv) => {
-            let key = &kv.key;
-            assert!(
-                key.len() >= codec::TX_EID_OP_SUFFIX,
-                "Key too short ({} bytes) to contain tx_eid + op suffix",
-                key.len()
-            );
-            if key[key.len() - 1] == codec::RETRACT {
-                Ok(None)
-            } else {
-                Ok(Some(kv.key))
-            }
-        }
-        None => Ok(None),
-    }
 }
 
 fn lookup_ref_ave_prefix(attr_eid: i64, value: &DataType) -> Vec<u8> {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -7,7 +7,7 @@ use edn::symbols::Keyword;
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
 use crate::indexer::ave_key_to_parts;
 use crate::metadata::PartitionMap;
-use crate::ops::{DataType, Datom, DatomOp, EntityRef, TxOp};
+use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::partition::{DB_PARTITION, USER_PARTITION};
 use crate::schema::{Schema, ValueType};
 use crate::slate::DEFAULT_SCAN_OPTIONS;
@@ -260,7 +260,7 @@ pub async fn resolve_lookup_refs(
     txn: &slatedb::DbTransaction,
 ) -> Result<Vec<DatomWithTempids>> {
     // Collect all unique lookup refs keyed by their encoded AVE lookup prefix.
-    let mut lookup_refs: BTreeMap<Vec<u8>, (i64, DataType)> = BTreeMap::new();
+    let mut lookup_refs: BTreeMap<Vec<u8>, (Entid, DataType)> = BTreeMap::new();
     for d in &datoms {
         if let EntityExpanded::LookupRef(a, v) = &d.entity {
             lookup_refs.insert(lookup_ref_ave_prefix(*a, v), (*a, v.clone()));
@@ -270,7 +270,8 @@ pub async fn resolve_lookup_refs(
         }
     }
 
-    let mut resolved_map: HashMap<(i64, DataType), i64> = HashMap::new();
+    // Attribute entid + value → resolved entid lookup map.
+    let mut resolved_map: HashMap<(Entid, DataType), Entid> = HashMap::new();
 
     if let Some(first_prefix) = lookup_refs.keys().next() {
         let mut iter = txn


### PR DESCRIPTION
## Summary
- Batch cardinality-one old-value lookups in finalize_datoms_for_commit using sorted EAV prefixes and a single scan/seek pass
- Skip old-value lookups for entities that are not present in the pre-transaction partition map
- Add coverage for overwriting multiple existing cardinality-one values in one transaction

Fixes #239

## Test Plan
- cargo test test_resolve
- cargo test retract_on
- cargo test cardinality
- cargo test