### PR TITLE
Refactor server DB handles to TxBasis

### DIFF
--- a/design/ENCODING.md
+++ b/design/ENCODING.md
@@ -74,7 +74,7 @@ Structural fields with fixed schemas (e.g., entity IDs, attribute IDs) are **not
 
 ### 2.6 Type Tag Values
 
-Reuse the wire protocol tags from `design/WIRE_PROTOCOL.md`:
+Reuse the wire protocol tags from `design/PROTOCOL.md`:
 
 | Tag | Name                                                             | Rust Type                      |
 |-----|------------------------------------------------------------------|--------------------------------|

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -74,9 +74,9 @@ Each transaction is reified as an entity in this partition. The transaction enti
 | `db/txId`       | long       | The sequential tx_id assigned by the log                       |
 | `db/txError`    | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
 
-A transaction with counter value `t` has entity ID `(1 << 42) | t`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
+A transaction with counter value `t` has entity ID `(1 << 42) | t`. This transaction entity ID is the temporal read basis (`tx_eid`) used to bound historical reads: a DB opened at a given basis sees datoms whose transaction entity is at or before that `tx_eid`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
 
-Note: the relationship between `db/txId` (the sequential log position) and the transaction entity's entity ID (partition 1, counter T) is not yet unified. In the future we may align these so that the log tx_id and the entity ID counter share the same value.
+Note: `db/txId` remains the sequential log position, while `tx_eid` is the transaction entity ID used by covering indices and temporal reads. They are related but intentionally distinct identifiers.
 
 ### 2.3 :db.part/user (partition 2)
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -43,23 +43,27 @@ outcome.
 | **200** | Success             | Request processed successfully. For `/tx/execute`, check the `status` field of the TxResult body: `0` = committed, `1` = aborted. |
 | **400** | Bad Request         | Malformed request body (decode failure), Datalog parse error, or invalid field combinations. |
 | **404** | Not Found           | Invalid or expired `db_id` handle. |
-| **500** | Internal Server Error | Unexpected engine error: query execution failure, transaction infrastructure error, DB cache exhaustion. |
+| **500** | Internal Server Error | Unexpected engine error: query execution failure, transaction infrastructure error, or open DB handle exhaustion. |
 
 All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body) body.
 
 ### 1.2 DB Handle Lifecycle
 
-DB handles are scoped to an HTTP/2 connection. Each connection is assigned a
-unique `conn_id` on accept, and all handles opened on that connection are
-tracked against it. Two cleanup mechanisms ensure handles are released:
+DB handles are scoped to an HTTP/2 connection. Each `db_id` maps to a
+transaction basis: the transaction log key (`tx_id` + `system_time`) plus the
+transaction entity ID (`tx_eid`) that bounds temporal reads. The server does
+not cache DB snapshots for handles; it creates transient read views from the
+stored basis when queries execute. Each connection is assigned a unique
+`conn_id` on accept, and all handles opened on that connection are tracked
+against it. Two cleanup mechanisms ensure handles are released:
 
 1. **Connection-drop** (fast path): When an HTTP/2 connection closes, all
    handles belonging to that connection are released immediately.
 2. **TTL reaper** (safety net): A background task periodically evicts handles
    that have not been used for 24 hours.
 
-Servers should enforce a configurable maximum number of open DB handles per
-connection (default 16). Exceeding the limit returns
+Servers should enforce a configurable maximum number of open DB handles
+(default 1024). Exceeding the limit returns
 `ErrorResponse(code=5001 TooManyOpenDbs)`.
 
 Using an invalid or closed `db_id` returns
@@ -201,20 +205,20 @@ than a single-member union.
 ### 4.2 OpenDb Request — `POST /db/open`
 
 ```
-{"tx_id": <int>|nil, "system_time": <Timestamp>|nil}
+{"tx_id": <int>|nil, "system_time": <Timestamp>|nil, "tx_eid": <int>|nil}
 ```
 
-Either both fields are present (pinned snapshot) or both are `nil` (latest
-indexed). Mixing `nil` with a value is rejected with HTTP 400.
+Either all three fields are present (pinned transaction basis) or all three are
+`nil` (latest indexed). Mixing `nil` with a value is rejected with HTTP 400.
 
 ### 4.3 DbOpened Response
 
 ```
-{"db_id": <int>, "tx_id": <int>}
+{"db_id": <int>, "tx_eid": <int>}
 ```
 
-`db_id` is a server-assigned u32 handle. `tx_id` is the actual tx the snapshot
-is pinned to (may differ from the requested `tx_id`).
+`db_id` is a server-assigned u32 handle. `tx_eid` is the transaction entity ID
+that bounds reads through that handle.
 
 ### 4.4 DbClosed Response — `DELETE /db/{db_id}`
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -43,7 +43,7 @@ outcome.
 | **200** | Success             | Request processed successfully. For `/tx/execute`, check the `status` field of the TxResult body: `0` = committed, `1` = aborted. |
 | **400** | Bad Request         | Malformed request body (decode failure), Datalog parse error, or invalid field combinations. |
 | **404** | Not Found           | Invalid or expired `db_id` handle. |
-| **500** | Internal Server Error | Unexpected engine error: query execution failure, transaction infrastructure error, or open DB handle exhaustion. |
+| **500** | Internal Server Error | Unexpected engine error: query execution failure or transaction infrastructure error. |
 
 All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body) body.
 
@@ -61,10 +61,6 @@ against it. Two cleanup mechanisms ensure handles are released:
    handles belonging to that connection are released immediately.
 2. **TTL reaper** (safety net): A background task periodically evicts handles
    that have not been used for 24 hours.
-
-Servers should enforce a configurable maximum number of open DB handles
-(default 1024). Exceeding the limit returns
-`ErrorResponse(code=5001 TooManyOpenDbs)`.
 
 Using an invalid or closed `db_id` returns
 `ErrorResponse(code=5000 InvalidDbHandle)` with HTTP status 404.
@@ -308,7 +304,7 @@ a numeric error code (see §5).
 | 2xxx  | Query errors          | 2000 ParseError, 2001 QueryError, 2002 InvalidQuery, 2003 EmptyQuery |
 | 3xxx  | Transaction errors    | 3000 TxError, 3001 TxAborted, 3002 TxNotIndexed                    |
 | 4xxx  | Internal/protocol     | 4000 InternalError, 4001 MessageTooLarge, 4002 InvalidMessageType, 4003 QueryCancelled, 4004 ServerShuttingDown |
-| 5xxx  | DB handle errors      | 5000 InvalidDbHandle, 5001 TooManyOpenDbs                          |
+| 5xxx  | DB handle errors      | 5000 InvalidDbHandle                                                |
 
 ---
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -239,11 +239,7 @@ async fn open_db<L: TxLog + 'static>(
                 },
                 tx_eid,
             };
-            state
-                .node
-                .db_as_of(basis)
-                .await
-                .map_err(open_db_error)?;
+            state.node.db_as_of(basis).await.map_err(open_db_error)?;
             let db_id = state
                 .handle_store
                 .open(conn_id.0, basis)

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,8 +3,8 @@
 //! Replaces the custom TCP wire protocol with HTTP/2 transport while keeping
 //! the same binary payload encoding. Each operation maps to an HTTP endpoint:
 //!
-//! - `POST /db/open`           — Open a DB snapshot
-//! - `DELETE /db/{db_id}`      — Release a DB snapshot
+//! - `POST /db/open`           — Open a DB read handle
+//! - `DELETE /db/{db_id}`      — Release a DB read handle
 //! - `POST /db/{db_id}/query`  — Execute a Datalog query
 //! - `POST /tx/submit`         — Submit a fire-and-forget transaction
 //! - `POST /tx/execute`        — Execute a transaction and wait for indexing
@@ -28,13 +28,13 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::error::TriploxError;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
 use hyper_util::service::TowerToHyperService;
 
+use crate::error::TriploxError;
 use crate::log::TxLog;
-use crate::node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult, DB};
+use crate::node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult};
 use triplox_client::msgpack_codec::{
     decode_execute_request, decode_open_db_request, decode_query_request,
     encode_db_closed_response, encode_db_opened_response, encode_error_body, encode_query_response,
@@ -47,147 +47,37 @@ use triplox_client::protocol::{
 use triplox_client::transaction::{TxBasis, TxKey};
 
 // ---------------------------------------------------------------------------
-// DB Cache
-// ---------------------------------------------------------------------------
-
-const MAX_OPEN_DBS: usize = 1024;
-
-#[derive(Debug, thiserror::Error)]
-enum OpenDbError {
-    #[error("Too many open DB snapshots (max {max})")]
-    TooManyOpenDbs { max: usize },
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct DbCacheKey {
-    tx_id: i64,
-    system_time: crate::clock::Instant,
-    tx_eid: i64,
-}
-
-impl From<TxBasis> for DbCacheKey {
-    fn from(basis: TxBasis) -> Self {
-        DbCacheKey {
-            tx_id: basis.tx_key.tx_id,
-            system_time: basis.tx_key.system_time,
-            tx_eid: basis.tx_eid,
-        }
-    }
-}
-
-/// A shared, reference-counted cache of DB snapshots.
-/// Keyed by the full TxBasis so stale basis values cannot alias a valid snapshot.
-/// DBs are read-only and safe to share across connections.
-struct DbCacheEntry {
-    db: Arc<DB>,
-    refcount: usize,
-}
-
-pub(crate) struct DbCache {
-    entries: RwLock<HashMap<DbCacheKey, DbCacheEntry>>,
-}
-
-impl DbCache {
-    pub(crate) fn new() -> Self {
-        DbCache {
-            entries: RwLock::new(HashMap::new()),
-        }
-    }
-
-    /// Get or create a DB snapshot for the given TxKey.
-    /// The `create` future is only evaluated on cache miss.
-    async fn acquire<F, Fut>(&self, key: DbCacheKey, create: F) -> Result<Arc<DB>>
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Result<DB>>,
-    {
-        // Fast path: cache hit (uses write lock because we mutate refcount)
-        {
-            let mut entries = self.entries.write().await;
-            if let Some(entry) = entries.get_mut(&key) {
-                entry.refcount += 1;
-                return Ok(entry.db.clone());
-            }
-            if entries.len() >= MAX_OPEN_DBS {
-                return Err(OpenDbError::TooManyOpenDbs { max: MAX_OPEN_DBS }.into());
-            }
-        }
-
-        let db = create().await?;
-        let arc_db = Arc::new(db);
-
-        let mut entries = self.entries.write().await;
-        if let Some(entry) = entries.get_mut(&key) {
-            entry.refcount += 1;
-            return Ok(entry.db.clone());
-        }
-        if entries.len() >= MAX_OPEN_DBS {
-            return Err(OpenDbError::TooManyOpenDbs { max: MAX_OPEN_DBS }.into());
-        }
-        entries.insert(
-            key,
-            DbCacheEntry {
-                db: arc_db.clone(),
-                refcount: 1,
-            },
-        );
-        Ok(arc_db)
-    }
-
-    /// Release a reference to a DB snapshot.
-    /// Evicts the entry when refcount reaches 0.
-    async fn release(&self, key: DbCacheKey) {
-        let mut entries = self.entries.write().await;
-        if let Some(entry) = entries.get_mut(&key) {
-            entry.refcount -= 1;
-            if entry.refcount == 0 {
-                entries.remove(&key);
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Handle Store
 // ---------------------------------------------------------------------------
 
 struct HandleEntry {
     conn_id: u64,
-    cache_key: DbCacheKey,
-    db: Arc<DB>,
+    basis: TxBasis,
     last_used: Instant,
 }
 
 struct HandleStore {
     handles: RwLock<HashMap<u32, HandleEntry>>,
     next_id: AtomicU32,
-    db_cache: Arc<DbCache>,
 }
 
 impl HandleStore {
-    fn new(db_cache: Arc<DbCache>) -> Self {
+    fn new() -> Self {
         HandleStore {
             handles: RwLock::new(HashMap::new()),
             next_id: AtomicU32::new(1),
-            db_cache,
         }
     }
 
-    /// Acquire a DB snapshot via the cache and allocate a handle for it.
-    async fn open<F, Fut>(&self, conn_id: u64, cache_key: DbCacheKey, create: F) -> Result<u32>
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Result<DB>>,
-    {
-        let db = self.db_cache.acquire(cache_key, create).await?;
+    /// Allocate a DB read handle for a transaction basis.
+    async fn open(&self, conn_id: u64, basis: TxBasis) -> Result<u32> {
         let db_id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut handles = self.handles.write().await;
         handles.insert(
             db_id,
             HandleEntry {
                 conn_id,
-                cache_key,
-                db,
+                basis,
                 last_used: Instant::now(),
             },
         );
@@ -195,69 +85,32 @@ impl HandleStore {
     }
 
     // TODO(P1): Validate conn_id in get_db/remove so global db_ids cannot cross connection boundaries.
-    async fn get_db(&self, db_id: u32) -> Option<Arc<DB>> {
+    async fn get_basis(&self, db_id: u32) -> Option<TxBasis> {
         let mut handles = self.handles.write().await;
         if let Some(entry) = handles.get_mut(&db_id) {
             entry.last_used = Instant::now();
-            Some(entry.db.clone())
+            Some(entry.basis)
         } else {
             None
         }
     }
 
-    /// Remove a handle and release its DbCache refcount. Returns true if the
-    /// handle existed.
+    /// Remove a handle. Returns true if the handle existed.
     async fn remove(&self, db_id: u32) -> bool {
-        let cache_key = {
-            let mut handles = self.handles.write().await;
-            match handles.remove(&db_id) {
-                Some(entry) => entry.cache_key,
-                None => return false,
-            }
-        };
-        self.db_cache.release(cache_key).await;
-        true
+        self.handles.write().await.remove(&db_id).is_some()
     }
 
-    /// Remove all handles belonging to a connection, releasing their DbCache
-    /// refcounts.
+    /// Remove all handles belonging to a connection.
     async fn remove_by_conn(&self, conn_id: u64) {
-        let cache_keys: Vec<DbCacheKey> = {
-            let mut handles = self.handles.write().await;
-            let to_remove: Vec<u32> = handles
-                .iter()
-                .filter(|(_, e)| e.conn_id == conn_id)
-                .map(|(id, _)| *id)
-                .collect();
-            to_remove
-                .into_iter()
-                .filter_map(|id| handles.remove(&id).map(|e| e.cache_key))
-                .collect()
-        };
-        for cache_key in cache_keys {
-            self.db_cache.release(cache_key).await;
-        }
+        let mut handles = self.handles.write().await;
+        handles.retain(|_, entry| entry.conn_id != conn_id);
     }
 
-    /// Remove handles idle for longer than `ttl`, releasing their DbCache
-    /// refcounts.
+    /// Remove handles idle for longer than `ttl`.
     async fn reap_expired(&self, ttl: Duration) {
-        let cache_keys: Vec<DbCacheKey> = {
-            let mut handles = self.handles.write().await;
-            let now = Instant::now();
-            let to_remove: Vec<u32> = handles
-                .iter()
-                .filter(|(_, e)| now.duration_since(e.last_used) > ttl)
-                .map(|(id, _)| *id)
-                .collect();
-            to_remove
-                .into_iter()
-                .filter_map(|id| handles.remove(&id).map(|e| e.cache_key))
-                .collect()
-        };
-        for cache_key in cache_keys {
-            self.db_cache.release(cache_key).await;
-        }
+        let mut handles = self.handles.write().await;
+        let now = Instant::now();
+        handles.retain(|_, entry| now.duration_since(entry.last_used) <= ttl);
     }
 }
 
@@ -320,9 +173,6 @@ fn open_db_error(e: Error) -> ApiError {
         Some(TriploxError::TxIndexingTimeout { .. }) => {
             ApiError::new(StatusCode::CONFLICT, ErrorCode::TxNotIndexed, message)
         }
-        _ if e.downcast_ref::<OpenDbError>().is_some() => {
-            ApiError::internal(ErrorCode::TooManyOpenDbs, message)
-        }
         _ => ApiError::internal(ErrorCode::InternalError, message),
     }
 }
@@ -362,7 +212,7 @@ async fn open_db<L: TxLog + 'static>(
         )
     })?;
 
-    let (db_id, tx_id) = match (
+    let (db_id, tx_eid) = match (
         open_request.tx_id,
         open_request.system_time,
         open_request.tx_eid,
@@ -373,14 +223,13 @@ async fn open_db<L: TxLog + 'static>(
                 .db()
                 .await
                 .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-            let tx_id = db.tx_key().tx_id;
-            let cache_key = (*db.tx_basis()).into();
+            let basis = *db.tx_basis();
             let db_id = state
                 .handle_store
-                .open(conn_id.0, cache_key, || async move { Ok(db) })
+                .open(conn_id.0, basis)
                 .await
-                .map_err(open_db_error)?;
-            (db_id, tx_id)
+                .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
+            (db_id, basis.tx_eid)
         }
         (Some(tid), Some(system_time), Some(tx_eid)) => {
             let basis = TxBasis {
@@ -390,15 +239,17 @@ async fn open_db<L: TxLog + 'static>(
                 },
                 tx_eid,
             };
-            let node = state.node.clone();
-            let db_id = state
-                .handle_store
-                .open(conn_id.0, basis.into(), || async move {
-                    node.db_as_of(basis).await
-                })
+            state
+                .node
+                .db_as_of(basis)
                 .await
                 .map_err(open_db_error)?;
-            (db_id, tid)
+            let db_id = state
+                .handle_store
+                .open(conn_id.0, basis)
+                .await
+                .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
+            (db_id, tx_eid)
         }
         _ => {
             return Err(ApiError::bad_request(
@@ -408,7 +259,7 @@ async fn open_db<L: TxLog + 'static>(
         }
     };
 
-    let body = encode_db_opened_response(&DbOpenedResponse { db_id, tx_id })
+    let body = encode_db_opened_response(&DbOpenedResponse { db_id, tx_eid })
         .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
     Ok(ok_response(body))
 }
@@ -434,12 +285,17 @@ async fn query<L: TxLog + 'static>(
     Path(db_id): Path<u32>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
-    let db = state.handle_store.get_db(db_id).await.ok_or_else(|| {
+    let basis = state.handle_store.get_basis(db_id).await.ok_or_else(|| {
         ApiError::not_found(
             ErrorCode::InvalidDbHandle,
             format!("Invalid DB handle: {}", db_id),
         )
     })?;
+    let db = state
+        .node
+        .db_as_of(basis)
+        .await
+        .map_err(|e| ApiError::internal(ErrorCode::QueryError, e.to_string()))?;
 
     let query_request = decode_query_request(&body).map_err(|e| {
         ApiError::bad_request(
@@ -566,8 +422,7 @@ pub struct Server<L: TxLog> {
 
 impl<L: TxLog + 'static> Server<L> {
     pub fn new(node: Arc<Node<L>>) -> Self {
-        let db_cache = Arc::new(DbCache::new());
-        let handle_store = Arc::new(HandleStore::new(db_cache));
+        let handle_store = Arc::new(HandleStore::new());
         Server { node, handle_store }
     }
 
@@ -645,8 +500,7 @@ impl DevServer {
             move |stream, _peer, conn_id, conn_token, join_set| {
                 join_set.spawn(async move {
                     let node = Arc::new(Node::memory_node().await);
-                    let db_cache = Arc::new(DbCache::new());
-                    let handle_store = Arc::new(HandleStore::new(db_cache));
+                    let handle_store = Arc::new(HandleStore::new());
 
                     let app_state = Arc::new(Server {
                         node: node.clone(),

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -180,7 +180,7 @@ async fn test_open_close_multiple_dbs() {
     define_base_schema(&client).await;
 
     // Insert data
-    client
+    let result = client
         .execute_tx(vec![TxOp::Add {
             entity: "alice".into(),
             attribute: kw!(:name),
@@ -188,10 +188,16 @@ async fn test_open_close_multiple_dbs() {
         }])
         .await
         .unwrap();
+    let basis = match result {
+        TransactionResult::TxCommited(basis) => basis,
+        _ => panic!("Expected TxCommited"),
+    };
 
-    // Open two DB handles
-    let db1 = client.db().await.unwrap();
-    let db2 = client.db().await.unwrap();
+    // Open two DB handles for the same basis.
+    let db1 = client.db_as_of(basis).await.unwrap();
+    let db2 = client.db_as_of(basis).await.unwrap();
+    assert_eq!(db1.tx_eid(), basis.tx_eid);
+    assert_eq!(db2.tx_eid(), basis.tx_eid);
 
     // Both should return same data
     let r1 = db1
@@ -206,6 +212,12 @@ async fn test_open_close_multiple_dbs() {
     assert_eq!(r2.len(), 1);
 
     db1.close().await.unwrap();
+    let r2_after_close = db2
+        .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
+        .await
+        .unwrap();
+    assert_eq!(r2_after_close.len(), 1);
+
     db2.close().await.unwrap();
     token.cancel();
 }
@@ -300,6 +312,50 @@ async fn test_db_as_of() {
 
     // Open DB pinned to the first transaction basis — should only see alice
     let db = client.db_as_of(basis1).await.unwrap();
+    assert_eq!(db.tx_eid(), basis1.tx_eid);
+    let result = db
+        .query("{:find [?name] :where [[?e :name ?name]]}")
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
+
+    db.close().await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_open_latest_db_handle_stays_pinned_after_later_tx() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    define_base_schema(&client).await;
+
+    let result1 = client
+        .execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap();
+    let basis1 = match result1 {
+        TransactionResult::TxCommited(basis) => basis,
+        _ => panic!("Expected TxCommited"),
+    };
+
+    let db = client.db().await.unwrap();
+    assert_eq!(db.tx_eid(), basis1.tx_eid);
+
+    client
+        .execute_tx(vec![TxOp::Add {
+            entity: "bob".into(),
+            attribute: kw!(:name),
+            value: "bob".into(),
+        }])
+        .await
+        .unwrap();
+
     let result = db
         .query("{:find [?name] :where [[?e :name ?name]]}")
         .await

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -91,7 +91,7 @@ impl ClientNode {
 
         Ok(ClientDb {
             db_id: opened.db_id,
-            tx_id: opened.tx_id,
+            tx_eid: opened.tx_eid,
             client: self.client.clone(),
             base_url: self.base_url.clone(),
         })
@@ -169,22 +169,22 @@ impl QueryNode for ClientNode {
 // ClientDb
 // ---------------------------------------------------------------------------
 
-/// A remote DB snapshot handle. Mirrors the `DB` API.
+/// A remote DB read handle. Mirrors the `DB` API.
 ///
 /// Callers should call [`.close()`](ClientDb::close) when done to release
 /// the server-side handle. If not closed explicitly, the server will clean
 /// up via TTL expiration or connection-drop detection.
 pub struct ClientDb {
     db_id: u32,
-    tx_id: i64,
+    tx_eid: i64,
     client: Client,
     base_url: String,
 }
 
 impl ClientDb {
-    /// The tx_id this snapshot is pinned to.
-    pub fn tx_id(&self) -> i64 {
-        self.tx_id
+    /// The transaction entity id this handle is pinned to.
+    pub fn tx_eid(&self) -> i64 {
+        self.tx_eid
     }
 
     /// Release this DB handle on the server.

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -1448,15 +1448,6 @@ mod tests {
     }
 
     #[test]
-    fn decode_db_opened_rejects_old_tx_id_field() {
-        let body = pack(Value::Map(vec![
-            (Value::String("db_id".into()), Value::Integer(7.into())),
-            (Value::String("tx_id".into()), Value::Integer(12345.into())),
-        ]));
-        assert!(decode_db_opened_response(&body).is_err());
-    }
-
-    #[test]
     fn decode_db_opened_rejects_db_id_overflow() {
         // db_id > u32::MAX
         let body = pack(Value::Map(vec![

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -641,7 +641,7 @@ pub struct OpenDbRequest {
 #[derive(Debug, Clone, PartialEq)]
 pub struct DbOpenedResponse {
     pub db_id: u32,
-    pub tx_id: i64,
+    pub tx_eid: i64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -715,27 +715,27 @@ pub fn decode_open_db_request(data: &[u8]) -> Result<OpenDbRequest> {
     })
 }
 
-/// Encode a DbOpened response: `{"db_id": int, "tx_id": int}`.
+/// Encode a DbOpened response: `{"db_id": int, "tx_eid": int}`.
 pub fn encode_db_opened_response(resp: &DbOpenedResponse) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 2)?;
     rmp::encode::write_str(&mut buf, "db_id")?;
     rmp::encode::write_uint(&mut buf, resp.db_id as u64)?;
-    rmp::encode::write_str(&mut buf, "tx_id")?;
-    rmp::encode::write_sint(&mut buf, resp.tx_id)?;
+    rmp::encode::write_str(&mut buf, "tx_eid")?;
+    rmp::encode::write_sint(&mut buf, resp.tx_eid)?;
     Ok(buf)
 }
 
 pub fn decode_db_opened_response(data: &[u8]) -> Result<DbOpenedResponse> {
     let mut map = map_from_value(read_body_value(data)?)?;
     let db_id = take_i64(&mut map, "db_id")?;
-    let tx_id = take_i64(&mut map, "tx_id")?;
+    let tx_eid = take_i64(&mut map, "tx_eid")?;
     if db_id < 0 || db_id > u32::MAX as i64 {
         bail!("db_id out of u32 range: {db_id}");
     }
     Ok(DbOpenedResponse {
         db_id: db_id as u32,
-        tx_id,
+        tx_eid,
     })
 }
 
@@ -1287,7 +1287,7 @@ mod tests {
     fn round_trip_db_opened_response_body() {
         let response = DbOpenedResponse {
             db_id: 7,
-            tx_id: 12345,
+            tx_eid: 12345,
         };
         let buf = encode_db_opened_response(&response).unwrap();
         assert_eq!(decode_db_opened_response(&buf).unwrap(), response);
@@ -1439,10 +1439,19 @@ mod tests {
 
     #[test]
     fn decode_db_opened_rejects_wrong_type() {
-        // {"db_id": "not an int", "tx_id": 7}
+        // {"db_id": "not an int", "tx_eid": 7}
         let body = pack(Value::Map(vec![
             (Value::String("db_id".into()), Value::String("nope".into())),
-            (Value::String("tx_id".into()), Value::Integer(7.into())),
+            (Value::String("tx_eid".into()), Value::Integer(7.into())),
+        ]));
+        assert!(decode_db_opened_response(&body).is_err());
+    }
+
+    #[test]
+    fn decode_db_opened_rejects_old_tx_id_field() {
+        let body = pack(Value::Map(vec![
+            (Value::String("db_id".into()), Value::Integer(7.into())),
+            (Value::String("tx_id".into()), Value::Integer(12345.into())),
         ]));
         assert!(decode_db_opened_response(&body).is_err());
     }
@@ -1455,7 +1464,7 @@ mod tests {
                 Value::String("db_id".into()),
                 Value::Integer((u64::from(u32::MAX) + 1).into()),
             ),
-            (Value::String("tx_id".into()), Value::Integer(0.into())),
+            (Value::String("tx_eid".into()), Value::Integer(0.into())),
         ]));
         assert!(decode_db_opened_response(&body).is_err());
     }

--- a/triplox-client/src/protocol.rs
+++ b/triplox-client/src/protocol.rs
@@ -88,7 +88,6 @@ pub enum ErrorCode {
     ServerShuttingDown = 4004,
     // DB handle errors (5xxx)
     InvalidDbHandle = 5000,
-    TooManyOpenDbs = 5001,
 }
 
 impl ErrorCode {
@@ -109,7 +108,6 @@ impl ErrorCode {
             4003 => Ok(ErrorCode::QueryCancelled),
             4004 => Ok(ErrorCode::ServerShuttingDown),
             5000 => Ok(ErrorCode::InvalidDbHandle),
-            5001 => Ok(ErrorCode::TooManyOpenDbs),
             _ => bail!("Unknown error code: {}", code),
         }
     }

--- a/triplox-jvm/src/main/java/io/triplox/client/BackendMessage.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/BackendMessage.java
@@ -6,7 +6,7 @@ import java.time.Instant;
  * Decoded HTTP response bodies. Used internally by {@link WireCodec}.
  */
 public sealed interface BackendMessage {
-    record DbOpened(int dbId, long txId) implements BackendMessage {}
+    record DbOpened(int dbId, long txEid) implements BackendMessage {}
     record DbClosed(int dbId) implements BackendMessage {}
     record TxKey(long txId, Instant systemTime) implements BackendMessage {}
     record TxResult(byte status, long txId, Instant systemTime, long txEid, String errorMessage)

--- a/triplox-jvm/src/main/java/io/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/Db.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Handle to an open DB snapshot on the server.
+ * Handle to an open DB read basis on the server.
  *
  * <p>Obtained via {@link TriploxNode#openDb()}. Provides query execution
  * and must be closed when no longer needed to release server resources.</p>
@@ -12,19 +12,19 @@ import java.util.List;
 public class Db implements AutoCloseable {
     private final TriploxNode node;
     private final int dbId;
-    private final long txId;
+    private final long txEid;
 
-    Db(TriploxNode node, int dbId, long txId) {
+    Db(TriploxNode node, int dbId, long txEid) {
         this.node = node;
         this.dbId = dbId;
-        this.txId = txId;
+        this.txEid = txEid;
     }
 
     int dbId() { return dbId; }
-    public long txId() { return txId; }
+    public long txEid() { return txEid; }
 
     /**
-     * Execute a Datalog query against this DB snapshot.
+     * Execute a Datalog query against this DB read basis.
      */
     public List<List<Object>> query(String edn) throws IOException {
         return node.queryInternal(this, edn).rows();
@@ -38,7 +38,7 @@ public class Db implements AutoCloseable {
     }
 
     /**
-     * Release this DB snapshot on the server.
+     * Release this DB handle on the server.
      */
     @Override
     public void close() throws IOException {

--- a/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TriploxNode.java
@@ -37,14 +37,14 @@ public class TriploxNode implements AutoCloseable {
     }
 
     /**
-     * Open a DB snapshot at the latest indexed transaction.
+     * Open a DB read handle at the latest indexed transaction.
      */
     public Db openDb() throws IOException {
         return openDbInternal(null);
     }
 
     /**
-     * Open a DB snapshot at a specific indexed transaction basis.
+     * Open a DB read handle at a specific indexed transaction basis.
      */
     public Db openDbAsOf(TxBasis basis) throws IOException {
         return openDbInternal(basis);
@@ -54,18 +54,18 @@ public class TriploxNode implements AutoCloseable {
         byte[] body = WireCodec.encodeOpenDbBody(basis);
         byte[] responseBody = postBinary("/db/open", body);
         var opened = WireCodec.decodeDbOpened(responseBody);
-        return new Db(this, opened.dbId(), opened.txId());
+        return new Db(this, opened.dbId(), opened.txEid());
     }
 
     /**
-     * Release a previously opened DB snapshot.
+     * Release a previously opened DB read handle.
      */
     void closeDbInternal(Db db) throws IOException {
         deleteBinary("/db/" + db.dbId());
     }
 
     /**
-     * Execute a Datalog query against an open DB snapshot.
+     * Execute a Datalog query against an open DB read handle.
      */
     QueryResult queryInternal(Db db, String edn) throws IOException {
         return queryInternal(db, edn, List.of());

--- a/triplox-jvm/src/main/java/io/triplox/client/TxBasis.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxBasis.java
@@ -3,6 +3,6 @@ package io.triplox.client;
 import java.time.Instant;
 
 /**
- * Indexed transaction basis for opening an as-of DB snapshot.
+ * Indexed transaction basis for opening an as-of DB read handle.
  */
 public record TxBasis(long txId, Instant systemTime, long txEid) {}

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
@@ -13,7 +13,7 @@ import org.msgpack.core.MessageUnpacker;
  * MessagePack codec for {@link TxOp} and {@link EntityRef} values.
  *
  * <p>Tagged unions use {@code {"kind": "<variant>", ...fields}} maps.
- * See {@code design/WIRE_PROTOCOL.md}.</p>
+ * See {@code design/PROTOCOL.md}.</p>
  */
 public final class TxOpCodec {
     private TxOpCodec() {}

--- a/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/WireCodec.java
@@ -15,7 +15,7 @@ import org.msgpack.core.MessageUnpacker;
  * MessagePack codec for the HTTP/2 request and response bodies.
  *
  * <p>Each body is a single msgpack map with string keys. See
- * {@code design/WIRE_PROTOCOL.md} for the schemas.</p>
+ * {@code design/PROTOCOL.md} for the schemas.</p>
  */
 public final class WireCodec {
     private WireCodec() {}
@@ -86,8 +86,8 @@ public final class WireCodec {
     public static BackendMessage.DbOpened decodeDbOpened(byte[] body) throws IOException {
         var fields = readFields(body);
         long dbId = expectLong(fields, "db_id");
-        long txId = expectLong(fields, "tx_id");
-        return new BackendMessage.DbOpened(toInt(dbId), txId);
+        long txEid = expectLong(fields, "tx_eid");
+        return new BackendMessage.DbOpened(toInt(dbId), txEid);
     }
 
     public static BackendMessage.DbClosed decodeDbClosed(byte[] body) throws IOException {

--- a/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
@@ -90,10 +90,16 @@ class WireCodecTest {
 
     @Test
     void testDecodeDbOpened() throws IOException {
-        byte[] body = packMap2("db_id", 5L, "tx_id", 42L);
+        byte[] body = packMap2("db_id", 5L, "tx_eid", 42L);
         var opened = WireCodec.decodeDbOpened(body);
         assertEquals(5, opened.dbId());
-        assertEquals(42L, opened.txId());
+        assertEquals(42L, opened.txEid());
+    }
+
+    @Test
+    void testDecodeDbOpenedRejectsOldTxIdField() throws IOException {
+        byte[] body = packMap2("db_id", 5L, "tx_id", 42L);
+        assertThrows(IOException.class, () -> WireCodec.decodeDbOpened(body));
     }
 
     @Test

--- a/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
@@ -97,12 +97,6 @@ class WireCodecTest {
     }
 
     @Test
-    void testDecodeDbOpenedRejectsOldTxIdField() throws IOException {
-        byte[] body = packMap2("db_id", 5L, "tx_id", 42L);
-        assertThrows(IOException.class, () -> WireCodec.decodeDbOpened(body));
-    }
-
-    @Test
     void testDecodeDbClosed() throws IOException {
         byte[] body = packMap1("db_id", 5L);
         var closed = WireCodec.decodeDbClosed(body);


### PR DESCRIPTION
## Summary
- store TxBasis in server DB handles instead of cached DB snapshots
- return tx_eid from /db/open and update Rust/JVM opened-DB wire/client surfaces
- update protocol/design docs for the transaction entity read basis

## Tests
- cargo fmt --check
- cargo test -p triplox --test client_server_test
- cargo test -p triplox test_db_as_of
- cargo test -p triplox
- cargo test -p triplox-edn
- cargo test -p triplox-client
- cargo clippy --workspace --all-targets --all-features
- cd triplox-jvm && ./gradlew test