### PR TITLE
Reject repeated query pattern variables

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -785,6 +785,61 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_loop_edge_is_rejected_at_validation_time() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![TxOp::put(vec![
+            (kw!(:db/ident), DataType::Keyword(kw!(:g/to))),
+            (
+                kw!(:db/valueType),
+                DataType::Keyword(Keyword::namespaced("db.type", "ref")),
+            ),
+            (
+                kw!(:db/cardinality),
+                DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
+            ),
+        ])])
+        .await
+        .unwrap();
+
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("alice".to_string())),
+                (kw!(:name), "alice".into()),
+                (kw!(:g/to), DataType::String("alice".to_string())),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("bob".to_string())),
+                (kw!(:name), "bob".into()),
+                (kw!(:g/to), DataType::String("alice".to_string())),
+            ]),
+        ])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let alice = db
+            .query(r#"{:find [?x] :where [[?x :name "alice"]]}"#)
+            .await
+            .unwrap();
+        assert_eq!(alice.len(), 1);
+
+        let result = db
+            .query("{:find [?x] :where [[?x :g/to ?x]]}")
+            .await
+            .unwrap_err();
+
+        assert!(
+            result
+                .to_string()
+                .contains("Repeated variable ?x in a single pattern is not supported"),
+            "unexpected error: {}",
+            result
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_or_clause_basic() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -785,61 +785,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_query_loop_edge_is_rejected_at_validation_time() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-
-        node.execute_tx(vec![TxOp::put(vec![
-            (kw!(:db/ident), DataType::Keyword(kw!(:g/to))),
-            (
-                kw!(:db/valueType),
-                DataType::Keyword(Keyword::namespaced("db.type", "ref")),
-            ),
-            (
-                kw!(:db/cardinality),
-                DataType::Keyword(Keyword::namespaced("db.cardinality", "one")),
-            ),
-        ])])
-        .await
-        .unwrap();
-
-        node.execute_tx(vec![
-            TxOp::put(vec![
-                (kw!(:db/id), DataType::String("alice".to_string())),
-                (kw!(:name), "alice".into()),
-                (kw!(:g/to), DataType::String("alice".to_string())),
-            ]),
-            TxOp::put(vec![
-                (kw!(:db/id), DataType::String("bob".to_string())),
-                (kw!(:name), "bob".into()),
-                (kw!(:g/to), DataType::String("alice".to_string())),
-            ]),
-        ])
-        .await
-        .unwrap();
-
-        let db = node.db().await.unwrap();
-        let alice = db
-            .query(r#"{:find [?x] :where [[?x :name "alice"]]}"#)
-            .await
-            .unwrap();
-        assert_eq!(alice.len(), 1);
-
-        let result = db
-            .query("{:find [?x] :where [[?x :g/to ?x]]}")
-            .await
-            .unwrap_err();
-
-        assert!(
-            result
-                .to_string()
-                .contains("Repeated variable ?x in a single pattern is not supported"),
-            "unexpected error: {}",
-            result
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_or_clause_basic() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/query.rs
+++ b/src/query.rs
@@ -428,6 +428,47 @@ fn validate_not_clauses(
     Ok(())
 }
 
+fn validate_pattern_variables(where_clauses: &[WhereClause]) -> Result<(), Error> {
+    for clause in where_clauses {
+        validate_pattern_variables_in_clause(clause)?;
+    }
+    Ok(())
+}
+
+fn validate_pattern_variables_in_or_branch(branch: &OrWhereClause) -> Result<(), Error> {
+    match branch {
+        OrWhereClause::Clause(clause) => validate_pattern_variables_in_clause(clause),
+        OrWhereClause::And(children) => validate_pattern_variables(children),
+    }
+}
+
+fn validate_pattern_variables_in_clause(clause: &WhereClause) -> Result<(), Error> {
+    match clause {
+        WhereClause::Pattern(pattern) => validate_single_pattern_variables(pattern),
+        WhereClause::OrJoin(oj) => {
+            for branch in &oj.clauses {
+                validate_pattern_variables_in_or_branch(branch)?;
+            }
+            Ok(())
+        }
+        WhereClause::NotJoin(nj) => validate_pattern_variables(&nj.clauses),
+        _ => Ok(()),
+    }
+}
+
+fn validate_single_pattern_variables(pattern: &Pattern) -> Result<(), Error> {
+    let mut seen = HashSet::new();
+    for var in pattern_variables(pattern) {
+        if !seen.insert(var.clone()) {
+            return Err(anyhow::anyhow!(
+                "Repeated variable {} in a single pattern is not supported",
+                var
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Validate that all variables in Predicate clauses are bound by positive clauses,
 /// and that each predicate has at least one variable.
 fn validate_predicate_clauses(
@@ -1148,6 +1189,7 @@ pub fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Erro
             validate_or_branches(&oj.clauses)?;
         }
     }
+    validate_pattern_variables(&query.where_clauses)?;
     validate_not_clauses(&query.where_clauses, &var_index)?;
     validate_predicate_clauses(&query.where_clauses, &var_index)?;
     validate_fn_clauses(&query.where_clauses, &var_index)?;
@@ -1458,6 +1500,18 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("at least one variable"));
+    }
+
+    #[test]
+    fn test_validate_rejects_repeated_variable_in_single_pattern() {
+        let parsed = parse_query("{:find [?x] :where [[?x :g/to ?x]]}");
+        let err = validate_query(&parsed, &[]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Repeated variable ?x in a single pattern is not supported"),
+            "unexpected error: {}",
+            err
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject repeated variables within a single datalog pattern during query validation
- add validation-level regression coverage for loop-edge query shape `{:find [?x] :where [[?x :g/to ?x]]}`

## Tests
- `cargo fmt --check`
- `cargo test -p triplox query::tests::test_validate_rejects_repeated_variable_in_single_pattern -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Generated with Codex (GPT-5).
