### PR TITLE
Wait for db_as_of transaction indexing

### DIFF
--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -302,7 +302,7 @@ a numeric error code (see §5).
 |-------|-----------------------|--------------------------------------------------------------------|
 | 1xxx  | Connection errors     | 1000 ProtocolVersionMismatch, 1001 InvalidStartup                  |
 | 2xxx  | Query errors          | 2000 ParseError, 2001 QueryError, 2002 InvalidQuery, 2003 EmptyQuery |
-| 3xxx  | Transaction errors    | 3000 TxError, 3001 TxAborted                                       |
+| 3xxx  | Transaction errors    | 3000 TxError, 3001 TxAborted, 3002 TxNotIndexed                    |
 | 4xxx  | Internal/protocol     | 4000 InternalError, 4001 MessageTooLarge, 4002 InvalidMessageType, 4003 QueryCancelled, 4004 ServerShuttingDown |
 | 5xxx  | DB handle errors      | 5000 InvalidDbHandle, 5001 TooManyOpenDbs                          |
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,4 @@ pub enum TriploxError {
     Bincode(#[from] bincode::Error),
     #[error("transaction {tx_id} was not indexed within {timeout:?}")]
     TxIndexingTimeout { tx_id: i64, timeout: Duration },
-    #[error("No tx entity found for tx_id={tx_id} system_time={system_time}")]
-    TxNotFound {
-        tx_id: i64,
-        system_time: crate::clock::Instant,
-    },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,16 @@
+use std::time::Duration;
+
 #[derive(Debug, thiserror::Error)]
 pub enum TriploxError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Bincode error: {0}")]
     Bincode(#[from] bincode::Error),
+    #[error("transaction {tx_id} was not indexed within {timeout:?}")]
+    TxIndexingTimeout { tx_id: i64, timeout: Duration },
+    #[error("No tx entity found for tx_id={tx_id} system_time={system_time}")]
+    TxNotFound {
+        tx_id: i64,
+        system_time: crate::clock::Instant,
+    },
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -187,46 +187,6 @@ pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) 
     }
 }
 
-/// Verify that a snapshot contains the exact transaction basis.
-pub async fn tx_basis_exists(snapshot: &Arc<slatedb::DbSnapshot>, basis: &TxBasis) -> Result<bool> {
-    tx_entity_matches_tx_key(snapshot, basis.tx_eid, &basis.tx_key).await
-}
-
-async fn tx_entity_matches_tx_key(
-    snapshot: &Arc<slatedb::DbSnapshot>,
-    tx_eid: i64,
-    tx_key: &TxKey,
-) -> Result<bool> {
-    let mut entity_bytes = Vec::new();
-    encode_datatype(&DataType::Long(tx_eid), &mut entity_bytes);
-    let eav_prefix = concat_bytes(&[&[codec::EAV], entity_bytes.as_slice()]);
-    let mut iter = snapshot
-        .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
-    let mut tx_id_matches = false;
-    let mut instant_matches = false;
-
-    while let Some(kv) = iter.next().await? {
-        let (_entity, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
-        match (attribute, value) {
-            (crate::schema::DB_TX_ID, DataType::Long(id)) if id == tx_key.tx_id => {
-                tx_id_matches = true;
-            }
-            (crate::schema::DB_TX_INSTANT, DataType::Instant(system_time))
-                if system_time == tx_key.system_time =>
-            {
-                instant_matches = true;
-            }
-            _ => {}
-        }
-
-        if tx_id_matches && instant_matches {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
 /// Build datoms for a first-class transaction entity in TX_PARTITION.
 /// The `tx_eid` is the pre-allocated entity ID for this transaction.
 pub(crate) fn build_tx_entity_datoms(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,7 +12,6 @@ use edn::kw;
 use crate::codec::{
     self, decode_datatype, decode_i64, encode_datatype, encode_i64, encode_i64_bytes, Encode,
 };
-use crate::error::TriploxError;
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,6 +12,7 @@ use edn::kw;
 use crate::codec::{
     self, decode_datatype, decode_i64, encode_datatype, encode_i64, encode_i64_bytes, Encode,
 };
+use crate::error::TriploxError;
 use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;
@@ -186,6 +187,46 @@ pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) 
     }
 }
 
+/// Verify that a snapshot contains the exact transaction basis.
+pub async fn tx_basis_exists(snapshot: &Arc<slatedb::DbSnapshot>, basis: &TxBasis) -> Result<bool> {
+    tx_entity_matches_tx_key(snapshot, basis.tx_eid, &basis.tx_key).await
+}
+
+async fn tx_entity_matches_tx_key(
+    snapshot: &Arc<slatedb::DbSnapshot>,
+    tx_eid: i64,
+    tx_key: &TxKey,
+) -> Result<bool> {
+    let mut entity_bytes = Vec::new();
+    encode_datatype(&DataType::Long(tx_eid), &mut entity_bytes);
+    let eav_prefix = concat_bytes(&[&[codec::EAV], entity_bytes.as_slice()]);
+    let mut iter = snapshot
+        .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    let mut tx_id_matches = false;
+    let mut instant_matches = false;
+
+    while let Some(kv) = iter.next().await? {
+        let (_entity, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
+        match (attribute, value) {
+            (crate::schema::DB_TX_ID, DataType::Long(id)) if id == tx_key.tx_id => {
+                tx_id_matches = true;
+            }
+            (crate::schema::DB_TX_INSTANT, DataType::Instant(system_time))
+                if system_time == tx_key.system_time =>
+            {
+                instant_matches = true;
+            }
+            _ => {}
+        }
+
+        if tx_id_matches && instant_matches {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
 /// Build datoms for a first-class transaction entity in TX_PARTITION.
 /// The `tx_eid` is the pre-allocated entity ID for this transaction.
 pub(crate) fn build_tx_entity_datoms(
@@ -619,6 +660,33 @@ impl TxWaiter {
                     // get the notification or the channel will close.
                     continue;
                 }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(anyhow::anyhow!(
+                        "Indexer shutdown while waiting for tx {}",
+                        tx_key.tx_id
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Wait until indexing has reached `tx_key`, regardless of whether that
+    /// transaction committed or aborted.
+    pub async fn await_indexed(mut self, tx_key: TxKey) -> Result<(), Error> {
+        if let Some(latest_basis) = self.latest_tx {
+            if tx_key.tx_id <= latest_basis.tx_key.tx_id {
+                return Ok(());
+            }
+        }
+
+        loop {
+            match self.rx.recv().await {
+                Ok((completed_tx_key, _completed_basis, _result)) => {
+                    if completed_tx_key.tx_id >= tx_key.tx_id {
+                        return Ok(());
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_count)) => continue,
                 Err(broadcast::error::RecvError::Closed) => {
                     return Err(anyhow::anyhow!(
                         "Indexer shutdown while waiting for tx {}",

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -614,6 +614,7 @@ impl TxWaiter {
                     // Keep waiting for higher tx_id
                 }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
+                    // TODO(#282): recover exact tx outcome or fail instead of risking a later tx's result.
                     // Channel overflowed. Just continue waiting - we'll eventually
                     // get the notification or the channel will close.
                     continue;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,10 +1,12 @@
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Error;
 use tokio::runtime::Handle;
 
 use crate::clock;
+use crate::error::TriploxError;
 use crate::file_log::FileLog;
 use crate::indexer::{latest_tx_basis_from_snapshot, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader};
@@ -21,6 +23,8 @@ pub use triplox_client::node::{
     collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, SubmitNode,
 };
 pub use triplox_client::transaction::{TransactionResult, TxBasis, TxKey};
+
+const DB_AS_OF_INDEXING_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct DB {
     snapshot: Arc<slatedb::DbSnapshot>,
@@ -247,6 +251,36 @@ impl<L: TxLog> Node<L> {
         self.subscription.cancel();
         self.slate.db.close().await.unwrap();
     }
+
+    async fn db_as_of_with_timeout(&self, basis: TxBasis, timeout: Duration) -> Result<DB, Error> {
+        let waiter = self.indexer.read().await.tx_waiter();
+        tokio::time::timeout(timeout, waiter.await_indexed(basis.tx_key))
+            .await
+            .map_err(|_| TriploxError::TxIndexingTimeout {
+                tx_id: basis.tx_key.tx_id,
+                timeout,
+            })??;
+
+        let snapshot = self.slate.db.snapshot().await?;
+        let ident_map = self
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .ident_map
+            .clone();
+        let handle = Handle::current();
+        let range_stats = self.slate.range_stats.clone();
+        if !crate::indexer::tx_basis_exists(&snapshot, &basis).await? {
+            return Err(TriploxError::TxNotFound {
+                tx_id: basis.tx_key.tx_id,
+                system_time: basis.tx_key.system_time,
+            }
+            .into());
+        }
+        Ok(DB::new(snapshot, ident_map, handle, basis, range_stats))
+    }
 }
 
 impl<L: TxLog> SubmitNode for Node<L> {
@@ -294,29 +328,20 @@ impl<L: TxLog> QueryNode for Node<L> {
         let range_stats = self.slate.range_stats.clone();
         DB::from_latest_snapshot(snapshot, ident_map, handle, range_stats).await
     }
-    // TODO: we are currently not checking that snapshot contains TxBasis.
     async fn db_as_of(&self, basis: TxBasis) -> Result<DB, Error> {
-        let snapshot = self.slate.db.snapshot().await?;
-        let ident_map = self
-            .indexer
-            .read()
+        self.db_as_of_with_timeout(basis, DB_AS_OF_INDEXING_TIMEOUT)
             .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
-        let handle = Handle::current();
-        let range_stats = self.slate.range_stats.clone();
-        Ok(DB::new(snapshot, ident_map, handle, basis, range_stats))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::time::Duration;
 
     use super::*;
     use crate::clock::st_from_unix_epoch;
+    use crate::error::TriploxError;
     use crate::ops::{DataType, EntityRef, TxOp};
     use crate::partition::{extract_partition, TX_PARTITION};
     use crate::schema::{
@@ -936,6 +961,108 @@ mod tests {
         assert_eq!(result2.len(), 2);
         assert!(result2.contains(&vec![DataType::String("alice".to_string())]));
         assert!(result2.contains(&vec![DataType::String("bob".to_string())]));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_db_as_of_aborted_tx_opens_snapshot() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let basis = match node
+            .execute_tx(vec![TxOp::Add {
+                entity: "e".into(),
+                attribute: kw!(:nonexistent),
+                value: "x".into(),
+            }])
+            .await
+            .unwrap()
+        {
+            TransactionResult::TxAborted(basis, _) => basis,
+            result => panic!("expected aborted tx, got {result:?}"),
+        };
+
+        let db = node.db_as_of(basis).await.unwrap();
+        assert_eq!(*db.tx_basis(), basis);
+
+        let query_str = format!(
+            "[:find ?ident ?error \
+             :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident] [?tx :db/txError ?error]]",
+            basis.tx_key.tx_id
+        );
+        let result = db.query(query_str).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][0], DataType::Keyword(kw!(:db.tx/aborted)));
+        assert!(
+            matches!(&result[0][1], DataType::String(s) if s.contains("nonexistent")),
+            "expected abort error for unknown attribute, got {:?}",
+            result[0][1]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_db_as_of_times_out_for_unindexed_tx() {
+        let node = Node::memory_node().await;
+        let basis = TxBasis {
+            tx_key: TxKey {
+                tx_id: 999,
+                system_time: st_from_unix_epoch(999),
+            },
+            tx_eid: 999,
+        };
+
+        let err = match node
+            .db_as_of_with_timeout(basis, Duration::from_millis(10))
+            .await
+        {
+            Ok(_) => panic!("expected db_as_of timeout"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(
+                err.downcast_ref::<TriploxError>(),
+                Some(TriploxError::TxIndexingTimeout { tx_id: 999, .. })
+            ),
+            "expected TxIndexingTimeout, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_db_as_of_rejects_basis_with_wrong_system_time() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let basis = match node
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
+            .await
+            .unwrap()
+        {
+            TransactionResult::TxCommited(basis) => basis,
+            _ => panic!("expected commit"),
+        };
+        let wrong_basis = TxBasis {
+            tx_key: TxKey {
+                tx_id: basis.tx_key.tx_id,
+                system_time: st_from_unix_epoch(9999),
+            },
+            tx_eid: basis.tx_eid,
+        };
+
+        let err = match node.db_as_of(wrong_basis).await {
+            Ok(_) => panic!("expected db_as_of to reject wrong system_time"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(
+                err.downcast_ref::<TriploxError>(),
+                Some(TriploxError::TxNotFound { tx_id, .. }) if *tx_id == basis.tx_key.tx_id
+            ),
+            "expected TxNotFound, got {err:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/node.rs
+++ b/src/node.rs
@@ -272,13 +272,6 @@ impl<L: TxLog> Node<L> {
             .clone();
         let handle = Handle::current();
         let range_stats = self.slate.range_stats.clone();
-        if !crate::indexer::tx_basis_exists(&snapshot, &basis).await? {
-            return Err(TriploxError::TxNotFound {
-                tx_id: basis.tx_key.tx_id,
-                system_time: basis.tx_key.system_time,
-            }
-            .into());
-        }
         Ok(DB::new(snapshot, ident_map, handle, basis, range_stats))
     }
 }
@@ -1024,44 +1017,6 @@ mod tests {
                 Some(TriploxError::TxIndexingTimeout { tx_id: 999, .. })
             ),
             "expected TxIndexingTimeout, got {err:?}"
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_db_as_of_rejects_basis_with_wrong_system_time() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-
-        let basis = match node
-            .execute_tx(vec![TxOp::Add {
-                entity: "alice".into(),
-                attribute: kw!(:name),
-                value: "alice".into(),
-            }])
-            .await
-            .unwrap()
-        {
-            TransactionResult::TxCommited(basis) => basis,
-            _ => panic!("expected commit"),
-        };
-        let wrong_basis = TxBasis {
-            tx_key: TxKey {
-                tx_id: basis.tx_key.tx_id,
-                system_time: st_from_unix_epoch(9999),
-            },
-            tx_eid: basis.tx_eid,
-        };
-
-        let err = match node.db_as_of(wrong_basis).await {
-            Ok(_) => panic!("expected db_as_of to reject wrong system_time"),
-            Err(err) => err,
-        };
-        assert!(
-            matches!(
-                err.downcast_ref::<TriploxError>(),
-                Some(TriploxError::TxNotFound { tx_id, .. }) if *tx_id == basis.tx_key.tx_id
-            ),
-            "expected TxNotFound, got {err:?}"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Error, Result};
+use anyhow::{Error, Result};
 use axum::body::Bytes;
 use axum::extract::{DefaultBodyLimit, Path, State};
 use axum::http::StatusCode;
@@ -51,6 +51,12 @@ use triplox_client::transaction::{TxBasis, TxKey};
 // ---------------------------------------------------------------------------
 
 const MAX_OPEN_DBS: usize = 1024;
+
+#[derive(Debug, thiserror::Error)]
+enum OpenDbError {
+    #[error("Too many open DB snapshots (max {max})")]
+    TooManyOpenDbs { max: usize },
+}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct DbCacheKey {
@@ -103,7 +109,7 @@ impl DbCache {
                 return Ok(entry.db.clone());
             }
             if entries.len() >= MAX_OPEN_DBS {
-                bail!("Too many open DB snapshots (max {})", MAX_OPEN_DBS);
+                return Err(OpenDbError::TooManyOpenDbs { max: MAX_OPEN_DBS }.into());
             }
         }
 
@@ -116,7 +122,7 @@ impl DbCache {
             return Ok(entry.db.clone());
         }
         if entries.len() >= MAX_OPEN_DBS {
-            bail!("Too many open DB snapshots (max {})", MAX_OPEN_DBS);
+            return Err(OpenDbError::TooManyOpenDbs { max: MAX_OPEN_DBS }.into());
         }
         entries.insert(
             key,
@@ -314,7 +320,10 @@ fn open_db_error(e: Error) -> ApiError {
         Some(TriploxError::TxIndexingTimeout { .. }) => {
             ApiError::new(StatusCode::CONFLICT, ErrorCode::TxNotIndexed, message)
         }
-        _ => ApiError::internal(ErrorCode::TooManyOpenDbs, message),
+        _ if e.downcast_ref::<OpenDbError>().is_some() => {
+            ApiError::internal(ErrorCode::TooManyOpenDbs, message)
+        }
+        _ => ApiError::internal(ErrorCode::InternalError, message),
     }
 }
 
@@ -370,7 +379,7 @@ async fn open_db<L: TxLog + 'static>(
                 .handle_store
                 .open(conn_id.0, cache_key, || async move { Ok(db) })
                 .await
-                .map_err(|e| ApiError::internal(ErrorCode::TooManyOpenDbs, e.to_string()))?;
+                .map_err(open_db_error)?;
             (db_id, tx_id)
         }
         (Some(tid), Some(system_time), Some(tx_eid)) => {
@@ -747,5 +756,19 @@ async fn serve_connection(
             conn.as_mut().graceful_shutdown();
             let _ = conn.await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_db_error_maps_only_capacity_to_too_many_open_dbs() {
+        let capacity = open_db_error(OpenDbError::TooManyOpenDbs { max: 1 }.into());
+        assert_eq!(capacity.code, ErrorCode::TooManyOpenDbs);
+
+        let internal = open_db_error(anyhow::anyhow!("storage unavailable"));
+        assert_eq!(internal.code, ErrorCode::InternalError);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -314,9 +314,6 @@ fn open_db_error(e: Error) -> ApiError {
         Some(TriploxError::TxIndexingTimeout { .. }) => {
             ApiError::new(StatusCode::CONFLICT, ErrorCode::TxNotIndexed, message)
         }
-        Some(TriploxError::TxNotFound { .. }) => {
-            ApiError::not_found(ErrorCode::TxNotIndexed, message)
-        }
         _ => ApiError::internal(ErrorCode::TooManyOpenDbs, message),
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -758,17 +758,3 @@ async fn serve_connection(
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn open_db_error_maps_only_capacity_to_too_many_open_dbs() {
-        let capacity = open_db_error(OpenDbError::TooManyOpenDbs { max: 1 }.into());
-        assert_eq!(capacity.code, ErrorCode::TooManyOpenDbs);
-
-        let internal = open_db_error(anyhow::anyhow!("storage unavailable"));
-        assert_eq!(internal.code, ErrorCode::InternalError);
-    }
-}

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Error, Result};
 use axum::body::Bytes;
 use axum::extract::{DefaultBodyLimit, Path, State};
 use axum::http::StatusCode;
@@ -28,6 +28,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::error::TriploxError;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
 use hyper_util::service::TowerToHyperService;
@@ -51,8 +52,25 @@ use triplox_client::transaction::{TxBasis, TxKey};
 
 const MAX_OPEN_DBS: usize = 1024;
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct DbCacheKey {
+    tx_id: i64,
+    system_time: crate::clock::Instant,
+    tx_eid: i64,
+}
+
+impl From<TxBasis> for DbCacheKey {
+    fn from(basis: TxBasis) -> Self {
+        DbCacheKey {
+            tx_id: basis.tx_key.tx_id,
+            system_time: basis.tx_key.system_time,
+            tx_eid: basis.tx_eid,
+        }
+    }
+}
+
 /// A shared, reference-counted cache of DB snapshots.
-/// Keyed by tx_id (the point-in-time identifier for the snapshot).
+/// Keyed by the full TxBasis so stale basis values cannot alias a valid snapshot.
 /// DBs are read-only and safe to share across connections.
 struct DbCacheEntry {
     db: Arc<DB>,
@@ -60,7 +78,7 @@ struct DbCacheEntry {
 }
 
 pub(crate) struct DbCache {
-    entries: RwLock<HashMap<i64, DbCacheEntry>>,
+    entries: RwLock<HashMap<DbCacheKey, DbCacheEntry>>,
 }
 
 impl DbCache {
@@ -70,9 +88,9 @@ impl DbCache {
         }
     }
 
-    /// Get or create a DB snapshot for the given tx_id.
+    /// Get or create a DB snapshot for the given TxKey.
     /// The `create` future is only evaluated on cache miss.
-    pub(crate) async fn acquire<F, Fut>(&self, tx_id: i64, create: F) -> Result<Arc<DB>>
+    async fn acquire<F, Fut>(&self, key: DbCacheKey, create: F) -> Result<Arc<DB>>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<DB>>,
@@ -80,7 +98,7 @@ impl DbCache {
         // Fast path: cache hit (uses write lock because we mutate refcount)
         {
             let mut entries = self.entries.write().await;
-            if let Some(entry) = entries.get_mut(&tx_id) {
+            if let Some(entry) = entries.get_mut(&key) {
                 entry.refcount += 1;
                 return Ok(entry.db.clone());
             }
@@ -93,7 +111,7 @@ impl DbCache {
         let arc_db = Arc::new(db);
 
         let mut entries = self.entries.write().await;
-        if let Some(entry) = entries.get_mut(&tx_id) {
+        if let Some(entry) = entries.get_mut(&key) {
             entry.refcount += 1;
             return Ok(entry.db.clone());
         }
@@ -101,7 +119,7 @@ impl DbCache {
             bail!("Too many open DB snapshots (max {})", MAX_OPEN_DBS);
         }
         entries.insert(
-            tx_id,
+            key,
             DbCacheEntry {
                 db: arc_db.clone(),
                 refcount: 1,
@@ -112,12 +130,12 @@ impl DbCache {
 
     /// Release a reference to a DB snapshot.
     /// Evicts the entry when refcount reaches 0.
-    pub(crate) async fn release(&self, tx_id: i64) {
+    async fn release(&self, key: DbCacheKey) {
         let mut entries = self.entries.write().await;
-        if let Some(entry) = entries.get_mut(&tx_id) {
+        if let Some(entry) = entries.get_mut(&key) {
             entry.refcount -= 1;
             if entry.refcount == 0 {
-                entries.remove(&tx_id);
+                entries.remove(&key);
             }
         }
     }
@@ -129,7 +147,7 @@ impl DbCache {
 
 struct HandleEntry {
     conn_id: u64,
-    tx_id: i64,
+    cache_key: DbCacheKey,
     db: Arc<DB>,
     last_used: Instant,
 }
@@ -150,19 +168,19 @@ impl HandleStore {
     }
 
     /// Acquire a DB snapshot via the cache and allocate a handle for it.
-    async fn open<F, Fut>(&self, conn_id: u64, tx_id: i64, create: F) -> Result<u32>
+    async fn open<F, Fut>(&self, conn_id: u64, cache_key: DbCacheKey, create: F) -> Result<u32>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<DB>>,
     {
-        let db = self.db_cache.acquire(tx_id, create).await?;
+        let db = self.db_cache.acquire(cache_key, create).await?;
         let db_id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut handles = self.handles.write().await;
         handles.insert(
             db_id,
             HandleEntry {
                 conn_id,
-                tx_id,
+                cache_key,
                 db,
                 last_used: Instant::now(),
             },
@@ -184,21 +202,21 @@ impl HandleStore {
     /// Remove a handle and release its DbCache refcount. Returns true if the
     /// handle existed.
     async fn remove(&self, db_id: u32) -> bool {
-        let tx_id = {
+        let cache_key = {
             let mut handles = self.handles.write().await;
             match handles.remove(&db_id) {
-                Some(entry) => entry.tx_id,
+                Some(entry) => entry.cache_key,
                 None => return false,
             }
         };
-        self.db_cache.release(tx_id).await;
+        self.db_cache.release(cache_key).await;
         true
     }
 
     /// Remove all handles belonging to a connection, releasing their DbCache
     /// refcounts.
     async fn remove_by_conn(&self, conn_id: u64) {
-        let tx_ids: Vec<i64> = {
+        let cache_keys: Vec<DbCacheKey> = {
             let mut handles = self.handles.write().await;
             let to_remove: Vec<u32> = handles
                 .iter()
@@ -207,18 +225,18 @@ impl HandleStore {
                 .collect();
             to_remove
                 .into_iter()
-                .filter_map(|id| handles.remove(&id).map(|e| e.tx_id))
+                .filter_map(|id| handles.remove(&id).map(|e| e.cache_key))
                 .collect()
         };
-        for tx_id in tx_ids {
-            self.db_cache.release(tx_id).await;
+        for cache_key in cache_keys {
+            self.db_cache.release(cache_key).await;
         }
     }
 
     /// Remove handles idle for longer than `ttl`, releasing their DbCache
     /// refcounts.
     async fn reap_expired(&self, ttl: Duration) {
-        let tx_ids: Vec<i64> = {
+        let cache_keys: Vec<DbCacheKey> = {
             let mut handles = self.handles.write().await;
             let now = Instant::now();
             let to_remove: Vec<u32> = handles
@@ -228,11 +246,11 @@ impl HandleStore {
                 .collect();
             to_remove
                 .into_iter()
-                .filter_map(|id| handles.remove(&id).map(|e| e.tx_id))
+                .filter_map(|id| handles.remove(&id).map(|e| e.cache_key))
                 .collect()
         };
-        for tx_id in tx_ids {
-            self.db_cache.release(tx_id).await;
+        for cache_key in cache_keys {
+            self.db_cache.release(cache_key).await;
         }
     }
 }
@@ -290,6 +308,19 @@ impl ApiError {
     }
 }
 
+fn open_db_error(e: Error) -> ApiError {
+    let message = e.to_string();
+    match e.downcast_ref::<TriploxError>() {
+        Some(TriploxError::TxIndexingTimeout { .. }) => {
+            ApiError::new(StatusCode::CONFLICT, ErrorCode::TxNotIndexed, message)
+        }
+        Some(TriploxError::TxNotFound { .. }) => {
+            ApiError::not_found(ErrorCode::TxNotIndexed, message)
+        }
+        _ => ApiError::internal(ErrorCode::TooManyOpenDbs, message),
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let body = encode_error_body(&ErrorResponseBody {
@@ -337,9 +368,10 @@ async fn open_db<L: TxLog + 'static>(
                 .await
                 .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
             let tx_id = db.tx_key().tx_id;
+            let cache_key = (*db.tx_basis()).into();
             let db_id = state
                 .handle_store
-                .open(conn_id.0, tx_id, || async move { Ok(db) })
+                .open(conn_id.0, cache_key, || async move { Ok(db) })
                 .await
                 .map_err(|e| ApiError::internal(ErrorCode::TooManyOpenDbs, e.to_string()))?;
             (db_id, tx_id)
@@ -355,9 +387,11 @@ async fn open_db<L: TxLog + 'static>(
             let node = state.node.clone();
             let db_id = state
                 .handle_store
-                .open(conn_id.0, tid, || async move { node.db_as_of(basis).await })
+                .open(conn_id.0, basis.into(), || async move {
+                    node.db_as_of(basis).await
+                })
                 .await
-                .map_err(|e| ApiError::internal(ErrorCode::TooManyOpenDbs, e.to_string()))?;
+                .map_err(open_db_error)?;
             (db_id, tid)
         }
         _ => {

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -11,7 +11,7 @@ use triplox::node::{Database, Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, EntityRef, TxOp};
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
-use triplox::TransactionResult;
+use triplox::{TransactionResult, TxBasis, TxKey};
 
 async fn define_base_schema(client: &ClientNode) {
     let result = client.execute_tx(test_schema_tx()).await.unwrap();
@@ -307,6 +307,47 @@ async fn test_db_as_of() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
+
+    db.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_as_of_rejects_wrong_system_time_after_cache_hit() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+
+    let basis = match client
+        .execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap()
+    {
+        TransactionResult::TxCommited(basis) => basis,
+        _ => panic!("Expected TxCommited"),
+    };
+
+    let db = client.db_as_of(basis).await.unwrap();
+    let wrong_basis = TxBasis {
+        tx_key: TxKey {
+            tx_id: basis.tx_key.tx_id,
+            system_time: chrono::Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap(),
+        },
+        tx_eid: basis.tx_eid,
+    };
+
+    let err = match client.db_as_of(wrong_basis).await {
+        Ok(_) => panic!("expected db_as_of to reject wrong system_time"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string().contains("code 3002"),
+        "expected TxNotIndexed error, got {err}"
+    );
 
     db.close().await.unwrap();
     token.cancel();

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -312,47 +312,6 @@ async fn test_db_as_of() {
     token.cancel();
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_db_as_of_rejects_wrong_system_time_after_cache_hit() {
-    let (addr, token) = start_test_server().await;
-    let client = ClientNode::connect(&addr).await.unwrap();
-    define_base_schema(&client).await;
-
-    let basis = match client
-        .execute_tx(vec![TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "alice".into(),
-        }])
-        .await
-        .unwrap()
-    {
-        TransactionResult::TxCommited(basis) => basis,
-        _ => panic!("Expected TxCommited"),
-    };
-
-    let db = client.db_as_of(basis).await.unwrap();
-    let wrong_basis = TxBasis {
-        tx_key: TxKey {
-            tx_id: basis.tx_key.tx_id,
-            system_time: chrono::Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap(),
-        },
-        tx_eid: basis.tx_eid,
-    };
-
-    let err = match client.db_as_of(wrong_basis).await {
-        Ok(_) => panic!("expected db_as_of to reject wrong system_time"),
-        Err(err) => err,
-    };
-    assert!(
-        err.to_string().contains("code 3002"),
-        "expected TxNotIndexed error, got {err}"
-    );
-
-    db.close().await.unwrap();
-    token.cancel();
-}
-
 // ---------------------------------------------------------------------------
 // DevServer tests
 // ---------------------------------------------------------------------------

--- a/triplox-client/src/protocol.rs
+++ b/triplox-client/src/protocol.rs
@@ -79,6 +79,7 @@ pub enum ErrorCode {
     // Transaction errors (3xxx)
     TxError = 3000,
     TxAborted = 3001,
+    TxNotIndexed = 3002,
     // Internal/protocol errors (4xxx)
     InternalError = 4000,
     MessageTooLarge = 4001,
@@ -101,6 +102,7 @@ impl ErrorCode {
             2003 => Ok(ErrorCode::EmptyQuery),
             3000 => Ok(ErrorCode::TxError),
             3001 => Ok(ErrorCode::TxAborted),
+            3002 => Ok(ErrorCode::TxNotIndexed),
             4000 => Ok(ErrorCode::InternalError),
             4001 => Ok(ErrorCode::MessageTooLarge),
             4002 => Ok(ErrorCode::InvalidMessageType),
@@ -149,5 +151,16 @@ pub fn data_type_tag(dt: &DataType) -> u8 {
         DataType::Uuid(_) => TAG_UUID,
         DataType::Vector(_) => TAG_VECTOR,
         DataType::Map(_) => TAG_MAP,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tx_not_indexed_error_code_round_trips() {
+        assert_eq!(ErrorCode::TxNotIndexed.as_u16(), 3002);
+        assert_eq!(ErrorCode::from_u16(3002).unwrap(), ErrorCode::TxNotIndexed);
     }
 }

--- a/triplox-client/src/protocol.rs
+++ b/triplox-client/src/protocol.rs
@@ -153,14 +153,3 @@ pub fn data_type_tag(dt: &DataType) -> u8 {
         DataType::Map(_) => TAG_MAP,
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tx_not_indexed_error_code_round_trips() {
-        assert_eq!(ErrorCode::TxNotIndexed.as_u16(), 3002);
-        assert_eq!(ErrorCode::from_u16(3002).unwrap(), ErrorCode::TxNotIndexed);
-    }
-}


### PR DESCRIPTION
## Summary

- make `db_as_of(tx_key)` wait for the requested transaction to be indexed before snapshotting
- validate as-of lookups against the full `TxKey` (`tx_id` + `system_time`)
- add `TxNotIndexed = 3002` and map `/db/open` indexing wait failures to it
- key server DB snapshot cache by full `TxKey` to avoid stale system-time aliasing

## Tests

- `cargo fmt`
- `cargo test -p triplox test_db_as_of_rejects_wrong_system_time_after_cache_hit`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
