### PR TITLE
Parse TxOp from EDN strings; submit_tx accepts Vec<&str>

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,9 @@
 use anyhow::{bail, Error, Result};
 use reqwest::Client;
 
-use crate::node::{Database, IntoQuery, QueryNode, SubmitNode, TransactionResult, TxKey};
+use crate::node::{
+    collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, SubmitNode, TransactionResult, TxKey,
+};
 use crate::ops::{DataType, QueryArg, TxOp};
 use crate::protocol::*;
 use crate::query::QueryResult;
@@ -88,7 +90,8 @@ impl ClientNode {
 }
 
 impl SubmitNode for ClientNode {
-    async fn submit_tx(&self, ops: Vec<TxOp>) -> Result<TxKey, Error> {
+    async fn submit_tx<O: IntoTxOp>(&self, ops: Vec<O>) -> Result<TxKey, Error> {
+        let ops = collect_tx_ops(ops)?;
         let body = encode_execute_request(&ops);
         let resp = self
             .client
@@ -107,7 +110,8 @@ impl SubmitNode for ClientNode {
         })
     }
 
-    async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error> {
+    async fn execute_tx<O: IntoTxOp>(&self, ops: Vec<O>) -> Result<TransactionResult, Error> {
+        let ops = collect_tx_ops(ops)?;
         let body = encode_execute_request(&ops);
         let resp = self
             .client

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,8 +20,39 @@ use tokio_util::sync::CancellationToken;
 
 #[allow(async_fn_in_trait)]
 pub trait SubmitNode {
-    async fn submit_tx(&self, ops: Vec<TxOp>) -> Result<TxKey, Error>;
-    async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error>;
+    async fn submit_tx<O: IntoTxOp>(&self, ops: Vec<O>) -> Result<TxKey, Error>;
+    async fn execute_tx<O: IntoTxOp>(
+        &self,
+        ops: Vec<O>,
+    ) -> Result<TransactionResult, Error>;
+}
+
+/// Per-element conversion to `TxOp`. Lets `submit_tx`/`execute_tx` accept
+/// either `Vec<TxOp>` or `Vec<&str>`/`Vec<String>` (each string parsed as one EDN tx op).
+pub trait IntoTxOp {
+    fn into_tx_op(self) -> Result<TxOp, Error>;
+}
+
+impl IntoTxOp for TxOp {
+    fn into_tx_op(self) -> Result<TxOp, Error> {
+        Ok(self)
+    }
+}
+
+impl IntoTxOp for &str {
+    fn into_tx_op(self) -> Result<TxOp, Error> {
+        self.parse()
+    }
+}
+
+impl IntoTxOp for String {
+    fn into_tx_op(self) -> Result<TxOp, Error> {
+        self.as_str().into_tx_op()
+    }
+}
+
+pub(crate) fn collect_tx_ops<O: IntoTxOp>(ops: Vec<O>) -> Result<Vec<TxOp>, Error> {
+    ops.into_iter().map(IntoTxOp::into_tx_op).collect()
 }
 
 pub trait IntoQuery {
@@ -289,12 +320,17 @@ impl<L: TxLog> Node<L> {
 }
 
 impl<L: TxLog> SubmitNode for Node<L> {
-    async fn submit_tx(&self, ops: Vec<TxOp>) -> Result<TxKey, Error> {
+    async fn submit_tx<O: IntoTxOp>(&self, ops: Vec<O>) -> Result<TxKey, Error> {
+        let ops = collect_tx_ops(ops)?;
         let serialized = bincode::serialize(&ops)?;
         Ok(self.log.write().await.append_tx(serialized).await)
     }
 
-    async fn execute_tx(&self, ops: Vec<TxOp>) -> Result<TransactionResult, Error> {
+    async fn execute_tx<O: IntoTxOp>(
+        &self,
+        ops: Vec<O>,
+    ) -> Result<TransactionResult, Error> {
+        let ops = collect_tx_ops(ops)?;
         let serialized = bincode::serialize(&ops)?;
 
         let waiter = self.indexer.read().await.tx_waiter();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -230,10 +230,8 @@ pub(crate) fn value_to_data_type(value: Value) -> Result<DataType> {
             Ok(DataType::Map(out))
         }
         Value::Nil => anyhow::bail!("nil is not a valid TxOp value"),
-        Value::List(_) => {
-            anyhow::bail!("lookup-ref / tx-function in value position is not supported")
-        }
         Value::Set(_) => anyhow::bail!("set is not a valid TxOp value"),
+        v @ Value::List(_) => anyhow::bail!("invalid TxOp value: {:?}", v),
         Value::PlainSymbol(s) => anyhow::bail!("symbol {} is not a valid TxOp value", s),
         Value::NamespacedSymbol(s) => anyhow::bail!("symbol {} is not a valid TxOp value", s),
     }
@@ -241,7 +239,7 @@ pub(crate) fn value_to_data_type(value: Value) -> Result<DataType> {
 
 /// Convert an EDN `Value` to an `EntityRef`.
 /// Accepts: integer (`Id`), text (`TempId`), namespaced keyword (`Ident`),
-/// or `(lookup-ref :attr value)` list (`LookupRef`).
+/// or `[:attr value]` 2-vector (`LookupRef`, Datomic-style).
 pub(crate) fn value_to_entity_ref(value: Value) -> Result<EntityRef> {
     match value {
         Value::Integer(i) => Ok(EntityRef::Id(i)),
@@ -252,40 +250,26 @@ pub(crate) fn value_to_entity_ref(value: Value) -> Result<EntityRef> {
             }
             Ok(EntityRef::Ident(k))
         }
-        Value::List(items) => {
-            let mut iter = items.into_iter();
-            match iter.next() {
-                Some(Value::PlainSymbol(sym)) if sym.0 == "lookup-ref" => {
-                    let attr = match iter.next() {
-                        Some(Value::Keyword(k)) => k,
-                        Some(other) => {
-                            anyhow::bail!(
-                                "lookup-ref attribute must be a keyword, got {:?}",
-                                other
-                            )
-                        }
-                        None => anyhow::bail!("lookup-ref missing attribute"),
-                    };
-                    let v = match iter.next() {
-                        Some(v) => value_to_data_type(v)?,
-                        None => anyhow::bail!("lookup-ref missing value"),
-                    };
-                    if iter.next().is_some() {
-                        anyhow::bail!("lookup-ref takes exactly two arguments");
-                    }
-                    Ok(EntityRef::LookupRef(attr, v))
-                }
-                Some(Value::PlainSymbol(sym)) => {
-                    anyhow::bail!("unsupported list form: ({} ...)", sym.0)
-                }
-                Some(other) => {
-                    anyhow::bail!("expected entity ref, got list starting with {:?}", other)
-                }
-                None => anyhow::bail!("empty list is not a valid entity ref"),
+        Value::Vector(items) => {
+            if items.len() != 2 {
+                anyhow::bail!(
+                    "lookup ref must be [:attr value] 2-vector, got {} elements",
+                    items.len()
+                );
             }
+            let mut iter = items.into_iter();
+            let attr = match iter.next().unwrap() {
+                Value::Keyword(k) => k,
+                other => anyhow::bail!(
+                    "lookup ref attribute must be a keyword, got {:?}",
+                    other
+                ),
+            };
+            let v = value_to_data_type(iter.next().unwrap())?;
+            Ok(EntityRef::LookupRef(attr, v))
         }
         other => anyhow::bail!(
-            "expected entity ref (integer, string, keyword, or lookup-ref), got {:?}",
+            "expected entity ref (integer, string, keyword, or [:attr value] lookup ref), got {:?}",
             other
         ),
     }
@@ -690,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_parse_add_with_lookup_ref() {
-        let op: TxOp = "[:db/add (lookup-ref :user/email \"a@b.c\") :user/name \"A\"]"
+        let op: TxOp = "[:db/add [:user/email \"a@b.c\"] :user/name \"A\"]"
             .parse()
             .unwrap();
         assert_eq!(

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use edn::symbols::Keyword;
+use edn::types::Value;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
@@ -191,6 +192,205 @@ impl TxOp {
     /// Build a Put without explicit entity ID (auto-allocated).
     pub fn put(attrs: Vec<(Keyword, DataType)>) -> Self {
         TxOp::Put(attrs.into_iter().collect())
+    }
+}
+
+/// Convert an EDN `Value` to a `DataType` for the value position of a TxOp.
+///
+/// Map keys here must be `Value::Text` because `DataType::Map` uses `String` keys.
+/// (Top-level Put maps use `Value::Keyword` keys — that's handled in `tx_op_from_value`.)
+pub(crate) fn value_to_data_type(value: Value) -> Result<DataType> {
+    match value {
+        Value::Boolean(b) => Ok(DataType::Boolean(b)),
+        Value::Integer(i) => Ok(DataType::Long(i)),
+        Value::BigInteger(bi) => bi
+            .to_string()
+            .parse::<i128>()
+            .map(DataType::BigInt)
+            .map_err(|_| anyhow::anyhow!("BigInt out of i128 range: {}", bi)),
+        Value::Float(f) => Ok(DataType::Double(f.into_inner())),
+        Value::Text(s) => Ok(DataType::String(s)),
+        Value::Uuid(u) => Ok(DataType::Uuid(u)),
+        Value::Instant(d) => Ok(DataType::Instant(d)),
+        Value::Keyword(k) => Ok(DataType::Keyword(k)),
+        Value::Vector(items) => items
+            .into_iter()
+            .map(value_to_data_type)
+            .collect::<Result<Vec<_>>>()
+            .map(DataType::Vector),
+        Value::Map(m) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in m {
+                let key = match k {
+                    Value::Text(s) => s,
+                    other => anyhow::bail!("nested map keys must be strings, got {:?}", other),
+                };
+                out.insert(key, value_to_data_type(v)?);
+            }
+            Ok(DataType::Map(out))
+        }
+        Value::Nil => anyhow::bail!("nil is not a valid TxOp value"),
+        Value::List(_) => {
+            anyhow::bail!("lookup-ref / tx-function in value position is not supported")
+        }
+        Value::Set(_) => anyhow::bail!("set is not a valid TxOp value"),
+        Value::PlainSymbol(s) => anyhow::bail!("symbol {} is not a valid TxOp value", s),
+        Value::NamespacedSymbol(s) => anyhow::bail!("symbol {} is not a valid TxOp value", s),
+    }
+}
+
+/// Convert an EDN `Value` to an `EntityRef`.
+/// Accepts: integer (`Id`), text (`TempId`), namespaced keyword (`Ident`),
+/// or `(lookup-ref :attr value)` list (`LookupRef`).
+pub(crate) fn value_to_entity_ref(value: Value) -> Result<EntityRef> {
+    match value {
+        Value::Integer(i) => Ok(EntityRef::Id(i)),
+        Value::Text(s) => Ok(EntityRef::TempId(s)),
+        Value::Keyword(k) => {
+            if k.is_backward() {
+                anyhow::bail!("reverse keyword {} not supported in entity position", k);
+            }
+            Ok(EntityRef::Ident(k))
+        }
+        Value::List(items) => {
+            let mut iter = items.into_iter();
+            match iter.next() {
+                Some(Value::PlainSymbol(sym)) if sym.0 == "lookup-ref" => {
+                    let attr = match iter.next() {
+                        Some(Value::Keyword(k)) => k,
+                        Some(other) => {
+                            anyhow::bail!(
+                                "lookup-ref attribute must be a keyword, got {:?}",
+                                other
+                            )
+                        }
+                        None => anyhow::bail!("lookup-ref missing attribute"),
+                    };
+                    let v = match iter.next() {
+                        Some(v) => value_to_data_type(v)?,
+                        None => anyhow::bail!("lookup-ref missing value"),
+                    };
+                    if iter.next().is_some() {
+                        anyhow::bail!("lookup-ref takes exactly two arguments");
+                    }
+                    Ok(EntityRef::LookupRef(attr, v))
+                }
+                Some(Value::PlainSymbol(sym)) => {
+                    anyhow::bail!("unsupported list form: ({} ...)", sym.0)
+                }
+                Some(other) => {
+                    anyhow::bail!("expected entity ref, got list starting with {:?}", other)
+                }
+                None => anyhow::bail!("empty list is not a valid entity ref"),
+            }
+        }
+        other => anyhow::bail!(
+            "expected entity ref (integer, string, keyword, or lookup-ref), got {:?}",
+            other
+        ),
+    }
+}
+
+/// Convert an EDN `Value` to a single `TxOp`.
+///
+/// Accepted forms:
+/// - `[:db/add e a v]`     → `TxOp::Add`
+/// - `[:db/retract e a v]` → `TxOp::Retract`
+/// - `[:db/delete e]`      → `TxOp::Delete`
+/// - `[:db/erase e]`       → `TxOp::Erase`
+/// - `{:attr v ...}`       → `TxOp::Put` (`:db/id` is passed through as a normal entry)
+pub(crate) fn tx_op_from_value(value: Value) -> Result<TxOp> {
+    match value {
+        Value::Vector(items) => {
+            let mut iter = items.into_iter();
+            let head = iter
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("empty vector is not a valid TxOp"))?;
+            let op_kw = match head {
+                Value::Keyword(k) => k,
+                other => anyhow::bail!(
+                    "expected operation keyword (e.g. :db/add), got {:?}",
+                    other
+                ),
+            };
+            match (op_kw.namespace(), op_kw.name()) {
+                (Some("db"), name @ ("add" | "retract")) => {
+                    let entity = match iter.next() {
+                        Some(v) => value_to_entity_ref(v)?,
+                        None => anyhow::bail!("{} missing entity", op_kw),
+                    };
+                    let attribute = match iter.next() {
+                        Some(Value::Keyword(k)) => k,
+                        Some(other) => anyhow::bail!(
+                            "{} attribute must be a keyword, got {:?}",
+                            op_kw,
+                            other
+                        ),
+                        None => anyhow::bail!("{} missing attribute", op_kw),
+                    };
+                    let value = match iter.next() {
+                        Some(v) => value_to_data_type(v)?,
+                        None => anyhow::bail!("{} missing value", op_kw),
+                    };
+                    if iter.next().is_some() {
+                        anyhow::bail!("{} takes exactly 3 arguments", op_kw);
+                    }
+                    Ok(if name == "add" {
+                        TxOp::Add {
+                            entity,
+                            attribute,
+                            value,
+                        }
+                    } else {
+                        TxOp::Retract {
+                            entity,
+                            attribute,
+                            value,
+                        }
+                    })
+                }
+                (Some("db"), name @ ("delete" | "erase")) => {
+                    let entity = match iter.next() {
+                        Some(v) => value_to_entity_ref(v)?,
+                        None => anyhow::bail!("{} missing entity", op_kw),
+                    };
+                    if iter.next().is_some() {
+                        anyhow::bail!("{} takes exactly 1 argument", op_kw);
+                    }
+                    Ok(if name == "delete" {
+                        TxOp::Delete(entity)
+                    } else {
+                        TxOp::Erase(entity)
+                    })
+                }
+                _ => anyhow::bail!("unknown TxOp operation: {}", op_kw),
+            }
+        }
+        Value::Map(m) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in m {
+                let key = match k {
+                    Value::Keyword(kw) => kw,
+                    other => {
+                        anyhow::bail!("Put map keys must be keywords, got {:?}", other)
+                    }
+                };
+                out.insert(key, value_to_data_type(v)?);
+            }
+            Ok(TxOp::Put(out))
+        }
+        other => anyhow::bail!("expected TxOp (vector or map form), got {:?}", other),
+    }
+}
+
+impl std::str::FromStr for TxOp {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let value = edn::parse::value(s)
+            .map_err(|e| anyhow::anyhow!("EDN parse error: {}", e))?
+            .without_spans();
+        tx_op_from_value(value)
     }
 }
 
@@ -447,5 +647,182 @@ mod tests {
             EntityRef::from("temp-1"),
             EntityRef::TempId("temp-1".to_string())
         );
+    }
+
+    #[test]
+    fn test_parse_add_with_id() {
+        let op: TxOp = "[:db/add 1 :user/name \"Alice\"]".parse().unwrap();
+        assert_eq!(
+            op,
+            TxOp::Add {
+                entity: EntityRef::Id(1),
+                attribute: kw!(:user/name),
+                value: DataType::String("Alice".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_add_with_tempid() {
+        let op: TxOp = "[:db/add \"alice\" :user/age 30]".parse().unwrap();
+        assert_eq!(
+            op,
+            TxOp::Add {
+                entity: EntityRef::TempId("alice".to_string()),
+                attribute: kw!(:user/age),
+                value: DataType::Long(30),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_add_with_ident() {
+        let op: TxOp = "[:db/add :user/me :user/name \"Me\"]".parse().unwrap();
+        assert_eq!(
+            op,
+            TxOp::Add {
+                entity: EntityRef::Ident(kw!(:user/me)),
+                attribute: kw!(:user/name),
+                value: DataType::String("Me".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_add_with_lookup_ref() {
+        let op: TxOp = "[:db/add (lookup-ref :user/email \"a@b.c\") :user/name \"A\"]"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            op,
+            TxOp::Add {
+                entity: EntityRef::LookupRef(
+                    kw!(:user/email),
+                    DataType::String("a@b.c".to_string())
+                ),
+                attribute: kw!(:user/name),
+                value: DataType::String("A".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_retract() {
+        let op: TxOp = "[:db/retract 7 :user/age 30]".parse().unwrap();
+        assert_eq!(
+            op,
+            TxOp::Retract {
+                entity: EntityRef::Id(7),
+                attribute: kw!(:user/age),
+                value: DataType::Long(30),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_delete() {
+        let op: TxOp = "[:db/delete 42]".parse().unwrap();
+        assert_eq!(op, TxOp::Delete(EntityRef::Id(42)));
+    }
+
+    #[test]
+    fn test_parse_erase() {
+        let op: TxOp = "[:db/erase \"tempid-1\"]".parse().unwrap();
+        assert_eq!(op, TxOp::Erase(EntityRef::TempId("tempid-1".to_string())));
+    }
+
+    #[test]
+    fn test_parse_put_no_id() {
+        let op: TxOp = "{:user/name \"Alice\" :user/age 30}".parse().unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(kw!(:user/name), DataType::String("Alice".to_string()));
+        expected.insert(kw!(:user/age), DataType::Long(30));
+        assert_eq!(op, TxOp::Put(expected));
+    }
+
+    #[test]
+    fn test_parse_put_with_db_id_long() {
+        let op: TxOp = "{:db/id 100 :user/name \"X\"}".parse().unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(kw!(:db/id), DataType::Long(100));
+        expected.insert(kw!(:user/name), DataType::String("X".to_string()));
+        assert_eq!(op, TxOp::Put(expected));
+    }
+
+    #[test]
+    fn test_parse_put_with_db_id_tempid() {
+        let op: TxOp = "{:db/id \"alice\" :user/name \"Alice\"}".parse().unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(kw!(:db/id), DataType::String("alice".to_string()));
+        expected.insert(kw!(:user/name), DataType::String("Alice".to_string()));
+        assert_eq!(op, TxOp::Put(expected));
+    }
+
+    #[test]
+    fn test_parse_put_with_db_id_ident() {
+        let op: TxOp = "{:db/id :user/me :user/name \"Me\"}".parse().unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(kw!(:db/id), DataType::Keyword(kw!(:user/me)));
+        expected.insert(kw!(:user/name), DataType::String("Me".to_string()));
+        assert_eq!(op, TxOp::Put(expected));
+    }
+
+    #[test]
+    fn test_parse_value_types() {
+        let op: TxOp = "[:db/add 1 :a/b true]".parse().unwrap();
+        assert!(matches!(
+            op,
+            TxOp::Add {
+                value: DataType::Boolean(true),
+                ..
+            }
+        ));
+        let op: TxOp = "[:db/add 1 :a/b 3.14]".parse().unwrap();
+        assert!(matches!(
+            op,
+            TxOp::Add {
+                value: DataType::Double(_),
+                ..
+            }
+        ));
+        let op: TxOp = "[:db/add 1 :a/b :some/kw]".parse().unwrap();
+        assert!(matches!(
+            op,
+            TxOp::Add {
+                value: DataType::Keyword(_),
+                ..
+            }
+        ));
+        let op: TxOp = "[:db/add 1 :a/b [1 2 3]]".parse().unwrap();
+        if let TxOp::Add {
+            value: DataType::Vector(v),
+            ..
+        } = op
+        {
+            assert_eq!(v.len(), 3);
+        } else {
+            panic!("expected vector value");
+        }
+    }
+
+    #[test]
+    fn test_parse_errors() {
+        // Wrong arity
+        assert!("[:db/add 1 :a]".parse::<TxOp>().is_err());
+        assert!("[:db/add 1 :a 2 3]".parse::<TxOp>().is_err());
+        assert!("[:db/delete 1 2]".parse::<TxOp>().is_err());
+        // Unknown op
+        assert!("[:db/frobnicate 1]".parse::<TxOp>().is_err());
+        // Bad shape
+        assert!("42".parse::<TxOp>().is_err());
+        assert!("[]".parse::<TxOp>().is_err());
+        // Map key not a keyword
+        assert!("{\"name\" \"Alice\"}".parse::<TxOp>().is_err());
+        // Bad EDN
+        assert!("[:db/add 1 :a".parse::<TxOp>().is_err());
+        // Reverse keyword in entity position
+        assert!("[:db/add :user/_friend :a 1]".parse::<TxOp>().is_err());
+        // Set in value position
+        assert!("[:db/add 1 :a #{1 2}]".parse::<TxOp>().is_err());
     }
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -76,6 +76,46 @@ async fn test_execute_tx_and_query() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_execute_tx_with_string_ops() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+
+    // Mix [:db/add ...] form and {:db/id ...} map form, both as &str.
+    let result = client
+        .execute_tx(vec![
+            "[:db/add \"alice\" :name \"Alice\"]",
+            "[:db/add \"alice\" :age 30]",
+            "{:db/id \"bob\" :name \"Bob\" :age 42}",
+        ])
+        .await
+        .unwrap();
+    assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+    let db = client.db().await.unwrap();
+    let result = db
+        .query("{:find [?name ?age] :where [[?e :name ?name] [?e :age ?age]]}")
+        .await
+        .unwrap();
+
+    let mut rows: Vec<(String, i64)> = result
+        .into_iter()
+        .map(|row| match row.as_slice() {
+            [DataType::String(n), DataType::Long(a)] => (n.clone(), *a),
+            other => panic!("unexpected row {:?}", other),
+        })
+        .collect();
+    rows.sort();
+    assert_eq!(
+        rows,
+        vec![("Alice".to_string(), 30), ("Bob".to_string(), 42)]
+    );
+
+    db.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_submit_tx() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();


### PR DESCRIPTION
## Summary

- `impl FromStr for TxOp` (Err = `anyhow::Error`) — accepts Datomic-style EDN: `[:db/add e a v]`, `[:db/retract e a v]`, `[:db/delete e]`, `[:db/erase e]`, and `{:attr v ...}` map form (with optional `:db/id`).
- New `IntoTxOp` trait (sibling to `IntoQuery`) with impls for `TxOp`, `&str`, `String`. `SubmitNode::submit_tx` and `execute_tx` are now generic over `Vec<O: IntoTxOp>`, so existing `Vec<TxOp>` call sites keep working and `Vec<&str>` / `Vec<String>` is now accepted (each element parsed as one tx op).
- `:db/id` in map form is passed through unchanged; the existing expander (`src/tx.rs:100-127`) routes `Long → entid`, `String → tempid`, `Keyword → ident`, `Vector → lookup-ref`.

Mirrors the `IntoQuery` / `FromStr<ParsedQuery>` pattern from #172.

## Test plan

- [x] `cargo test --lib` — 422 unit tests pass (13 new ops::tests covering each variant, `:db/id` as Long/String/Keyword, lookup-refs, value-type coverage, and error cases)
- [x] `cargo test --test client_server_test` — 22 integration tests pass, including the new `test_execute_tx_with_string_ops` smoke test that mixes `[:db/add ...]` and `{:db/id ...}` forms in a `Vec<&str>` and verifies the datoms are queryable end-to-end
- [x] `cargo build --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)