### PR TITLE
Reject value-only tempids

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -2118,6 +2118,34 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_tempid_only_in_ref_value_position_aborts() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let result = node
+            .execute_tx(vec![
+                TxOp::Add {
+                    entity: "bob".into(),
+                    attribute: kw!(:name),
+                    value: "Bob".into(),
+                },
+                TxOp::Add {
+                    entity: "bob".into(),
+                    attribute: kw!(:follows),
+                    value: DataType::String("alice".into()),
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(result, TransactionResult::TxAborted(_, _)),
+            "tempids that appear only in value position must abort, got {:?}",
+            result
+        );
+    }
+
     /// Cross-iteration EV→E resolution where the second-iteration store
     /// lookup misses entirely. alice-temp and bob-temp both resolve in iter 1
     /// via `:user/email`; the EV `(alice-temp :spouse bob-temp)` promotes to

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1041,14 +1041,24 @@ mod tests {
             .collect()
     }
 
-    async fn to_datoms_async(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
+    async fn to_datoms_result_async(ops: &[TxOp], schema: &Schema) -> Result<Vec<Datom>> {
         let slate = in_memory_slate().await;
         let mut pm = PartitionMap::new();
         let expanded = tx::expand_tx_ops(ops, schema).unwrap();
         let with_tempids = expanded_to_tempids(expanded);
-        tempids::resolve_tempids(with_tempids, schema, &slate.db, &mut pm)
-            .await
+        tempids::resolve_tempids(with_tempids, schema, &slate.db, &mut pm).await
+    }
+
+    async fn to_datoms_async(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
+        to_datoms_result_async(ops, schema).await.unwrap()
+    }
+
+    fn to_datoms_result(ops: &[TxOp], schema: &Schema) -> Result<Vec<Datom>> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
             .unwrap()
+            .block_on(to_datoms_result_async(ops, schema))
     }
 
     fn to_datoms(ops: &[TxOp], schema: &Schema) -> Vec<Datom> {
@@ -1288,17 +1298,19 @@ mod tests {
         let validation = schema.validate_datoms(&to_datoms(&ops, &schema)).unwrap();
         assert!(!validation.schema_changes_detected);
 
-        // String in ref position is interpreted as tempid (resolved to Long)
+        // String in ref position must name a tempid introduced in entity position.
         let ops = [TxOp::Add {
             entity: "follower".into(),
             attribute: kw!(:follows),
             value: DataType::String("some-tempid".to_string()),
         }];
-        let datoms = to_datoms(&ops, &schema);
-        // After expand_tx_ops, the string becomes a TempRef which resolves to a Long,
-        // so validate_datoms should accept it.
-        let validation = schema.validate_datoms(&datoms).unwrap();
-        assert!(!validation.schema_changes_detected);
+        let err = to_datoms_result(&ops, &schema).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Tempid some-tempid referenced only in value position"),
+            "unexpected error: {}",
+            err
+        );
     }
 
     #[test]

--- a/src/tempids.rs
+++ b/src/tempids.rs
@@ -13,7 +13,7 @@ use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid};
 use crate::partition::{dominant_partition, DB_PARTITION, DEFAULT_PARTITION, USER_PARTITION};
 use crate::schema::Schema;
-use crate::tx::{self, DatomWithTempids, IdOrTempId, ValueWithTempIds};
+use crate::tx::{self, DatomWithTempids, IdOrTempId};
 use crate::upsert_resolution::{Generation, TempIdMap, UniqueLookup};
 
 async fn resolve_temp_id_avs(
@@ -83,9 +83,6 @@ fn infer_tempid_partitions(datoms: &[DatomWithTempids]) -> TempIdPartitions {
                 out.entry(t.clone()).or_insert(USER_PARTITION);
             }
         }
-        if let ValueWithTempIds::TempRef(t) = &d.value {
-            out.entry(t.clone()).or_insert(USER_PARTITION);
-        }
     }
     out
 }
@@ -153,6 +150,7 @@ mod tests {
     use crate::partition::{extract_counter, extract_partition};
     use crate::schema::{Attribute, Unique, ValueType, DB_IDENT};
     use crate::slate::in_memory_slate;
+    use crate::tx::ValueWithTempIds;
 
     fn tempid_test_schema() -> Schema {
         let mut schema = Schema::default();
@@ -256,6 +254,26 @@ mod tests {
         assert!(resolved
             .iter()
             .any(|d| d.attribute == kw!(:follows) && d.value == DataType::Long(alice_eid)));
+    }
+
+    #[tokio::test]
+    async fn test_tempref_only_in_value_position_errors() {
+        let slate = in_memory_slate().await;
+        let schema = tempid_test_schema();
+        let mut pm = PartitionMap::new();
+        let datoms = vec![DatomWithTempids {
+            entity: IdOrTempId::Id(999),
+            attribute: kw!(:follows),
+            value: ValueWithTempIds::TempRef("alice".to_string()),
+            op: DatomOp::Assert,
+        }];
+
+        let result = resolve_tempids(datoms, &schema, &slate.db, &mut pm).await;
+
+        assert!(
+            result.is_err(),
+            "tempids that appear only in value position must not be allocated"
+        );
     }
 
     #[tokio::test]

--- a/src/upsert_resolution.rs
+++ b/src/upsert_resolution.rs
@@ -286,6 +286,7 @@ impl Generation {
         schema: &Schema,
     ) -> Result<BTreeMap<String, usize>> {
         let mut tempids = BTreeSet::new();
+        let mut value_temprefs = BTreeSet::new();
         let mut identity_groups: HashMap<(Entid, ValueWithTempIds), Vec<String>> = HashMap::new();
 
         for d in &self.allocations {
@@ -307,7 +308,7 @@ impl Generation {
                 tempids.insert(t.clone());
             }
             if let ValueWithTempIds::TempRef(t) = &d.value {
-                tempids.insert(t.clone());
+                value_temprefs.insert(t.clone());
             }
 
             let (attr_eid, identity) = datom_with_entid_attr(d, schema)?;
@@ -318,6 +319,15 @@ impl Generation {
                         .or_default()
                         .push(t.clone());
                 }
+            }
+        }
+
+        for t in value_temprefs {
+            if !tempids.contains(&t) {
+                return Err(anyhow::anyhow!(
+                    "Tempid {} referenced only in value position",
+                    t
+                ));
             }
         }
 
@@ -381,4 +391,3 @@ impl Generation {
         Ok(populations)
     }
 }
-


### PR DESCRIPTION
## Summary
- reject tempids that only appear in ref value position instead of allocating them
- stop inferring allocation partitions from value-position temprefs
- add resolver, schema, and node-level regression coverage

## Tests
- cargo test

Note: cargo fmt --check still reports existing repo-wide formatting diffs unrelated to this change.