### PR TITLE
Remove max_open_dbs from config and server

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,8 +34,6 @@ pub struct ServerConfig {
     pub host: String,
     #[serde(default = "default_port")]
     pub port: u16,
-    #[serde(default = "default_max_open_dbs")]
-    pub max_open_dbs: usize,
 }
 
 fn default_region() -> String {
@@ -50,16 +48,11 @@ fn default_port() -> u16 {
     5490
 }
 
-fn default_max_open_dbs() -> usize {
-    1024
-}
-
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
             host: default_host(),
             port: default_port(),
-            max_open_dbs: default_max_open_dbs(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ fn load_config() -> Result<Config> {
 
 async fn run_server(config: Config) -> Result<()> {
     let bind_addr = format!("{}:{}", config.server.host, config.server.port);
-    let max_open_dbs = config.server.max_open_dbs;
 
     let token = CancellationToken::new();
     let shutdown_token = token.clone();
@@ -51,17 +50,17 @@ async fn run_server(config: Config) -> Result<()> {
 
     match config.storage {
         StorageConfig::Dev => {
-            let server = DevServer::new(max_open_dbs);
+            let server = DevServer::new();
             server.listen(&bind_addr, token).await
         }
         StorageConfig::Memory => {
             let node = Arc::new(Node::memory_node().await);
-            let server = Server::new(node, max_open_dbs);
+            let server = Server::new(node);
             server.listen(&bind_addr, token).await
         }
         StorageConfig::Local { path } => {
             let node = Arc::new(Node::local_node(&path).await?);
-            let server = Server::new(node, max_open_dbs);
+            let server = Server::new(node);
             server.listen(&bind_addr, token).await
         }
         StorageConfig::Remote {
@@ -76,7 +75,7 @@ async fn run_server(config: Config) -> Result<()> {
                 Node::remote_node(&log_path, &endpoint, &bucket, &access_key, &secret_key, &region)
                     .await?,
             );
-            let server = Server::new(node, max_open_dbs);
+            let server = Server::new(node);
             server.listen(&bind_addr, token).await
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,6 +40,8 @@ use crate::protocol::*;
 // DB Cache
 // ---------------------------------------------------------------------------
 
+const MAX_OPEN_DBS: usize = 1024;
+
 /// A shared, reference-counted cache of DB snapshots.
 /// Keyed by tx_id (the point-in-time identifier for the snapshot).
 /// DBs are read-only and safe to share across connections.
@@ -50,14 +52,12 @@ struct DbCacheEntry {
 
 pub(crate) struct DbCache {
     entries: RwLock<HashMap<i64, DbCacheEntry>>,
-    max_open: usize,
 }
 
 impl DbCache {
-    pub(crate) fn new(max_open: usize) -> Self {
+    pub(crate) fn new() -> Self {
         DbCache {
             entries: RwLock::new(HashMap::new()),
-            max_open,
         }
     }
 
@@ -75,8 +75,8 @@ impl DbCache {
                 entry.refcount += 1;
                 return Ok(entry.db.clone());
             }
-            if entries.len() >= self.max_open {
-                bail!("Too many open DB snapshots (max {})", self.max_open);
+            if entries.len() >= MAX_OPEN_DBS {
+                bail!("Too many open DB snapshots (max {})", MAX_OPEN_DBS);
             }
         }
 
@@ -88,8 +88,8 @@ impl DbCache {
             entry.refcount += 1;
             return Ok(entry.db.clone());
         }
-        if entries.len() >= self.max_open {
-            bail!("Too many open DB snapshots (max {})", self.max_open);
+        if entries.len() >= MAX_OPEN_DBS {
+            bail!("Too many open DB snapshots (max {})", MAX_OPEN_DBS);
         }
         entries.insert(
             tx_id,
@@ -418,8 +418,8 @@ pub struct Server<L: TxLog> {
 }
 
 impl<L: TxLog + 'static> Server<L> {
-    pub fn new(node: Arc<Node<L>>, max_open_dbs: usize) -> Self {
-        let db_cache = Arc::new(DbCache::new(max_open_dbs));
+    pub fn new(node: Arc<Node<L>>) -> Self {
+        let db_cache = Arc::new(DbCache::new());
         let handle_store = Arc::new(HandleStore::new(db_cache));
         Server {
             node,
@@ -475,13 +475,11 @@ impl<L: TxLog + 'static> Server<L> {
 // Dev Server (per-connection in-memory nodes)
 // ---------------------------------------------------------------------------
 
-pub struct DevServer {
-    max_open_dbs: usize,
-}
+pub struct DevServer;
 
 impl DevServer {
-    pub fn new(max_open_dbs: usize) -> Self {
-        DevServer { max_open_dbs }
+    pub fn new() -> Self {
+        DevServer
     }
 
     pub async fn listen(&self, addr: &str, token: CancellationToken) -> Result<()> {
@@ -490,7 +488,6 @@ impl DevServer {
     }
 
     pub async fn listen_on(&self, listener: TcpListener, token: CancellationToken) -> Result<()> {
-        let max_open_dbs = self.max_open_dbs;
         accept_loop(
             listener,
             token,
@@ -498,7 +495,7 @@ impl DevServer {
             move |stream, _peer, conn_id, conn_token, join_set| {
                 join_set.spawn(async move {
                     let node = Arc::new(Node::memory_node().await);
-                    let db_cache = Arc::new(DbCache::new(max_open_dbs));
+                    let db_cache = Arc::new(DbCache::new());
                     let handle_store = Arc::new(HandleStore::new(db_cache));
 
                     let app_state = Arc::new(Server {

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -26,7 +26,7 @@ async fn start_test_server() -> (String, CancellationToken) {
     let url = format!("http://{}", addr);
 
     let node = Arc::new(Node::memory_node().await);
-    let server = Server::new(node, 1024);
+    let server = Server::new(node);
 
     let token = CancellationToken::new();
     let server_token = token.clone();
@@ -317,7 +317,7 @@ async fn start_dev_server() -> (String, CancellationToken) {
     let addr = listener.local_addr().unwrap();
     let url = format!("http://{}", addr);
 
-    let server = DevServer::new(1024);
+    let server = DevServer::new();
 
     let token = CancellationToken::new();
     let server_token = token.clone();


### PR DESCRIPTION
## Summary
- Remove the `max_open_dbs` field from `ServerConfig` and stop plumbing it through `Server::new` / `DevServer::new` / `DbCache::new`.
- `DbCache` now uses a hardcoded `MAX_OPEN_DBS = 1024` constant; the cap behavior (bail when exceeded) is unchanged, just no longer configurable.
- `DevServer` becomes a unit struct since it no longer holds any state.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (all 22 client/server integration tests pass)
- [x] `rg max_open_dbs` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)