### PR TITLE
Fix clippy warnings across workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,4 +43,10 @@ Once the new tests pass, also run all tests with:
 cargo test
 ```
 
+Also run clippy across the workspace and resolve any warnings before declaring work done:
+
+```bash
+cargo clippy --workspace --all-targets --all-features
+```
+
 For JVM client integration tests, see [triplox-jvm/README.md](triplox-jvm/README.md).

--- a/edn/src/pretty_print.rs
+++ b/edn/src/pretty_print.rs
@@ -117,7 +117,7 @@ mod test {
         let string = "$";
         let data = parse::value(string).unwrap().without_spans();
 
-        assert_eq!(data.write_pretty(40, &mut Vec::new()).is_ok(), true);
+        assert!(data.write_pretty(40, &mut Vec::new()).is_ok());
     }
 
     #[test]

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -732,6 +732,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_print_edn() {
         assert_eq!("1234N", Value::from_bigint("1234").unwrap().to_string());
 

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -18,11 +18,11 @@ use edn::query::{
 
 use edn::parse::parse_query;
 
-///! N.B., parsing a query can be done without reference to a DB.
-///! Processing the parsed query into something we can work with
-///! for planning involves interrogating the schema and idents in
-///! the store.
-///! See <https://github.com/mozilla/mentat/wiki/Querying> for more.
+// N.B., parsing a query can be done without reference to a DB.
+// Processing the parsed query into something we can work with
+// for planning involves interrogating the schema and idents in
+// the store.
+// See <https://github.com/mozilla/mentat/wiki/Querying> for more.
 #[test]
 fn can_parse_predicates() {
     let s = "[:find [?x ...] :where [?x _ ?y] [(< ?y 10)]]";

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -328,7 +328,7 @@ fn test_inst() {
 fn test_bigint() {
     use self::Value::*;
 
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     assert_eq!(bigint("0N").unwrap(), BigInteger(Zero::zero()));
@@ -344,7 +344,7 @@ fn test_bigint() {
 
 #[test]
 fn test_span_bigint() {
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     assert_eq!(
@@ -526,7 +526,7 @@ fn test_span_keyword() {
 fn test_value() {
     use self::Value::*;
 
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     assert_eq!(value("nil").unwrap(), Nil);
@@ -581,7 +581,7 @@ fn test_value() {
 
 #[test]
 fn test_span_value() {
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     assert_eq!(
@@ -706,7 +706,7 @@ fn test_span_value() {
 fn test_vector() {
     use self::Value::*;
 
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     let test = "[]";
@@ -1492,7 +1492,7 @@ macro_rules! def_test_into_type {
 #[test]
 #[allow(clippy::float_cmp)]
 fn test_is_and_as_type_helper_functions() {
-    let max_i64 = i64::max_value().to_bigint().unwrap();
+    let max_i64 = i64::MAX.to_bigint().unwrap();
     let bigger = &max_i64 * &max_i64;
 
     let values = [
@@ -1549,7 +1549,7 @@ fn test_is_and_as_type_helper_functions() {
         if i == 0 {
             assert_eq!(value.as_nil().unwrap(), ())
         } else {
-            assert!(!value.as_nil().is_some())
+            assert!(value.as_nil().is_none())
         }
 
         // These return copied values, not references.

--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -199,7 +199,7 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                if subscriber.read().await.records.len() >= 1 {
+                if !subscriber.read().await.records.is_empty() {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(5)).await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1491,7 +1491,7 @@ mod tests {
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
 
-        let mut attrs = vec![
+        let mut attrs = [
             (
                 kw!(:name),
                 DataType::String("old-name".to_string()),

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -26,6 +26,7 @@ pub struct GenericPrefixExtender {
 }
 
 impl GenericPrefixExtender {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         slate: Arc<slatedb::DbSnapshot>,
         handle: Handle,

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -181,7 +181,7 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if subscriber.read().await.records.len() >= 1 {
+                if !subscriber.read().await.records.is_empty() {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(5)).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1326,10 +1326,7 @@ mod tests {
         // Define "sex" attribute with keyword value type
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword))),
             (
                 kw!(:db/cardinality),
                 DataType::Keyword(kw!(:db.cardinality/one)),
@@ -1376,10 +1373,7 @@ mod tests {
 
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword))),
             (
                 kw!(:db/cardinality),
                 DataType::Keyword(kw!(:db.cardinality/one)),
@@ -1426,10 +1420,7 @@ mod tests {
         // Define "last-name" attribute
         node.execute_tx(vec![TxOp::put(vec![
             (kw!(:db/ident), DataType::Keyword(kw!(:last-name))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/string)),
-            ),
+            (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string))),
             (
                 kw!(:db/cardinality),
                 DataType::Keyword(kw!(:db.cardinality/one)),

--- a/src/node.rs
+++ b/src/node.rs
@@ -1325,14 +1325,14 @@ mod tests {
 
         // Define "sex" attribute with keyword value type
         node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
+            (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
             (
                 kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)).into(),
+                DataType::Keyword(kw!(:db.type/keyword)),
             ),
             (
                 kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+                DataType::Keyword(kw!(:db.cardinality/one)),
             ),
         ])])
         .await
@@ -1347,7 +1347,7 @@ mod tests {
         for (name, sex) in people {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
-                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
             .await
             .unwrap();
@@ -1375,14 +1375,14 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/ident), DataType::Keyword(kw!(:sex)).into()),
+            (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
             (
                 kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/keyword)).into(),
+                DataType::Keyword(kw!(:db.type/keyword)),
             ),
             (
                 kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+                DataType::Keyword(kw!(:db.cardinality/one)),
             ),
         ])])
         .await
@@ -1397,7 +1397,7 @@ mod tests {
         for (name, sex) in people {
             node.execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
-                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
             .await
             .unwrap();
@@ -1425,14 +1425,14 @@ mod tests {
 
         // Define "last-name" attribute
         node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/ident), DataType::Keyword(kw!(:last-name)).into()),
+            (kw!(:db/ident), DataType::Keyword(kw!(:last-name))),
             (
                 kw!(:db/valueType),
-                DataType::Keyword(kw!(:db.type/string)).into(),
+                DataType::Keyword(kw!(:db.type/string)),
             ),
             (
                 kw!(:db/cardinality),
-                DataType::Keyword(kw!(:db.cardinality/one)).into(),
+                DataType::Keyword(kw!(:db.cardinality/one)),
             ),
         ])])
         .await

--- a/src/query.rs
+++ b/src/query.rs
@@ -673,6 +673,7 @@ fn compute_constant_prefix(pattern: &Pattern, index_type: IndexType) -> Result<V
 }
 
 /// Compile a Pattern into a PrefixExtender.
+#[allow(clippy::too_many_arguments)]
 pub fn compile_pattern(
     pattern: &Pattern,
     join_order: &[Variable],
@@ -1189,6 +1190,7 @@ pub fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Erro
 }
 
 /// Compile an OrWhereClause into a PrefixExtender.
+#[allow(clippy::too_many_arguments)]
 fn compile_or_branch(
     branch: &OrWhereClause,
     join_order: &[Variable],
@@ -1232,6 +1234,7 @@ fn compile_or_branch(
 }
 
 /// Compile a single WhereClause into a PrefixExtender, recursively handling nested clauses.
+#[allow(clippy::too_many_arguments)]
 fn compile_where_clause(
     clause: &WhereClause,
     join_order: &[Variable],

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -95,6 +95,7 @@ static V1_IDENTS: LazyLock<Vec<(Keyword, i64)>> = LazyLock::new(|| {
 
 /// Schema properties for bootstrap attributes using symbolic keywords.
 /// (ident, value_type_ident, cardinality_ident, unique_ident)
+#[allow(clippy::type_complexity)]
 static V1_ATTRIBUTES: LazyLock<Vec<(Keyword, Keyword, Keyword, Option<Keyword>)>> =
     LazyLock::new(|| {
         vec![

--- a/src/server.rs
+++ b/src/server.rs
@@ -575,6 +575,12 @@ impl<L: TxLog + 'static> Server<L> {
 
 pub struct DevServer;
 
+impl Default for DevServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DevServer {
     pub fn new() -> Self {
         DevServer

--- a/src/upsert_resolution.rs
+++ b/src/upsert_resolution.rs
@@ -293,14 +293,13 @@ impl Generation {
         let mut identity_groups: HashMap<(Entid, ValueWithTempIds), Vec<String>> = HashMap::new();
 
         for d in &self.allocations {
-            if d.op == DatomOp::Retract {
-                if matches!(d.entity, IdOrTempId::TempId(_))
-                    || matches!(d.value, ValueWithTempIds::TempRef(_))
-                {
-                    return Err(anyhow::anyhow!(
-                        "[:db/retract ...] referenced tempid that did not upsert"
-                    ));
-                }
+            if d.op == DatomOp::Retract
+                && (matches!(d.entity, IdOrTempId::TempId(_))
+                    || matches!(d.value, ValueWithTempIds::TempRef(_)))
+            {
+                return Err(anyhow::anyhow!(
+                    "[:db/retract ...] referenced tempid that did not upsert"
+                ));
             }
 
             if d.op != DatomOp::Assert {

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -371,17 +371,14 @@ async fn test_dev_server_connections_are_isolated() {
 async fn define_schema_attr(client: &ClientNode, name: &str, vtype: &str) {
     client
         .execute_tx(vec![TxOp::put(vec![
-            (
-                kw!(:db/ident),
-                DataType::Keyword(Keyword::plain(name)).into(),
-            ),
+            (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
             (
                 kw!(:db/valueType),
-                DataType::Keyword(Keyword::namespaced("db.type", vtype)).into(),
+                DataType::Keyword(Keyword::namespaced("db.type", vtype)),
             ),
             (
                 kw!(:db/cardinality),
-                DataType::Keyword(Keyword::namespaced("db.cardinality", "one")).into(),
+                DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
             ),
         ])])
         .await
@@ -418,7 +415,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
         client
             .execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
-                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
             .await
             .unwrap();
@@ -466,7 +463,7 @@ async fn test_aggregates_and_or() {
             .execute_tx(vec![TxOp::put(vec![
                 (kw!(:name), name.into()),
                 (kw!(:last-name), last.into()),
-                (kw!(:sex), DataType::Keyword(Keyword::plain(sex)).into()),
+                (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
                 (kw!(:age), (age as i64).into()),
             ])])
             .await


### PR DESCRIPTION
## Summary
- Resolved all warnings/errors surfaced by `cargo clippy --workspace --all-targets --all-features`: useless conversions/`vec!`, `len_zero`, `collapsible_if`, `new_without_default`, legacy `i64::max_value()`, `bool_assert_comparison`, `nonminimal_bool`, and an outer doc comment that wasn't applied.
- Added targeted `#[allow]` attributes for genuinely intentional cases: `too_many_arguments` on four query/extender constructors, `type_complexity` on `V1_ATTRIBUTES`, and `approx_constant` on `test_print_edn` (where `3.14` must match a literal in the expected output string).
- Documented the clippy step in AGENTS.md so it's run alongside `cargo test` before declaring work done.

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features` is clean
- [x] `cargo test --workspace --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)