### PR TITLE
Fix VAE lookup iterator overshoot

### DIFF
--- a/src/iterator/forward_only_iterator.rs
+++ b/src/iterator/forward_only_iterator.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use bytes::Bytes;
+
+use crate::slate::DEFAULT_SCAN_OPTIONS;
+
+pub(crate) struct ForwardOnlyIterator {
+    inner: slatedb::DbIterator,
+    current_key: Option<Bytes>,
+}
+
+impl ForwardOnlyIterator {
+    pub async fn scan_prefix(db: &slatedb::Db, prefix: &[u8]) -> Result<Self> {
+        let mut inner = db
+            .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)
+            .await?;
+        let current_key = inner.next().await?.map(|kv| kv.key);
+        Ok(Self { inner, current_key })
+    }
+
+    pub async fn seek(&mut self, key: &[u8]) -> Result<()> {
+        if let Some(current) = &self.current_key {
+            if current.as_ref() >= key {
+                return Ok(());
+            }
+        }
+
+        self.inner.seek(Bytes::copy_from_slice(key)).await?;
+        self.current_key = self.inner.next().await?.map(|kv| kv.key);
+        Ok(())
+    }
+
+    pub async fn next(&mut self) -> Result<Option<Bytes>> {
+        self.current_key = self.inner.next().await?.map(|kv| kv.key);
+        Ok(self.current_key.clone())
+    }
+
+    pub fn get_value(&self) -> Option<&Bytes> {
+        self.current_key.as_ref()
+    }
+}

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod forward_only_iterator;
 pub(crate) mod generic_and_prefix_extender;
 pub(crate) mod generic_fn_prefix_extender;
 pub(crate) mod generic_not_prefix_extender;

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -1,10 +1,10 @@
-pub(crate) mod forward_only_iterator;
 pub(crate) mod generic_and_prefix_extender;
 pub(crate) mod generic_fn_prefix_extender;
 pub(crate) mod generic_not_prefix_extender;
 pub(crate) mod generic_or_prefix_extender;
 pub(crate) mod generic_predicate_prefix_extender;
 pub(crate) mod generic_prefix_extender;
+pub(crate) mod slate_key_iterator;
 pub(crate) mod slate_iterator;
 pub(crate) mod temporal_filter_iterator;
 

--- a/src/iterator/slate_key_iterator.rs
+++ b/src/iterator/slate_key_iterator.rs
@@ -34,7 +34,7 @@ impl SlateKeyIterator {
         Ok(self.current_key.clone())
     }
 
-    pub fn get_value(&self) -> Option<&Bytes> {
+    pub fn peek(&self) -> Option<&Bytes> {
         self.current_key.as_ref()
     }
 }
@@ -55,7 +55,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_slate_key_iterator_get_value_and_next() -> Result<()> {
+    async fn test_slate_key_iterator_peek_and_next() -> Result<()> {
         let slate = in_memory_slate().await.db;
         let first = key(PFX, b"aa");
         let second = key(PFX, b"bb");
@@ -66,10 +66,10 @@ mod tests {
 
         let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
 
-        assert_eq!(iter.get_value(), Some(&Bytes::from(first)));
+        assert_eq!(iter.peek(), Some(&Bytes::from(first)));
         assert_eq!(iter.next().await?, Some(Bytes::from(second)));
         assert_eq!(iter.next().await?, None);
-        assert_eq!(iter.get_value(), None);
+        assert_eq!(iter.peek(), None);
         Ok(())
     }
 
@@ -85,7 +85,7 @@ mod tests {
         let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
         iter.seek(&key(PFX, b"bb")).await?;
 
-        assert_eq!(iter.get_value(), Some(&Bytes::from(second)));
+        assert_eq!(iter.peek(), Some(&Bytes::from(second)));
         Ok(())
     }
 
@@ -100,7 +100,27 @@ mod tests {
         iter.seek(&key(PFX, b"aa")).await?;
         iter.seek(&key(PFX, b"bb")).await?;
 
-        assert_eq!(iter.get_value(), Some(&Bytes::from(overshot)));
+        assert_eq!(iter.peek(), Some(&Bytes::from(overshot)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_slate_key_iterator_next_after_seek_advances_past_landed_key() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let first = key(PFX, b"aa");
+        let second = key(PFX, b"bb");
+        let third = key(PFX, b"cc");
+
+        slate.put(&first, b"").await?;
+        slate.put(&second, b"").await?;
+        slate.put(&third, b"").await?;
+
+        let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
+        iter.seek(&key(PFX, b"bb")).await?;
+
+        assert_eq!(iter.peek(), Some(&Bytes::from(second)));
+        assert_eq!(iter.next().await?, Some(Bytes::from(third.clone())));
+        assert_eq!(iter.peek(), Some(&Bytes::from(third)));
         Ok(())
     }
 
@@ -113,7 +133,7 @@ mod tests {
         let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
         iter.seek(&key(PFX, b"zz")).await?;
 
-        assert_eq!(iter.get_value(), None);
+        assert_eq!(iter.peek(), None);
         Ok(())
     }
 }

--- a/src/iterator/slate_key_iterator.rs
+++ b/src/iterator/slate_key_iterator.rs
@@ -38,3 +38,82 @@ impl SlateKeyIterator {
         self.current_key.as_ref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::slate::in_memory_slate;
+
+    const PFX: &[u8] = b"\x05";
+    const OTHER_PFX: &[u8] = b"\x06";
+
+    fn key(prefix: &[u8], suffix: &[u8]) -> Vec<u8> {
+        let mut key = prefix.to_vec();
+        key.extend_from_slice(suffix);
+        key
+    }
+
+    #[tokio::test]
+    async fn test_slate_key_iterator_get_value_and_next() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let first = key(PFX, b"aa");
+        let second = key(PFX, b"bb");
+
+        slate.put(&first, b"").await?;
+        slate.put(&second, b"").await?;
+        slate.put(&key(OTHER_PFX, b"xx"), b"").await?;
+
+        let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
+
+        assert_eq!(iter.get_value(), Some(&Bytes::from(first)));
+        assert_eq!(iter.next().await?, Some(Bytes::from(second)));
+        assert_eq!(iter.next().await?, None);
+        assert_eq!(iter.get_value(), None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_slate_key_iterator_seek_forwards_to_next_key() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let first = key(PFX, b"aa");
+        let second = key(PFX, b"cc");
+
+        slate.put(&first, b"").await?;
+        slate.put(&second, b"").await?;
+
+        let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
+        iter.seek(&key(PFX, b"bb")).await?;
+
+        assert_eq!(iter.get_value(), Some(&Bytes::from(second)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_slate_key_iterator_seek_keeps_overshot_current_key() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let overshot = key(PFX, b"bb-full-key");
+
+        slate.put(&overshot, b"").await?;
+
+        let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
+        iter.seek(&key(PFX, b"aa")).await?;
+        iter.seek(&key(PFX, b"bb")).await?;
+
+        assert_eq!(iter.get_value(), Some(&Bytes::from(overshot)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_slate_key_iterator_seek_beyond_end() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+
+        slate.put(&key(PFX, b"aa"), b"").await?;
+
+        let mut iter = SlateKeyIterator::scan_prefix(slate.as_ref(), PFX).await?;
+        iter.seek(&key(PFX, b"zz")).await?;
+
+        assert_eq!(iter.get_value(), None);
+        Ok(())
+    }
+}

--- a/src/iterator/slate_key_iterator.rs
+++ b/src/iterator/slate_key_iterator.rs
@@ -3,12 +3,12 @@ use bytes::Bytes;
 
 use crate::slate::DEFAULT_SCAN_OPTIONS;
 
-pub(crate) struct ForwardOnlyIterator {
+pub(crate) struct SlateKeyIterator {
     inner: slatedb::DbIterator,
     current_key: Option<Bytes>,
 }
 
-impl ForwardOnlyIterator {
+impl SlateKeyIterator {
     pub async fn scan_prefix(db: &slatedb::Db, prefix: &[u8]) -> Result<Self> {
         let mut inner = db
             .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS)

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -9,7 +9,7 @@ use crate::indexer::vae_key_to_parts;
 use crate::iterator::slate_key_iterator::SlateKeyIterator;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::schema::{Schema, Unique, ValueType};
-use crate::util::concat_bytes;
+use crate::util::{concat_bytes, next_prefix};
 
 // ---------------------------------------------------------------------------
 // Stage 1 types: after ident resolution, before lookup ref resolution.
@@ -310,33 +310,41 @@ pub async fn batch_lookup_unique_eids(
 
     for (vae_prefix, (attr_eid, value)) in &prefixes {
         iter.seek(vae_prefix).await?;
-        let Some(key) = iter.get_value() else {
-            break;
-        };
+        loop {
+            let Some(key) = iter.get_value() else {
+                return Ok(resolved);
+            };
 
-        if !key.starts_with(vae_prefix) {
-            continue;
-        }
-
-        assert!(
-            key.len() >= codec::TX_EID_OP_SUFFIX,
-            "Key too short ({} bytes) to contain tx_eid + op suffix",
-            key.len()
-        );
-        if key[key.len() - 1] == codec::RETRACT {
-            continue;
-        }
-
-        let (_value, _attribute, entity, _tx_eid, _op) = vae_key_to_parts(key.clone())?;
-        match entity {
-            DataType::Long(eid) => {
-                resolved.insert((*attr_eid, value.clone()), eid);
+            if !key.starts_with(vae_prefix) {
+                break;
             }
-            other => {
-                return Err(anyhow::anyhow!(
-                    "Expected Long entity ID in VAE key, got {:?}",
-                    other
-                ));
+
+            assert!(
+                key.len() >= codec::TX_EID_OP_SUFFIX,
+                "Key too short ({} bytes) to contain tx_eid + op suffix",
+                key.len()
+            );
+            if key[key.len() - 1] == codec::RETRACT {
+                let logical_key_end = key.len() - codec::TX_EID_OP_SUFFIX;
+                let Some(next_entity) = next_prefix(&key[..logical_key_end]) else {
+                    return Ok(resolved);
+                };
+                iter.seek(&next_entity).await?;
+                continue;
+            }
+
+            let (_value, _attribute, entity, _tx_eid, _op) = vae_key_to_parts(key.clone())?;
+            match entity {
+                DataType::Long(eid) => {
+                    resolved.insert((*attr_eid, value.clone()), eid);
+                    break;
+                }
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "Expected Long entity ID in VAE key, got {:?}",
+                        other
+                    ));
+                }
             }
         }
     }
@@ -427,6 +435,20 @@ mod tests {
             },
         );
         schema
+    }
+
+    fn unique_vae_key(
+        attr_eid: i64,
+        value: &DataType,
+        entity: i64,
+        tx_eid: i64,
+        op: u8,
+    ) -> Vec<u8> {
+        let mut key = unique_vae_prefix(attr_eid, value);
+        key.extend_from_slice(&DataType::Long(entity).encode());
+        key.extend_from_slice(&codec::encode_i64_bytes(tx_eid));
+        key.push(op);
+        key
     }
 
     // --- expand_tx_ops tests ---
@@ -681,11 +703,12 @@ mod tests {
         let present_value = DataType::String("b@example.com".into());
         let present_eid = 100;
 
-        let mut key = unique_vae_prefix(attr_eid, &present_value);
-        key.extend_from_slice(&DataType::Long(present_eid).encode());
-        key.extend_from_slice(&codec::encode_i64_bytes(1));
-        key.push(codec::ADD);
-        slate.put(&key, b"").await?;
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &present_value, present_eid, 1, codec::ADD),
+                b"",
+            )
+            .await?;
 
         let resolved = batch_lookup_unique_eids(
             slate.as_ref(),
@@ -698,6 +721,67 @@ mod tests {
 
         assert!(!resolved.contains_key(&(attr_eid, missing_value)));
         assert_eq!(resolved.get(&(attr_eid, present_value)), Some(&present_eid));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_batch_lookup_unique_eids_skips_retracted_entity_for_live_entity() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let attr_eid = 42;
+        let value = DataType::String("email@example.com".into());
+        let retracted_eid = 200;
+        let live_eid = 100;
+
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &value, retracted_eid, 1, codec::ADD),
+                b"",
+            )
+            .await?;
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &value, retracted_eid, 2, codec::RETRACT),
+                b"",
+            )
+            .await?;
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &value, live_eid, 3, codec::ADD),
+                b"",
+            )
+            .await?;
+
+        let resolved =
+            batch_lookup_unique_eids(slate.as_ref(), &[(attr_eid, value.clone())]).await?;
+
+        assert_eq!(resolved.get(&(attr_eid, value)), Some(&live_eid));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_batch_lookup_unique_eids_ignores_only_retracted_entity() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let attr_eid = 42;
+        let value = DataType::String("email@example.com".into());
+        let retracted_eid = 100;
+
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &value, retracted_eid, 1, codec::ADD),
+                b"",
+            )
+            .await?;
+        slate
+            .put(
+                &unique_vae_key(attr_eid, &value, retracted_eid, 2, codec::RETRACT),
+                b"",
+            )
+            .await?;
+
+        let resolved =
+            batch_lookup_unique_eids(slate.as_ref(), &[(attr_eid, value.clone())]).await?;
+
+        assert!(!resolved.contains_key(&(attr_eid, value)));
         Ok(())
     }
 }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -311,7 +311,7 @@ pub async fn batch_lookup_unique_eids(
     for (vae_prefix, (attr_eid, value)) in &prefixes {
         iter.seek(vae_prefix).await?;
         loop {
-            let Some(key) = iter.get_value() else {
+            let Some(key) = iter.peek() else {
                 return Ok(resolved);
             };
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -6,9 +6,9 @@ use edn::symbols::Keyword;
 
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
 use crate::indexer::vae_key_to_parts;
+use crate::iterator::forward_only_iterator::ForwardOnlyIterator;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::schema::{Schema, Unique, ValueType};
-use crate::slate::DEFAULT_SCAN_OPTIONS;
 use crate::util::concat_bytes;
 
 // ---------------------------------------------------------------------------
@@ -306,43 +306,28 @@ pub async fn batch_lookup_unique_eids(
         return Ok(resolved);
     }
 
-    let mut iter = db
-        .scan_prefix_with_options(&[codec::VAE], &DEFAULT_SCAN_OPTIONS)
-        .await?;
-
-    // Slatedb forbids seeking strictly backward past the iterator's last
-    // returned key. On a miss, `next()` returns the next DB key past our
-    // prefix, which may exceed a subsequent prefix; we skip those — anything
-    // the iterator already overshot has no entry in the DB.
-    let mut last_returned: Option<Vec<u8>> = None;
+    let mut iter = ForwardOnlyIterator::scan_prefix(db, &[codec::VAE]).await?;
 
     for (vae_prefix, (attr_eid, value)) in &prefixes {
-        if let Some(last) = &last_returned {
-            if vae_prefix < last {
-                continue;
-            }
-        }
-
         iter.seek(vae_prefix).await?;
-        let Some(kv) = iter.next().await? else {
+        let Some(key) = iter.get_value() else {
             break;
         };
-        last_returned = Some(kv.key.to_vec());
 
-        if !kv.key.starts_with(vae_prefix) {
+        if !key.starts_with(vae_prefix) {
             continue;
         }
 
         assert!(
-            kv.key.len() >= codec::TX_EID_OP_SUFFIX,
+            key.len() >= codec::TX_EID_OP_SUFFIX,
             "Key too short ({} bytes) to contain tx_eid + op suffix",
-            kv.key.len()
+            key.len()
         );
-        if kv.key[kv.key.len() - 1] == codec::RETRACT {
+        if key[key.len() - 1] == codec::RETRACT {
             continue;
         }
 
-        let (_value, _attribute, entity, _tx_eid, _op) = vae_key_to_parts(kv.key)?;
+        let (_value, _attribute, entity, _tx_eid, _op) = vae_key_to_parts(key.clone())?;
         match entity {
             DataType::Long(eid) => {
                 resolved.insert((*attr_eid, value.clone()), eid);
@@ -415,6 +400,8 @@ pub async fn resolve_lookup_refs(
 mod tests {
     use super::*;
     use edn::kw;
+
+    use crate::slate::in_memory_slate;
 
     fn empty_schema() -> Schema {
         Schema::default()
@@ -684,5 +671,33 @@ mod tests {
     #[should_panic(expected = "Delete/Erase not yet implemented")]
     fn test_expand_erase_panics() {
         expand_tx_ops(&[TxOp::Erase(EntityRef::Id(200))], &empty_schema()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_batch_lookup_unique_eids_resolves_lookup_after_overshoot() -> Result<()> {
+        let slate = in_memory_slate().await.db;
+        let attr_eid = 42;
+        let missing_value = DataType::String("a@example.com".into());
+        let present_value = DataType::String("b@example.com".into());
+        let present_eid = 100;
+
+        let mut key = unique_vae_prefix(attr_eid, &present_value);
+        key.extend_from_slice(&DataType::Long(present_eid).encode());
+        key.extend_from_slice(&codec::encode_i64_bytes(1));
+        key.push(codec::ADD);
+        slate.put(&key, b"").await?;
+
+        let resolved = batch_lookup_unique_eids(
+            slate.as_ref(),
+            &[
+                (attr_eid, missing_value.clone()),
+                (attr_eid, present_value.clone()),
+            ],
+        )
+        .await?;
+
+        assert!(!resolved.contains_key(&(attr_eid, missing_value)));
+        assert_eq!(resolved.get(&(attr_eid, present_value)), Some(&present_eid));
+        Ok(())
     }
 }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -6,7 +6,7 @@ use edn::symbols::Keyword;
 
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
 use crate::indexer::vae_key_to_parts;
-use crate::iterator::forward_only_iterator::ForwardOnlyIterator;
+use crate::iterator::slate_key_iterator::SlateKeyIterator;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::schema::{Schema, Unique, ValueType};
 use crate::util::concat_bytes;
@@ -306,7 +306,7 @@ pub async fn batch_lookup_unique_eids(
         return Ok(resolved);
     }
 
-    let mut iter = ForwardOnlyIterator::scan_prefix(db, &[codec::VAE]).await?;
+    let mut iter = SlateKeyIterator::scan_prefix(db, &[codec::VAE]).await?;
 
     for (vae_prefix, (attr_eid, value)) in &prefixes {
         iter.seek(vae_prefix).await?;


### PR DESCRIPTION
## Summary
- add a regression test for VAE lookup batch resolution after an iterator overshoot
- introduce a forward-only SlateDB iterator wrapper that keeps the current key available after seek
- update batch_lookup_unique_eids to use cached current-key matching instead of last_returned skip logic

Fixes #266.

## Tests
- cargo test tx::tests::test_batch_lookup_unique_eids_resolves_lookup_after_overshoot
- cargo test