### PR TITLE
Improve Java transaction ergonomics

### DIFF
--- a/examples/java/settings.gradle.kts
+++ b/examples/java/settings.gradle.kts
@@ -13,3 +13,9 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "triplox-java-example"
+
+includeBuild("../../triplox-jvm") {
+    dependencySubstitution {
+        substitute(module("xyz.triplox:triplox")).using(project(":"))
+    }
+}

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -1,4 +1,3 @@
-import clojure.lang.Keyword;
 import io.triplox.client.Db;
 import io.triplox.client.TriploxNode;
 import io.triplox.client.TxOp;
@@ -6,25 +5,23 @@ import io.triplox.client.TxResult;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+
+import static io.triplox.client.Util.kw;
+import static io.triplox.client.Util.map;
 
 public final class SimpleExample {
     private SimpleExample() {
     }
 
-    private static Map<Keyword, Object> schemaAttribute(String name, String valueType) {
-        var doc = new TreeMap<Keyword, Object>();
-        doc.put(Keyword.intern("db", "ident"), Keyword.intern(name));
-        doc.put(Keyword.intern("db", "valueType"), Keyword.intern("db.type", valueType));
-        doc.put(Keyword.intern("db", "cardinality"), Keyword.intern("db.cardinality", "one"));
-        return doc;
+    private static Map<String, Object> schemaAttribute(String name, String valueType) {
+        return map(
+                ":db/ident", kw(":" + name),
+                ":db/valueType", kw(":db.type/" + valueType),
+                ":db/cardinality", kw(":db.cardinality/one"));
     }
 
-    private static Map<Keyword, Object> person(String name, long age) {
-        var doc = new TreeMap<Keyword, Object>();
-        doc.put(Keyword.intern("name"), name);
-        doc.put(Keyword.intern("age"), age);
-        return doc;
+    private static Map<String, Object> person(String name, long age) {
+        return map(":name", name, ":age", age);
     }
 
     private static TxResult requireCommitted(String label, TxResult result) {

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -1,7 +1,6 @@
 import io.triplox.client.Db;
 import io.triplox.client.TriploxNode;
 import io.triplox.client.TxOp;
-import io.triplox.client.TxResult;
 
 import java.util.List;
 
@@ -12,13 +11,6 @@ public final class SimpleExample {
     private SimpleExample() {
     }
 
-    private static TxResult requireCommitted(String label, TxResult result) {
-        if (!result.isCommitted()) {
-            throw new IllegalStateException(label + " transaction aborted: " + result.errorMessage());
-        }
-        return result;
-    }
-
     public static void main(String[] args) throws Exception {
         var host = "localhost";
         var port = 5490;
@@ -27,7 +19,7 @@ public final class SimpleExample {
         try (var node = TriploxNode.connect(host, port)) {
             System.out.println("Connected.");
 
-            var schemaResult = requireCommitted("Schema", node.executeTx(List.of(
+            var schemaResult = node.executeTx(List.of(
                     new TxOp.Put(map(
                             ":db/ident", kw(":name"),
                             ":db/valueType", kw(":db.type/string"),
@@ -35,12 +27,18 @@ public final class SimpleExample {
                     new TxOp.Put(map(
                             ":db/ident", kw(":age"),
                             ":db/valueType", kw(":db.type/long"),
-                            ":db/cardinality", kw(":db.cardinality/one"))))));
+                            ":db/cardinality", kw(":db.cardinality/one")))));
+            if (!schemaResult.isCommitted()) {
+                throw new IllegalStateException("Schema transaction aborted: " + schemaResult.errorMessage());
+            }
             System.out.println("Schema defined (tx_id=" + schemaResult.txId() + ").");
 
-            var dataResult = requireCommitted("Data", node.executeTx(List.of(
+            var dataResult = node.executeTx(List.of(
                     new TxOp.Put(map(":name", "alice", ":age", 30L)),
-                    new TxOp.Put(map(":name", "bob", ":age", 25L)))));
+                    new TxOp.Put(map(":name", "bob", ":age", 25L))));
+            if (!dataResult.isCommitted()) {
+                throw new IllegalStateException("Data transaction aborted: " + dataResult.errorMessage());
+            }
             System.out.println("Data inserted (tx_id=" + dataResult.txId() + ").");
 
             try (Db db = node.openDb()) {

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -20,10 +20,6 @@ public final class SimpleExample {
                 ":db/cardinality", kw(":db.cardinality/one"));
     }
 
-    private static Map<String, Object> person(String name, long age) {
-        return map(":name", name, ":age", age);
-    }
-
     private static TxResult requireCommitted(String label, TxResult result) {
         if (!result.isCommitted()) {
             throw new IllegalStateException(label + " transaction aborted: " + result.errorMessage());
@@ -45,8 +41,8 @@ public final class SimpleExample {
             System.out.println("Schema defined (tx_id=" + schemaResult.txId() + ").");
 
             var dataResult = requireCommitted("Data", node.executeTx(List.of(
-                    new TxOp.Put(person("alice", 30)),
-                    new TxOp.Put(person("bob", 25)))));
+                    new TxOp.Put(map(":name", "alice", ":age", 30L)),
+                    new TxOp.Put(map(":name", "bob", ":age", 25L)))));
             System.out.println("Data inserted (tx_id=" + dataResult.txId() + ").");
 
             try (Db db = node.openDb()) {

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -2,9 +2,8 @@ import io.triplox.client.Db;
 import io.triplox.client.TriploxNode;
 import io.triplox.client.TxOp;
 
-import java.util.List;
-
 import static io.triplox.client.Util.kw;
+import static io.triplox.client.Util.list;
 import static io.triplox.client.Util.map;
 
 public final class SimpleExample {
@@ -19,7 +18,7 @@ public final class SimpleExample {
         try (var node = TriploxNode.connect(host, port)) {
             System.out.println("Connected.");
 
-            var schemaResult = node.executeTx(List.of(
+            var schemaResult = node.executeTx(list(
                     new TxOp.Put(map(
                             ":db/ident", kw(":name"),
                             ":db/valueType", kw(":db.type/string"),
@@ -33,7 +32,7 @@ public final class SimpleExample {
             }
             System.out.println("Schema defined (tx_id=" + schemaResult.txId() + ").");
 
-            var dataResult = node.executeTx(List.of(
+            var dataResult = node.executeTx(list(
                     new TxOp.Put(map(":name", "alice", ":age", 30L)),
                     new TxOp.Put(map(":name", "bob", ":age", 25L))));
             if (!dataResult.isCommitted()) {

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -4,20 +4,12 @@ import io.triplox.client.TxOp;
 import io.triplox.client.TxResult;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.triplox.client.Util.kw;
 import static io.triplox.client.Util.map;
 
 public final class SimpleExample {
     private SimpleExample() {
-    }
-
-    private static Map<String, Object> schemaAttribute(String name, String valueType) {
-        return map(
-                ":db/ident", kw(":" + name),
-                ":db/valueType", kw(":db.type/" + valueType),
-                ":db/cardinality", kw(":db.cardinality/one"));
     }
 
     private static TxResult requireCommitted(String label, TxResult result) {
@@ -36,8 +28,14 @@ public final class SimpleExample {
             System.out.println("Connected.");
 
             var schemaResult = requireCommitted("Schema", node.executeTx(List.of(
-                    new TxOp.Put(schemaAttribute("name", "string")),
-                    new TxOp.Put(schemaAttribute("age", "long")))));
+                    new TxOp.Put(map(
+                            ":db/ident", kw(":name"),
+                            ":db/valueType", kw(":db.type/string"),
+                            ":db/cardinality", kw(":db.cardinality/one"))),
+                    new TxOp.Put(map(
+                            ":db/ident", kw(":age"),
+                            ":db/valueType", kw(":db.type/long"),
+                            ":db/cardinality", kw(":db.cardinality/one"))))));
             System.out.println("Schema defined (tx_id=" + schemaResult.txId() + ").");
 
             var dataResult = requireCommitted("Data", node.executeTx(List.of(

--- a/triplox-jvm/src/main/clojure/io/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/tx.clj
@@ -9,22 +9,22 @@
   (cond
     (integer? v)  (EntityRef$Id. (long v))
     (string? v)   (EntityRef$TempId. v)
-    (keyword? v)  (EntityRef$Ident. v)
+    (keyword? v)  (EntityRef$Ident. (str v))
     (and (vector? v) (= 2 (count v)) (keyword? (first v)))
-    (EntityRef$LookupRef. (first v) (second v))
+    (EntityRef$LookupRef. (str (first v)) (second v))
     :else (throw (ex-info "Cannot convert to EntityRef" {:value v}))))
 
 (defn- map->put
   "Convert a Clojure map to a TxOp.Put."
   [m]
-  (TxOp$Put. (into {} m)))
+  (TxOp$Put. (into {} (map (fn [[k v]] [(if (keyword? k) (str k) k) v]) m))))
 
 (defn- vec->tx-op
   "Convert a Datomic-style tx-data vector to a TxOp."
   [[op :as v]]
   (case op
-    :db/add     (let [[_ e a val] v] (TxOp$Add. (->entity-ref e) a val))
-    :db/retract (let [[_ e a val] v] (TxOp$Retract. (->entity-ref e) a val))
+    :db/add     (let [[_ e a val] v] (TxOp$Add. (->entity-ref e) (str a) val))
+    :db/retract (let [[_ e a val] v] (TxOp$Retract. (->entity-ref e) (str a) val))
     :db/delete  (let [[_ eid] v] (TxOp$Delete. (->entity-ref eid)))
     :db/erase   (let [[_ eid] v] (TxOp$Erase. (->entity-ref eid)))
     (throw (ex-info (str "Unknown tx-data op: " op) {:op op :form v}))))

--- a/triplox-jvm/src/main/clojure/io/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/tx.clj
@@ -17,7 +17,12 @@
 (defn- map->put
   "Convert a Clojure map to a TxOp.Put."
   [m]
-  (TxOp$Put. (into {} (map (fn [[k v]] [(if (keyword? k) (str k) k) v]) m))))
+  (TxOp$Put. (into {} (map (fn [[k v]]
+                              (when-not (keyword? k)
+                                (throw (ex-info "TxOp.Put map keys must be keywords"
+                                                {:key k :map m})))
+                              [(str k) v])
+                            m))))
 
 (defn- vec->tx-op
   "Convert a Datomic-style tx-data vector to a TxOp."

--- a/triplox-jvm/src/main/clojure/io/triplox/tx.clj
+++ b/triplox-jvm/src/main/clojure/io/triplox/tx.clj
@@ -1,6 +1,7 @@
 (ns io.triplox.tx
   "Convert Datomic-style transaction data to TxOp objects."
-  (:import [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident EntityRef$LookupRef
+  (:import [clojure.lang MapEntry]
+           [io.triplox.client EntityRef$Id EntityRef$TempId EntityRef$Ident EntityRef$LookupRef
             TxOp$Put TxOp$Add TxOp$Retract TxOp$Delete TxOp$Erase]))
 
 (defn- ->entity-ref
@@ -17,12 +18,9 @@
 (defn- map->put
   "Convert a Clojure map to a TxOp.Put."
   [m]
-  (TxOp$Put. (into {} (map (fn [[k v]]
-                              (when-not (keyword? k)
-                                (throw (ex-info "TxOp.Put map keys must be keywords"
-                                                {:key k :map m})))
-                              [(str k) v])
-                            m))))
+  (when-not (every? keyword? (keys m))
+    (throw (ex-info "TxOp.Put map keys must be keywords" {:map m})))
+  (TxOp$Put. (into {} (map (fn [[k v]] (MapEntry/create (str k) v)) m))))
 
 (defn- vec->tx-op
   "Convert a Datomic-style tx-data vector to a TxOp."

--- a/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
@@ -230,8 +230,7 @@ public final class DataTypeCodec {
      * into a {@link Keyword}. Kept for the Clojure layer.
      */
     public static Keyword parseKeyword(String s) {
-        String stripped = s.startsWith(":") ? s.substring(1) : s;
-        return keywordFromWire(stripped);
+        return Util.kw(s);
     }
 
     private static String validateWireKeyword(String s) {

--- a/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/DataTypeCodec.java
@@ -202,16 +202,25 @@ public final class DataTypeCodec {
         return ns == null ? kw.getName() : ns + "/" + kw.getName();
     }
 
-    static Keyword keywordFromWire(String s) {
-        if (s.isEmpty()) {
-            throw new IllegalArgumentException("empty keyword");
+    static String keywordStringToWire(String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("keyword string cannot be null");
         }
+        if (!s.startsWith(":")) {
+            throw new IllegalArgumentException("keyword string must start with ':': " + s);
+        }
+        return validateWireKeyword(s.substring(1));
+    }
+
+    static String keywordWireToString(String s) {
+        return ":" + validateWireKeyword(s);
+    }
+
+    static Keyword keywordFromWire(String s) {
+        validateWireKeyword(s);
         int slash = s.indexOf('/');
         if (slash < 0) {
             return Keyword.intern(s);
-        }
-        if (slash == 0 || slash == s.length() - 1) {
-            throw new IllegalArgumentException("invalid keyword: " + s);
         }
         return Keyword.intern(s.substring(0, slash), s.substring(slash + 1));
     }
@@ -223,6 +232,17 @@ public final class DataTypeCodec {
     public static Keyword parseKeyword(String s) {
         String stripped = s.startsWith(":") ? s.substring(1) : s;
         return keywordFromWire(stripped);
+    }
+
+    private static String validateWireKeyword(String s) {
+        if (s.isEmpty()) {
+            throw new IllegalArgumentException("empty keyword");
+        }
+        int slash = s.indexOf('/');
+        if (slash == 0 || slash == s.length() - 1) {
+            throw new IllegalArgumentException("invalid keyword: " + s);
+        }
+        return s;
     }
 
     // ---------------------------------------------------------------

--- a/triplox-jvm/src/main/java/io/triplox/client/EntityRef.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/EntityRef.java
@@ -1,13 +1,11 @@
 package io.triplox.client;
 
-import clojure.lang.Keyword;
-
 /**
  * Entity reference variants for the Triplox wire protocol.
  */
 public sealed interface EntityRef {
     record Id(long id) implements EntityRef {}
     record TempId(String tempId) implements EntityRef {}
-    record Ident(Keyword ident) implements EntityRef {}
-    record LookupRef(Keyword attr, Object value) implements EntityRef {}
+    record Ident(String ident) implements EntityRef {}
+    record LookupRef(String attr, Object value) implements EntityRef {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOp.java
@@ -1,16 +1,14 @@
 package io.triplox.client;
 
-import clojure.lang.Keyword;
-
 import java.util.Map;
 
 /**
  * Transaction operations for the Triplox wire protocol.
  */
 public sealed interface TxOp {
-    record Put(Map<Keyword, Object> document) implements TxOp {}
-    record Add(EntityRef entity, Keyword attribute, Object value) implements TxOp {}
-    record Retract(EntityRef entity, Keyword attribute, Object value) implements TxOp {}
+    record Put(Map<String, Object> document) implements TxOp {}
+    record Add(EntityRef entity, String attribute, Object value) implements TxOp {}
+    record Retract(EntityRef entity, String attribute, Object value) implements TxOp {}
     record Delete(EntityRef entity) implements TxOp {}
     record Erase(EntityRef entity) implements TxOp {}
 }

--- a/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/TxOpCodec.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import clojure.lang.Keyword;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
 
@@ -57,12 +56,12 @@ public final class TxOpCodec {
             case EntityRef.Ident ident -> {
                 packer.packMapHeader(2);
                 packer.packString("kind"); packer.packString("ident");
-                packer.packString("ident"); packer.packString(DataTypeCodec.keywordToWire(ident.ident()));
+                packer.packString("ident"); packer.packString(DataTypeCodec.keywordStringToWire(ident.ident()));
             }
             case EntityRef.LookupRef lr -> {
                 packer.packMapHeader(3);
                 packer.packString("kind"); packer.packString("lookup");
-                packer.packString("attr"); packer.packString(DataTypeCodec.keywordToWire(lr.attr()));
+                packer.packString("attr"); packer.packString(DataTypeCodec.keywordStringToWire(lr.attr()));
                 packer.packString("value"); DataTypeCodec.pack(packer, lr.value());
             }
         }
@@ -78,9 +77,9 @@ public final class TxOpCodec {
         return switch (kind) {
             case "id" -> new EntityRef.Id((Long) requireField(map, "id"));
             case "temp" -> new EntityRef.TempId(takeString(map, "temp"));
-            case "ident" -> new EntityRef.Ident(DataTypeCodec.keywordFromWire(takeString(map, "ident")));
+            case "ident" -> new EntityRef.Ident(DataTypeCodec.keywordWireToString(takeString(map, "ident")));
             case "lookup" -> {
-                Keyword attr = DataTypeCodec.keywordFromWire(takeString(map, "attr"));
+                String attr = DataTypeCodec.keywordWireToString(takeString(map, "attr"));
                 Object value = requireField(map, "value");
                 yield new EntityRef.LookupRef(attr, value);
             }
@@ -98,10 +97,10 @@ public final class TxOpCodec {
                 packer.packMapHeader(2);
                 packer.packString("kind"); packer.packString("put");
                 packer.packString("doc");
-                Map<Keyword, Object> doc = put.document();
+                Map<String, Object> doc = put.document();
                 packer.packMapHeader(doc.size());
                 for (var entry : doc.entrySet()) {
-                    packer.packString(DataTypeCodec.keywordToWire(entry.getKey()));
+                    packer.packString(DataTypeCodec.keywordStringToWire(entry.getKey()));
                     DataTypeCodec.pack(packer, entry.getValue());
                 }
             }
@@ -109,14 +108,14 @@ public final class TxOpCodec {
                 packer.packMapHeader(4);
                 packer.packString("kind"); packer.packString("add");
                 packer.packString("entity"); packEntityRef(packer, add.entity());
-                packer.packString("attr"); packer.packString(DataTypeCodec.keywordToWire(add.attribute()));
+                packer.packString("attr"); packer.packString(DataTypeCodec.keywordStringToWire(add.attribute()));
                 packer.packString("value"); DataTypeCodec.pack(packer, add.value());
             }
             case TxOp.Retract ret -> {
                 packer.packMapHeader(4);
                 packer.packString("kind"); packer.packString("retract");
                 packer.packString("entity"); packEntityRef(packer, ret.entity());
-                packer.packString("attr"); packer.packString(DataTypeCodec.keywordToWire(ret.attribute()));
+                packer.packString("attr"); packer.packString(DataTypeCodec.keywordStringToWire(ret.attribute()));
                 packer.packString("value"); DataTypeCodec.pack(packer, ret.value());
             }
             case TxOp.Delete del -> {
@@ -147,9 +146,9 @@ public final class TxOpCodec {
 
     private static TxOp.Put readPut(Map<String, Object> map) throws IOException {
         Map<String, Object> rawDoc = expectStringMap(requireField(map, "doc"), "Put.doc");
-        Map<Keyword, Object> doc = new LinkedHashMap<>();
+        Map<String, Object> doc = new LinkedHashMap<>();
         for (var entry : rawDoc.entrySet()) {
-            doc.put(DataTypeCodec.keywordFromWire(entry.getKey()), entry.getValue());
+            doc.put(DataTypeCodec.keywordWireToString(entry.getKey()), entry.getValue());
         }
         return new TxOp.Put(doc);
     }
@@ -157,7 +156,7 @@ public final class TxOpCodec {
     private static TxOp readAddOrRetract(Map<String, Object> map, boolean retract)
             throws IOException {
         EntityRef entity = takeEntityRef(map, "entity");
-        Keyword attr = DataTypeCodec.keywordFromWire(takeString(map, "attr"));
+        String attr = DataTypeCodec.keywordWireToString(takeString(map, "attr"));
         Object value = requireField(map, "value");
         return retract ? new TxOp.Retract(entity, attr, value) : new TxOp.Add(entity, attr, value);
     }

--- a/triplox-jvm/src/main/java/io/triplox/client/Util.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/Util.java
@@ -1,5 +1,7 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,6 +20,21 @@ public final class Util {
             out.add(item);
         }
         return out;
+    }
+
+    public static Keyword kw(String s) {
+        String stripped = s.startsWith(":") ? s.substring(1) : s;
+        if (stripped.isEmpty()) {
+            throw new IllegalArgumentException("empty keyword");
+        }
+        int slash = stripped.indexOf('/');
+        if (slash < 0) {
+            return Keyword.intern(stripped);
+        }
+        if (slash == 0 || slash == stripped.length() - 1) {
+            throw new IllegalArgumentException("invalid keyword: " + stripped);
+        }
+        return Keyword.intern(stripped.substring(0, slash), stripped.substring(slash + 1));
     }
 
     public static Map<String, Object> map(Object... keyValues) {

--- a/triplox-jvm/src/main/java/io/triplox/client/Util.java
+++ b/triplox-jvm/src/main/java/io/triplox/client/Util.java
@@ -1,0 +1,36 @@
+package io.triplox.client;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Small Java collection helpers for Datomic-style transaction construction.
+ */
+public final class Util {
+    private Util() {}
+
+    @SafeVarargs
+    public static <T> List<T> list(T... items) {
+        var out = new ArrayList<T>(items.length);
+        for (T item : items) {
+            out.add(item);
+        }
+        return out;
+    }
+
+    public static Map<String, Object> map(Object... keyValues) {
+        if (keyValues.length % 2 != 0) {
+            throw new IllegalArgumentException("map requires an even number of arguments");
+        }
+        var out = new LinkedHashMap<String, Object>(keyValues.length / 2);
+        for (int i = 0; i < keyValues.length; i += 2) {
+            if (!(keyValues[i] instanceof String key)) {
+                throw new IllegalArgumentException("map keys must be String");
+            }
+            out.put(key, keyValues[i + 1]);
+        }
+        return out;
+    }
+}

--- a/triplox-jvm/src/test/clojure/io/triplox/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/io/triplox/tx_test.clj
@@ -10,8 +10,8 @@
           op (first ops)]
       (is (instance? TxOp$Put op))
       (let [doc (.document ^TxOp$Put op)]
-        (is (= 1 (.get doc :db/id)))
-        (is (= "alice" (.get doc :person/name)))))))
+        (is (= 1 (.get doc ":db/id")))
+        (is (= "alice" (.get doc ":person/name")))))))
 
 (deftest vec-to-add
   (testing "[:db/add e a v] -> TxOp.Add"
@@ -19,7 +19,7 @@
           op (first ops)]
       (is (instance? TxOp$Add op))
       (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Add op))))
-      (is (= :email (.attribute ^TxOp$Add op)))
+      (is (= ":email" (.attribute ^TxOp$Add op)))
       (is (= "test@example.com" (.value ^TxOp$Add op))))))
 
 (deftest vec-to-retract
@@ -28,7 +28,7 @@
           op (first ops)]
       (is (instance? TxOp$Retract op))
       (is (= 42 (.id ^EntityRef$Id (.entity ^TxOp$Retract op))))
-      (is (= :email (.attribute ^TxOp$Retract op)))
+      (is (= ":email" (.attribute ^TxOp$Retract op)))
       (is (= "old@example.com" (.value ^TxOp$Retract op))))))
 
 (deftest vec-to-delete
@@ -71,7 +71,7 @@
     (let [ops (tx/tx-data->ops [[:db/add :person/alice :name "Alice"]])
           op (first ops)]
       (is (instance? EntityRef$Ident (.entity ^TxOp$Add op)))
-      (is (= :person/alice (.ident ^EntityRef$Ident (.entity ^TxOp$Add op)))))))
+      (is (= ":person/alice" (.ident ^EntityRef$Ident (.entity ^TxOp$Add op)))))))
 
 (deftest lookup-ref-entity-ref
   (testing "Lookup ref vector in entity position becomes LookupRef"
@@ -79,7 +79,7 @@
           op (first ops)]
       (is (instance? TxOp$Add op))
       (is (instance? EntityRef$LookupRef (.entity ^TxOp$Add op)))
-      (is (= :email (.attr ^EntityRef$LookupRef (.entity ^TxOp$Add op))))
+      (is (= ":email" (.attr ^EntityRef$LookupRef (.entity ^TxOp$Add op))))
       (is (= "test@example.com" (.value ^EntityRef$LookupRef (.entity ^TxOp$Add op)))))))
 
 (deftest invalid-form-throws

--- a/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/TxOpCodecTest.java
@@ -1,6 +1,5 @@
 package io.triplox.client;
 
-import clojure.lang.Keyword;
 import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 
@@ -24,26 +23,26 @@ class TxOpCodecTest {
 
     @Test
     void testPut() throws IOException {
-        var doc = new TreeMap<Keyword, Object>();
-        doc.put(Keyword.intern("db", "id"), 1L);
-        doc.put(Keyword.intern("name"), "alice");
+        var doc = new TreeMap<String, Object>();
+        doc.put(":db/id", 1L);
+        doc.put(":name", "alice");
         var result = roundtrip(List.of(new TxOp.Put(doc)));
         assertEquals(1, result.size());
         var put = (TxOp.Put) result.get(0);
-        assertEquals(1L, put.document().get(Keyword.intern("db", "id")));
-        assertEquals("alice", put.document().get(Keyword.intern("name")));
+        assertEquals(1L, put.document().get(":db/id"));
+        assertEquals("alice", put.document().get(":name"));
     }
 
     @Test
     void testAdd() throws IOException {
         var result = roundtrip(List.of(new TxOp.Add(
                 new EntityRef.Id(42),
-                Keyword.intern("email"),
+                ":email",
                 "test@example.com")));
         assertEquals(1, result.size());
         var add = (TxOp.Add) result.get(0);
         assertEquals(42, ((EntityRef.Id) add.entity()).id());
-        assertEquals(Keyword.intern("email"), add.attribute());
+        assertEquals(":email", add.attribute());
         assertEquals("test@example.com", add.value());
     }
 
@@ -51,12 +50,12 @@ class TxOpCodecTest {
     void testRetract() throws IOException {
         var result = roundtrip(List.of(new TxOp.Retract(
                 new EntityRef.Id(42),
-                Keyword.intern("email"),
+                ":email",
                 "old@example.com")));
         assertEquals(1, result.size());
         var ret = (TxOp.Retract) result.get(0);
         assertEquals(42, ((EntityRef.Id) ret.entity()).id());
-        assertEquals(Keyword.intern("email"), ret.attribute());
+        assertEquals(":email", ret.attribute());
         assertEquals("old@example.com", ret.value());
     }
 
@@ -76,14 +75,14 @@ class TxOpCodecTest {
 
     @Test
     void testMultipleOps() throws IOException {
-        var doc = new TreeMap<Keyword, Object>();
-        doc.put(Keyword.intern("db", "id"), 1L);
-        doc.put(Keyword.intern("name"), "bob");
+        var doc = new TreeMap<String, Object>();
+        doc.put(":db/id", 1L);
+        doc.put(":name", "bob");
 
         var ops = List.<TxOp>of(
                 new TxOp.Put(doc),
-                new TxOp.Add(new EntityRef.Id(1), Keyword.intern("age"), 30L),
-                new TxOp.Retract(new EntityRef.Id(1), Keyword.intern("name"), "old-bob"),
+                new TxOp.Add(new EntityRef.Id(1), ":age", 30L),
+                new TxOp.Retract(new EntityRef.Id(1), ":name", "old-bob"),
                 new TxOp.Delete(new EntityRef.Id(99)),
                 new TxOp.Erase(new EntityRef.Id(100))
         );
@@ -101,22 +100,22 @@ class TxOpCodecTest {
         var ops = List.<TxOp>of(
                 new TxOp.Delete(new EntityRef.Id(42)),
                 new TxOp.Delete(new EntityRef.TempId("temp-1")),
-                new TxOp.Delete(new EntityRef.Ident(Keyword.intern("db", "ident"))),
-                new TxOp.Delete(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"))
+                new TxOp.Delete(new EntityRef.Ident(":db/ident")),
+                new TxOp.Delete(new EntityRef.LookupRef(":email", "test@example.com"))
         );
         var result = roundtrip(ops);
         assertEquals(4, result.size());
         assertEquals(new EntityRef.Id(42), ((TxOp.Delete) result.get(0)).entity());
         assertEquals(new EntityRef.TempId("temp-1"), ((TxOp.Delete) result.get(1)).entity());
-        assertEquals(new EntityRef.Ident(Keyword.intern("db", "ident")), ((TxOp.Delete) result.get(2)).entity());
-        assertEquals(new EntityRef.LookupRef(Keyword.intern("email"), "test@example.com"), ((TxOp.Delete) result.get(3)).entity());
+        assertEquals(new EntityRef.Ident(":db/ident"), ((TxOp.Delete) result.get(2)).entity());
+        assertEquals(new EntityRef.LookupRef(":email", "test@example.com"), ((TxOp.Delete) result.get(3)).entity());
     }
 
     @Test
     void testRefValueAsLong() throws IOException {
         var result = roundtrip(List.of(new TxOp.Add(
                 new EntityRef.Id(1),
-                Keyword.intern("friend"),
+                ":friend",
                 2L)));
         assertEquals(1, result.size());
         var add = (TxOp.Add) result.get(0);
@@ -141,9 +140,21 @@ class TxOpCodecTest {
                 assertEquals(1, result.size());
                 var add = (TxOp.Add) result.get(0);
                 assertEquals(new EntityRef.Id(42), add.entity());
-                assertEquals(Keyword.intern("name"), add.attribute());
+                assertEquals(":name", add.attribute());
                 assertEquals("alice", add.value());
             }
         }
+    }
+
+    @Test
+    void testPackRejectsInvalidKeywordStrings() {
+        assertThrows(IllegalArgumentException.class, () -> roundtrip(List.of(new TxOp.Add(
+                new EntityRef.Id(1),
+                "name",
+                "alice"))));
+        assertThrows(IllegalArgumentException.class, () -> roundtrip(List.of(new TxOp.Put(
+                java.util.Map.of(":", "alice")))));
+        assertThrows(IllegalArgumentException.class, () -> roundtrip(List.of(new TxOp.Delete(
+                new EntityRef.Ident("db/ident")))));
     }
 }

--- a/triplox-jvm/src/test/java/io/triplox/client/UtilTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/UtilTest.java
@@ -1,0 +1,32 @@
+package io.triplox.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilTest {
+    @Test
+    void testListPreservesItems() {
+        assertEquals(List.of("a", "b", "c"), Util.list("a", "b", "c"));
+    }
+
+    @Test
+    void testMapPreservesInsertionOrder() {
+        var map = Util.map(":db/id", 1L, ":name", "alice");
+        assertEquals(List.of(":db/id", ":name"), List.copyOf(map.keySet()));
+        assertEquals(1L, map.get(":db/id"));
+        assertEquals("alice", map.get(":name"));
+    }
+
+    @Test
+    void testMapRejectsOddArgumentCount() {
+        assertThrows(IllegalArgumentException.class, () -> Util.map(":db/id", 1L, ":name"));
+    }
+
+    @Test
+    void testMapRejectsNonStringKeys() {
+        assertThrows(IllegalArgumentException.class, () -> Util.map(1L, "alice"));
+    }
+}

--- a/triplox-jvm/src/test/java/io/triplox/client/UtilTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/UtilTest.java
@@ -1,5 +1,6 @@
 package io.triplox.client;
 
+import clojure.lang.Keyword;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,6 +11,12 @@ class UtilTest {
     @Test
     void testListPreservesItems() {
         assertEquals(List.of("a", "b", "c"), Util.list("a", "b", "c"));
+    }
+
+    @Test
+    void testKwParsesColonPrefixedKeyword() {
+        assertEquals(Keyword.intern("db.type", "string"), Util.kw(":db.type/string"));
+        assertEquals(Keyword.intern("name"), Util.kw(":name"));
     }
 
     @Test

--- a/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/WireCodecTest.java
@@ -1,6 +1,5 @@
 package io.triplox.client;
 
-import clojure.lang.Keyword;
 import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
@@ -70,8 +69,8 @@ class WireCodecTest {
 
     @Test
     void testEncodeExecuteBody() throws IOException {
-        var doc = new TreeMap<Keyword, Object>();
-        doc.put(Keyword.intern("db", "id"), 1L);
+        var doc = new TreeMap<String, Object>();
+        doc.put(":db/id", 1L);
         var ops = List.<TxOp>of(new TxOp.Put(doc));
 
         byte[] body = WireCodec.encodeExecuteBody(ops);

--- a/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
@@ -1,11 +1,11 @@
 package io.triplox.client.integration;
 
-import clojure.lang.Keyword;
 import io.triplox.client.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.triplox.client.Util.kw;
 import static io.triplox.client.Util.map;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,9 +24,9 @@ class TriploxNodeTest {
         try (var node = TriploxNode.connect(host(), port())) {
             // Schema: name attribute
             node.executeTx(List.of(new TxOp.Put(map(
-                    ":db/ident", Keyword.intern("name"),
-                    ":db/valueType", Keyword.intern("db.type", "string"),
-                    ":db/cardinality", Keyword.intern("db.cardinality", "one")))));
+                    ":db/ident", kw(":name"),
+                    ":db/valueType", kw(":db.type/string"),
+                    ":db/cardinality", kw(":db.cardinality/one")))));
 
             // Data
             var txResult = node.executeTx(List.of(new TxOp.Put(map(":name", "alice"))));
@@ -45,9 +45,9 @@ class TriploxNodeTest {
     void testOpenDbAtHistoricalTx() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
             node.executeTx(List.of(new TxOp.Put(map(
-                    ":db/ident", Keyword.intern("historical-name"),
-                    ":db/valueType", Keyword.intern("db.type", "string"),
-                    ":db/cardinality", Keyword.intern("db.cardinality", "one")))));
+                    ":db/ident", kw(":historical-name"),
+                    ":db/valueType", kw(":db.type/string"),
+                    ":db/cardinality", kw(":db.cardinality/one")))));
 
             var tx1 = node.executeTx(List.of(new TxOp.Put(map(":historical-name", "alice"))));
             assertTrue(tx1.isCommitted());

--- a/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/io/triplox/client/integration/TriploxNodeTest.java
@@ -5,9 +5,8 @@ import io.triplox.client.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
+import static io.triplox.client.Util.map;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TriploxNodeTest {
@@ -24,16 +23,13 @@ class TriploxNodeTest {
     void testConnectTransactQueryClose() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
             // Schema: name attribute
-            var schema = new TreeMap<Keyword, Object>();
-            schema.put(Keyword.intern("db", "ident"), Keyword.intern("name"));
-            schema.put(Keyword.intern("db", "valueType"), Keyword.intern("db.type", "string"));
-            schema.put(Keyword.intern("db", "cardinality"), Keyword.intern("db.cardinality", "one"));
-            node.executeTx(List.of(new TxOp.Put(schema)));
+            node.executeTx(List.of(new TxOp.Put(map(
+                    ":db/ident", Keyword.intern("name"),
+                    ":db/valueType", Keyword.intern("db.type", "string"),
+                    ":db/cardinality", Keyword.intern("db.cardinality", "one")))));
 
             // Data
-            var data = new TreeMap<Keyword, Object>();
-            data.put(Keyword.intern("name"), "alice");
-            var txResult = node.executeTx(List.of(new TxOp.Put(data)));
+            var txResult = node.executeTx(List.of(new TxOp.Put(map(":name", "alice"))));
             assertTrue(txResult.isCommitted());
 
             // Query
@@ -48,20 +44,15 @@ class TriploxNodeTest {
     @Test
     void testOpenDbAtHistoricalTx() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
-            var schema = new TreeMap<Keyword, Object>();
-            schema.put(Keyword.intern("db", "ident"), Keyword.intern("historical-name"));
-            schema.put(Keyword.intern("db", "valueType"), Keyword.intern("db.type", "string"));
-            schema.put(Keyword.intern("db", "cardinality"), Keyword.intern("db.cardinality", "one"));
-            node.executeTx(List.of(new TxOp.Put(schema)));
+            node.executeTx(List.of(new TxOp.Put(map(
+                    ":db/ident", Keyword.intern("historical-name"),
+                    ":db/valueType", Keyword.intern("db.type", "string"),
+                    ":db/cardinality", Keyword.intern("db.cardinality", "one")))));
 
-            var alice = new TreeMap<Keyword, Object>();
-            alice.put(Keyword.intern("historical-name"), "alice");
-            var tx1 = node.executeTx(List.of(new TxOp.Put(alice)));
+            var tx1 = node.executeTx(List.of(new TxOp.Put(map(":historical-name", "alice"))));
             assertTrue(tx1.isCommitted());
 
-            var bob = new TreeMap<Keyword, Object>();
-            bob.put(Keyword.intern("historical-name"), "bob");
-            var tx2 = node.executeTx(List.of(new TxOp.Put(bob)));
+            var tx2 = node.executeTx(List.of(new TxOp.Put(map(":historical-name", "bob"))));
             assertTrue(tx2.isCommitted());
 
             try (var db = node.openDbAsOf(tx1.basis())) {


### PR DESCRIPTION
## Summary
- change Java TxOp and entity-ref keyword positions to colon-prefixed String values
- keep the existing wire keyword encoding unchanged
- add Datomic-style Util.list and Util.map helpers for Java callers
- update Java and Clojure JVM client tests for the new API

## Tests
- cd triplox-jvm && ./gradlew test
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features