### PR TITLE
Add Rust EDN simple example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ From the `examples/rust/` directory:
 
 ```bash
 cargo run --bin simple-example
+cargo run --bin simple-example-edn
 ```
 
 ### Clojure
@@ -53,3 +54,7 @@ From the `examples/java/` directory:
 ### simple-example
 
 Connects to the running server, defines `:name` and `:age` schema attributes, inserts two documents (alice and bob), queries them back, and prints the results.
+
+### simple-example-edn
+
+Same flow as `simple-example`, but sends static EDN strings through the Rust `IntoTxOp` API instead of constructing typed `TxOp` values.

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -5,14 +5,22 @@ edition = "2021"
 publish = false
 readme = "README.md"
 
+[workspace]
+
 [[bin]]
 name = "simple-example"
 path = "src/simple_example.rs"
 test = false
 bench = false
 
+[[bin]]
+name = "simple-example-edn"
+path = "src/simple_example_edn.rs"
+test = false
+bench = false
+
 [dependencies]
 triplox = { path = "../.." }
-edn = { path = "../../edn" }
+edn = { package = "triplox-edn", path = "../../edn" }
 anyhow = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -19,14 +19,20 @@ use triplox::ops::{DataType, TxOp};
 fn schema_attribute(name: &str, value_type: &str) -> TxOp {
     TxOp::put(vec![
         (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
-        (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type))),
-        (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one))),
+        (
+            kw!(:db/valueType),
+            DataType::Keyword(Keyword::namespaced("db.type", value_type)),
+        ),
+        (
+            kw!(:db/cardinality),
+            DataType::Keyword(kw!(:db.cardinality/one)),
+        ),
     ])
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let addr = "127.0.0.1:5490";
+    let addr = "http://127.0.0.1:5490";
     println!("Connecting to {addr}...");
     let node = ClientNode::connect(addr).await?;
     println!("Connected.");
@@ -38,8 +44,8 @@ async fn main() -> Result<()> {
     ];
     let result = node.execute_tx(schema_ops).await?;
     match &result {
-        TransactionResult::TxCommited(tx_key) => {
-            println!("Schema defined (tx_id={}).", tx_key.tx_id);
+        TransactionResult::TxCommited(basis) => {
+            println!("Schema defined (tx_id={}).", basis.tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {
             anyhow::bail!("Schema transaction aborted: {err}");
@@ -52,15 +58,12 @@ async fn main() -> Result<()> {
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ]),
-        TxOp::put(vec![
-            (kw!(:name), "bob".into()),
-            (kw!(:age), 25_i64.into()),
-        ]),
+        TxOp::put(vec![(kw!(:name), "bob".into()), (kw!(:age), 25_i64.into())]),
     ];
     let result = node.execute_tx(data_ops).await?;
     match &result {
-        TransactionResult::TxCommited(tx_key) => {
-            println!("Data inserted (tx_id={}).", tx_key.tx_id);
+        TransactionResult::TxCommited(basis) => {
+            println!("Data inserted (tx_id={}).", basis.tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {
             anyhow::bail!("Data transaction aborted: {err}");
@@ -69,7 +72,7 @@ async fn main() -> Result<()> {
 
     // 3. Open a DB snapshot and query
     let db = node.db().await?;
-    println!("Opened DB snapshot (tx_id={}).", db.tx_id());
+    println!("Opened DB snapshot (tx_eid={}).", db.tx_eid());
 
     let rows = db
         .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)
@@ -82,7 +85,6 @@ async fn main() -> Result<()> {
 
     // 4. Clean up
     db.close().await?;
-    node.close().await?;
     println!("Done.");
 
     Ok(())

--- a/examples/rust/src/simple_example_edn.rs
+++ b/examples/rust/src/simple_example_edn.rs
@@ -11,15 +11,6 @@ use anyhow::Result;
 use triplox::client::ClientNode;
 use triplox::node::{Database, QueryNode, SubmitNode, TransactionResult};
 
-const SCHEMA_OPS: &[&str] = &[
-    "{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}",
-    "{:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}",
-];
-
-const DATA_OPS: &[&str] = &["{:name \"alice\" :age 30}", "{:name \"bob\" :age 25}"];
-
-const QUERY: &str = "{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}";
-
 fn require_committed(label: &str, result: &TransactionResult) -> Result<()> {
     match result {
         TransactionResult::TxCommited(_) => Ok(()),
@@ -35,14 +26,21 @@ async fn main() -> Result<()> {
     println!("Connected.");
 
     // 1. Define schema attributes
-    let result = node.execute_tx(SCHEMA_OPS.to_vec()).await?;
+    let result = node
+        .execute_tx(vec![
+            "{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}",
+            "{:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}",
+        ])
+        .await?;
     require_committed("Schema", &result)?;
     if let TransactionResult::TxCommited(basis) = &result {
         println!("Schema defined (tx_id={}).", basis.tx_key.tx_id);
     }
 
     // 2. Insert some data
-    let result = node.execute_tx(DATA_OPS.to_vec()).await?;
+    let result = node
+        .execute_tx(vec!["{:name \"alice\" :age 30}", "{:name \"bob\" :age 25}"])
+        .await?;
     require_committed("Data", &result)?;
     if let TransactionResult::TxCommited(basis) = &result {
         println!("Data inserted (tx_id={}).", basis.tx_key.tx_id);
@@ -52,7 +50,9 @@ async fn main() -> Result<()> {
     let db = node.db().await?;
     println!("Opened DB snapshot (tx_eid={}).", db.tx_eid());
 
-    let rows = db.query(QUERY).await?;
+    let rows = db
+        .query("{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}")
+        .await?;
 
     println!("Query returned {} row(s):", rows.len());
     for row in &rows {

--- a/examples/rust/src/simple_example_edn.rs
+++ b/examples/rust/src/simple_example_edn.rs
@@ -1,0 +1,67 @@
+//! Simple example using static EDN strings: connect to a running Triplox server,
+//! define schema attributes, insert data, and query it back.
+//!
+//! Start the server first:
+//!   cargo run                             (from project root, uses config/triplox.toml)
+//!
+//! Then run this example:
+//!   cargo run --bin simple-example-edn  (from examples/rust/)
+
+use anyhow::Result;
+use triplox::client::ClientNode;
+use triplox::node::{Database, QueryNode, SubmitNode, TransactionResult};
+
+const SCHEMA_OPS: &[&str] = &[
+    "{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}",
+    "{:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}",
+];
+
+const DATA_OPS: &[&str] = &["{:name \"alice\" :age 30}", "{:name \"bob\" :age 25}"];
+
+const QUERY: &str = "{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}";
+
+fn require_committed(label: &str, result: &TransactionResult) -> Result<()> {
+    match result {
+        TransactionResult::TxCommited(_) => Ok(()),
+        TransactionResult::TxAborted(_, err) => anyhow::bail!("{label} transaction aborted: {err}"),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let addr = "http://127.0.0.1:5490";
+    println!("Connecting to {addr}...");
+    let node = ClientNode::connect(addr).await?;
+    println!("Connected.");
+
+    // 1. Define schema attributes
+    let result = node.execute_tx(SCHEMA_OPS.to_vec()).await?;
+    require_committed("Schema", &result)?;
+    if let TransactionResult::TxCommited(basis) = &result {
+        println!("Schema defined (tx_id={}).", basis.tx_key.tx_id);
+    }
+
+    // 2. Insert some data
+    let result = node.execute_tx(DATA_OPS.to_vec()).await?;
+    require_committed("Data", &result)?;
+    if let TransactionResult::TxCommited(basis) = &result {
+        println!("Data inserted (tx_id={}).", basis.tx_key.tx_id);
+    }
+
+    // 3. Open a DB snapshot and query
+    let db = node.db().await?;
+    println!("Opened DB snapshot (tx_eid={}).", db.tx_eid());
+
+    let rows = db.query(QUERY).await?;
+
+    println!("Query returned {} row(s):", rows.len());
+    for row in &rows {
+        println!("  {:?}", row);
+    }
+
+    // 4. Clean up
+    db.close().await?;
+    println!("Done.");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a Rust simple-example-edn binary that sends static EDN tx forms through IntoTxOp
- wire the Rust example package so it can run as its own workspace
- update the existing typed Rust example for the current client API

## Verification
- cargo fmt --all
- cargo fmt --manifest-path examples/rust/Cargo.toml --all
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- cargo check --manifest-path examples/rust/Cargo.toml --bin simple-example-edn
- cargo clippy --manifest-path examples/rust/Cargo.toml --all-targets --all-features

Autogenerated by Codex (GPT-5).