### PR TITLE
Add Java example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,11 @@ From the `examples/rust/` directory:
 cargo run --bin simple-example
 ```
 
+### Clojure
+
+See `examples/clojure/src/simple_example.clj` for a simple REPL session of how to interact
+with the server.
+
 ### Java
 
 From the `examples/java/` directory:
@@ -44,12 +49,6 @@ From the `examples/java/` directory:
 ```bash
 ../../triplox-jvm/gradlew run
 ```
-
-### Clojure
-
-See `examples/clojure/src/simple_example.clj` for a simple REPL session of how to interact
-with the server.
-
 
 ### simple-example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,14 @@ From the `examples/rust/` directory:
 cargo run --bin simple-example
 ```
 
+### Java
+
+From the `examples/java/` directory:
+
+```bash
+../../triplox-jvm/gradlew run
+```
+
 ### Clojure
 
 See `examples/clojure/src/simple_example.clj` for a simple REPL session of how to interact

--- a/examples/java/.gitignore
+++ b/examples/java/.gitignore
@@ -1,0 +1,2 @@
+.gradle
+build

--- a/examples/java/build.gradle.kts
+++ b/examples/java/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    application
+    java
+}
+
+dependencies {
+    implementation("xyz.triplox:triplox:0.1.0-alpha.3")
+    implementation("org.clojure:clojure:1.12.3")
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+application {
+    mainClass.set("SimpleExample")
+}

--- a/examples/java/settings.gradle.kts
+++ b/examples/java/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "triplox-java-example"

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -1,0 +1,68 @@
+import clojure.lang.Keyword;
+import io.triplox.client.Db;
+import io.triplox.client.TriploxNode;
+import io.triplox.client.TxOp;
+import io.triplox.client.TxResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public final class SimpleExample {
+    private SimpleExample() {
+    }
+
+    private static Map<Keyword, Object> schemaAttribute(String name, String valueType) {
+        var doc = new TreeMap<Keyword, Object>();
+        doc.put(Keyword.intern("db", "ident"), Keyword.intern(name));
+        doc.put(Keyword.intern("db", "valueType"), Keyword.intern("db.type", valueType));
+        doc.put(Keyword.intern("db", "cardinality"), Keyword.intern("db.cardinality", "one"));
+        return doc;
+    }
+
+    private static Map<Keyword, Object> person(String name, long age) {
+        var doc = new TreeMap<Keyword, Object>();
+        doc.put(Keyword.intern("name"), name);
+        doc.put(Keyword.intern("age"), age);
+        return doc;
+    }
+
+    private static TxResult requireCommitted(String label, TxResult result) {
+        if (!result.isCommitted()) {
+            throw new IllegalStateException(label + " transaction aborted: " + result.errorMessage());
+        }
+        return result;
+    }
+
+    public static void main(String[] args) throws Exception {
+        var host = "localhost";
+        var port = 5490;
+        System.out.println("Connecting to " + host + ":" + port + "...");
+
+        try (var node = TriploxNode.connect(host, port)) {
+            System.out.println("Connected.");
+
+            var schemaResult = requireCommitted("Schema", node.executeTx(List.of(
+                    new TxOp.Put(schemaAttribute("name", "string")),
+                    new TxOp.Put(schemaAttribute("age", "long")))));
+            System.out.println("Schema defined (tx_id=" + schemaResult.txId() + ").");
+
+            var dataResult = requireCommitted("Data", node.executeTx(List.of(
+                    new TxOp.Put(person("alice", 30)),
+                    new TxOp.Put(person("bob", 25)))));
+            System.out.println("Data inserted (tx_id=" + dataResult.txId() + ").");
+
+            try (Db db = node.openDb()) {
+                System.out.println("Opened DB snapshot (tx_eid=" + db.txEid() + ").");
+                var rows = db.query("{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}");
+
+                System.out.println("Query returned " + rows.size() + " row(s):");
+                for (var row : rows) {
+                    System.out.println("  " + row);
+                }
+            }
+        }
+
+        System.out.println("Done.");
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone Gradle Java example using the published `xyz.triplox:triplox:0.1.0-alpha.3` artifact
- mirror the Rust/Clojure example flow: define schema, insert Alice and Bob, query rows
- document how to run the Java example from `examples/java`

## Validation
- `cd examples/java && ../../triplox-jvm/gradlew compileJava`
- `cd triplox-jvm && ./gradlew test`
- `cargo run` server plus `cd examples/java && ../../triplox-jvm/gradlew run`
- `git diff --check`