### PR TITLE
Add bootstrap transaction entity

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Context, Result};
+use std::sync::LazyLock;
 
 use crate::clock::st_from_unix_epoch;
 use crate::codec;
 use crate::indexer::{build_tx_entity_datoms, write_index_entries};
 use crate::metadata::{Metadata, PartitionMap};
 use crate::partition::{
-    extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION,
+    extract_counter, partition_entity_prefix, COUNTER_BITS, DB_PARTITION, TX_PARTITION,
+    USER_PARTITION,
 };
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
 use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
@@ -21,6 +23,18 @@ const META_KEY_VERSION: &[u8] = b"version";
 /// New user-defined schema attributes start at this counter value,
 /// leaving room below for future bootstrap entities.
 const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
+
+/// Entity ID for the bootstrap transaction (TX_PARTITION, counter 0).
+/// Matches `make_entity_id(TX_PARTITION, 0)`; expressed as a const so
+/// `node::from_slate_and_log` can compare without recomputing.
+pub(crate) const BOOTSTRAP_TX_EID: i64 = (TX_PARTITION as i64) << COUNTER_BITS;
+
+/// TxKey written for the bootstrap transaction. `tx_id=0` and `system_time=epoch`
+/// collide with the first FileLog tx today; see TODO(#97).
+pub(crate) static BOOTSTRAP_TX_KEY: LazyLock<TxKey> = LazyLock::new(|| TxKey {
+    tx_id: 0,
+    system_time: st_from_unix_epoch(0),
+});
 
 /// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
 /// With descending encoding, the first entity per partition has the highest counter.
@@ -87,12 +101,9 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
-            let tx_key = TxKey {
-                tx_id: 0,
-                system_time: st_from_unix_epoch(0),
-            };
+            let tx_key = *BOOTSTRAP_TX_KEY;
+            let tx_eid = BOOTSTRAP_TX_EID;
             let mut boot_pm = PartitionMap::new();
-            let tx_eid = boot_pm.allocate_entid(TX_PARTITION);
 
             // Same normalization and tempid-resolution stages as the indexer.
             let expanded = tx::expand_tx_ops(&tx_ops, &bootstrap_schema).unwrap();

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,14 +1,16 @@
 use anyhow::{bail, Context, Result};
 
+use crate::clock::st_from_unix_epoch;
 use crate::codec;
-use crate::indexer::write_index_entries;
+use crate::indexer::{build_tx_entity_datoms, write_index_entries};
 use crate::metadata::{Metadata, PartitionMap};
 use crate::partition::{
     extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION,
 };
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
-use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
+use crate::transaction::TxKey;
+use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tx;
 use crate::util::concat_bytes;
 use slatedb::{Db, WriteBatch};
@@ -62,7 +64,8 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> Result<PartitionMap
 /// Initialize the database and return ready `Metadata`.
 ///
 /// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries
-///   directly to SlateDB, writes the version, and returns populated metadata.
+///   including a transaction entity directly to SlateDB, writes the version, and
+///   returns populated metadata.
 /// - **Existing DB**: loads the schema from indices via the Datalog query engine,
 ///   derives counters by scanning the EAV index.
 pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
@@ -84,16 +87,23 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
+            let tx_key = TxKey {
+                tx_id: 0,
+                system_time: st_from_unix_epoch(0),
+            };
+            let mut boot_pm = PartitionMap::new();
+            let tx_eid = boot_pm.allocate_entid(TX_PARTITION);
+
             // Same normalization and tempid-resolution stages as the indexer.
             let expanded = tx::expand_tx_ops(&tx_ops, &bootstrap_schema).unwrap();
             let with_tempids = tx::resolve_lookup_refs(expanded, &bootstrap_schema, &slate.db)
                 .await
                 .unwrap();
-            let mut boot_pm = PartitionMap::new();
-            let datoms =
+            let mut datoms =
                 tempids::resolve_tempids(with_tempids, &bootstrap_schema, &slate.db, &mut boot_pm)
                     .await
                     .unwrap();
+            datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
             // Validate against pre-built schema, then derive the bootstrap schema delta.
             let validation = bootstrap_schema.validate_datoms(&datoms).unwrap();
@@ -113,7 +123,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             );
 
             let mut batch = WriteBatch::new();
-            write_index_entries(&mut batch, &datoms, &bootstrap_schema, 0_i64).unwrap();
+            write_index_entries(&mut batch, &datoms, &bootstrap_schema, tx_eid).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             batch.put(&version_key, version.as_bytes());
@@ -159,6 +169,8 @@ mod tests {
             metadata.partition_map[&DB_PARTITION],
             DB_PARTITION_COUNTER_FLOOR
         );
+        assert_eq!(metadata.partition_map[&TX_PARTITION], 1);
+        assert_eq!(metadata.partition_map[&USER_PARTITION], 0);
         // Enum entities are in ident_map but not attribute_map
         assert!(metadata
             .schema
@@ -181,6 +193,10 @@ mod tests {
         assert_eq!(
             metadata1.partition_map[&DB_PARTITION],
             metadata2.partition_map[&DB_PARTITION]
+        );
+        assert_eq!(
+            metadata1.partition_map[&TX_PARTITION],
+            metadata2.partition_map[&TX_PARTITION]
         );
     }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -8,9 +8,9 @@ use crate::partition::{
     extract_counter, partition_entity_prefix, DB_PARTITION, TX_PARTITION, USER_PARTITION,
 };
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
+use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
 use crate::transaction::TxKey;
-use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tx;
 use crate::util::concat_bytes;
 use slatedb::{Db, WriteBatch};

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -137,8 +137,8 @@ pub(crate) fn write_index_entries(
 /// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
 /// system_time from `db/txInstant` value.
 ///
-/// TODO(#97): Return Option instead of sentinel. Needs coordination with
-/// the bootstrap transaction (tx_id=0).
+/// TODO(#97): Return Option instead of sentinel. This still needs coordination
+/// with callers that distinguish a truly empty DB from bootstrap tx_id=0.
 pub async fn latest_tx_key_from_snapshot(
     snapshot: &Arc<slatedb::DbSnapshot>,
 ) -> Result<(i64, TxKey)> {
@@ -217,7 +217,7 @@ pub async fn tx_eid_for_tx_key(snapshot: &Arc<slatedb::DbSnapshot>, tx_key: &TxK
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.
 /// The `tx_eid` is the pre-allocated entity ID for this transaction.
-fn build_tx_entity_datoms(
+pub(crate) fn build_tx_entity_datoms(
     tx_eid: i64,
     tx_key: TxKey,
     committed: bool,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -905,20 +905,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_latest_tx_key_empty_db_errors() -> Result<(), Error> {
-        let slate = in_memory_slate().await.db;
-        let snapshot = Arc::new(slate.snapshot().await?);
-        let err = latest_tx_key_from_snapshot(&snapshot)
-            .await
-            .expect_err("empty DB should error rather than return a sentinel");
-        assert!(
-            err.to_string().contains("TX_PARTITION is empty"),
-            "unexpected error: {err}"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_latest_tx_key_highest_wins() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let slate = components.db.clone();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -180,9 +180,9 @@ pub async fn latest_tx_key_from_snapshot(
             },
         )),
         (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
-        (Some(eid), tid, st) => bail!(
-            "Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})"
-        ),
+        (Some(eid), tid, st) => {
+            bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
+        }
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -128,7 +128,6 @@ pub(crate) fn write_index_entries(
 }
 
 /// Scan EAV entries for TX_PARTITION entities and return (tx_eid, TxKey) for the latest tx.
-/// If no transaction entities exist, returns a sentinel (0, TxKey{tx_id=0, system_time=epoch}).
 ///
 /// Uses the high bits of TX_PARTITION entity IDs to build a targeted EAV prefix,
 /// restricting the scan to TX_PARTITION entities. With descending entity encoding,
@@ -137,8 +136,9 @@ pub(crate) fn write_index_entries(
 /// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
 /// system_time from `db/txInstant` value.
 ///
-/// TODO(#97): Return Option instead of sentinel. This still needs coordination
-/// with callers that distinguish a truly empty DB from bootstrap tx_id=0.
+/// Errors if no TX_PARTITION entity exists (an initialized DB always has the
+/// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
+/// `:db/txInstant`.
 pub async fn latest_tx_key_from_snapshot(
     snapshot: &Arc<slatedb::DbSnapshot>,
 ) -> Result<(i64, TxKey)> {
@@ -179,13 +179,10 @@ pub async fn latest_tx_key_from_snapshot(
                 system_time: st,
             },
         )),
-        _ => Ok((
-            0,
-            TxKey {
-                tx_id: 0,
-                system_time: crate::clock::st_from_unix_epoch(0),
-            },
-        )),
+        (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
+        (Some(eid), tid, st) => bail!(
+            "Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})"
+        ),
     }
 }
 
@@ -908,12 +905,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_latest_tx_key_empty_db() -> Result<(), Error> {
+    async fn test_latest_tx_key_empty_db_errors() -> Result<(), Error> {
         let slate = in_memory_slate().await.db;
         let snapshot = Arc::new(slate.snapshot().await?);
-        let (tx_eid, latest) = latest_tx_key_from_snapshot(&snapshot).await?;
-        assert_eq!(latest.tx_id, 0, "Should return sentinel for empty DB");
-        assert_eq!(tx_eid, 0, "Should return sentinel tx_eid for empty DB");
+        let err = latest_tx_key_from_snapshot(&snapshot)
+            .await
+            .expect_err("empty DB should error rather than return a sentinel");
+        assert!(
+            err.to_string().contains("TX_PARTITION is empty"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -157,8 +157,11 @@ impl Node<FileLog> {
         // and restore the indexer's in-memory state for TxWaiter fast-path.
         let snapshot = Arc::new(slate.db.snapshot().await?);
         let (latest_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
-        // Bootstrap and the first FileLog transaction both currently use tx_id=0.
-        // Only skip log catch-up when a tx entity after bootstrap has been indexed.
+        // Bootstrap and the first FileLog transaction both currently use tx_id=0,
+        // so we can't disambiguate them by tx_id alone. Use the entity ID instead:
+        // only advance the log cursor past tx_id=0 once a tx entity beyond bootstrap
+        // has been indexed; otherwise replay the log from the start so the first
+        // user tx isn't skipped.
         let latest_indexed_tx = if latest_tx_eid > crate::bootstrap::BOOTSTRAP_TX_EID {
             Some(latest_indexed)
         } else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -157,6 +157,9 @@ impl Node<FileLog> {
         // and restore the indexer's in-memory state for TxWaiter fast-path.
         let snapshot = Arc::new(slate.db.snapshot().await?);
         let (_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
+        // Bootstrap currently has tx_id=0, and an empty FileLog also assigns
+        // tx_id=0 to its first real transaction. Until log tx_ids move past
+        // bootstrap, do not use tx_id=0 as a catch-up skip point.
         let latest_indexed_tx = if latest_indexed.tx_id > 0 {
             Some(latest_indexed)
         } else {
@@ -991,6 +994,37 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.contains(&vec![DataType::String("alice".to_string())]));
         assert!(results.contains(&vec![DataType::String("bob".to_string())]));
+
+        node.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_node_bootstrap_only_restart_does_not_skip_first_log_tx() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().to_path_buf();
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        node.close().await;
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            node.execute_tx(test_schema_tx()),
+        )
+        .await
+        .expect("first log transaction after bootstrap-only restart should not be skipped")
+        .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         node.close().await;
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -156,11 +156,11 @@ impl Node<FileLog> {
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
         let snapshot = Arc::new(slate.db.snapshot().await?);
-        let (_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
-        // Bootstrap currently has tx_id=0, and an empty FileLog also assigns
-        // tx_id=0 to its first real transaction. Until log tx_ids move past
-        // bootstrap, do not use tx_id=0 as a catch-up skip point.
-        let latest_indexed_tx = if latest_indexed.tx_id > 0 {
+        let (latest_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
+        // Bootstrap and the first FileLog transaction both currently use tx_id=0.
+        // Only skip log catch-up when a tx entity after bootstrap has been indexed.
+        let bootstrap_tx_eid = crate::partition::make_entity_id(crate::partition::TX_PARTITION, 0);
+        let latest_indexed_tx = if latest_tx_eid > bootstrap_tx_eid {
             Some(latest_indexed)
         } else {
             None
@@ -1025,6 +1025,26 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
+
+        node.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_node_restart_skips_already_indexed_first_log_tx() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().to_path_buf();
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        define_test_schema(&node).await;
+        node.close().await;
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        let db = node.db().await.unwrap();
+        let txs = db
+            .query("[:find ?tx :where [?tx :db/txId 0]]")
+            .await
+            .unwrap();
+        assert_eq!(txs.len(), 2);
 
         node.close().await;
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -311,7 +311,9 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
+    use crate::clock::st_from_unix_epoch;
     use crate::ops::{DataType, EntityRef, TxOp};
+    use crate::partition::{extract_partition, TX_PARTITION};
     use crate::schema::{
         test_schema_tx, unique_identity_schema_attribute, unique_value_schema_attribute,
     };
@@ -1142,12 +1144,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_db_on_fresh_node_returns_sentinel_tx_key() {
+    async fn test_db_on_fresh_node_returns_bootstrap_tx_key() {
         let node = Node::memory_node().await;
 
         let db = node.db().await.unwrap();
         let tx_key = db.tx_key();
         assert_eq!(tx_key.tx_id, 0);
+
+        node.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_fresh_db_has_queryable_bootstrap_transaction_entity() {
+        let node = Node::memory_node().await;
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query(
+                "[:find ?tx ?tx_id ?instant ?ident \
+                 :where [?tx :db/txId ?tx_id] \
+                        [?tx :db/txInstant ?instant] \
+                        [?tx :db/txResult ?result] \
+                        [?result :db/ident ?ident]]",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let tx_eid = match &result[0][0] {
+            DataType::Long(id) => *id,
+            other => panic!("Expected Long tx entity ID, got {:?}", other),
+        };
+        assert_eq!(extract_partition(tx_eid), TX_PARTITION);
+        assert_eq!(result[0][1], DataType::Long(0));
+        assert_eq!(result[0][2], DataType::Instant(st_from_unix_epoch(0)));
+        assert_eq!(result[0][3], DataType::Keyword(kw!(:db.tx/committed)));
+
+        node.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_first_submitted_tx_temporarily_shares_bootstrap_tx_id() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?tx :where [?tx :db/txId 0]]")
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
 
         node.close().await;
     }
@@ -2471,8 +2518,7 @@ mod tests {
             );
             assert_eq!(pm[&crate::partition::USER_PARTITION], 0);
             assert!(pm[&crate::partition::DB_PARTITION] > 0);
-            // TX_PARTITION is 0 after bootstrap (tx entities created by indexer, not bootstrap)
-            assert_eq!(pm[&crate::partition::TX_PARTITION], 0);
+            assert_eq!(pm[&crate::partition::TX_PARTITION], 1);
         }
 
         // Insert a user entity, close, and reopen

--- a/src/node.rs
+++ b/src/node.rs
@@ -159,8 +159,7 @@ impl Node<FileLog> {
         let (latest_tx_eid, latest_indexed) = latest_tx_key_from_snapshot(&snapshot).await?;
         // Bootstrap and the first FileLog transaction both currently use tx_id=0.
         // Only skip log catch-up when a tx entity after bootstrap has been indexed.
-        let bootstrap_tx_eid = crate::partition::make_entity_id(crate::partition::TX_PARTITION, 0);
-        let latest_indexed_tx = if latest_tx_eid > bootstrap_tx_eid {
+        let latest_indexed_tx = if latest_tx_eid > crate::bootstrap::BOOTSTRAP_TX_EID {
             Some(latest_indexed)
         } else {
             None


### PR DESCRIPTION
## Summary
- make fresh DB bootstrap write a committed transaction entity using the shared tx entity datom builder
- write bootstrap datoms with the allocated tx_eid and advance the TX partition counter
- add tests for queryable bootstrap tx entity and restart catch-up behavior around tx_id=0

## Known follow-ups
- Bootstrap and the first FileLog transaction both currently use `tx_id=0`. That duplicate txId is a bad design and should be fixed by giving bootstrap and log transactions distinct logical IDs.
- Restart catch-up now has a workaround that distinguishes bootstrap from the first FileLog transaction by comparing tx entity IDs. This quirk should be removed once txId allocation is corrected.

## Tests
- cargo test