### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -12,13 +12,11 @@ jobs:
       packages: write
 
     steps:
-      - name: Delete old SHA-tagged images
+      - name: Delete old untagged images
         uses: snok/container-retention-policy@v3
         with:
           account: FiV0
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: triplox
           cut-off: 1 week ago UTC
-          tag-selection: "both"
-          filter-tags: "main,v*"
-          filter-include-untagged: true
+          tag-selection: untagged

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -20,3 +20,22 @@ jobs:
           image-names: triplox
           cut-off: 1 week ago UTC
           tag-selection: untagged
+
+      - name: Delete old SHA-only images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cutoff="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+          ids="$(
+            gh api --paginate '/users/FiV0/packages/container/triplox/versions?per_page=100' \
+              --jq '.[] | select(.created_at < "'"$cutoff"'") | select((.metadata.container.tags // []) | length > 0) | select(all(.metadata.container.tags[]; startswith("sha-"))) | .id'
+          )"
+
+          if [[ -z "$ids" ]]; then
+            echo "No old SHA-only images to delete."
+            exit 0
+          fi
+
+          while IFS= read -r id; do
+            gh api --method DELETE "/users/FiV0/packages/container/triplox/versions/$id"
+          done <<< "$ids"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,10 +20,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate release tag
+        id: version
         run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v0\.1\.0-alpha\.[0-9]+$ ]]; then
-            echo "Docker images are only published from v0.1.0-alpha.N tags."
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            echo "Docker images are only published from vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-beta.N tags."
             exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            echo "minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "minor=" >> "$GITHUB_OUTPUT"
+            echo "stable=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Docker Buildx
@@ -42,9 +53,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=match,pattern=v(.*),group=1
-            type=match,pattern=v(.*\..*)\.[0-9]+$,group=1
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.stable == 'true' }}
             type=sha,prefix=sha-
 
       - name: Build and push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Validate release tag
         id: version
         run: |
@@ -28,6 +31,12 @@ jobs:
           fi
 
           version="${GITHUB_REF_NAME#v}"
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "triplox") | .version')"
+          if [[ "$cargo_version" != "$version" ]]; then
+            echo "Tag version $version does not match Cargo workspace version $cargo_version."
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
           if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
             echo "minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,21 @@ name: Docker Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Publish mode
+        required: true
+        type: choice
+        default: snapshot
+        options:
+          - snapshot
+          - release
   workflow_call:
+    inputs:
+      mode:
+        required: false
+        type: string
+        default: release
 
 env:
   REGISTRY: ghcr.io
@@ -24,19 +38,35 @@ jobs:
       - name: Validate release tag
         id: version
         run: |
+          mode="${{ inputs.mode }}"
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "triplox") | .version')"
+
+          if [[ "$mode" == "snapshot" ]]; then
+            echo "version=$cargo_version-snapshot" >> "$GITHUB_OUTPUT"
+            echo "minor=" >> "$GITHUB_OUTPUT"
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$mode" != "release" ]]; then
+            echo "Unsupported Docker publish mode: $mode"
+            exit 1
+          fi
+
           if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
-            echo "Docker images are only published from vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-beta.N tags."
+            echo "Release Docker images are only published from vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-beta.N tags."
             exit 1
           fi
 
           version="${GITHUB_REF_NAME#v}"
-          cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "triplox") | .version')"
           if [[ "$cargo_version" != "$version" ]]; then
             echo "Tag version $version does not match Cargo workspace version $cargo_version."
             exit 1
           fi
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "snapshot=false" >> "$GITHUB_OUTPUT"
           if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
             echo "minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
             echo "stable=true" >> "$GITHUB_OUTPUT"
@@ -62,6 +92,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=snapshot,enable=${{ steps.version.outputs.snapshot == 'true' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.stable == 'true' }}
             type=sha,prefix=sha-
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,8 @@
 name: Docker Publish
 
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -20,6 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate release tag
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v0\.1\.0-alpha\.[0-9]+$ ]]; then
+            echo "Docker images are only published from v0.1.0-alpha.N tags."
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,10 +42,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=sha,prefix=
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=v(.*),group=1
+            type=match,pattern=v(.*\..*)\.[0-9]+$,group=1
+            type=sha,prefix=sha-
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,17 @@ jobs:
             -PclojarsUsername="$CLOJARS_USERNAME" \
             -PclojarsPassword="$CLOJARS_PASSWORD"
 
+  docker-image:
+    needs: verify
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit
+
   github-release:
     runs-on: ubuntu-latest
-    needs: [verify, rust-crates, jvm-client]
+    needs: [verify, rust-crates, jvm-client, docker-image]
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,8 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/docker-publish.yml
+    with:
+      mode: release
     secrets: inherit
 
   github-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Validate tag and workspace version
         id: version
         run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v0\.1\.0-alpha\.[0-9]+$ ]]; then
-            echo "Releases are only published from v0.1.0-alpha.N tags."
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            echo "Releases are only published from vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-beta.N tags."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate tag and workspace version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || ! "${GITHUB_REF_NAME}" =~ ^v0\.1\.0-alpha\.[0-9]+$ ]]; then
+            echo "Releases are only published from v0.1.0-alpha.N tags."
+            exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "triplox") | .version')"
+          if [[ "$cargo_version" != "$version" ]]; then
+            echo "Tag version $version does not match Cargo workspace version $cargo_version."
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run workspace tests
+        run: cargo test --workspace
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  rust-crates:
+    runs-on: ubuntu-latest
+    needs: verify
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish triplox-edn
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p triplox-edn
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Publish triplox-client
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p triplox-client
+
+  jvm-client:
+    runs-on: ubuntu-latest
+    needs: verify
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Publish JVM client to Clojars
+        env:
+          CLOJARS_USERNAME: ${{ vars.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+          TRIPLOX_VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          cd triplox-jvm
+          ./gradlew publishMavenPublicationToClojarsRepository \
+            -Dorg.gradle.internal.publish.checksums.insecure=true \
+            -PtriploxVersion="$TRIPLOX_VERSION" \
+            -PclojarsUsername="$CLOJARS_USERNAME" \
+            -PclojarsPassword="$CLOJARS_PASSWORD"
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: [verify, rust-crates, jvm-client]
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          name: Triplox ${{ github.ref_name }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 # Release Process
 
 Triplox releases use one version for the Rust workspace, Docker image, JVM
-client, and GitHub Release. Release tags use the `v0.1.0-alpha.N` format; the
-package version omits the `v` prefix.
+client, and GitHub Release. Release tags use `vX.Y.Z`, `vX.Y.Z-alpha.N`, or
+`vX.Y.Z-beta.N`; the package version omits the `v` prefix.
 
 ## Prepare a release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,9 @@ Pushing the tag triggers GitHub Actions to publish the Rust crates, JVM client,
 Docker image, and GitHub Release.
 
 To publish only the Docker image for an existing release tag, run the
-`Docker Publish` workflow manually and select the release tag as the ref.
+`Docker Publish` workflow manually, select the release tag as the ref, and set
+`mode` to `release`. To publish a SNAPSHOT Docker image from a branch, run the
+same workflow on the branch ref with `mode` set to `snapshot`.
 
 ## Required GitHub secrets
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,9 @@ git push origin v0.1.0-alpha.2
 Pushing the tag triggers GitHub Actions to publish the Rust crates, JVM client,
 Docker image, and GitHub Release.
 
+To publish only the Docker image for an existing release tag, run the
+`Docker Publish` workflow manually and select the release tag as the ref.
+
 ## Required GitHub secrets
 
 - `CARGO_REGISTRY_TOKEN` for crates.io.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+# Release Process
+
+Triplox releases use one version for the Rust workspace, Docker image, JVM
+client, and GitHub Release. Release tags use the `v0.1.0-alpha.N` format; the
+package version omits the `v` prefix.
+
+## Prepare a release
+
+Run from a clean branch:
+
+```bash
+./scripts/release.sh 0.1.0-alpha.2
+```
+
+The script validates the version, updates Cargo versions, refreshes
+`Cargo.lock`, runs formatting/tests/clippy, creates a release commit, and adds
+an annotated tag.
+
+Review the generated commit, then publish:
+
+```bash
+git push origin main
+git push origin v0.1.0-alpha.2
+```
+
+Pushing the tag triggers GitHub Actions to publish the Rust crates, JVM client,
+Docker image, and GitHub Release.
+
+## Required GitHub secrets
+
+- `CARGO_REGISTRY_TOKEN` for crates.io.
+- `CLOJARS_PASSWORD` for Clojars.
+- `CLOJARS_USERNAME` as a repository variable.

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,11 +28,14 @@ Published tags:
 
 - `X.Y.Z-alpha.N` or `X.Y.Z-beta.N` for prereleases.
 - `X.Y.Z` and `X.Y` for stable releases.
+- `X.Y.Z-snapshot` and `snapshot` for manual SNAPSHOT builds.
 - `sha-<short-sha>` for traceability.
 
 Docker publishing runs as part of the release workflow. To publish only the
 Docker image for an existing release tag, run the `Docker Publish` workflow
-manually in GitHub Actions and select the release tag as the workflow ref.
+manually in GitHub Actions, select the release tag as the workflow ref, and set
+`mode` to `release`. To publish a SNAPSHOT image from a branch, select the
+branch ref and set `mode` to `snapshot`.
 
 ## Running
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,35 @@ Docker support for running Triplox with in-memory, local persisted, or remote S3
 
 ## Building
 
+For local development:
+
 ```bash
 ./docker/scripts/build-image.sh
 ```
 
 This builds and tags the image as `triplox:latest` and `triplox:<short-sha>`.
+
+## Published images
+
+Release images are published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/fiv0/triplox:0.1.0-alpha.2
+```
+
+Images are published only from release tags matching `vX.Y.Z`,
+`vX.Y.Z-alpha.N`, or `vX.Y.Z-beta.N`. The tag version must match the Cargo
+workspace version in the tagged commit.
+
+Published tags:
+
+- `X.Y.Z-alpha.N` or `X.Y.Z-beta.N` for prereleases.
+- `X.Y.Z` and `X.Y` for stable releases.
+- `sha-<short-sha>` for traceability.
+
+Docker publishing runs as part of the release workflow. To publish only the
+Docker image for an existing release tag, run the `Docker Publish` workflow
+manually in GitHub Actions and select the release tag as the workflow ref.
 
 ## Running
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,8 +56,7 @@ cargo test --workspace
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 git add Cargo.toml Cargo.lock
-git commit -m "Release $tag" \
-    -m "Co-authored-by: Codex <noreply@openai.com>"
+git commit -m "Release $tag"
 git tag -a "$tag" -m "Release $tag"
 
 cat <<EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <0.1.0-alpha.N|v0.1.0-alpha.N>"
+    echo "Usage: $0 <VERSION|vVERSION>"
+    echo "Examples: $0 0.1.0, $0 0.1.0-alpha.1, $0 0.1.0-beta.1"
 }
 
 if [[ $# -ne 1 ]]; then
@@ -14,8 +15,8 @@ input_version="$1"
 version="${input_version#v}"
 tag="v$version"
 
-if [[ ! "$version" =~ ^0\.1\.0-alpha\.[0-9]+$ ]]; then
-    echo "Expected version format 0.1.0-alpha.N, got: $input_version" >&2
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+    echo "Expected version format X.Y.Z, X.Y.Z-alpha.N, or X.Y.Z-beta.N; got: $input_version" >&2
     exit 2
 fi
 
@@ -45,7 +46,7 @@ if [[ -z "$current_branch" ]]; then
     exit 1
 fi
 
-perl -0pi -e 's/(?m)^version = "0\.1\.0-alpha\.\d+"$/version = "'"$version"'"/' Cargo.toml
+perl -0pi -e 's/(?m)^version = "[0-9]+\.[0-9]+\.[0-9]+(?:-(?:alpha|beta)\.[0-9]+)?"$/version = "'"$version"'"/' Cargo.toml
 perl -0pi -e 's/(edn = \{ package = "triplox-edn", path = "edn", version = ")[^"]+(")/${1}'"$version"'${2}/' Cargo.toml
 perl -0pi -e 's/(triplox-client = \{ path = "triplox-client", version = ")[^"]+(")/${1}'"$version"'${2}/' Cargo.toml
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <0.1.0-alpha.N|v0.1.0-alpha.N>"
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+input_version="$1"
+version="${input_version#v}"
+tag="v$version"
+
+if [[ ! "$version" =~ ^0\.1\.0-alpha\.[0-9]+$ ]]; then
+    echo "Expected version format 0.1.0-alpha.N, got: $input_version" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+cd "$repo_root"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Working tree must be clean before preparing a release." >&2
+    exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    echo "Tag already exists locally: $tag" >&2
+    exit 1
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+    echo "Tag already exists on origin: $tag" >&2
+    exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ -z "$current_branch" ]]; then
+    echo "Release preparation must run on a branch, not a detached HEAD." >&2
+    exit 1
+fi
+
+perl -0pi -e 's/(?m)^version = "0\.1\.0-alpha\.\d+"$/version = "'"$version"'"/' Cargo.toml
+perl -0pi -e 's/(edn = \{ package = "triplox-edn", path = "edn", version = ")[^"]+(")/${1}'"$version"'${2}/' Cargo.toml
+perl -0pi -e 's/(triplox-client = \{ path = "triplox-client", version = ")[^"]+(")/${1}'"$version"'${2}/' Cargo.toml
+
+cargo metadata --format-version 1 >/dev/null
+cargo fmt --check
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+git add Cargo.toml Cargo.lock
+git commit -m "Release $tag" \
+    -m "Co-authored-by: Codex <noreply@openai.com>"
+git tag -a "$tag" -m "Release $tag"
+
+cat <<EOF
+Prepared release $tag on branch $current_branch.
+
+Review the commit, then publish with:
+  git push origin $current_branch
+  git push origin $tag
+EOF

--- a/triplox-jvm/README.md
+++ b/triplox-jvm/README.md
@@ -34,14 +34,14 @@ TRIPLOX_HOST=192.168.1.10 TRIPLOX_PORT=5491 ./gradlew integrationTest
 ```
 
 ### Deploying
-To deploy an alpha version to Clojars:
+To deploy the current workspace version to Clojars:
 ```bash
 ./gradlew publishMavenPublicationToClojarsRepository
 ```
 
-To deploy an alpha SNAPSHOT:
+To override the published version:
 ```bash
 ./gradlew publishMavenPublicationToClojarsRepository \
     -Dorg.gradle.internal.publish.checksums.insecure=true \
-    -PtriploxVersion=0.1.0-alpha-SNAPSHOT
+    -PtriploxVersion=0.1.0-alpha.2
 ```

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -9,6 +9,23 @@ repositories {
     maven { url = uri("https://repo.clojars.org/") }
 }
 
+fun workspaceVersion(): String {
+    var inWorkspacePackage = false
+    for (line in rootProject.projectDir.parentFile.resolve("Cargo.toml").readLines()) {
+        val trimmed = line.trim()
+        when {
+            trimmed == "[workspace.package]" -> inWorkspacePackage = true
+            inWorkspacePackage && trimmed.startsWith("[") -> inWorkspacePackage = false
+            inWorkspacePackage && trimmed.startsWith("version = ") -> {
+                return trimmed.substringAfter('"').substringBefore('"')
+            }
+        }
+    }
+    error("Could not read workspace package version from Cargo.toml")
+}
+
+val triploxVersion = (findProperty("triploxVersion") as String?) ?: workspaceVersion()
+
 dependencies {
     // Clojure
     implementation("org.clojure", "clojure", "1.12.3")
@@ -59,7 +76,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "xyz.triplox"
             artifactId = "triplox"
-            version = (findProperty("triploxVersion") as String?) ?: "0.1.0-alpha"
+            version = triploxVersion
 
             from(components["java"])
 


### PR DESCRIPTION
## Summary
- add a local release-prep script for v0.1.0-alpha.N releases
- add tag-triggered release workflow for Rust crates, JVM client, and GitHub Releases
- restrict Docker publishing to release tags and make JVM publishing derive the workspace version

## Validation
- bash -n scripts/release.sh
- workflow YAML parse
- git diff --check
- cargo fmt --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cd triplox-jvm && ./gradlew test --quiet
