### PR TITLE
Make read path accept DbReadOps

### DIFF
--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -52,7 +52,7 @@ All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body)
 DB handles are scoped to an HTTP/2 connection. Each `db_id` maps to a
 transaction basis: the transaction log key (`tx_id` + `system_time`) plus the
 transaction entity ID (`tx_eid`) that bounds temporal reads. The server does
-not cache DB snapshots for handles; it creates transient read views from the
+not cache pinned SlateDB read state for handles; it creates transient read views from the
 stored basis when queries execute. Each connection is assigned a unique
 `conn_id` on accept, and all handles opened on that connection are tracked
 against it. Two cleanup mechanisms ensure handles are released:

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -29,7 +29,7 @@
 
 
 
-;; 3. Open a DB snapshot and query
+;; 3. Open a DB handle and query
 (with-open [db (tc/db conn)]
   (tc/q db '{:find [?e ?name ?age]
              :where [[?e :name ?name]

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -67,9 +67,9 @@ async fn main() -> Result<()> {
         }
     }
 
-    // 3. Open a DB snapshot and query
+    // 3. Open a DB handle and query
     let db = node.db().await?;
-    println!("Opened DB snapshot (tx_id={}).", db.tx_id());
+    println!("Opened DB handle (tx_id={}).", db.tx_id());
 
     let rows = db
         .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -942,8 +942,7 @@ mod tests {
         }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        let snapshot = slate.snapshot().await?;
-        let latest = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
+        let latest = latest_tx_basis_from_sdb(slate.as_ref()).await?;
         assert_eq!(latest.tx_key.tx_id, 42);
         assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(1000));
         assert!(latest.tx_eid > 0, "tx_eid should be a valid entity ID");
@@ -970,8 +969,7 @@ mod tests {
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let snapshot = slate.snapshot().await?;
-        let latest = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
+        let latest = latest_tx_basis_from_sdb(slate.as_ref()).await?;
         assert_eq!(latest.tx_key.tx_id, 3, "Should return highest tx_id");
         assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(300));
         Ok(())
@@ -1502,20 +1500,12 @@ mod tests {
             .await?;
 
         let query: ParsedQuery = r#"[:find ?e ?name :where [?e :name ?name]]"#.parse()?;
-        let snapshot = slate.snapshot().await?;
+        let sdb = slate.clone();
         let handle = tokio::runtime::Handle::current();
         let ident_map = indexer.metadata().schema.ident_map.clone();
         let range_stats = components.range_stats.clone();
         let rows = tokio::task::spawn_blocking(move || {
-            execute_query(
-                &query,
-                &[],
-                snapshot,
-                handle,
-                &ident_map,
-                i64::MAX,
-                range_stats,
-            )
+            execute_query(&query, &[], sdb, handle, &ident_map, i64::MAX, range_stats)
         })
         .await??;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Error, Result};
 use bytes::Bytes;
 use log::{error, trace, warn};
 use slatedb::Db;
+use slatedb::DbReadOps;
 use slatedb::WriteBatch;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -141,9 +142,12 @@ pub(crate) fn write_index_entries(
 /// Errors if no TX_PARTITION entity exists (an initialized DB always has the
 /// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
 /// `:db/txInstant`.
-pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxBasis> {
+pub async fn latest_tx_basis_from_read_ops<D>(read_ops: &D) -> Result<TxBasis>
+where
+    D: DbReadOps + Sync,
+{
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = snapshot
+    let mut iter = read_ops
         .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
         .await?;
     let mut first_eid: Option<i64> = None;
@@ -184,6 +188,10 @@ pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) 
             bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
         }
     }
+}
+
+pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxBasis> {
+    latest_tx_basis_from_read_ops(snapshot.as_ref()).await
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -142,12 +142,12 @@ pub(crate) fn write_index_entries(
 /// Errors if no TX_PARTITION entity exists (an initialized DB always has the
 /// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
 /// `:db/txInstant`.
-pub async fn latest_tx_basis_from_read_ops<D>(read_ops: &D) -> Result<TxBasis>
+pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
 where
     D: DbReadOps + Sync,
 {
     let eav_tx_prefix = concat_bytes(&[&[codec::EAV], &partition_entity_prefix(TX_PARTITION)]);
-    let mut iter = read_ops
+    let mut iter = sdb
         .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
         .await?;
     let mut first_eid: Option<i64> = None;
@@ -188,10 +188,6 @@ where
             bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
         }
     }
-}
-
-pub async fn latest_tx_basis_from_snapshot(snapshot: &Arc<slatedb::DbSnapshot>) -> Result<TxBasis> {
-    latest_tx_basis_from_read_ops(snapshot.as_ref()).await
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.
@@ -946,8 +942,8 @@ mod tests {
         }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        let snapshot = Arc::new(slate.snapshot().await?);
-        let latest = latest_tx_basis_from_snapshot(&snapshot).await?;
+        let snapshot = slate.snapshot().await?;
+        let latest = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
         assert_eq!(latest.tx_key.tx_id, 42);
         assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(1000));
         assert!(latest.tx_eid > 0, "tx_eid should be a valid entity ID");
@@ -974,8 +970,8 @@ mod tests {
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let snapshot = Arc::new(slate.snapshot().await?);
-        let latest = latest_tx_basis_from_snapshot(&snapshot).await?;
+        let snapshot = slate.snapshot().await?;
+        let latest = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
         assert_eq!(latest.tx_key.tx_id, 3, "Should return highest tx_id");
         assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(300));
         Ok(())

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -265,10 +265,8 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         let slate = components.db.clone();
         let range_stats = components.range_stats.clone();
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV, IndexType::AVE],
@@ -302,10 +300,8 @@ mod tests {
             }))
             .unwrap();
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV],
@@ -332,10 +328,8 @@ mod tests {
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Alice")))?;
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Bob")))?;
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV],
@@ -366,10 +360,8 @@ mod tests {
         runtime.block_on(insert_ave(&slate, attr_name, encode_string("Alice"), 1))?;
         runtime.block_on(insert_ave(&slate, attr_name, encode_string("Bob"), 2))?;
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV, IndexType::AVE],
@@ -400,10 +392,8 @@ mod tests {
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Alice")))?;
         runtime.block_on(insert_av(&slate, attr_name, encode_string("Bob")))?;
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV],
@@ -444,14 +434,12 @@ mod tests {
         let value_bytes = Bytes::from(DataType::String("alice".to_string()).encode());
         runtime.block_on(insert_ave(&slate, attr_name, value_bytes.clone(), 1))?;
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         // This mirrors how compile_pattern sets up a single-variable AVE pattern:
         // - index_types: [AVE]
         // - constant_prefix: serialized value bytes
         // - participating_levels: [0] (only one variable)
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AVE],
@@ -477,10 +465,8 @@ mod tests {
         let range_stats = components.range_stats.clone();
         let attr_name = 42i64;
 
-        let snapshot = runtime.block_on(slate.snapshot()).unwrap();
-
         let extender = GenericPrefixExtender::new(
-            snapshot,
+            slate,
             runtime.handle().clone(),
             range_stats.clone(),
             vec![IndexType::AV],

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -112,7 +112,7 @@ where
             IndexType::AE | IndexType::AV => Box::new(
                 SlateIterator::new(
                     slate_prefix,
-                    &self.slate,
+                    self.slate.as_ref(),
                     self.handle.clone(),
                     extractor,
                     self.range_stats.clone(),
@@ -122,7 +122,7 @@ where
             IndexType::EAV | IndexType::AVE | IndexType::AEV | IndexType::VAE => Box::new(
                 TemporalFilterIterator::new(
                     slate_prefix,
-                    &self.slate,
+                    self.slate.as_ref(),
                     self.handle.clone(),
                     extractor,
                     self.as_of,

--- a/src/iterator/generic_prefix_extender.rs
+++ b/src/iterator/generic_prefix_extender.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Error;
 use bytes::Bytes;
+use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
@@ -15,22 +16,30 @@ use super::temporal_filter_iterator::TemporalFilterIterator;
 /// GenericPrefixExtender implements PrefixExtender using SlateDB with byte prefixes.
 ///
 /// The caller is responsible for determining index types, attribute IDs, and level participation.
-pub struct GenericPrefixExtender {
-    slate: Arc<slatedb::DbSnapshot>,
+pub struct GenericPrefixExtender<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    slate: Arc<D>,
     handle: Handle,
-    range_stats: Arc<slatedb_estimates::RangeStats>,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     index_types: Vec<IndexType>,      // e.g., [AV, AVE]
     constant_prefix: Vec<u8>,         // attr_bytes + serialized constant values from the pattern
     participating_levels: Vec<usize>, // Which join levels this participates in
     as_of: i64,                       // temporal filter: only see facts at or before this time
 }
 
-impl GenericPrefixExtender {
+impl<D, M> GenericPrefixExtender<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        slate: Arc<slatedb::DbSnapshot>,
+        slate: Arc<D>,
         handle: Handle,
-        range_stats: Arc<slatedb_estimates::RangeStats>,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
         index_types: Vec<IndexType>,
         attribute_id: i64,
         constant_prefix: Vec<u8>,
@@ -103,7 +112,7 @@ impl GenericPrefixExtender {
             IndexType::AE | IndexType::AV => Box::new(
                 SlateIterator::new(
                     slate_prefix,
-                    self.slate.as_ref(),
+                    &self.slate,
                     self.handle.clone(),
                     extractor,
                     self.range_stats.clone(),
@@ -113,7 +122,7 @@ impl GenericPrefixExtender {
             IndexType::EAV | IndexType::AVE | IndexType::AEV | IndexType::VAE => Box::new(
                 TemporalFilterIterator::new(
                     slate_prefix,
-                    self.slate.as_ref(),
+                    &self.slate,
                     self.handle.clone(),
                     extractor,
                     self.as_of,
@@ -145,7 +154,11 @@ impl GenericPrefixExtender {
     }
 }
 
-impl PrefixExtender for GenericPrefixExtender {
+impl<D, M> PrefixExtender for GenericPrefixExtender<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     fn count(&self, join_prefix: &Prefix) -> usize {
         // TODO: proper error handling
         let (slate_prefix, index_type) = self

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -37,7 +37,7 @@ where
 {
     pub fn new<D>(
         prefix: &[u8],
-        slate: &Arc<D>,
+        slate: &D,
         handle: Handle,
         extractor: Extractor,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
@@ -46,11 +46,8 @@ where
         D: DbReadOps + Send + Sync,
     {
         let prefix_bytes = Bytes::from(prefix.to_vec());
-        let mut iterator = handle.block_on(
-            slate
-                .as_ref()
-                .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS),
-        )?;
+        let mut iterator =
+            handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
         let mut current_key = None;
         if let Some(next_key) = handle.block_on(iterator.next())? {
             current_key = Some(next_key.key.clone());
@@ -281,7 +278,8 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
+            let mut iter =
+                SlateIterator::new(PFX, sdb.as_ref(), handle, extractor, range_stats).unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("aa")));
@@ -310,7 +308,8 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
+            let mut iter =
+                SlateIterator::new(PFX, sdb.as_ref(), handle, extractor, range_stats).unwrap();
 
             iter.seek(Bytes::from("cc")).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("cc")));
@@ -334,7 +333,8 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
+            let iter =
+                SlateIterator::new(PFX, sdb.as_ref(), handle, extractor, range_stats).unwrap();
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
         })
@@ -365,7 +365,8 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
+            let iter =
+                SlateIterator::new(PFX, sdb.as_ref(), handle, extractor, range_stats).unwrap();
             let count = iter.count().unwrap();
             assert_eq!(count, 3);
         })

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -19,9 +19,8 @@ pub(crate) trait Index {
 /// Type alias for extractor functions that extract a component from a full key.
 pub type Extractor = Box<dyn Fn(Bytes) -> Bytes + Send + Sync>;
 
-pub(crate) struct SlateIterator<D, M>
+pub(crate) struct SlateIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
     inner: slatedb::DbIterator,
@@ -30,21 +29,22 @@ where
     handle: Handle,
     extractor: Extractor,
     range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-    _read_ops: std::marker::PhantomData<D>,
 }
 
-impl<D, M> SlateIterator<D, M>
+impl<M> SlateIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
-    pub fn new(
+    pub fn new<D>(
         prefix: &[u8],
         slate: &Arc<D>,
         handle: Handle,
         extractor: Extractor,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        D: DbReadOps + Send + Sync,
+    {
         let prefix_bytes = Bytes::from(prefix.to_vec());
         let mut iterator = handle.block_on(
             slate
@@ -62,14 +62,12 @@ where
             handle,
             extractor,
             range_stats,
-            _read_ops: std::marker::PhantomData,
         })
     }
 }
 
-impl<D, M> Index for SlateIterator<D, M>
+impl<M> Index for SlateIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
     fn count(&self) -> Result<u64, Error> {

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use anyhow::Error;
+use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::slate::DEFAULT_SCAN_OPTIONS;
@@ -18,26 +19,38 @@ pub(crate) trait Index {
 /// Type alias for extractor functions that extract a component from a full key.
 pub type Extractor = Box<dyn Fn(Bytes) -> Bytes + Send + Sync>;
 
-pub(crate) struct SlateIterator {
+pub(crate) struct SlateIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     inner: slatedb::DbIterator,
     current_key: Option<Bytes>,
     prefix: Bytes,
     handle: Handle,
     extractor: Extractor,
-    range_stats: Arc<slatedb_estimates::RangeStats>,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    _read_ops: std::marker::PhantomData<D>,
 }
 
-impl SlateIterator {
+impl<D, M> SlateIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     pub fn new(
         prefix: &[u8],
-        slate: &slatedb::DbSnapshot,
+        slate: &Arc<D>,
         handle: Handle,
         extractor: Extractor,
-        range_stats: Arc<slatedb_estimates::RangeStats>,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
         let prefix_bytes = Bytes::from(prefix.to_vec());
-        let mut iterator =
-            handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
+        let mut iterator = handle.block_on(
+            slate
+                .as_ref()
+                .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS),
+        )?;
         let mut current_key = None;
         if let Some(next_key) = handle.block_on(iterator.next())? {
             current_key = Some(next_key.key.clone());
@@ -49,11 +62,16 @@ impl SlateIterator {
             handle,
             extractor,
             range_stats,
+            _read_ops: std::marker::PhantomData,
         })
     }
 }
 
-impl Index for SlateIterator {
+impl<D, M> Index for SlateIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     fn count(&self) -> Result<u64, Error> {
         Ok(self.handle.block_on(
             self.range_stats

--- a/src/iterator/slate_iterator.rs
+++ b/src/iterator/slate_iterator.rs
@@ -277,12 +277,11 @@ mod tests {
         slate.put(&make_key(PFX, b"cc"), b"").await;
         slate.put(&make_key(OTHER_PFX, b"xx"), b"").await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter =
-                SlateIterator::new(PFX, &snapshot, handle, extractor, range_stats).unwrap();
+            let mut iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("aa")));
@@ -307,12 +306,11 @@ mod tests {
         slate.put(&make_key(PFX, b"cc"), b"").await;
         slate.put(&make_key(PFX, b"ee"), b"").await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter =
-                SlateIterator::new(PFX, &snapshot, handle, extractor, range_stats).unwrap();
+            let mut iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
 
             iter.seek(Bytes::from("cc")).unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("cc")));
@@ -332,11 +330,11 @@ mod tests {
 
         slate.put(&make_key(OTHER_PFX, b"aa"), b"").await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor, range_stats).unwrap();
+            let iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
         })
@@ -363,11 +361,11 @@ mod tests {
             .await
             .unwrap();
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = SlateIterator::new(PFX, &snapshot, handle, extractor, range_stats).unwrap();
+            let iter = SlateIterator::new(PFX, &sdb, handle, extractor, range_stats).unwrap();
             let count = iter.count().unwrap();
             assert_eq!(count, 3);
         })

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -22,9 +22,8 @@ use super::slate_iterator::{Extractor, Index};
 ///
 /// TODO(#102): Add a history mode option that iterates over all history
 /// <= `as_of` including retractions, rather than resolving to current state.
-pub(crate) struct TemporalFilterIterator<D, M>
+pub(crate) struct TemporalFilterIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
     inner: slatedb::DbIterator,
@@ -34,7 +33,6 @@ where
     extractor: Extractor,
     as_of_encoded: [u8; 8],
     range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-    _read_ops: std::marker::PhantomData<D>,
 }
 
 /// Extract the logical key from a full key (everything except timestamp + op suffix).
@@ -43,19 +41,21 @@ fn logical_key(key: &[u8]) -> &[u8] {
     &key[..key.len() - codec::TX_EID_OP_SUFFIX]
 }
 
-impl<D, M> TemporalFilterIterator<D, M>
+impl<M> TemporalFilterIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
-    pub fn new(
+    pub fn new<D>(
         prefix: &[u8],
         slate: &Arc<D>,
         handle: Handle,
         extractor: Extractor,
         as_of: i64,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        D: DbReadOps + Send + Sync,
+    {
         let prefix_bytes = Bytes::from(prefix.to_vec());
         let as_of_encoded = codec::encode_i64_bytes(as_of);
         let iterator = handle.block_on(
@@ -72,7 +72,6 @@ where
             extractor,
             as_of_encoded,
             range_stats,
-            _read_ops: std::marker::PhantomData,
         };
 
         // Advance to the first valid entry
@@ -147,9 +146,8 @@ where
     }
 }
 
-impl<D, M> Index for TemporalFilterIterator<D, M>
+impl<M> Index for TemporalFilterIterator<M>
 where
-    D: DbReadOps + Send + Sync,
     M: DbMetadataOps + Send + Sync,
 {
     fn count(&self) -> Result<u64, Error> {

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use anyhow::Error;
+use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::codec;
@@ -21,14 +22,19 @@ use super::slate_iterator::{Extractor, Index};
 ///
 /// TODO(#102): Add a history mode option that iterates over all history
 /// <= `as_of` including retractions, rather than resolving to current state.
-pub(crate) struct TemporalFilterIterator {
+pub(crate) struct TemporalFilterIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     inner: slatedb::DbIterator,
     current_key: Option<Bytes>,
     prefix: Bytes,
     handle: Handle,
     extractor: Extractor,
     as_of_encoded: [u8; 8],
-    range_stats: Arc<slatedb_estimates::RangeStats>,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    _read_ops: std::marker::PhantomData<D>,
 }
 
 /// Extract the logical key from a full key (everything except timestamp + op suffix).
@@ -37,19 +43,26 @@ fn logical_key(key: &[u8]) -> &[u8] {
     &key[..key.len() - codec::TX_EID_OP_SUFFIX]
 }
 
-impl TemporalFilterIterator {
+impl<D, M> TemporalFilterIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     pub fn new(
         prefix: &[u8],
-        slate: &slatedb::DbSnapshot,
+        slate: &Arc<D>,
         handle: Handle,
         extractor: Extractor,
         as_of: i64,
-        range_stats: Arc<slatedb_estimates::RangeStats>,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
         let prefix_bytes = Bytes::from(prefix.to_vec());
         let as_of_encoded = codec::encode_i64_bytes(as_of);
-        let iterator =
-            handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
+        let iterator = handle.block_on(
+            slate
+                .as_ref()
+                .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS),
+        )?;
 
         let mut iter = Self {
             inner: iterator,
@@ -59,6 +72,7 @@ impl TemporalFilterIterator {
             extractor,
             as_of_encoded,
             range_stats,
+            _read_ops: std::marker::PhantomData,
         };
 
         // Advance to the first valid entry
@@ -133,7 +147,11 @@ impl TemporalFilterIterator {
     }
 }
 
-impl Index for TemporalFilterIterator {
+impl<D, M> Index for TemporalFilterIterator<D, M>
+where
+    D: DbReadOps + Send + Sync,
+    M: DbMetadataOps + Send + Sync,
+{
     fn count(&self) -> Result<u64, Error> {
         Ok(self.handle.block_on(
             self.range_stats

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -225,14 +225,13 @@ mod tests {
             .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, 2000, range_stats)
-                    .unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
+                .unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -257,15 +256,14 @@ mod tests {
             .put(&make_key(PFX, b"alice", t2, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             // Query as-of t1 — should see alice (t2 is in the future)
             let extractor = make_test_extractor(PFX.len());
             let iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, t1, range_stats)
-                    .unwrap();
+                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, t1, range_stats).unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -285,15 +283,14 @@ mod tests {
             .put(&make_key(PFX, b"alice", t1, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             // Query as-of before t1 — should see nothing
             let extractor = make_test_extractor(PFX.len());
-            let iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, 1000, range_stats)
-                    .unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 1000, range_stats)
+                .unwrap();
 
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
@@ -316,13 +313,13 @@ mod tests {
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
         slate.put(&make_key(PFX, b"bob", t2, codec::ADD), b"").await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, 3000, range_stats)
+                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 3000, range_stats)
                     .unwrap();
 
             // Should see alice and bob (deduplicated)
@@ -361,15 +358,16 @@ mod tests {
             .put(&make_key(PFX, b"alice", t3, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         // as-of T0: nothing
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &snap, handle, extractor, t0, rs).unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t0, rs)
+                .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -377,12 +375,13 @@ mod tests {
 
         // as-of T1: alice visible
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snap, handle, extractor, t1, rs).unwrap();
+                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
             assert!(!iter.has_next());
@@ -392,11 +391,12 @@ mod tests {
 
         // as-of T2: alice hidden (retracted)
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &snap, handle, extractor, t2, rs).unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
+                .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -404,12 +404,13 @@ mod tests {
 
         // as-of T3: alice visible again (re-added)
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snap, handle, extractor, t3, rs).unwrap();
+                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t3, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
             assert!(!iter.has_next());
@@ -435,13 +436,13 @@ mod tests {
             .put(&make_key(PFX, b"charlie", t1, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, 2000, range_stats)
+                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
                     .unwrap();
 
             // Initially at alice
@@ -482,16 +483,17 @@ mod tests {
             .await;
         slate.put(&make_key(PFX, b"bob", t1, codec::ADD), b"").await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         // as-of T1: alice and bob
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snap, handle, extractor, t1, rs).unwrap();
+                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
@@ -503,12 +505,13 @@ mod tests {
 
         // as-of T2: only bob (alice retracted)
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &snap, handle, extractor, t2, rs).unwrap();
+                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
             iter.next().unwrap();
             assert!(!iter.has_next());
@@ -538,15 +541,16 @@ mod tests {
             .put(&make_key(PFX, b"alice", t3, codec::ADD), b"")
             .await;
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
 
         // as-of T1: alice visible
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &snap, handle, extractor, t1, rs).unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
+                .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         })
         .await
@@ -554,11 +558,12 @@ mod tests {
 
         // as-of T2: alice retracted
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &snap, handle, extractor, t2, rs).unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
+                .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -566,11 +571,12 @@ mod tests {
 
         // as-of T3: alice visible again
         let handle = tokio::runtime::Handle::current();
-        let snap = snapshot.clone();
+        let sdb_for_query = sdb.clone();
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &snap, handle, extractor, t3, rs).unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t3, rs)
+                .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         })
         .await
@@ -600,14 +606,13 @@ mod tests {
             .await
             .unwrap();
 
-        let snapshot = slate.snapshot().await.unwrap();
+        let sdb = slate;
         let handle = tokio::runtime::Handle::current();
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter =
-                TemporalFilterIterator::new(PFX, &snapshot, handle, extractor, 2000, range_stats)
-                    .unwrap();
+            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
+                .unwrap();
             let count = iter.count().unwrap();
             assert_eq!(count, 3);
         })

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -47,7 +47,7 @@ where
 {
     pub fn new<D>(
         prefix: &[u8],
-        slate: &Arc<D>,
+        slate: &D,
         handle: Handle,
         extractor: Extractor,
         as_of: i64,
@@ -58,11 +58,8 @@ where
     {
         let prefix_bytes = Bytes::from(prefix.to_vec());
         let as_of_encoded = codec::encode_i64_bytes(as_of);
-        let iterator = handle.block_on(
-            slate
-                .as_ref()
-                .scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS),
-        )?;
+        let iterator =
+            handle.block_on(slate.scan_prefix_with_options(prefix, &DEFAULT_SCAN_OPTIONS))?;
 
         let mut iter = Self {
             inner: iterator,
@@ -230,8 +227,15 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
-                .unwrap();
+            let iter = TemporalFilterIterator::new(
+                PFX,
+                sdb.as_ref(),
+                handle,
+                extractor,
+                2000,
+                range_stats,
+            )
+            .unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -263,7 +267,8 @@ mod tests {
             // Query as-of t1 — should see alice (t2 is in the future)
             let extractor = make_test_extractor(PFX.len());
             let iter =
-                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, t1, range_stats).unwrap();
+                TemporalFilterIterator::new(PFX, sdb.as_ref(), handle, extractor, t1, range_stats)
+                    .unwrap();
 
             assert!(iter.has_next());
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -289,8 +294,15 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             // Query as-of before t1 — should see nothing
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 1000, range_stats)
-                .unwrap();
+            let iter = TemporalFilterIterator::new(
+                PFX,
+                sdb.as_ref(),
+                handle,
+                extractor,
+                1000,
+                range_stats,
+            )
+            .unwrap();
 
             assert!(!iter.has_next());
             assert_eq!(iter.get_value().unwrap(), None);
@@ -318,9 +330,15 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 3000, range_stats)
-                    .unwrap();
+            let mut iter = TemporalFilterIterator::new(
+                PFX,
+                sdb.as_ref(),
+                handle,
+                extractor,
+                3000,
+                range_stats,
+            )
+            .unwrap();
 
             // Should see alice and bob (deduplicated)
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -366,8 +384,9 @@ mod tests {
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t0, rs)
-                .unwrap();
+            let iter =
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t0, rs)
+                    .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -380,7 +399,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t1, rs)
                     .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -395,8 +414,9 @@ mod tests {
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
-                .unwrap();
+            let iter =
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t2, rs)
+                    .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -409,7 +429,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t3, rs)
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t3, rs)
                     .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -441,9 +461,15 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
-                    .unwrap();
+            let mut iter = TemporalFilterIterator::new(
+                PFX,
+                sdb.as_ref(),
+                handle,
+                extractor,
+                2000,
+                range_stats,
+            )
+            .unwrap();
 
             // Initially at alice
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
@@ -492,7 +518,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t1, rs)
                     .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
             iter.next().unwrap();
@@ -510,7 +536,7 @@ mod tests {
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
             let mut iter =
-                TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t2, rs)
                     .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("bob")));
             iter.next().unwrap();
@@ -549,8 +575,9 @@ mod tests {
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t1, rs)
-                .unwrap();
+            let iter =
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t1, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         })
         .await
@@ -562,8 +589,9 @@ mod tests {
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t2, rs)
-                .unwrap();
+            let iter =
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t2, rs)
+                    .unwrap();
             assert!(!iter.has_next());
         })
         .await
@@ -575,8 +603,9 @@ mod tests {
         let rs = range_stats.clone();
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb_for_query, handle, extractor, t3, rs)
-                .unwrap();
+            let iter =
+                TemporalFilterIterator::new(PFX, sdb_for_query.as_ref(), handle, extractor, t3, rs)
+                    .unwrap();
             assert_eq!(iter.get_value().unwrap(), Some(Bytes::from("alice")));
         })
         .await
@@ -611,8 +640,15 @@ mod tests {
 
         tokio::task::spawn_blocking(move || {
             let extractor = make_test_extractor(PFX.len());
-            let iter = TemporalFilterIterator::new(PFX, &sdb, handle, extractor, 2000, range_stats)
-                .unwrap();
+            let iter = TemporalFilterIterator::new(
+                PFX,
+                sdb.as_ref(),
+                handle,
+                extractor,
+                2000,
+                range_stats,
+            )
+            .unwrap();
             let count = iter.count().unwrap();
             assert_eq!(count, 3);
         })

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,7 +8,7 @@ use tokio::runtime::Handle;
 use crate::clock;
 use crate::error::TriploxError;
 use crate::file_log::FileLog;
-use crate::indexer::{latest_tx_basis_from_read_ops, latest_tx_basis_from_snapshot, Indexer};
+use crate::indexer::{latest_tx_basis_from_sdb, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
@@ -30,7 +30,7 @@ where
     D: slatedb::DbReadOps + Send + Sync + 'static,
     M: slatedb::DbMetadataOps + Send + Sync + 'static,
 {
-    read_ops: Arc<D>,
+    sdb: Arc<D>,
     ident_map: IdentMap,
     handle: Handle,
     tx_basis: TxBasis,
@@ -44,14 +44,14 @@ where
     M: slatedb::DbMetadataOps + Send + Sync + 'static,
 {
     pub fn new(
-        read_ops: Arc<D>,
+        sdb: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
         tx_basis: TxBasis,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Self {
         Self {
-            read_ops,
+            sdb,
             ident_map,
             handle,
             tx_basis,
@@ -59,16 +59,16 @@ where
         }
     }
 
-    /// Construct a DB from read ops by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
-    pub async fn from_latest_read_ops(
-        read_ops: Arc<D>,
+    /// Construct a DB from sdb by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
+    pub async fn from_latest_sdb(
+        sdb: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
-        let tx_basis = latest_tx_basis_from_read_ops(read_ops.as_ref()).await?;
+        let tx_basis = latest_tx_basis_from_sdb(sdb.as_ref()).await?;
         Ok(Self {
-            read_ops,
+            sdb,
             ident_map,
             handle,
             tx_basis,
@@ -99,7 +99,7 @@ where
         handle: Handle,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
-        Self::from_latest_read_ops(snapshot, ident_map, handle, range_stats).await
+        Self::from_latest_sdb(snapshot, ident_map, handle, range_stats).await
     }
 }
 
@@ -122,7 +122,7 @@ where
     ) -> Result<QueryResult, Error> {
         validate_query(query, args)?;
 
-        let read_ops = self.read_ops.clone();
+        let sdb = self.sdb.clone();
         let handle = self.handle.clone();
         let ident_map = self.ident_map.clone();
         let query = query.clone();
@@ -131,15 +131,7 @@ where
         let range_stats = self.range_stats.clone();
 
         tokio::task::spawn_blocking(move || {
-            execute_query(
-                &query,
-                &args,
-                read_ops,
-                handle,
-                &ident_map,
-                as_of,
-                range_stats,
-            )
+            execute_query(&query, &args, sdb, handle, &ident_map, as_of, range_stats)
         })
         .await
         .map_err(|e| anyhow::anyhow!("Query task failed: {}", e))?
@@ -184,8 +176,8 @@ impl Node<FileLog> {
 
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
-        let snapshot = Arc::new(slate.db.snapshot().await?);
-        let latest_indexed = latest_tx_basis_from_snapshot(&snapshot).await?;
+        let snapshot = slate.db.snapshot().await?;
+        let latest_indexed = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
         // Bootstrap and the first FileLog transaction both currently use tx_id=0,
         // so we can't disambiguate them by tx_id alone. Use the entity ID instead:
         // only advance the log cursor past tx_id=0 once a tx entity beyond bootstrap
@@ -428,7 +420,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_db_can_query_from_db_read_ops() {
+    async fn test_db_can_query_from_sdb() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -448,7 +440,7 @@ mod tests {
             .schema
             .ident_map
             .clone();
-        let db = DB::from_latest_read_ops(
+        let db = DB::from_latest_sdb(
             node.slate.db.clone(),
             ident_map,
             Handle::current(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,7 +25,7 @@ pub use triplox_client::transaction::{TransactionResult, TxBasis, TxKey};
 
 const DB_AS_OF_INDEXING_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub struct DB<D = slatedb::DbSnapshot, M = slatedb::Db>
+pub struct DB<D = slatedb::Db, M = slatedb::Db>
 where
     D: slatedb::DbReadOps + Send + Sync + 'static,
     M: slatedb::DbMetadataOps + Send + Sync + 'static,
@@ -89,20 +89,6 @@ where
     }
 }
 
-impl<M> DB<slatedb::DbSnapshot, M>
-where
-    M: slatedb::DbMetadataOps + Send + Sync + 'static,
-{
-    pub async fn from_latest_snapshot(
-        snapshot: Arc<slatedb::DbSnapshot>,
-        ident_map: IdentMap,
-        handle: Handle,
-        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
-    ) -> Result<Self, Error> {
-        Self::from_latest_sdb(snapshot, ident_map, handle, range_stats).await
-    }
-}
-
 impl<D, M> Database for DB<D, M>
 where
     D: slatedb::DbReadOps + Send + Sync + 'static,
@@ -113,7 +99,7 @@ where
         self.query_with_args(&parsed, &[]).await
     }
 
-    /// Execute a query against this database snapshot.
+    /// Execute a query against this database basis.
     /// Runs the sync join algorithm in a blocking task to avoid blocking the async runtime.
     async fn query_with_args(
         &self,
@@ -176,8 +162,7 @@ impl Node<FileLog> {
 
         // Determine the latest already-indexed tx_id so we skip replaying it
         // and restore the indexer's in-memory state for TxWaiter fast-path.
-        let snapshot = slate.db.snapshot().await?;
-        let latest_indexed = latest_tx_basis_from_sdb(snapshot.as_ref()).await?;
+        let latest_indexed = latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
         // Bootstrap and the first FileLog transaction both currently use tx_id=0,
         // so we can't disambiguate them by tx_id alone. Use the entity ID instead:
         // only advance the log cursor past tx_id=0 once a tx entity beyond bootstrap
@@ -272,7 +257,6 @@ impl<L: TxLog> Node<L> {
                 timeout,
             })??;
 
-        let snapshot = self.slate.db.snapshot().await?;
         let ident_map = self
             .indexer
             .read()
@@ -283,7 +267,13 @@ impl<L: TxLog> Node<L> {
             .clone();
         let handle = Handle::current();
         let range_stats = self.slate.range_stats.clone();
-        Ok(DB::new(snapshot, ident_map, handle, basis, range_stats))
+        Ok(DB::new(
+            self.slate.db.clone(),
+            ident_map,
+            handle,
+            basis,
+            range_stats,
+        ))
     }
 }
 
@@ -318,8 +308,8 @@ impl<L: TxLog> SubmitNode for Node<L> {
 
 impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
+
     async fn db(&self) -> Result<DB, Error> {
-        let snapshot = self.slate.db.snapshot().await?;
         let ident_map = self
             .indexer
             .read()
@@ -330,8 +320,9 @@ impl<L: TxLog> QueryNode for Node<L> {
             .clone();
         let handle = Handle::current();
         let range_stats = self.slate.range_stats.clone();
-        DB::from_latest_snapshot(snapshot, ident_map, handle, range_stats).await
+        DB::from_latest_sdb(self.slate.db.clone(), ident_map, handle, range_stats).await
     }
+
     async fn db_as_of(&self, basis: TxBasis) -> Result<DB, Error> {
         self.db_as_of_with_timeout(basis, DB_AS_OF_INDEXING_TIMEOUT)
             .await
@@ -1005,7 +996,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_db_as_of_aborted_tx_opens_snapshot() {
+    async fn test_db_as_of_aborted_tx_opens_basis() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -1231,7 +1222,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_db_as_of_pins_snapshot() {
+    async fn test_db_as_of_filters_by_basis() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -1258,7 +1249,7 @@ mod tests {
         .await
         .unwrap();
 
-        // db_as_of pinned to first tx should only see alice
+        // db_as_of at the first tx basis should only see alice
         let db = node.db_as_of(basis1).await.unwrap();
         let results = db
             .query("[:find ?name :where [?e :name ?name]]")

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,7 +8,7 @@ use tokio::runtime::Handle;
 use crate::clock;
 use crate::error::TriploxError;
 use crate::file_log::FileLog;
-use crate::indexer::{latest_tx_basis_from_snapshot, Indexer};
+use crate::indexer::{latest_tx_basis_from_read_ops, latest_tx_basis_from_snapshot, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
@@ -25,25 +25,33 @@ pub use triplox_client::transaction::{TransactionResult, TxBasis, TxKey};
 
 const DB_AS_OF_INDEXING_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub struct DB {
-    snapshot: Arc<slatedb::DbSnapshot>,
+pub struct DB<D = slatedb::DbSnapshot, M = slatedb::Db>
+where
+    D: slatedb::DbReadOps + Send + Sync + 'static,
+    M: slatedb::DbMetadataOps + Send + Sync + 'static,
+{
+    read_ops: Arc<D>,
     ident_map: IdentMap,
     handle: Handle,
     tx_basis: TxBasis,
-    range_stats: Arc<slatedb_estimates::RangeStats>,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
 }
 
 #[allow(unused)]
-impl DB {
+impl<D, M> DB<D, M>
+where
+    D: slatedb::DbReadOps + Send + Sync + 'static,
+    M: slatedb::DbMetadataOps + Send + Sync + 'static,
+{
     pub fn new(
-        snapshot: Arc<slatedb::DbSnapshot>,
+        read_ops: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
         tx_basis: TxBasis,
-        range_stats: Arc<slatedb_estimates::RangeStats>,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Self {
         Self {
-            snapshot,
+            read_ops,
             ident_map,
             handle,
             tx_basis,
@@ -51,16 +59,16 @@ impl DB {
         }
     }
 
-    /// Construct a DB from a snapshot by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
-    pub async fn from_latest_snapshot(
-        snapshot: Arc<slatedb::DbSnapshot>,
+    /// Construct a DB from read ops by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
+    pub async fn from_latest_read_ops(
+        read_ops: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
-        range_stats: Arc<slatedb_estimates::RangeStats>,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
-        let tx_basis = crate::indexer::latest_tx_basis_from_snapshot(&snapshot).await?;
+        let tx_basis = latest_tx_basis_from_read_ops(read_ops.as_ref()).await?;
         Ok(Self {
-            snapshot,
+            read_ops,
             ident_map,
             handle,
             tx_basis,
@@ -81,7 +89,25 @@ impl DB {
     }
 }
 
-impl Database for DB {
+impl<M> DB<slatedb::DbSnapshot, M>
+where
+    M: slatedb::DbMetadataOps + Send + Sync + 'static,
+{
+    pub async fn from_latest_snapshot(
+        snapshot: Arc<slatedb::DbSnapshot>,
+        ident_map: IdentMap,
+        handle: Handle,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    ) -> Result<Self, Error> {
+        Self::from_latest_read_ops(snapshot, ident_map, handle, range_stats).await
+    }
+}
+
+impl<D, M> Database for DB<D, M>
+where
+    D: slatedb::DbReadOps + Send + Sync + 'static,
+    M: slatedb::DbMetadataOps + Send + Sync + 'static,
+{
     async fn query(&self, query: impl IntoQuery) -> Result<QueryResult, Error> {
         let parsed = query.into_query()?;
         self.query_with_args(&parsed, &[]).await
@@ -96,7 +122,7 @@ impl Database for DB {
     ) -> Result<QueryResult, Error> {
         validate_query(query, args)?;
 
-        let snapshot = self.snapshot.clone();
+        let read_ops = self.read_ops.clone();
         let handle = self.handle.clone();
         let ident_map = self.ident_map.clone();
         let query = query.clone();
@@ -108,7 +134,7 @@ impl Database for DB {
             execute_query(
                 &query,
                 &args,
-                snapshot,
+                read_ops,
                 handle,
                 &ident_map,
                 as_of,
@@ -399,6 +425,43 @@ mod tests {
             result[0],
             vec![DataType::String("test@example.com".to_string())]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_db_can_query_from_db_read_ops() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:name),
+            value: "alice".into(),
+        }])
+        .await
+        .unwrap();
+
+        let ident_map = node
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .ident_map
+            .clone();
+        let db = DB::from_latest_read_ops(
+            node.slate.db.clone(),
+            ident_map,
+            Handle::current(),
+            node.slate.range_stats.clone(),
+        )
+        .await
+        .unwrap();
+        let result = db
+            .query(r#"[:find ?name :where [?e :name ?name]]"#)
+            .await
+            .unwrap();
+
+        assert_eq!(result, vec![vec![DataType::String("alice".to_string())]]);
     }
 
     // End-to-end query tests

--- a/src/node.rs
+++ b/src/node.rs
@@ -410,43 +410,6 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_db_can_query_from_sdb() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-
-        node.execute_tx(vec![TxOp::Add {
-            entity: "alice".into(),
-            attribute: kw!(:name),
-            value: "alice".into(),
-        }])
-        .await
-        .unwrap();
-
-        let ident_map = node
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
-        let db = DB::from_latest_sdb(
-            node.slate.db.clone(),
-            ident_map,
-            Handle::current(),
-            node.slate.range_stats.clone(),
-        )
-        .await
-        .unwrap();
-        let result = db
-            .query(r#"[:find ?name :where [?e :name ?name]]"#)
-            .await
-            .unwrap();
-
-        assert_eq!(result, vec![vec![DataType::String("alice".to_string())]]);
-    }
-
     // End-to-end query tests
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/node.rs
+++ b/src/node.rs
@@ -59,7 +59,7 @@ where
         }
     }
 
-    /// Construct a DB from sdb by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
+    /// Construct a DB from a Db by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
     pub async fn from_latest_sdb(
         sdb: Arc<D>,
         ident_map: IdentMap,

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Error;
+use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
 use crate::schema::IdentMap;
@@ -674,16 +675,20 @@ fn compute_constant_prefix(pattern: &Pattern, index_type: IndexType) -> Result<V
 
 /// Compile a Pattern into a PrefixExtender.
 #[allow(clippy::too_many_arguments)]
-pub fn compile_pattern(
+pub fn compile_pattern<D, M>(
     pattern: &Pattern,
     join_order: &[Variable],
     var_index: &HashMap<&Variable, usize>,
     attribute_id: i64,
-    slate: Arc<slatedb::DbSnapshot>,
+    slate: Arc<D>,
     handle: Handle,
     as_of: i64,
-    range_stats: Arc<slatedb_estimates::RangeStats>,
-) -> Result<GenericPrefixExtender, Error> {
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+) -> Result<GenericPrefixExtender<D, M>, Error>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     let pat_vars = pattern_variables(pattern);
 
     // Determine participating levels (sorted ascending — build_slate_prefix relies on
@@ -1191,16 +1196,20 @@ pub fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Erro
 
 /// Compile an OrWhereClause into a PrefixExtender.
 #[allow(clippy::too_many_arguments)]
-fn compile_or_branch(
+fn compile_or_branch<D, M>(
     branch: &OrWhereClause,
     join_order: &[Variable],
     var_index: &HashMap<&Variable, usize>,
-    slate: &Arc<slatedb::DbSnapshot>,
+    slate: &Arc<D>,
     handle: &Handle,
     ident_map: &IdentMap,
     as_of: i64,
-    range_stats: &Arc<slatedb_estimates::RangeStats>,
-) -> Result<Box<dyn PrefixExtender>, Error> {
+    range_stats: &Arc<slatedb_estimates::RangeStats<M>>,
+) -> Result<Box<dyn PrefixExtender>, Error>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     match branch {
         OrWhereClause::Clause(clause) => compile_where_clause(
             clause,
@@ -1235,16 +1244,20 @@ fn compile_or_branch(
 
 /// Compile a single WhereClause into a PrefixExtender, recursively handling nested clauses.
 #[allow(clippy::too_many_arguments)]
-fn compile_where_clause(
+fn compile_where_clause<D, M>(
     clause: &WhereClause,
     join_order: &[Variable],
     var_index: &HashMap<&Variable, usize>,
-    slate: &Arc<slatedb::DbSnapshot>,
+    slate: &Arc<D>,
     handle: &Handle,
     ident_map: &IdentMap,
     as_of: i64,
-    range_stats: &Arc<slatedb_estimates::RangeStats>,
-) -> Result<Box<dyn PrefixExtender>, Error> {
+    range_stats: &Arc<slatedb_estimates::RangeStats<M>>,
+) -> Result<Box<dyn PrefixExtender>, Error>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     match clause {
         WhereClause::Pattern(pattern) => {
             let attr_id = resolve_attribute_from_pattern(&pattern.attribute, ident_map)?;
@@ -1336,15 +1349,19 @@ fn resolve_limit(limit: &Limit, in_bindings: &[Binding], args: &[QueryArg]) -> L
 }
 
 /// Execute a query against the database.
-pub fn execute_query(
+pub fn execute_query<D, M>(
     query: &ParsedQuery,
     args: &[QueryArg],
-    slate: Arc<slatedb::DbSnapshot>,
+    slate: Arc<D>,
     handle: Handle,
     ident_map: &IdentMap,
     as_of: i64,
-    range_stats: Arc<slatedb_estimates::RangeStats>,
-) -> Result<QueryResult, Error> {
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+) -> Result<QueryResult, Error>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
     // 1. Extract variable order (in_bindings prepended)
     let join_order = query_variable_order(&query.in_bindings, &query.where_clauses);
     let num_levels = join_order.len();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -832,11 +832,7 @@ pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> 
     bootstrap_ident_map.insert(kw!(:db/valueType), DB_VALUE_TYPE);
     bootstrap_ident_map.insert(kw!(:db/cardinality), DB_CARDINALITY);
     bootstrap_ident_map.insert(kw!(:db/unique), DB_UNIQUE);
-    let snapshot = slate
-        .db
-        .snapshot()
-        .await
-        .expect("Failed to create snapshot");
+    let sdb = slate.db.clone();
     let range_stats = slate.range_stats.clone();
     let handle = Handle::current();
 
@@ -855,7 +851,7 @@ pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> 
         let idents = execute_query(
             &ident_query,
             &[],
-            snapshot.clone(),
+            sdb.clone(),
             handle.clone(),
             &bootstrap_ident_map,
             i64::MAX,
@@ -864,7 +860,7 @@ pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> 
         let attrs = execute_query(
             &attr_query,
             &[],
-            snapshot.clone(),
+            sdb.clone(),
             handle.clone(),
             &bootstrap_ident_map,
             i64::MAX,
@@ -873,7 +869,7 @@ pub async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> 
         let uniques = execute_query(
             &unique_query,
             &[],
-            snapshot,
+            sdb,
             handle,
             &bootstrap_ident_map,
             i64::MAX,

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -387,10 +387,10 @@ mod tests {
         db.close().await.unwrap();
     }
 
-    // --- Snapshot + CdcStream integration tests ---
+    // --- Cursor + CdcStream integration tests ---
 
     #[tokio::test]
-    async fn test_cdc_after_snapshot_all_caught_up() {
+    async fn test_cdc_from_current_seq_all_caught_up() {
         let (db, object_store) = setup_db("/test_snap_caught_up").await;
 
         db.put(b"k1", b"v1").await.unwrap();
@@ -400,10 +400,9 @@ mod tests {
         db.put(b"k3", b"v3").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
 
-        let snapshot = db.snapshot().await.unwrap();
-        let snap_seq = snapshot.seq();
+        let current_seq = db.status().durable_seq;
 
-        // CdcStream starting from snapshot seq — nothing new after snapshot.
+        // CdcStream starting from the current durable seq has nothing new.
         let wal_reader = WalReader::new("/test_snap_caught_up", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
@@ -411,7 +410,7 @@ mod tests {
             wal_reader,
             CdcCursor {
                 wal_id: 0,
-                last_seq: snap_seq,
+                last_seq: current_seq,
             },
             Duration::from_millis(10),
             cancel,
@@ -420,24 +419,23 @@ mod tests {
         .unwrap();
 
         let result = stream.next_transaction().await.unwrap();
-        assert!(result.is_none(), "expected no transactions after snapshot");
+        assert!(result.is_none(), "expected no transactions after cursor");
         db.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_cdc_after_snapshot_some_new() {
+    async fn test_cdc_from_current_seq_some_new() {
         let (db, object_store) = setup_db("/test_snap_some_new").await;
 
-        // Before snapshot.
+        // Before cursor.
         db.put(b"k1", b"v1").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
         db.put(b"k2", b"v2").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
 
-        let snapshot = db.snapshot().await.unwrap();
-        let snap_seq = snapshot.seq();
+        let current_seq = db.status().durable_seq;
 
-        // After snapshot.
+        // After cursor.
         db.put(b"k3", b"v3").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
         db.put(b"k4", b"v4").await.unwrap();
@@ -450,7 +448,7 @@ mod tests {
             wal_reader,
             CdcCursor {
                 wal_id: 0,
-                last_seq: snap_seq,
+                last_seq: current_seq,
             },
             Duration::from_millis(10),
             cancel,
@@ -461,30 +459,29 @@ mod tests {
         let mut txs = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
             assert!(
-                tx.seq > snap_seq,
-                "tx.seq {} should be > snapshot seq {}",
+                tx.seq > current_seq,
+                "tx.seq {} should be > cursor seq {}",
                 tx.seq,
-                snap_seq
+                current_seq
             );
             txs.push(tx);
         }
         assert!(
             txs.len() >= 2,
-            "expected at least 2 post-snapshot transactions, got {}",
+            "expected at least 2 post-cursor transactions, got {}",
             txs.len()
         );
         db.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_cdc_after_snapshot_all_after() {
+    async fn test_cdc_from_current_seq_all_after() {
         let (db, object_store) = setup_db("/test_snap_all_after").await;
 
-        // Snapshot on empty-ish DB.
-        let snapshot = db.snapshot().await.unwrap();
-        let snap_seq = snapshot.seq();
+        // Cursor on empty-ish DB.
+        let current_seq = db.status().durable_seq;
 
-        // All transactions after snapshot.
+        // All transactions after cursor.
         db.put(b"k1", b"v1").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
         db.put(b"k2", b"v2").await.unwrap();
@@ -497,7 +494,7 @@ mod tests {
             wal_reader,
             CdcCursor {
                 wal_id: 0,
-                last_seq: snap_seq,
+                last_seq: current_seq,
             },
             Duration::from_millis(10),
             cancel,
@@ -508,10 +505,10 @@ mod tests {
         let mut txs = Vec::new();
         while let Some(tx) = stream.next_transaction().await.unwrap() {
             assert!(
-                tx.seq > snap_seq,
-                "tx.seq {} should be > snapshot seq {}",
+                tx.seq > current_seq,
+                "tx.seq {} should be > cursor seq {}",
                 tx.seq,
-                snap_seq
+                current_seq
             );
             txs.push(tx);
         }
@@ -524,15 +521,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cdc_after_snapshot_live_streaming() {
+    async fn test_cdc_from_current_seq_live_streaming() {
         tokio::time::timeout(Duration::from_secs(5), async {
             let (db, object_store) = setup_db("/test_snap_live").await;
 
             db.put(b"k1", b"v1").await.unwrap();
             db.flush_with_options(flush_opts()).await.unwrap();
 
-            let snapshot = db.snapshot().await.unwrap();
-            let snap_seq = snapshot.seq();
+            let current_seq = db.status().durable_seq;
 
             // Create stream BEFORE new transactions exist.
             let wal_reader = WalReader::new("/test_snap_live", object_store);
@@ -542,7 +538,7 @@ mod tests {
                 wal_reader,
                 CdcCursor {
                     wal_id: 0,
-                    last_seq: snap_seq,
+                    last_seq: current_seq,
                 },
                 Duration::from_millis(10),
                 cancel,
@@ -565,10 +561,10 @@ mod tests {
             let mut txs = Vec::new();
             while let Some(tx) = stream.next_transaction().await.unwrap() {
                 assert!(
-                    tx.seq > snap_seq,
-                    "tx.seq {} should be > snapshot seq {}",
+                    tx.seq > current_seq,
+                    "tx.seq {} should be > cursor seq {}",
                     tx.seq,
-                    snap_seq
+                    current_seq
                 );
                 txs.push(tx);
             }
@@ -579,22 +575,21 @@ mod tests {
             );
         })
         .await
-        .expect("test_cdc_after_snapshot_live_streaming timed out");
+        .expect("test_cdc_from_current_seq_live_streaming timed out");
     }
 
     #[tokio::test]
-    async fn test_cdc_after_snapshot_mixed_timing() {
+    async fn test_cdc_from_current_seq_mixed_timing() {
         tokio::time::timeout(Duration::from_secs(5), async {
             let (db, object_store) = setup_db("/test_snap_mixed").await;
 
-            // Before snapshot.
+            // Before cursor.
             db.put(b"k1", b"v1").await.unwrap();
             db.flush_with_options(flush_opts()).await.unwrap();
 
-            let snapshot = db.snapshot().await.unwrap();
-            let snap_seq = snapshot.seq();
+            let current_seq = db.status().durable_seq;
 
-            // After snapshot but before stream creation.
+            // After cursor but before stream creation.
             db.put(b"k2", b"v2").await.unwrap();
             db.flush_with_options(flush_opts()).await.unwrap();
 
@@ -606,7 +601,7 @@ mod tests {
                 wal_reader,
                 CdcCursor {
                     wal_id: 0,
-                    last_seq: snap_seq,
+                    last_seq: current_seq,
                 },
                 Duration::from_millis(10),
                 cancel,
@@ -626,10 +621,10 @@ mod tests {
             let mut txs = Vec::new();
             while let Some(tx) = stream.next_transaction().await.unwrap() {
                 assert!(
-                    tx.seq > snap_seq,
-                    "tx.seq {} should be > snapshot seq {}",
+                    tx.seq > current_seq,
+                    "tx.seq {} should be > cursor seq {}",
                     tx.seq,
-                    snap_seq
+                    current_seq
                 );
                 txs.push(tx);
             }
@@ -641,6 +636,6 @@ mod tests {
             );
         })
         .await
-        .expect("test_cdc_after_snapshot_mixed_timing timed out");
+        .expect("test_cdc_from_current_seq_mixed_timing timed out");
     }
 }

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -390,8 +390,8 @@ mod tests {
     // --- Cursor + CdcStream integration tests ---
 
     #[tokio::test]
-    async fn test_cdc_from_current_seq_all_caught_up() {
-        let (db, object_store) = setup_db("/test_snap_caught_up").await;
+    async fn test_cdc_cursor_at_end_returns_none() {
+        let (db, object_store) = setup_db("/test_cursor_at_end").await;
 
         db.put(b"k1", b"v1").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
@@ -403,7 +403,7 @@ mod tests {
         let current_seq = db.status().durable_seq;
 
         // CdcStream starting from the current durable seq has nothing new.
-        let wal_reader = WalReader::new("/test_snap_caught_up", object_store);
+        let wal_reader = WalReader::new("/test_cursor_at_end", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
         let mut stream = CdcStream::new(
@@ -424,8 +424,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cdc_from_current_seq_some_new() {
-        let (db, object_store) = setup_db("/test_snap_some_new").await;
+    async fn test_cdc_cursor_skips_existing_transactions() {
+        let (db, object_store) = setup_db("/test_cursor_skips_existing").await;
 
         // Before cursor.
         db.put(b"k1", b"v1").await.unwrap();
@@ -441,7 +441,7 @@ mod tests {
         db.put(b"k4", b"v4").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
 
-        let wal_reader = WalReader::new("/test_snap_some_new", object_store);
+        let wal_reader = WalReader::new("/test_cursor_skips_existing", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
         let mut stream = CdcStream::new(
@@ -475,8 +475,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cdc_from_current_seq_all_after() {
-        let (db, object_store) = setup_db("/test_snap_all_after").await;
+    async fn test_cdc_cursor_from_zero_reads_later_transactions() {
+        let (db, object_store) = setup_db("/test_cursor_from_zero").await;
 
         // Cursor on empty-ish DB.
         let current_seq = db.status().durable_seq;
@@ -487,7 +487,7 @@ mod tests {
         db.put(b"k2", b"v2").await.unwrap();
         db.flush_with_options(flush_opts()).await.unwrap();
 
-        let wal_reader = WalReader::new("/test_snap_all_after", object_store);
+        let wal_reader = WalReader::new("/test_cursor_from_zero", object_store);
         let cancel = CancellationToken::new();
         cancel.cancel();
         let mut stream = CdcStream::new(
@@ -521,9 +521,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cdc_from_current_seq_live_streaming() {
+    async fn test_cdc_cursor_waits_for_live_transactions() {
         tokio::time::timeout(Duration::from_secs(5), async {
-            let (db, object_store) = setup_db("/test_snap_live").await;
+            let (db, object_store) = setup_db("/test_cursor_live").await;
 
             db.put(b"k1", b"v1").await.unwrap();
             db.flush_with_options(flush_opts()).await.unwrap();
@@ -531,7 +531,7 @@ mod tests {
             let current_seq = db.status().durable_seq;
 
             // Create stream BEFORE new transactions exist.
-            let wal_reader = WalReader::new("/test_snap_live", object_store);
+            let wal_reader = WalReader::new("/test_cursor_live", object_store);
             let cancel = CancellationToken::new();
             let cancel_clone = cancel.clone();
             let mut stream = CdcStream::new(
@@ -575,13 +575,13 @@ mod tests {
             );
         })
         .await
-        .expect("test_cdc_from_current_seq_live_streaming timed out");
+        .expect("test_cdc_cursor_waits_for_live_transactions timed out");
     }
 
     #[tokio::test]
-    async fn test_cdc_from_current_seq_mixed_timing() {
+    async fn test_cdc_cursor_reads_existing_and_live_transactions() {
         tokio::time::timeout(Duration::from_secs(5), async {
-            let (db, object_store) = setup_db("/test_snap_mixed").await;
+            let (db, object_store) = setup_db("/test_cursor_mixed").await;
 
             // Before cursor.
             db.put(b"k1", b"v1").await.unwrap();
@@ -594,7 +594,7 @@ mod tests {
             db.flush_with_options(flush_opts()).await.unwrap();
 
             // Create stream — k2 is already in WAL.
-            let wal_reader = WalReader::new("/test_snap_mixed", object_store);
+            let wal_reader = WalReader::new("/test_cursor_mixed", object_store);
             let cancel = CancellationToken::new();
             let cancel_clone = cancel.clone();
             let mut stream = CdcStream::new(
@@ -636,6 +636,6 @@ mod tests {
             );
         })
         .await
-        .expect("test_cdc_from_current_seq_mixed_timing timed out");
+        .expect("test_cdc_cursor_reads_existing_and_live_transactions timed out");
     }
 }

--- a/triplox-jvm/dev/dev.clj
+++ b/triplox-jvm/dev/dev.clj
@@ -12,7 +12,7 @@
   (t/transact conn [{:db/id 1001 :person/name "alice" :person/age 30}
                     {:db/id 1002 :person/name "bob" :person/age 25}])
 
-  ;; Open a DB snapshot and query
+  ;; Open a DB handle and query
   (with-open [db (t/db conn)]
     (t/q db '{:find [?name ?age]
                    :where [[?e :person/name ?name]

--- a/triplox-jvm/src/main/clojure/io/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/api.clj
@@ -10,7 +10,7 @@
   (TriploxNode/connect host (int port)))
 
 (defn db
-  "Open a DB snapshot. Returns a Db (AutoCloseable)."
+  "Open a DB handle. Returns a Db (AutoCloseable)."
   (^Db [conn]
    (db conn nil))
   (^Db [conn {:keys [tx-basis] :as _opts}]


### PR DESCRIPTION
## Summary
- Make the query DB and iterator plumbing generic over SlateDB `DbReadOps` (and `DbMetadataOps` for `RangeStats`).
- Drop snapshot acquisition from `Node::db()` / `Node::db_as_of()`; reads now go through `Arc<slatedb::Db>` and rely on the existing `as_of = tx_basis.tx_eid` temporal filter for isolation.
- Add `DB::from_latest_sdb` for reader-node preparation; add a regression test that queries directly through `Arc<slatedb::Db>`.
- Snapshot-backed DB construction is no longer used in-tree, but remains reachable via the generic parameter since `DbSnapshot: DbReadOps`.

## Testing
- cargo check -p triplox
- cargo test -p triplox
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features

Autogenerated by GPT-5.