### PR TITLE
Publish JVM client to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,21 @@ jobs:
             -PclojarsUsername="$CLOJARS_USERNAME" \
             -PclojarsPassword="$CLOJARS_PASSWORD"
 
+      - name: Publish JVM client to Maven Central
+        env:
+          CENTRAL_USERNAME: ${{ vars.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          TRIPLOX_VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          cd triplox-jvm
+          ./gradlew publishMavenPublicationToCentralPortal \
+            -PtriploxVersion="$TRIPLOX_VERSION" \
+            -PcentralUsername="$CENTRAL_USERNAME" \
+            -PcentralPassword="$CENTRAL_PASSWORD" \
+            -PcentralPublishingType=user_managed
+
   docker-image:
     needs: verify
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,18 +106,16 @@ jobs:
 
       - name: Publish JVM client to Maven Central
         env:
-          CENTRAL_USERNAME: ${{ vars.CENTRAL_USERNAME }}
-          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ vars.CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signAllPublications: "true"
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           TRIPLOX_VERSION: ${{ needs.verify.outputs.version }}
         run: |
           cd triplox-jvm
-          ./gradlew publishMavenPublicationToCentralPortal \
-            -PtriploxVersion="$TRIPLOX_VERSION" \
-            -PcentralUsername="$CENTRAL_USERNAME" \
-            -PcentralPassword="$CENTRAL_PASSWORD" \
-            -PcentralPublishingType=user_managed
+          ./gradlew publishToMavenCentral \
+            -PtriploxVersion="$TRIPLOX_VERSION"
 
   docker-image:
     needs: verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           TRIPLOX_VERSION: ${{ needs.verify.outputs.version }}
         run: |
           cd triplox-jvm
-          ./gradlew publishToMavenCentral \
+          ./gradlew publishAndReleaseToMavenCentral \
             -PtriploxVersion="$TRIPLOX_VERSION"
 
   docker-image:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,18 +45,3 @@ same workflow on the branch ref with `mode` set to `snapshot`.
 `CENTRAL_USERNAME` and `CENTRAL_PASSWORD` are the Sonatype Central Portal user
 token values, not the account login password. Generate them from the Central
 Portal account settings.
-
-`SIGNING_KEY` is the private key exported with:
-
-```bash
-gpg --armor --export-secret-keys <key-id>
-```
-
-Use a dedicated release signing key rather than a personal long-term GPG key.
-Publish the matching public key before the first release:
-
-```bash
-gpg --keyserver keyserver.ubuntu.com --send-keys <key-id>
-```
-
-`SIGNING_PASSWORD` is the passphrase for that private key.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,12 @@ git push origin v0.1.0-alpha.2
 ```
 
 Pushing the tag triggers GitHub Actions to publish the Rust crates, JVM client,
-Docker image, and GitHub Release.
+Docker image, and GitHub Release. The JVM client is published to Clojars and
+uploaded to Maven Central.
+
+After the workflow uploads the JVM client to Maven Central, open
+https://central.sonatype.com/publishing, inspect the deployment, and click
+Publish.
 
 To publish only the Docker image for an existing release tag, run the
 `Docker Publish` workflow manually, select the release tag as the ref, and set
@@ -36,3 +41,7 @@ same workflow on the branch ref with `mode` set to `snapshot`.
 - `CARGO_REGISTRY_TOKEN` for crates.io.
 - `CLOJARS_PASSWORD` for Clojars.
 - `CLOJARS_USERNAME` as a repository variable.
+- `CENTRAL_PASSWORD` for Maven Central.
+- `CENTRAL_USERNAME` as a repository variable.
+- `SIGNING_KEY` as an ASCII-armored GPG private key for Maven Central.
+- `SIGNING_PASSWORD` for the GPG private key.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,23 +25,38 @@ git push origin v0.1.0-alpha.2
 
 Pushing the tag triggers GitHub Actions to publish the Rust crates, JVM client,
 Docker image, and GitHub Release. The JVM client is published to Clojars and
-uploaded to Maven Central.
-
-After the workflow uploads the JVM client to Maven Central, open
-https://central.sonatype.com/publishing, inspect the deployment, and click
-Publish.
+published to Maven Central after Central Portal validation.
 
 To publish only the Docker image for an existing release tag, run the
 `Docker Publish` workflow manually, select the release tag as the ref, and set
 `mode` to `release`. To publish a SNAPSHOT Docker image from a branch, run the
 same workflow on the branch ref with `mode` set to `snapshot`.
 
-## Required GitHub secrets
+## Required GitHub variables and secrets
 
 - `CARGO_REGISTRY_TOKEN` for crates.io.
-- `CLOJARS_PASSWORD` for Clojars.
 - `CLOJARS_USERNAME` as a repository variable.
-- `CENTRAL_PASSWORD` for Maven Central.
+- `CLOJARS_PASSWORD` for Clojars.
 - `CENTRAL_USERNAME` as a repository variable.
+- `CENTRAL_PASSWORD` for Maven Central.
 - `SIGNING_KEY` as an ASCII-armored GPG private key for Maven Central.
 - `SIGNING_PASSWORD` for the GPG private key.
+
+`CENTRAL_USERNAME` and `CENTRAL_PASSWORD` are the Sonatype Central Portal user
+token values, not the account login password. Generate them from the Central
+Portal account settings.
+
+`SIGNING_KEY` is the private key exported with:
+
+```bash
+gpg --armor --export-secret-keys <key-id>
+```
+
+Use a dedicated release signing key rather than a personal long-term GPG key.
+Publish the matching public key before the first release:
+
+```bash
+gpg --keyserver keyserver.ubuntu.com --send-keys <key-id>
+```
+
+`SIGNING_PASSWORD` is the passphrase for that private key.

--- a/triplox-jvm/README.md
+++ b/triplox-jvm/README.md
@@ -52,24 +52,32 @@ To override the published Clojars version:
 To upload the current workspace version to Maven Central:
 
 ```bash
-CENTRAL_USERNAME=... \
-CENTRAL_PASSWORD=... \
-SIGNING_KEY="$(gpg --armor --export-secret-keys <key-id>)" \
-SIGNING_PASSWORD=... \
-./gradlew publishMavenPublicationToCentralPortal
+ORG_GRADLE_PROJECT_mavenCentralUsername=... \
+ORG_GRADLE_PROJECT_mavenCentralPassword=... \
+ORG_GRADLE_PROJECT_signAllPublications=true \
+ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --armor --export-secret-keys <key-id>)" \
+ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=... \
+./gradlew publishToMavenCentral
 ```
 
 To override the Maven Central version:
 
 ```bash
-CENTRAL_USERNAME=... \
-CENTRAL_PASSWORD=... \
-SIGNING_KEY="$(gpg --armor --export-secret-keys <key-id>)" \
-SIGNING_PASSWORD=... \
-./gradlew publishMavenPublicationToCentralPortal \
+ORG_GRADLE_PROJECT_mavenCentralUsername=... \
+ORG_GRADLE_PROJECT_mavenCentralPassword=... \
+ORG_GRADLE_PROJECT_signAllPublications=true \
+ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --armor --export-secret-keys <key-id>)" \
+ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=... \
+./gradlew publishToMavenCentral \
     -PtriploxVersion=0.1.0-alpha.2
 ```
 
-The Maven Central task uploads the deployment in `user_managed` mode by default.
+The Maven Central task uploads the deployment for manual publishing by default.
 After it succeeds, inspect the deployment at <https://central.sonatype.com/publishing>
-and click Publish.
+and click Publish. Use `./gradlew publishAndReleaseToMavenCentral` only when you
+want the plugin to publish automatically after Central Portal validation.
+
+If `signAllPublications=true` is set in `~/.gradle/gradle.properties`, local
+non-release checks such as `publishMavenPublicationToMavenLocal` also expect a
+signing key. Pass `-PsignAllPublications=false` for those checks when you are
+not testing signing.

--- a/triplox-jvm/README.md
+++ b/triplox-jvm/README.md
@@ -52,30 +52,35 @@ To override the published Clojars version:
 To upload the current workspace version to Maven Central:
 
 ```bash
-ORG_GRADLE_PROJECT_mavenCentralUsername=... \
-ORG_GRADLE_PROJECT_mavenCentralPassword=... \
+ORG_GRADLE_PROJECT_mavenCentralUsername=<central-token-username> \
+ORG_GRADLE_PROJECT_mavenCentralPassword=<central-token-password> \
 ORG_GRADLE_PROJECT_signAllPublications=true \
 ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --armor --export-secret-keys <key-id>)" \
-ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=... \
+ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=<gpg-key-passphrase> \
 ./gradlew publishToMavenCentral
 ```
 
 To override the Maven Central version:
 
 ```bash
-ORG_GRADLE_PROJECT_mavenCentralUsername=... \
-ORG_GRADLE_PROJECT_mavenCentralPassword=... \
+ORG_GRADLE_PROJECT_mavenCentralUsername=<central-token-username> \
+ORG_GRADLE_PROJECT_mavenCentralPassword=<central-token-password> \
 ORG_GRADLE_PROJECT_signAllPublications=true \
 ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --armor --export-secret-keys <key-id>)" \
-ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=... \
+ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=<gpg-key-passphrase> \
 ./gradlew publishToMavenCentral \
     -PtriploxVersion=0.1.0-alpha.2
 ```
 
+The Maven Central username and password are Central Portal user token values.
+The signing key is the ASCII-armored private GPG key, and the matching public
+key must be available on a public keyserver before release validation succeeds.
+
 The Maven Central task uploads the deployment for manual publishing by default.
 After it succeeds, inspect the deployment at <https://central.sonatype.com/publishing>
-and click Publish. Use `./gradlew publishAndReleaseToMavenCentral` only when you
-want the plugin to publish automatically after Central Portal validation.
+and click Publish. Use `./gradlew publishAndReleaseToMavenCentral` when you want
+the plugin to publish automatically after Central Portal validation. Tagged
+GitHub releases use the automatic task.
 
 If `signAllPublications=true` is set in `~/.gradle/gradle.properties`, local
 non-release checks such as `publishMavenPublicationToMavenLocal` also expect a

--- a/triplox-jvm/README.md
+++ b/triplox-jvm/README.md
@@ -33,15 +33,43 @@ By default the tests connect to `localhost:5490`. Override with environment vari
 TRIPLOX_HOST=192.168.1.10 TRIPLOX_PORT=5491 ./gradlew integrationTest
 ```
 
-### Deploying
+## Deploying
+
 To deploy the current workspace version to Clojars:
+
 ```bash
 ./gradlew publishMavenPublicationToClojarsRepository
 ```
 
-To override the published version:
+To override the published Clojars version:
+
 ```bash
 ./gradlew publishMavenPublicationToClojarsRepository \
     -Dorg.gradle.internal.publish.checksums.insecure=true \
     -PtriploxVersion=0.1.0-alpha.2
 ```
+
+To upload the current workspace version to Maven Central:
+
+```bash
+CENTRAL_USERNAME=... \
+CENTRAL_PASSWORD=... \
+SIGNING_KEY="$(gpg --armor --export-secret-keys <key-id>)" \
+SIGNING_PASSWORD=... \
+./gradlew publishMavenPublicationToCentralPortal
+```
+
+To override the Maven Central version:
+
+```bash
+CENTRAL_USERNAME=... \
+CENTRAL_PASSWORD=... \
+SIGNING_KEY="$(gpg --armor --export-secret-keys <key-id>)" \
+SIGNING_PASSWORD=... \
+./gradlew publishMavenPublicationToCentralPortal \
+    -PtriploxVersion=0.1.0-alpha.2
+```
+
+The Maven Central task uploads the deployment in `user_managed` mode by default.
+After it succeeds, inspect the deployment at <https://central.sonatype.com/publishing>
+and click Publish.

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -82,7 +82,7 @@ mavenPublishing {
 
     pom {
         name.set("triplox")
-        description.set("A triple store built on top of XTDB")
+        description.set("A Datomic-like triplestore in Rust on top of SlateDB")
         url.set("https://github.com/FiV0/triplox")
 
         licenses {

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -1,6 +1,13 @@
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Base64
+
 plugins {
     `java-library`
     `maven-publish`
+    signing
     id("dev.clojurephant.clojure") version "0.8.0-beta.7"
 }
 
@@ -25,6 +32,9 @@ fun workspaceVersion(): String {
 }
 
 val triploxVersion = (findProperty("triploxVersion") as String?) ?: workspaceVersion()
+
+fun propertyOrEnv(propertyName: String, envName: String): String? =
+    (findProperty(propertyName) as String?) ?: System.getenv(envName)
 
 dependencies {
     // Clojure
@@ -69,7 +79,11 @@ tasks.checkClojure {
     enabled = false
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+    withSourcesJar()
+    withJavadocJar()
+}
 
 publishing {
     publications {
@@ -113,9 +127,72 @@ publishing {
             name = "clojars"
             url = uri("https://clojars.org/repo")
             credentials {
-                username = findProperty("clojarsUsername") as String?
-                password = findProperty("clojarsPassword") as String?
+                username = propertyOrEnv("clojarsUsername", "CLOJARS_USERNAME")
+                password = propertyOrEnv("clojarsPassword", "CLOJARS_PASSWORD")
+            }
+        }
+
+        maven {
+            name = "central"
+            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+            credentials {
+                username = propertyOrEnv("centralUsername", "CENTRAL_USERNAME")
+                password = propertyOrEnv("centralPassword", "CENTRAL_PASSWORD")
             }
         }
     }
+}
+
+signing {
+    setRequired {
+        gradle.taskGraph.hasTask(":publishMavenPublicationToCentralRepository") ||
+            gradle.taskGraph.hasTask(":publishMavenPublicationToCentralPortal")
+    }
+
+    val signingKey = propertyOrEnv("signingInMemoryKey", "SIGNING_KEY")
+    val signingPassword = propertyOrEnv("signingInMemoryKeyPassword", "SIGNING_PASSWORD")
+    if (signingKey != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
+    sign(publishing.publications["maven"])
+}
+
+tasks.register("uploadCentralDeployment") {
+    group = "publishing"
+    description = "Uploads the Central OSSRH compatibility staging repository to the Central Portal."
+    dependsOn("publishMavenPublicationToCentralRepository")
+
+    doLast {
+        val username = propertyOrEnv("centralUsername", "CENTRAL_USERNAME")
+            ?: throw GradleException("Missing centralUsername property or CENTRAL_USERNAME environment variable")
+        val password = propertyOrEnv("centralPassword", "CENTRAL_PASSWORD")
+            ?: throw GradleException("Missing centralPassword property or CENTRAL_PASSWORD environment variable")
+        val namespace = propertyOrEnv("centralNamespace", "CENTRAL_NAMESPACE") ?: "xyz.triplox"
+        val publishingType = propertyOrEnv("centralPublishingType", "CENTRAL_PUBLISHING_TYPE") ?: "user_managed"
+        val auth = Base64.getEncoder().encodeToString("$username:$password".toByteArray(Charsets.UTF_8))
+
+        val request = HttpRequest.newBuilder(
+            URI.create(
+                "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/" +
+                    "$namespace?publishing_type=$publishingType",
+            ),
+        )
+            .header("Authorization", "Bearer $auth")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build()
+
+        val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in 200..299) {
+            throw GradleException(
+                "Central Portal upload failed with HTTP ${response.statusCode()}: ${response.body()}",
+            )
+        }
+        logger.lifecycle("Uploaded Maven Central deployment for namespace $namespace using publishing_type=$publishingType")
+    }
+}
+
+tasks.register("publishMavenPublicationToCentralPortal") {
+    group = "publishing"
+    description = "Publishes the JVM client to the Central Portal using the Central OSSRH compatibility API."
+    dependsOn("uploadCentralDeployment")
 }

--- a/triplox-jvm/build.gradle.kts
+++ b/triplox-jvm/build.gradle.kts
@@ -1,14 +1,8 @@
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.util.Base64
-
 plugins {
     `java-library`
     `maven-publish`
-    signing
     id("dev.clojurephant.clojure") version "0.8.0-beta.7"
+    id("com.vanniktech.maven.publish") version "0.34.0"
 }
 
 repositories {
@@ -79,49 +73,41 @@ tasks.checkClojure {
     enabled = false
 }
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
-    withSourcesJar()
-    withJavadocJar()
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+mavenPublishing {
+    publishToMavenCentral()
+
+    coordinates("xyz.triplox", "triplox", triploxVersion)
+
+    pom {
+        name.set("triplox")
+        description.set("A triple store built on top of XTDB")
+        url.set("https://github.com/FiV0/triplox")
+
+        licenses {
+            license {
+                name.set("Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("FiV0")
+                name.set("Finn Völkel")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/FiV0/triplox")
+            connection.set("scm:git:git://github.com/FiV0/triplox.git")
+            developerConnection.set("scm:git:ssh://git@github.com/FiV0/triplox.git")
+        }
+    }
 }
 
 publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = "xyz.triplox"
-            artifactId = "triplox"
-            version = triploxVersion
-
-            from(components["java"])
-
-            pom {
-                name.set("triplox")
-                description.set("A triple store built on top of XTDB")
-                url.set("https://github.com/FiV0/triplox")
-
-                licenses {
-                    license {
-                        name.set("Apache License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                }
-
-                developers {
-                    developer {
-                        id.set("FiV0")
-                        name.set("Finn Völkel")
-                    }
-                }
-
-                scm {
-                    url.set("https://github.com/FiV0/triplox")
-                    connection.set("scm:git:git://github.com/FiV0/triplox.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/FiV0/triplox.git")
-                }
-            }
-        }
-    }
-
     repositories {
         maven {
             name = "clojars"
@@ -131,68 +117,5 @@ publishing {
                 password = propertyOrEnv("clojarsPassword", "CLOJARS_PASSWORD")
             }
         }
-
-        maven {
-            name = "central"
-            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-            credentials {
-                username = propertyOrEnv("centralUsername", "CENTRAL_USERNAME")
-                password = propertyOrEnv("centralPassword", "CENTRAL_PASSWORD")
-            }
-        }
     }
-}
-
-signing {
-    setRequired {
-        gradle.taskGraph.hasTask(":publishMavenPublicationToCentralRepository") ||
-            gradle.taskGraph.hasTask(":publishMavenPublicationToCentralPortal")
-    }
-
-    val signingKey = propertyOrEnv("signingInMemoryKey", "SIGNING_KEY")
-    val signingPassword = propertyOrEnv("signingInMemoryKeyPassword", "SIGNING_PASSWORD")
-    if (signingKey != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-    }
-    sign(publishing.publications["maven"])
-}
-
-tasks.register("uploadCentralDeployment") {
-    group = "publishing"
-    description = "Uploads the Central OSSRH compatibility staging repository to the Central Portal."
-    dependsOn("publishMavenPublicationToCentralRepository")
-
-    doLast {
-        val username = propertyOrEnv("centralUsername", "CENTRAL_USERNAME")
-            ?: throw GradleException("Missing centralUsername property or CENTRAL_USERNAME environment variable")
-        val password = propertyOrEnv("centralPassword", "CENTRAL_PASSWORD")
-            ?: throw GradleException("Missing centralPassword property or CENTRAL_PASSWORD environment variable")
-        val namespace = propertyOrEnv("centralNamespace", "CENTRAL_NAMESPACE") ?: "xyz.triplox"
-        val publishingType = propertyOrEnv("centralPublishingType", "CENTRAL_PUBLISHING_TYPE") ?: "user_managed"
-        val auth = Base64.getEncoder().encodeToString("$username:$password".toByteArray(Charsets.UTF_8))
-
-        val request = HttpRequest.newBuilder(
-            URI.create(
-                "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/" +
-                    "$namespace?publishing_type=$publishingType",
-            ),
-        )
-            .header("Authorization", "Bearer $auth")
-            .POST(HttpRequest.BodyPublishers.noBody())
-            .build()
-
-        val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
-        if (response.statusCode() !in 200..299) {
-            throw GradleException(
-                "Central Portal upload failed with HTTP ${response.statusCode()}: ${response.body()}",
-            )
-        }
-        logger.lifecycle("Uploaded Maven Central deployment for namespace $namespace using publishing_type=$publishingType")
-    }
-}
-
-tasks.register("publishMavenPublicationToCentralPortal") {
-    group = "publishing"
-    description = "Publishes the JVM client to the Central Portal using the Central OSSRH compatibility API."
-    dependsOn("uploadCentralDeployment")
 }


### PR DESCRIPTION
## Summary
- add a direct Gradle maven-publish path for Maven Central uploads
- add signing, sources, and Javadoc artifacts required by Central
- wire the release workflow to upload a user-managed Central deployment
- document local Central publishing and required release secrets

## Validation
- cd triplox-jvm && ./gradlew tasks --all
- cd triplox-jvm && ./gradlew publishMavenPublicationToMavenLocal
- cd triplox-jvm && ./gradlew test
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- cd triplox-jvm && ./gradlew publishMavenPublicationToCentralPortal --dry-run
- cd triplox-jvm && ./gradlew publishMavenPublicationToClojarsRepository --dry-run
- git diff --check