### PR TITLE
Rename :db.tx/error to :db/txError; sync design docs

### DIFF
--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -69,14 +69,14 @@ Each transaction is reified as an entity in this partition. The transaction enti
 
 | Attribute      | Value Type | Description                                                    |
 |----------------|------------|----------------------------------------------------------------|
-| `db.tx/instant` | instant    | Wall-clock time of the transaction                             |
-| `db.tx/result`  | keyword    | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)      |
-| `db.tx/id`      | long       | The sequential tx_id assigned by the log                       |
-| `db.tx/error`   | string     | Error message (present only when `db.tx/result` is `:db.tx/aborted`) |
+| `db/txInstant`  | instant    | Wall-clock time of the transaction                             |
+| `db/txResult`   | ref        | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)      |
+| `db/txId`       | long       | The sequential tx_id assigned by the log                       |
+| `db/txError`    | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
 
 A transaction with counter value `t` has entity ID `(1 << 42) | t`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
 
-Note: the relationship between `db.tx/id` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
+Note: the relationship between `db/txId` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
 
 ### 2.3 :db.part/user (partition 2)
 

--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -85,10 +85,10 @@ A fresh database is initialized with a bootstrap transaction (tx_id=0) that inst
 | `db/valueType`     | ref        | one         |          |
 | `db/cardinality`   | ref        | one         |          |
 | `db/unique`        | ref        | one         |          |
-| `db.tx/instant`    | instant    | one         |          |
-| `db.tx/result`     | ref        | one         |          |
-| `db.tx/id`         | long       | one         |          |
-| `db.tx/error`      | string     | one         |          |
+| `db/txInstant`     | instant    | one         |          |
+| `db/txResult`      | ref        | one         |          |
+| `db/txId`          | long       | one         |          |
+| `db/txError`       | string     | one         |          |
 
 The first four attributes are self-referential: they describe themselves. `db/ident`, `db/valueType`, and `db/cardinality` are the minimal required set needed to define any further schema attributes; `db/unique` adds optional uniqueness semantics. Attributes 32–35 are used on transaction entities (see `PARTITIONS.md`).
 
@@ -96,7 +96,7 @@ The bootstrap transaction also installs enum entities for value types (`:db.type
 
 ### 2.1 Transaction Result Enums
 
-The bootstrap transaction installs two enum entities representing transaction outcomes. These are used as values for the `db.tx/result` attribute on transaction entities (see `PARTITIONS.md`):
+The bootstrap transaction installs two enum entities representing transaction outcomes. These are used as values for the `db/txResult` attribute on transaction entities (see `PARTITIONS.md`):
 
 | Ident               |
 |---------------------|
@@ -107,7 +107,7 @@ The bootstrap transaction installs two enum entities representing transaction ou
 
 `ValueType::Ref` is a supported schema type. Ref values are stored as `DataType::Long` with the same byte-level encoding (same tag). The schema is the sole authority on whether a Long value is an entity reference — this allows ref values and entity IDs to unify at the byte level in the generic join algorithm without special-casing.
 
-`db/valueType`, `db/cardinality`, `db/unique`, and `db.tx/result` are ref-typed attributes whose values are entity IDs pointing to the enum entities defined in the bootstrap transaction (e.g. the entity for `:db.type/string`, `:db.cardinality/one`, `:db.unique/identity`, or `:db.tx/committed`).
+`db/valueType`, `db/cardinality`, `db/unique`, and `db/txResult` are ref-typed attributes whose values are entity IDs pointing to the enum entities defined in the bootstrap transaction (e.g. the entity for `:db.type/string`, `:db.cardinality/one`, `:db.unique/identity`, or `:db.tx/committed`).
 
 ---
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -153,7 +153,7 @@ mod tests {
         assert!(metadata.schema.get_attribute(&kw!(:db/txInstant)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txId)).is_some());
         assert!(metadata.schema.get_attribute(&kw!(:db/txResult)).is_some());
-        assert!(metadata.schema.get_attribute(&kw!(:db.tx/error)).is_some());
+        assert!(metadata.schema.get_attribute(&kw!(:db/txError)).is_some());
         // Counter is clamped to DB_PARTITION_COUNTER_FLOOR (room for future bootstrap entities)
         assert_eq!(
             metadata.partition_map[&DB_PARTITION],

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -252,7 +252,7 @@ fn build_tx_entity_datoms(
     if let Some(err) = error {
         datoms.push(Datom {
             entity: tx_eid,
-            attribute: kw!(:db.tx/error),
+            attribute: kw!(:db/txError),
             value: DataType::String(err),
             op: DatomOp::Assert,
         });

--- a/src/node.rs
+++ b/src/node.rs
@@ -1689,7 +1689,7 @@ mod tests {
         let db = node.db().await.unwrap();
         let query_str = format!(
             "[:find ?ident ?error \
-             :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident] [?tx :db.tx/error ?error]]",
+             :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident] [?tx :db/txError ?error]]",
             tx_key.tx_id
         );
         let result = db.query(query_str).await.unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -86,7 +86,7 @@ static V1_IDENTS: LazyLock<Vec<(Keyword, i64)>> = LazyLock::new(|| {
         (kw!(:db/txInstant), DB_TX_INSTANT),
         (kw!(:db/txId), DB_TX_ID),
         (kw!(:db/txResult), DB_TX_RESULT),
-        (kw!(:db.tx/error), DB_TX_ERROR),
+        (kw!(:db/txError), DB_TX_ERROR),
         // Transaction result enum entities
         (kw!(:db.tx/committed), DB_TX_COMMITTED),
         (kw!(:db.tx/aborted), DB_TX_ABORTED),
@@ -142,7 +142,7 @@ static V1_ATTRIBUTES: LazyLock<Vec<(Keyword, Keyword, Keyword, Option<Keyword>)>
                 None,
             ),
             (
-                kw!(:db.tx/error),
+                kw!(:db/txError),
                 kw!(:db.type/string),
                 kw!(:db.cardinality/one),
                 None,


### PR DESCRIPTION
## Summary

- Rename the transaction error attribute from `:db.tx/error` to `:db/txError`, matching the existing `db/tx<Camel>` convention used by `:db/txInstant`, `:db/txId`, `:db/txResult`. The result enum values `:db.tx/committed` and `:db.tx/aborted` remain in the `db.tx/...` namespace since they're values, not attributes.
- Sync `design/SCHEMA.md` and `design/PARTITIONS.md` so the listed attribute idents match the code (`db/txInstant`, `db/txId`, `db/txResult`, `db/txError`).
- Correct the `db/txResult` value-type column in `PARTITIONS.md` from `keyword` to `ref` — the schema in `src/schema.rs` defines it as a ref to the enum entity.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test --lib bootstrap::tests::test_init_db_fresh\`
- [x] \`cargo test --lib node::tests::test_aborted_tx_entity\` (covers the abort → error datom written → query reads it back path)
- [x] \`rg 'db\.tx/error'\` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)