### PR TITLE
Remove DataType::Tuple

### DIFF
--- a/design/ENCODING.md
+++ b/design/ENCODING.md
@@ -88,7 +88,7 @@ Reuse the wire protocol tags from `design/WIRE_PROTOCOL.md`:
 | 7   | Long                                                             | `i64`                          |
 | 8   | *(reserved — Ref shares tag 7/Long, differentiated via schema)*  | —                              |
 | 9   | String                                                           | `String`                       |
-| 10  | Tuple                                                            | `Vec<DataType>`                |
+| 10  | *(reserved — formerly Tuple)*                                    | —                              |
 | 11  | Uuid                                                             | `Uuid` (16 bytes)              |
 | 12  | Vector                                                           | `Vec<DataType>`                |
 | 13  | Map                                                              | `BTreeMap<String, DataType>`   |

--- a/design/ENCODING.md
+++ b/design/ENCODING.md
@@ -88,11 +88,10 @@ Reuse the wire protocol tags from `design/WIRE_PROTOCOL.md`:
 | 7   | Long                                                             | `i64`                          |
 | 8   | *(reserved — Ref shares tag 7/Long, differentiated via schema)*  | —                              |
 | 9   | String                                                           | `String`                       |
-| 10  | *(reserved — formerly Tuple)*                                    | —                              |
-| 11  | Uuid                                                             | `Uuid` (16 bytes)              |
-| 12  | Vector                                                           | `Vec<DataType>`                |
-| 13  | Map                                                              | `BTreeMap<String, DataType>`   |
-| 14  | Keyword                                                          | `Keyword`                      |
+| 10  | Uuid                                                             | `Uuid` (16 bytes)              |
+| 11  | Vector                                                           | `Vec<DataType>`                |
+| 12  | Map                                                              | `BTreeMap<String, DataType>`   |
+| 13  | Keyword                                                          | `Keyword`                      |
 
 ---
 

--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -48,7 +48,6 @@ granular schema evolvement. This will require more work in the indexer so likely
 | `:db.type/uuid`      | 128-bit UUID                                                      |
 | `:db.type/bytes`     | Arbitrary binary data                                             |
 | `:db.type/bigint`    | Arbitrary precision integer                                       |
-| `:db.type/tuple`     | Ordered heterogeneous collection                                  |
 | `:db.type/vector`    | Ordered homogeneous collection                                    |
 | `:db.type/map`       | String-keyed map                                                  |
 

--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -559,7 +559,7 @@ Used in RowDescription to describe column types and as the discriminant byte in 
 | 7   | Long    |
 | 8   | Ref     |
 | 9   | String  |
-| 10  | Tuple   |
+| 10  | *(reserved — formerly Tuple)* |
 | 11  | Uuid    |
 | 12  | Vector  |
 | 13  | Map     |
@@ -658,7 +658,7 @@ A `DataType` value is encoded as a 1-byte type tag (from [Section 10](#10-data-t
 | 7   | Long    | `i64` (8 bytes)                                  |
 | 8   | Ref     | `i64` (8 bytes, entity reference)                |
 | 9   | String  | `String` (u32 length + UTF-8 bytes)              |
-| 10  | Tuple   | `Vec<DataType>` (u32 count + elements)           |
+| 10  | *(reserved — formerly Tuple)* | —                                  |
 | 11  | Uuid    | 16 bytes, raw RFC 4122 layout                    |
 | 12  | Vector  | `Vec<DataType>` (u32 count + elements)           |
 | 13  | Map     | `Map<String, DataType>` (u32 count + entries)    |

--- a/design/WIRE_PROTOCOL.md
+++ b/design/WIRE_PROTOCOL.md
@@ -559,15 +559,14 @@ Used in RowDescription to describe column types and as the discriminant byte in 
 | 7   | Long    |
 | 8   | Ref     |
 | 9   | String  |
-| 10  | *(reserved — formerly Tuple)* |
-| 11  | Uuid    |
-| 12  | Vector  |
-| 13  | Map     |
-| 14  | Keyword |
+| 10  | Uuid    |
+| 11  | Vector  |
+| 12  | Map     |
+| 13  | Keyword |
 | 127 | Union   |
 | 255 | Unknown |
 
-Tags 1–14 (and future concrete types up to 126) are used in two contexts: as the discriminant byte in DataRow value encoding, and as a column type in ColumnDescription.
+Tags 1–13 (and future concrete types up to 126) are used in two contexts: as the discriminant byte in DataRow value encoding, and as a column type in ColumnDescription.
 
 Tag 127 (Union) and tag 255 (Unknown) are **ColumnDescription-only** — they never appear as DataRow value discriminants. `Union` means the column contains values from a known, finite set of concrete types (members listed inline in the ColumnDescription). `Unknown` means the type is truly indeterminate.
 
@@ -658,11 +657,10 @@ A `DataType` value is encoded as a 1-byte type tag (from [Section 10](#10-data-t
 | 7   | Long    | `i64` (8 bytes)                                  |
 | 8   | Ref     | `i64` (8 bytes, entity reference)                |
 | 9   | String  | `String` (u32 length + UTF-8 bytes)              |
-| 10  | *(reserved — formerly Tuple)* | —                                  |
-| 11  | Uuid    | 16 bytes, raw RFC 4122 layout                    |
-| 12  | Vector  | `Vec<DataType>` (u32 count + elements)           |
-| 13  | Map     | `Map<String, DataType>` (u32 count + entries)    |
-| 14  | Keyword | `String` (u32 length + UTF-8 bytes)              |
+| 10  | Uuid    | 16 bytes, raw RFC 4122 layout                    |
+| 11  | Vector  | `Vec<DataType>` (u32 count + elements)           |
+| 12  | Map     | `Map<String, DataType>` (u32 count + entries)    |
+| 13  | Keyword | `String` (u32 length + UTF-8 bytes)              |
 
 ### 11.8 EntityRef Encoding
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -12,7 +12,7 @@ use crate::index::IndexType;
 use crate::ops::DataType;
 use crate::protocol::{
     data_type_tag, micros_to_datetime, TAG_BIG_INT, TAG_BOOLEAN, TAG_BYTES, TAG_DOUBLE, TAG_FLOAT,
-    TAG_INSTANT, TAG_KEYWORD, TAG_LONG, TAG_MAP, TAG_STRING, TAG_TUPLE, TAG_UUID, TAG_VECTOR,
+    TAG_INSTANT, TAG_KEYWORD, TAG_LONG, TAG_MAP, TAG_STRING, TAG_UUID, TAG_VECTOR,
 };
 
 // ---------------------------------------------------------------------------
@@ -351,7 +351,6 @@ pub fn encode_datatype(value: &DataType, buf: &mut Vec<u8>) {
         DataType::Keyword(v) => encode_keyword(v, buf),
         DataType::Long(v) => encode_i64(*v, buf),
         DataType::String(v) => encode_string(v, buf),
-        DataType::Tuple(v) => encode_composite(v, buf),
         DataType::Uuid(v) => encode_uuid(v, buf),
         DataType::Vector(v) => encode_composite(v, buf),
         DataType::Map(v) => encode_map(v, buf),
@@ -394,7 +393,6 @@ fn decode_datatype_payload(tag: u8, cursor: &mut &[u8]) -> Result<DataType, Deco
         TAG_KEYWORD => Ok(DataType::Keyword(decode_keyword(cursor)?)),
         TAG_LONG => Ok(DataType::Long(decode_i64(cursor)?)),
         TAG_STRING => Ok(DataType::String(decode_string(cursor)?)),
-        TAG_TUPLE => Ok(DataType::Tuple(decode_composite(cursor)?)),
         TAG_UUID => Ok(DataType::Uuid(decode_uuid(cursor)?)),
         TAG_VECTOR => Ok(DataType::Vector(decode_composite(cursor)?)),
         TAG_MAP => Ok(DataType::Map(decode_map(cursor)?)),
@@ -462,7 +460,7 @@ pub fn skip_datatype(cursor: &mut &[u8]) -> Result<(), DecodeError> {
         TAG_LONG => skip_n(cursor, 8),
         TAG_STRING => skip_terminated(cursor),
         TAG_UUID => skip_n(cursor, 16),
-        TAG_TUPLE | TAG_VECTOR => skip_composite(cursor),
+        TAG_VECTOR => skip_composite(cursor),
         TAG_MAP => skip_map(cursor),
         _ => Err(format!("unknown type tag in skip: 0x{:02x}", tag).into()),
     }
@@ -797,7 +795,6 @@ mod tests {
             DataType::Long(i64::MIN),
             DataType::String("hello".to_string()),
             DataType::String("".to_string()),
-            DataType::Tuple(vec![DataType::Long(1), DataType::String("a".to_string())]),
             DataType::Uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             DataType::Vector(vec![DataType::Long(1), DataType::Long(2)]),
             DataType::Map({
@@ -816,7 +813,6 @@ mod tests {
     #[test]
     fn roundtrip_datatype_empty_composites() {
         let values = vec![
-            DataType::Tuple(vec![]),
             DataType::Vector(vec![]),
             DataType::Map(BTreeMap::new()),
             DataType::Bytes(vec![]),
@@ -832,7 +828,7 @@ mod tests {
     #[test]
     fn roundtrip_datatype_nested_composite() {
         let nested = DataType::Vector(vec![
-            DataType::Tuple(vec![
+            DataType::Vector(vec![
                 DataType::Long(1),
                 DataType::String("inner".to_string()),
             ]),
@@ -1008,13 +1004,6 @@ mod tests {
     // --- Composite ordering tests ---
 
     #[test]
-    fn tuple_prefix_ordering() {
-        let short = DataType::Tuple(vec![DataType::Long(1)]).encode();
-        let long = DataType::Tuple(vec![DataType::Long(1), DataType::Long(2)]).encode();
-        assert!(short < long);
-    }
-
-    #[test]
     fn vector_prefix_ordering() {
         let short = DataType::Vector(vec![DataType::Long(1)]).encode();
         let long = DataType::Vector(vec![DataType::Long(1), DataType::Long(2)]).encode();
@@ -1051,7 +1040,6 @@ mod tests {
             DataType::Keyword(kw!(:db/id)),
             DataType::Long(99),
             DataType::String("test".to_string()),
-            DataType::Tuple(vec![DataType::Long(1)]),
             DataType::Uuid(Uuid::nil()),
             DataType::Vector(vec![DataType::Boolean(false)]),
             DataType::Map({

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -61,8 +61,7 @@ pub enum DataType {
     Long(i64),              // Long integers (also used for Ref values; see ValueType::Ref)
     String(String),         // Strings
     // Symbol(NamespacedSymbol),                  // Symbols (can be represented as strings)
-    Tuple(Vec<DataType>), // Tuples (can be represented as a vector of DataTypes)
-    Uuid(Uuid),           // Universally unique identifier
+    Uuid(Uuid), // Universally unique identifier
     // TODO
     //Uri(Uri),                        // URIs (could also be represented as strings)
 
@@ -88,7 +87,6 @@ impl std::hash::Hash for DataType {
             DataType::Keyword(v) => v.hash(state),
             DataType::Long(v) => v.hash(state),
             DataType::String(v) => v.hash(state),
-            DataType::Tuple(v) => v.hash(state),
             DataType::Uuid(v) => v.hash(state),
             DataType::Vector(v) => v.hash(state),
             DataType::Map(v) => v.hash(state),
@@ -110,7 +108,6 @@ impl DataType {
             DataType::Keyword(_) => ValueType::Keyword,
             DataType::Long(_) => ValueType::Long,
             DataType::String(_) => ValueType::String,
-            DataType::Tuple(_) => ValueType::Tuple,
             DataType::Uuid(_) => ValueType::Uuid,
             DataType::Vector(_) => ValueType::Vector,
             DataType::Map(_) => ValueType::Map,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -83,11 +83,10 @@ pub const TAG_INSTANT: u8 = 6;
 pub const TAG_LONG: u8 = 7;
 pub const TAG_REF: u8 = 8;
 pub const TAG_STRING: u8 = 9;
-// 10 reserved (formerly TAG_TUPLE)
-pub const TAG_UUID: u8 = 11;
-pub const TAG_VECTOR: u8 = 12;
-pub const TAG_MAP: u8 = 13;
-pub const TAG_KEYWORD: u8 = 14;
+pub const TAG_UUID: u8 = 10;
+pub const TAG_VECTOR: u8 = 11;
+pub const TAG_MAP: u8 = 12;
+pub const TAG_KEYWORD: u8 = 13;
 pub const TAG_UNKNOWN: u8 = 255;
 
 // TxOp tag bytes

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -83,7 +83,7 @@ pub const TAG_INSTANT: u8 = 6;
 pub const TAG_LONG: u8 = 7;
 pub const TAG_REF: u8 = 8;
 pub const TAG_STRING: u8 = 9;
-pub const TAG_TUPLE: u8 = 10;
+// 10 reserved (formerly TAG_TUPLE)
 pub const TAG_UUID: u8 = 11;
 pub const TAG_VECTOR: u8 = 12;
 pub const TAG_MAP: u8 = 13;
@@ -382,7 +382,6 @@ pub fn data_type_tag(dt: &DataType) -> u8 {
         DataType::Keyword(_) => TAG_KEYWORD,
         DataType::Long(_) => TAG_LONG,
         DataType::String(_) => TAG_STRING,
-        DataType::Tuple(_) => TAG_TUPLE,
         DataType::Uuid(_) => TAG_UUID,
         DataType::Vector(_) => TAG_VECTOR,
         DataType::Map(_) => TAG_MAP,
@@ -401,7 +400,6 @@ fn encode_data_type(buf: &mut Vec<u8>, dt: &DataType) {
         DataType::Keyword(v) => encode_string(buf, &v.to_string()),
         DataType::Long(v) => encode_i64(buf, *v),
         DataType::String(v) => encode_string(buf, v),
-        DataType::Tuple(v) => encode_data_type_vec(buf, v),
         DataType::Uuid(v) => buf.extend_from_slice(v.as_bytes()),
         DataType::Vector(v) => encode_data_type_vec(buf, v),
         DataType::Map(v) => encode_data_type_map(buf, v),
@@ -689,7 +687,6 @@ fn decode_data_type(cursor: &mut Cursor) -> Result<DataType> {
         // TODO: support TAG_REF once DataType::Ref is added
         TAG_REF => bail!("TAG_REF is not currently supported"),
         TAG_STRING => Ok(DataType::String(cursor.read_string()?)),
-        TAG_TUPLE => Ok(DataType::Tuple(decode_data_type_vec(cursor)?)),
         TAG_UUID => Ok(DataType::Uuid(Uuid::from_bytes(cursor.read_array()?))),
         TAG_VECTOR => Ok(DataType::Vector(decode_data_type_vec(cursor)?)),
         TAG_MAP => Ok(DataType::Map(decode_data_type_map(cursor)?)),
@@ -1447,12 +1444,6 @@ mod tests {
     }
 
     #[test]
-    fn test_data_type_tuple() {
-        let dt = DataType::Tuple(vec![DataType::Long(42), DataType::Boolean(true)]);
-        assert_eq!(roundtrip_data_type(&dt), dt);
-    }
-
-    #[test]
     fn test_data_type_map() {
         let mut map = BTreeMap::new();
         map.insert("name".to_string(), DataType::String("alice".to_string()));
@@ -1467,7 +1458,7 @@ mod tests {
         inner_map.insert("x".to_string(), DataType::Long(1));
         let dt = DataType::Vector(vec![
             DataType::Map(inner_map),
-            DataType::Tuple(vec![
+            DataType::Vector(vec![
                 DataType::String("hello".to_string()),
                 DataType::Boolean(false),
             ]),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -30,9 +30,8 @@ pub const DB_TYPE_INSTANT: i64 = 17;
 pub const DB_TYPE_UUID: i64 = 18;
 pub const DB_TYPE_BYTES: i64 = 19;
 pub const DB_TYPE_BIGINT: i64 = 20;
-// 21 reserved (formerly DB_TYPE_TUPLE)
-pub const DB_TYPE_VECTOR: i64 = 22;
-pub const DB_TYPE_MAP: i64 = 23;
+pub const DB_TYPE_VECTOR: i64 = 21;
+pub const DB_TYPE_MAP: i64 = 22;
 
 // Cardinality enum entities
 pub const DB_CARDINALITY_ONE: i64 = 30;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -30,7 +30,7 @@ pub const DB_TYPE_INSTANT: i64 = 17;
 pub const DB_TYPE_UUID: i64 = 18;
 pub const DB_TYPE_BYTES: i64 = 19;
 pub const DB_TYPE_BIGINT: i64 = 20;
-pub const DB_TYPE_TUPLE: i64 = 21;
+// 21 reserved (formerly DB_TYPE_TUPLE)
 pub const DB_TYPE_VECTOR: i64 = 22;
 pub const DB_TYPE_MAP: i64 = 23;
 
@@ -69,7 +69,6 @@ static V1_IDENTS: LazyLock<Vec<(Keyword, i64)>> = LazyLock::new(|| {
         (kw!(:db.type/uuid), DB_TYPE_UUID),
         (kw!(:db.type/bytes), DB_TYPE_BYTES),
         (kw!(:db.type/bigint), DB_TYPE_BIGINT),
-        (kw!(:db.type/tuple), DB_TYPE_TUPLE),
         (kw!(:db.type/vector), DB_TYPE_VECTOR),
         (kw!(:db.type/map), DB_TYPE_MAP),
         // Cardinality enum entities
@@ -141,7 +140,6 @@ pub enum ValueType {
     Uuid,
     Bytes,
     BigInt,
-    Tuple,
     Vector,
     Map,
 }
@@ -160,7 +158,6 @@ impl std::fmt::Display for ValueType {
             ValueType::Uuid => write!(f, "uuid"),
             ValueType::Bytes => write!(f, "bytes"),
             ValueType::BigInt => write!(f, "bigint"),
-            ValueType::Tuple => write!(f, "tuple"),
             ValueType::Vector => write!(f, "vector"),
             ValueType::Map => write!(f, "map"),
         }
@@ -182,7 +179,6 @@ impl ValueType {
             DB_TYPE_UUID => Ok(ValueType::Uuid),
             DB_TYPE_BYTES => Ok(ValueType::Bytes),
             DB_TYPE_BIGINT => Ok(ValueType::BigInt),
-            DB_TYPE_TUPLE => Ok(ValueType::Tuple),
             DB_TYPE_VECTOR => Ok(ValueType::Vector),
             DB_TYPE_MAP => Ok(ValueType::Map),
             _ => Err(anyhow::anyhow!("Unknown value type entity ID: {}", id)),
@@ -203,7 +199,6 @@ impl ValueType {
             ValueType::Uuid => DB_TYPE_UUID,
             ValueType::Bytes => DB_TYPE_BYTES,
             ValueType::BigInt => DB_TYPE_BIGINT,
-            ValueType::Tuple => DB_TYPE_TUPLE,
             ValueType::Vector => DB_TYPE_VECTOR,
             ValueType::Map => DB_TYPE_MAP,
         }
@@ -1060,7 +1055,6 @@ mod tests {
             ValueType::Uuid,
             ValueType::Bytes,
             ValueType::BigInt,
-            ValueType::Tuple,
             ValueType::Vector,
             ValueType::Map,
         ] {

--- a/triplox-jvm/src/main/clojure/io/triplox/types.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/types.clj
@@ -1,12 +1,10 @@
 (ns io.triplox.types
   "Conversion between Triplox wire types and Clojure types."
-  (:import [java.util Map]
-           [io.triplox.client DataTypeCodec$TaggedTuple]))
+  (:import [java.util Map]))
 
 (defn wire->clj
   "Convert a wire protocol value to an idiomatic Clojure value.
    TreeMap<String,Object> → Clojure map with keyword keys.
-   TaggedTuple → vector (same as Vector for Clojure consumers).
    Most types pass through unchanged."
   [v]
   (cond
@@ -17,9 +15,6 @@
                        (wire->clj (.getValue ^java.util.Map$Entry entry))))
              (transient {})
              (.entrySet ^Map v)))
-
-    (instance? DataTypeCodec$TaggedTuple v)
-    (mapv wire->clj (.elements ^DataTypeCodec$TaggedTuple v))
 
     (instance? java.util.List v)
     (mapv wire->clj v)

--- a/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
@@ -30,7 +30,6 @@ import static io.triplox.client.MessageTypes.*;
  *   Long           → Long
  *   Ref            → UnsupportedOperationException
  *   String         → String
- *   Tuple          → List<Object>
  *   Uuid           → UUID
  *   Vector         → List<Object>
  *   Map            → TreeMap<String, Object>
@@ -98,10 +97,6 @@ public final class DataTypeCodec {
                 out.writeByte(TAG_VECTOR);
                 encodeDataTypeVec(out, list);
             }
-            case TaggedTuple tt -> {
-                out.writeByte(TAG_TUPLE);
-                encodeDataTypeVec(out, tt.elements());
-            }
             default -> throw new IllegalArgumentException("Cannot encode value of type: " + value.getClass().getName());
         }
     }
@@ -131,12 +126,6 @@ public final class DataTypeCodec {
             case TAG_LONG -> in.readLong();
             case TAG_REF -> throw new UnsupportedOperationException("Ref type is not yet supported");
             case TAG_STRING -> decodeString(in);
-            case TAG_TUPLE -> {
-                int count = in.readInt();
-                var list = new ArrayList<>(count);
-                for (int i = 0; i < count; i++) list.add(decode(in));
-                yield new TaggedTuple(list);
-            }
             case TAG_UUID -> new UUID(in.readLong(), in.readLong());
             case TAG_VECTOR -> decodeDataTypeVec(in);
             case TAG_MAP -> decodeDataTypeMap(in);
@@ -318,9 +307,4 @@ public final class DataTypeCodec {
         }
     }
 
-    /**
-     * Wrapper to distinguish Tuple from Vector during encoding.
-     * Decoded tuples come back as TaggedTuple; vectors as List.
-     */
-    public record TaggedTuple(List<Object> elements) {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
@@ -51,7 +51,7 @@ public final class MessageTypes {
     public static final byte TAG_LONG     = 7;
     public static final byte TAG_REF      = 8;
     public static final byte TAG_STRING   = 9;
-    public static final byte TAG_TUPLE    = 10;
+    // 10 reserved (formerly TAG_TUPLE)
     public static final byte TAG_UUID     = 11;
     public static final byte TAG_VECTOR   = 12;
     public static final byte TAG_MAP      = 13;

--- a/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/MessageTypes.java
@@ -51,11 +51,10 @@ public final class MessageTypes {
     public static final byte TAG_LONG     = 7;
     public static final byte TAG_REF      = 8;
     public static final byte TAG_STRING   = 9;
-    // 10 reserved (formerly TAG_TUPLE)
-    public static final byte TAG_UUID     = 11;
-    public static final byte TAG_VECTOR   = 12;
-    public static final byte TAG_MAP      = 13;
-    public static final byte TAG_KEYWORD  = 14;
+    public static final byte TAG_UUID     = 10;
+    public static final byte TAG_VECTOR   = 11;
+    public static final byte TAG_MAP      = 12;
+    public static final byte TAG_KEYWORD  = 13;
     public static final byte TAG_UNKNOWN  = (byte) 255;
 
     // TxOp tag bytes

--- a/triplox-jvm/src/test/clojure/io/triplox/types_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/types_test.clj
@@ -1,8 +1,7 @@
 (ns io.triplox.types-test
   (:require [clojure.test :refer [deftest is testing]]
             [io.triplox.types :as types])
-  (:import [java.util TreeMap ArrayList]
-           [io.triplox.client DataTypeCodec$TaggedTuple]))
+  (:import [java.util TreeMap ArrayList]))
 
 (deftest wire->clj-primitives
   (testing "Primitives pass through unchanged"
@@ -30,8 +29,3 @@
   (testing "Java List → Clojure vector"
     (let [list (ArrayList. [1 "two" true])]
       (is (= [1 "two" true] (types/wire->clj list))))))
-
-(deftest wire->clj-tagged-tuple
-  (testing "TaggedTuple → Clojure vector"
-    (let [tuple (DataTypeCodec$TaggedTuple. (ArrayList. [42 true]))]
-      (is (= [42 true] (types/wire->clj tuple))))))

--- a/triplox-jvm/src/test/java/io/triplox/client/DataTypeCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/DataTypeCodecTest.java
@@ -141,15 +141,6 @@ class DataTypeCodecTest {
     }
 
     @Test
-    void testTuple() throws IOException {
-        var tuple = new DataTypeCodec.TaggedTuple(new ArrayList<>(List.of(42L, true)));
-        var result = (DataTypeCodec.TaggedTuple) roundtrip(tuple);
-        assertEquals(2, result.elements().size());
-        assertEquals(42L, result.elements().get(0));
-        assertEquals(true, result.elements().get(1));
-    }
-
-    @Test
     void testMap() throws IOException {
         var map = new TreeMap<String, Object>();
         map.put("age", 30L);


### PR DESCRIPTION
## Summary
- Drop the `Tuple` variant from `DataType` along with `ValueType::Tuple`, `DB_TYPE_TUPLE`, the `:db.type/tuple` ident, and `TAG_TUPLE`. `Vector` already carried the same payload.
- Remove the corresponding codec encode/decode/skip arms, tests, JVM client `TaggedTuple`, the `wire->clj` branch, and the design-doc rows; mark tag 10 / entid 21 as reserved.
- Keep `QueryArg::Tuple` / `QUERY_ARG_TUPLE = 2` — tuple input bindings remain reserved on the wire even though no value-level tuples exist.
- `Binding::BindTuple` and `FindSpec::FindTuple` in `edn/` are query-shape constructs and were left untouched.

## Test plan
- [x] `cargo build --workspace --tests`
- [x] `cargo test --workspace`
- [ ] `./gradlew test` (or Maven equivalent) on `triplox-jvm/`