### PR TITLE
Make remote DB values stateless

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Afterwards you connect with your favorite client.
                    {:name "bob" :age 25}])
 
 ;; query
-(with-open [db (tc/db conn)]
-  (tc/q db '{:find [?e ?name ?age]
-             :where [[?e :name ?name]
-                     [?e :age ?age]]}))
+(def db (tc/db conn))
+(tc/q db '{:find [?e ?name ?age]
+           :where [[?e :name ?name]
+                   [?e :age ?age]]})
 ;; => [[8796093022209 "alice" 30] [8796093022208 "bob" 25]]
 ```
 

--- a/bench/graph/src/graph/main.clj
+++ b/bench/graph/src/graph/main.clj
@@ -84,7 +84,7 @@
         (ingest-graph! conn config)
         (let [end-ingest (System/nanoTime)
               config (assoc config :ingest-secs (/ (- (System/nanoTime) start) 1e9))
-              triangle-count (with-open [db (tc/db conn)]
+              triangle-count (let [db (tc/db conn)]
                                (count (tc/q db gg/triangle-query)))]
           (print-report (assoc config
                                :ingest-secs (/ (- end-ingest start) 1e9)
@@ -100,7 +100,7 @@
   (ingest-graph! conn {:vertices 10000 :probability 0.00182 :batch-size 1000})
 
   (time
-   (with-open [db (tc/db conn)]
+   (let [db (tc/db conn)]
      (count (tc/q db gg/triangle-query))))
 
   )

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -26,8 +26,7 @@ and are reserved for a future revision.
 | Endpoint                  | Method   | Request Body              | Success Body               |
 |---------------------------|----------|---------------------------|-----------------------------|
 | `/db/open`                | `POST`   | OpenDb                    | DbOpened                    |
-| `/db/{db_id}`             | `DELETE` | *(empty)*                 | DbClosed                    |
-| `/db/{db_id}/query`       | `POST`   | Query                     | QueryResponse               |
+| `/db/query`               | `POST`   | Query                     | QueryResponse               |
 | `/tx/submit`              | `POST`   | Execute                   | TxKey                       |
 | `/tx/execute`             | `POST`   | Execute                   | TxResult                    |
 
@@ -42,28 +41,20 @@ outcome.
 |--------|---------------------|---------------|
 | **200** | Success             | Request processed successfully. For `/tx/execute`, check the `status` field of the TxResult body: `0` = committed, `1` = aborted. |
 | **400** | Bad Request         | Malformed request body (decode failure), Datalog parse error, or invalid field combinations. |
-| **404** | Not Found           | Invalid or expired `db_id` handle. |
+| **409** | Conflict            | Requested DB basis has not been indexed yet. |
 | **500** | Internal Server Error | Unexpected engine error: query execution failure or transaction infrastructure error. |
 
 All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body) body.
 
-### 1.2 DB Handle Lifecycle
+### 1.2 DB Values
 
-DB handles are scoped to an HTTP/2 connection. Each `db_id` maps to a
-transaction basis: the transaction log key (`tx_id` + `system_time`) plus the
-transaction entity ID (`tx_eid`) that bounds temporal reads. The server does
-not cache pinned SlateDB read state for handles; it creates transient read views from the
-stored basis when queries execute. Each connection is assigned a unique
-`conn_id` on accept, and all handles opened on that connection are tracked
-against it. Two cleanup mechanisms ensure handles are released:
+DB values are immutable read bases. A DB value contains the transaction log key
+(`tx_id` + `system_time`) plus the transaction entity ID (`tx_eid`) that bounds
+temporal reads. The server does not allocate or retain per-DB resources. Query
+requests carry the DB value, and the server creates a transient read view from
+that basis when the query executes.
 
-1. **Connection-drop** (fast path): When an HTTP/2 connection closes, all
-   handles belonging to that connection are released immediately.
-2. **TTL reaper** (safety net): A background task periodically evicts handles
-   that have not been used for 24 hours.
-
-Using an invalid or closed `db_id` returns
-`ErrorResponse(code=5000 InvalidDbHandle)` with HTTP status 404.
+DB values do not need to be closed.
 
 ---
 
@@ -210,26 +201,21 @@ Either all three fields are present (pinned transaction basis) or all three are
 ### 4.3 DbOpened Response
 
 ```
-{"db_id": <int>, "tx_eid": <int>}
+{"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>}
 ```
 
-`db_id` is a server-assigned u32 handle. `tx_eid` is the transaction entity ID
-that bounds reads through that handle.
+The response is the immutable DB read basis. `tx_eid` is the transaction entity
+ID that bounds temporal reads.
 
-### 4.4 DbClosed Response — `DELETE /db/{db_id}`
-
-```
-{"db_id": <int>}
-```
-
-Echoes the released handle.
-
-### 4.5 Query Request — `POST /db/{db_id}/query`
+### 4.4 Query Request — `POST /db/query`
 
 ```
-{"query": <str>, "args": [<QueryArg>, ...]}
+{"db": {"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>},
+ "query": <str>,
+ "args": [<QueryArg>, ...]}
 ```
 
+`db` is a DB read basis returned by `DbOpened` or a previous transaction result.
 `query` is a Datalog query in EDN text. `args` provides values for variables
 declared in the query's `:in` clause; the number and order must match. For
 queries without `:in`, pass an empty array.
@@ -304,7 +290,6 @@ a numeric error code (see §5).
 | 2xxx  | Query errors          | 2000 ParseError, 2001 QueryError, 2002 InvalidQuery, 2003 EmptyQuery |
 | 3xxx  | Transaction errors    | 3000 TxError, 3001 TxAborted, 3002 TxNotIndexed                    |
 | 4xxx  | Internal/protocol     | 4000 InternalError, 4001 MessageTooLarge, 4002 InvalidMessageType, 4003 QueryCancelled, 4004 ServerShuttingDown |
-| 5xxx  | DB handle errors      | 5000 InvalidDbHandle                                                |
 
 ---
 

--- a/examples/clojure/src/simple_example.clj
+++ b/examples/clojure/src/simple_example.clj
@@ -27,9 +27,9 @@
 
 
 
-;; 3. Open a DB handle and query
-(with-open [db (tc/db conn)]
-  (tc/q db '{:find [?e ?name ?age]
-             :where [[?e :name ?name]
-                     [?e :age ?age]]}))
+;; 3. Open a DB value and query
+(def db (tc/db conn))
+(tc/q db '{:find [?e ?name ?age]
+           :where [[?e :name ?name]
+                   [?e :age ?age]]})
 ;; => [[8796093022209 "alice" 30] [8796093022208 "bob" 25]]

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -1,4 +1,3 @@
-import xyz.triplox.client.Db;
 import xyz.triplox.client.TriploxNode;
 import xyz.triplox.client.TxOp;
 
@@ -40,14 +39,13 @@ public final class SimpleExample {
             }
             System.out.println("Data inserted (tx_id=" + dataResult.txId() + ").");
 
-            try (Db db = node.openDb()) {
-                System.out.println("Opened DB snapshot (tx_eid=" + db.txEid() + ").");
-                var rows = db.query("{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}");
+            var db = node.openDb();
+            System.out.println("Opened DB value (tx_eid=" + db.txEid() + ").");
+            var rows = db.query("{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}");
 
-                System.out.println("Query returned " + rows.size() + " row(s):");
-                for (var row : rows) {
-                    System.out.println("  " + row);
-                }
+            System.out.println("Query returned " + rows.size() + " row(s):");
+            for (var row : rows) {
+                System.out.println("  " + row);
             }
         }
 

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -26,7 +26,7 @@ fn schema_attribute(name: &str, value_type: &str) -> TxOp {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let addr = "127.0.0.1:5490";
+    let addr = "http://127.0.0.1:5490";
     println!("Connecting to {addr}...");
     let node = ClientNode::connect(addr).await?;
     println!("Connected.");
@@ -67,9 +67,9 @@ async fn main() -> Result<()> {
         }
     }
 
-    // 3. Open a DB handle and query
+    // 3. Open a DB value and query
     let db = node.db().await?;
-    println!("Opened DB handle (tx_id={}).", db.tx_id());
+    println!("Opened DB value (tx_eid={}).", db.tx_eid());
 
     let rows = db
         .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)
@@ -80,9 +80,6 @@ async fn main() -> Result<()> {
         println!("  {:?}", row);
     }
 
-    // 4. Clean up
-    db.close().await?;
-    node.close().await?;
     println!("Done.");
 
     Ok(())

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
 
     // 3. Open a DB value and query
     let db = node.db().await?;
-    println!("Opened DB value (tx_eid={}).", db.tx_eid());
+    println!("Opened DB value (tx_eid={}).", db.tx_basis().tx_eid);
 
     let rows = db
         .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,27 +3,24 @@
 //! Replaces the custom TCP wire protocol with HTTP/2 transport while keeping
 //! the same binary payload encoding. Each operation maps to an HTTP endpoint:
 //!
-//! - `POST /db/open`           — Open a DB read handle
-//! - `DELETE /db/{db_id}`      — Release a DB read handle
-//! - `POST /db/{db_id}/query`  — Execute a Datalog query
+//! - `POST /db/open`           — Open a DB read basis
+//! - `POST /db/query`          — Execute a Datalog query
 //! - `POST /tx/submit`         — Submit a fire-and-forget transaction
 //! - `POST /tx/execute`        — Execute a transaction and wait for indexing
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::{Error, Result};
 use axum::body::Bytes;
-use axum::extract::{DefaultBodyLimit, Path, State};
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{delete, post};
+use axum::routing::post;
 use axum::Router;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -37,90 +34,14 @@ use crate::log::TxLog;
 use crate::node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult};
 use triplox_client::msgpack_codec::{
     decode_execute_request, decode_open_db_request, decode_query_request,
-    encode_db_closed_response, encode_db_opened_response, encode_error_body, encode_query_response,
-    encode_tx_key_response, encode_tx_result_response, DbClosedResponse, DbOpenedResponse,
-    ErrorResponseBody, QueryResponse, TxKeyResponse, TxResultResponse,
+    encode_db_opened_response, encode_error_body, encode_query_response, encode_tx_key_response,
+    encode_tx_result_response, DbOpenedResponse, ErrorResponseBody, QueryResponse, TxKeyResponse,
+    TxResultResponse,
 };
 use triplox_client::protocol::{
     ColumnDescription, ErrorCode, DEFAULT_MAX_MESSAGE_SIZE, SEVERITY_ERROR, TAG_UNKNOWN,
 };
 use triplox_client::transaction::{TxBasis, TxKey};
-
-// ---------------------------------------------------------------------------
-// Handle Store
-// ---------------------------------------------------------------------------
-
-struct HandleEntry {
-    conn_id: u64,
-    basis: TxBasis,
-    last_used: Instant,
-}
-
-struct HandleStore {
-    handles: RwLock<HashMap<u32, HandleEntry>>,
-    next_id: AtomicU32,
-}
-
-impl HandleStore {
-    fn new() -> Self {
-        HandleStore {
-            handles: RwLock::new(HashMap::new()),
-            next_id: AtomicU32::new(1),
-        }
-    }
-
-    /// Allocate a DB read handle for a transaction basis.
-    async fn open(&self, conn_id: u64, basis: TxBasis) -> Result<u32> {
-        let db_id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let mut handles = self.handles.write().await;
-        handles.insert(
-            db_id,
-            HandleEntry {
-                conn_id,
-                basis,
-                last_used: Instant::now(),
-            },
-        );
-        Ok(db_id)
-    }
-
-    // TODO(P1): Validate conn_id in get_db/remove so global db_ids cannot cross connection boundaries.
-    async fn get_basis(&self, db_id: u32) -> Option<TxBasis> {
-        let mut handles = self.handles.write().await;
-        if let Some(entry) = handles.get_mut(&db_id) {
-            entry.last_used = Instant::now();
-            Some(entry.basis)
-        } else {
-            None
-        }
-    }
-
-    /// Remove a handle. Returns true if the handle existed.
-    async fn remove(&self, db_id: u32) -> bool {
-        self.handles.write().await.remove(&db_id).is_some()
-    }
-
-    /// Remove all handles belonging to a connection.
-    async fn remove_by_conn(&self, conn_id: u64) {
-        let mut handles = self.handles.write().await;
-        handles.retain(|_, entry| entry.conn_id != conn_id);
-    }
-
-    /// Remove handles idle for longer than `ttl`.
-    async fn reap_expired(&self, ttl: Duration) {
-        let mut handles = self.handles.write().await;
-        let now = Instant::now();
-        handles.retain(|_, entry| now.duration_since(entry.last_used) <= ttl);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Connection ID middleware
-// ---------------------------------------------------------------------------
-
-/// Extension inserted into each request to identify its HTTP/2 connection.
-#[derive(Clone, Copy)]
-struct ConnId(u64);
 
 static NEXT_CONN_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -202,7 +123,6 @@ impl IntoResponse for ApiError {
 
 async fn open_db<L: TxLog + 'static>(
     State(state): State<Arc<Server<L>>>,
-    axum::Extension(conn_id): axum::Extension<ConnId>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
     let open_request = decode_open_db_request(&body).map_err(|e| {
@@ -212,7 +132,7 @@ async fn open_db<L: TxLog + 'static>(
         )
     })?;
 
-    let (db_id, tx_eid) = match (
+    let basis = match (
         open_request.tx_id,
         open_request.system_time,
         open_request.tx_eid,
@@ -223,13 +143,7 @@ async fn open_db<L: TxLog + 'static>(
                 .db()
                 .await
                 .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-            let basis = *db.tx_basis();
-            let db_id = state
-                .handle_store
-                .open(conn_id.0, basis)
-                .await
-                .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-            (db_id, basis.tx_eid)
+            *db.tx_basis()
         }
         (Some(tid), Some(system_time), Some(tx_eid)) => {
             let basis = TxBasis {
@@ -240,12 +154,7 @@ async fn open_db<L: TxLog + 'static>(
                 tx_eid,
             };
             state.node.db_as_of(basis).await.map_err(open_db_error)?;
-            let db_id = state
-                .handle_store
-                .open(conn_id.0, basis)
-                .await
-                .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-            (db_id, tx_eid)
+            basis
         }
         _ => {
             return Err(ApiError::bad_request(
@@ -255,50 +164,30 @@ async fn open_db<L: TxLog + 'static>(
         }
     };
 
-    let body = encode_db_opened_response(&DbOpenedResponse { db_id, tx_eid })
-        .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
+    let body = encode_db_opened_response(&DbOpenedResponse {
+        tx_id: basis.tx_key.tx_id,
+        system_time: basis.tx_key.system_time,
+        tx_eid: basis.tx_eid,
+    })
+    .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
     Ok(ok_response(body))
-}
-
-async fn close_db<L: TxLog + 'static>(
-    State(state): State<Arc<Server<L>>>,
-    Path(db_id): Path<u32>,
-) -> Result<Response, ApiError> {
-    if state.handle_store.remove(db_id).await {
-        let body = encode_db_closed_response(&DbClosedResponse { db_id })
-            .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-        Ok(ok_response(body))
-    } else {
-        Err(ApiError::not_found(
-            ErrorCode::InvalidDbHandle,
-            format!("Invalid DB handle: {}", db_id),
-        ))
-    }
 }
 
 async fn query<L: TxLog + 'static>(
     State(state): State<Arc<Server<L>>>,
-    Path(db_id): Path<u32>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
-    let basis = state.handle_store.get_basis(db_id).await.ok_or_else(|| {
-        ApiError::not_found(
-            ErrorCode::InvalidDbHandle,
-            format!("Invalid DB handle: {}", db_id),
-        )
-    })?;
-    let db = state
-        .node
-        .db_as_of(basis)
-        .await
-        .map_err(|e| ApiError::internal(ErrorCode::QueryError, e.to_string()))?;
-
     let query_request = decode_query_request(&body).map_err(|e| {
         ApiError::bad_request(
             ErrorCode::ParseError,
             format!("Invalid query request: {}", e),
         )
     })?;
+    let db = state
+        .node
+        .db_as_of(query_request.db)
+        .await
+        .map_err(open_db_error)?;
 
     let parsed = query_request
         .query
@@ -403,8 +292,7 @@ async fn execute_tx<L: TxLog + 'static>(
 fn build_router<L: TxLog + 'static>(state: Arc<Server<L>>) -> Router {
     Router::new()
         .route("/db/open", post(open_db::<L>))
-        .route("/db/{db_id}", delete(close_db::<L>))
-        .route("/db/{db_id}/query", post(query::<L>))
+        .route("/db/query", post(query::<L>))
         .route("/tx/submit", post(submit_tx::<L>))
         .route("/tx/execute", post(execute_tx::<L>))
         .layer(DefaultBodyLimit::max(DEFAULT_MAX_MESSAGE_SIZE as usize))
@@ -413,13 +301,11 @@ fn build_router<L: TxLog + 'static>(state: Arc<Server<L>>) -> Router {
 
 pub struct Server<L: TxLog> {
     node: Arc<Node<L>>,
-    handle_store: Arc<HandleStore>,
 }
 
 impl<L: TxLog + 'static> Server<L> {
     pub fn new(node: Arc<Node<L>>) -> Self {
-        let handle_store = Arc::new(HandleStore::new());
-        Server { node, handle_store }
+        Server { node }
     }
 
     pub async fn listen(&self, addr: &str, token: CancellationToken) -> Result<()> {
@@ -428,36 +314,18 @@ impl<L: TxLog + 'static> Server<L> {
     }
 
     pub async fn listen_on(&self, listener: TcpListener, token: CancellationToken) -> Result<()> {
-        let reaper_handle_store = self.handle_store.clone();
-        let reaper_token = token.clone();
-        tokio::spawn(async move {
-            let ttl = Duration::from_secs(86400); // 24 hours
-            let mut interval = tokio::time::interval(Duration::from_secs(300));
-            loop {
-                tokio::select! {
-                    _ = reaper_token.cancelled() => break,
-                    _ = interval.tick() => reaper_handle_store.reap_expired(ttl).await,
-                }
-            }
-        });
-
         let app_state = Arc::new(Server {
             node: self.node.clone(),
-            handle_store: self.handle_store.clone(),
         });
-        let handle_store = self.handle_store.clone();
 
         accept_loop(
             listener,
             token,
             "HTTP",
             move |stream, _peer, conn_id, conn_token, join_set| {
-                let router =
-                    build_router(app_state.clone()).layer(axum::Extension(ConnId(conn_id)));
-                let handle_store = handle_store.clone();
+                let router = build_router(app_state.clone());
                 join_set.spawn(async move {
                     serve_connection(stream, router, conn_id, conn_token, "HTTP").await;
-                    handle_store.remove_by_conn(conn_id).await;
                     info!("HTTP connection {} closed", conn_id);
                 });
             },
@@ -496,17 +364,12 @@ impl DevServer {
             move |stream, _peer, conn_id, conn_token, join_set| {
                 join_set.spawn(async move {
                     let node = Arc::new(Node::memory_node().await);
-                    let handle_store = Arc::new(HandleStore::new());
 
-                    let app_state = Arc::new(Server {
-                        node: node.clone(),
-                        handle_store: handle_store.clone(),
-                    });
-                    let router = build_router(app_state).layer(axum::Extension(ConnId(conn_id)));
+                    let app_state = Arc::new(Server { node: node.clone() });
+                    let router = build_router(app_state);
 
                     serve_connection(stream, router, conn_id, conn_token, "Dev HTTP").await;
 
-                    handle_store.remove_by_conn(conn_id).await;
                     let node = Arc::try_unwrap(node).unwrap_or_else(|_| {
                         panic!("dev node Arc should have refcount 1 after connection close")
                     });

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -70,8 +70,6 @@ async fn test_execute_tx_and_query() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -110,8 +108,6 @@ async fn test_execute_tx_with_string_ops() {
         rows,
         vec![("Alice".to_string(), 30), ("Bob".to_string(), 42)]
     );
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -168,13 +164,11 @@ async fn test_multiple_transactions_and_query() {
     assert_eq!(result.len(), 2);
     assert!(result.contains(&vec![DataType::String("alice".to_string())]));
     assert!(result.contains(&vec![DataType::String("bob".to_string())]));
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_open_close_multiple_dbs() {
+async fn test_multiple_stateless_dbs_for_same_basis() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
@@ -193,13 +187,13 @@ async fn test_open_close_multiple_dbs() {
         _ => panic!("Expected TxCommited"),
     };
 
-    // Open two DB handles for the same basis.
+    // Open two DB values for the same basis.
     let db1 = client.db_as_of(basis).await.unwrap();
     let db2 = client.db_as_of(basis).await.unwrap();
     assert_eq!(db1.tx_eid(), basis.tx_eid);
     assert_eq!(db2.tx_eid(), basis.tx_eid);
 
-    // Both should return same data
+    // Both should return the same data independently.
     let r1 = db1
         .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
         .await
@@ -210,15 +204,12 @@ async fn test_open_close_multiple_dbs() {
         .unwrap();
     assert_eq!(r1.len(), 1);
     assert_eq!(r2.len(), 1);
-
-    db1.close().await.unwrap();
-    let r2_after_close = db2
+    drop(db1);
+    let r2_after_drop = db2
         .query(r#"{:find [?e] :where [[?e :name "alice"]]}"#)
         .await
         .unwrap();
-    assert_eq!(r2_after_close.len(), 1);
-
-    db2.close().await.unwrap();
+    assert_eq!(r2_after_drop.len(), 1);
     token.cancel();
 }
 
@@ -246,8 +237,6 @@ async fn test_two_connections() {
         .await
         .unwrap();
     assert_eq!(result.len(), 1);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -320,13 +309,11 @@ async fn test_db_as_of() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_open_latest_db_handle_stays_pinned_after_later_tx() {
+async fn test_open_latest_db_value_stays_pinned_after_later_tx() {
     let (addr, token) = start_test_server().await;
     let client = ClientNode::connect(&addr).await.unwrap();
     define_base_schema(&client).await;
@@ -363,8 +350,6 @@ async fn test_open_latest_db_handle_stays_pinned_after_later_tx() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::String("alice".to_string())]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -422,9 +407,6 @@ async fn test_dev_server_connections_are_isolated() {
         .await
         .unwrap();
     assert_eq!(result2.len(), 0, "client2 should not see client1's data");
-
-    db1.close().await.unwrap();
-    db2.close().await.unwrap();
     token.cancel();
 }
 
@@ -497,8 +479,6 @@ async fn test_query_keyword_value_comparison_via_wire() {
     );
     assert!(result.contains(&vec![DataType::String("Ivan".to_string())]));
     assert!(result.contains(&vec![DataType::String("Petr".to_string())]));
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -569,8 +549,6 @@ async fn test_aggregates_and_or() {
         DataType::Long(1),
         DataType::Long(21),
     ]));
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -599,8 +577,6 @@ async fn test_aggregate_set_semantics() {
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(3)]]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -637,8 +613,6 @@ async fn test_datascript_aggregates() {
     assert_eq!(row[2], DataType::Long(3), "max");
     assert_eq!(row[3], DataType::Long(4), "count");
     assert_eq!(row[4], DataType::Long(2), "count-distinct");
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -666,8 +640,6 @@ async fn test_aggregate_avg() {
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Double(22.0)]]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -697,8 +669,6 @@ async fn test_aggregate_min_max_strings() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0][0], DataType::String("Alice".to_string()));
     assert_eq!(result[0][1], DataType::String("Charlie".to_string()));
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -716,8 +686,6 @@ async fn test_aggregate_empty_result() {
         .await
         .unwrap();
     assert_eq!(result, vec![vec![DataType::Long(0)]]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -805,8 +773,6 @@ async fn test_order_and_limit() {
         result[4],
         vec![DataType::String("Eve".to_string()), DataType::Long(50)]
     );
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -832,8 +798,6 @@ async fn test_aggregate_min_incompatible_types() {
         .query("{:find [(min ?v)] :where [(or [?e :name ?v] [?e :age ?v])]}")
         .await;
     assert!(result.is_err(), "min over incompatible types should error");
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -860,7 +824,6 @@ async fn test_join_ref_with_plain_long() {
         DataType::Long(id) => *id,
         other => panic!("Expected Long entity ID, got {:?}", other),
     };
-    db.close().await.unwrap();
 
     // Insert Alice with :follows pointing to Bob's entity id
     client
@@ -880,8 +843,6 @@ async fn test_join_ref_with_plain_long() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::String("Bob".to_string())]);
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -911,7 +872,6 @@ async fn test_upsert_with_resolved_entity_id() {
         DataType::Long(id) => *id,
         other => panic!("Expected Long entity ID, got {:?}", other),
     };
-    db.close().await.unwrap();
 
     // Upsert: update age using the discovered entity ID
     client
@@ -934,8 +894,6 @@ async fn test_upsert_with_resolved_entity_id() {
         result[0],
         vec![DataType::String("alice".to_string()), DataType::Long(31)]
     );
-
-    db.close().await.unwrap();
     token.cancel();
 }
 
@@ -980,7 +938,5 @@ async fn test_year_and_month_extraction() {
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], vec![DataType::Long(6)]);
-
-    db.close().await.unwrap();
     token.cancel();
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -190,8 +190,8 @@ async fn test_multiple_stateless_dbs_for_same_basis() {
     // Open two DB values for the same basis.
     let db1 = client.db_as_of(basis).await.unwrap();
     let db2 = client.db_as_of(basis).await.unwrap();
-    assert_eq!(db1.tx_eid(), basis.tx_eid);
-    assert_eq!(db2.tx_eid(), basis.tx_eid);
+    assert_eq!(db1.tx_basis().tx_eid, basis.tx_eid);
+    assert_eq!(db2.tx_basis().tx_eid, basis.tx_eid);
 
     // Both should return the same data independently.
     let r1 = db1
@@ -301,7 +301,7 @@ async fn test_db_as_of() {
 
     // Open DB pinned to the first transaction basis — should only see alice
     let db = client.db_as_of(basis1).await.unwrap();
-    assert_eq!(db.tx_eid(), basis1.tx_eid);
+    assert_eq!(db.tx_basis().tx_eid, basis1.tx_eid);
     let result = db
         .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
@@ -332,7 +332,7 @@ async fn test_open_latest_db_value_stays_pinned_after_later_tx() {
     };
 
     let db = client.db().await.unwrap();
-    assert_eq!(db.tx_eid(), basis1.tx_eid);
+    assert_eq!(db.tx_basis().tx_eid, basis1.tx_eid);
 
     client
         .execute_tx(vec![TxOp::Add {

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -183,11 +183,6 @@ pub struct ClientDb {
 }
 
 impl ClientDb {
-    /// The transaction entity id this DB value is pinned to.
-    pub fn tx_eid(&self) -> i64 {
-        self.basis.tx_eid
-    }
-
     /// The transaction basis this DB value is pinned to.
     pub fn tx_basis(&self) -> TxBasis {
         self.basis

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -88,10 +88,16 @@ impl ClientNode {
 
         let data = check_response(resp).await?;
         let opened = decode_db_opened_response(&data)?;
+        let basis = TxBasis {
+            tx_key: TxKey {
+                tx_id: opened.tx_id,
+                system_time: opened.system_time,
+            },
+            tx_eid: opened.tx_eid,
+        };
 
         Ok(ClientDb {
-            db_id: opened.db_id,
-            tx_eid: opened.tx_eid,
+            basis,
             client: self.client.clone(),
             base_url: self.base_url.clone(),
         })
@@ -169,33 +175,22 @@ impl QueryNode for ClientNode {
 // ClientDb
 // ---------------------------------------------------------------------------
 
-/// A remote DB read handle. Mirrors the `DB` API.
-///
-/// Callers should call [`.close()`](ClientDb::close) when done to release
-/// the server-side handle. If not closed explicitly, the server will clean
-/// up via TTL expiration or connection-drop detection.
+/// A remote DB read basis. Mirrors the `DB` API.
 pub struct ClientDb {
-    db_id: u32,
-    tx_eid: i64,
+    basis: TxBasis,
     client: Client,
     base_url: String,
 }
 
 impl ClientDb {
-    /// The transaction entity id this handle is pinned to.
+    /// The transaction entity id this DB value is pinned to.
     pub fn tx_eid(&self) -> i64 {
-        self.tx_eid
+        self.basis.tx_eid
     }
 
-    /// Release this DB handle on the server.
-    pub async fn close(self) -> Result<()> {
-        let resp = self
-            .client
-            .delete(format!("{}/db/{}", self.base_url, self.db_id))
-            .send()
-            .await?;
-        check_response(resp).await?;
-        Ok(())
+    /// The transaction basis this DB value is pinned to.
+    pub fn tx_basis(&self) -> TxBasis {
+        self.basis
     }
 }
 
@@ -211,12 +206,13 @@ impl Database for ClientDb {
         args: &[QueryArg],
     ) -> Result<QueryResult, Error> {
         let body = encode_query_request(&QueryRequest {
+            db: self.basis,
             query: query.to_string(),
             args: args.to_vec(),
         })?;
         let resp = self
             .client
-            .post(format!("{}/db/{}/query", self.base_url, self.db_id))
+            .post(format!("{}/db/query", self.base_url))
             .header("Content-Type", CONTENT_TYPE)
             .body(body)
             .send()

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 
 use crate::ops::{DataType, EntityRef, QueryArg, TxOp};
 use crate::protocol::ColumnDescription;
+use crate::transaction::{TxBasis, TxKey};
 
 // =============================================================================
 // Ext type codes
@@ -640,17 +641,14 @@ pub struct OpenDbRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DbOpenedResponse {
-    pub db_id: u32,
+    pub tx_id: i64,
+    pub system_time: DateTime<Utc>,
     pub tx_eid: i64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct DbClosedResponse {
-    pub db_id: u32,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct QueryRequest {
+    pub db: TxBasis,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -715,12 +713,14 @@ pub fn decode_open_db_request(data: &[u8]) -> Result<OpenDbRequest> {
     })
 }
 
-/// Encode a DbOpened response: `{"db_id": int, "tx_eid": int}`.
+/// Encode a DbOpened response: `{"tx_id": int, "system_time": Timestamp, "tx_eid": int}`.
 pub fn encode_db_opened_response(resp: &DbOpenedResponse) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 2)?;
-    rmp::encode::write_str(&mut buf, "db_id")?;
-    rmp::encode::write_uint(&mut buf, resp.db_id as u64)?;
+    rmp::encode::write_map_len(&mut buf, 3)?;
+    rmp::encode::write_str(&mut buf, "tx_id")?;
+    rmp::encode::write_sint(&mut buf, resp.tx_id)?;
+    rmp::encode::write_str(&mut buf, "system_time")?;
+    write_timestamp(&mut buf, &resp.system_time)?;
     rmp::encode::write_str(&mut buf, "tx_eid")?;
     rmp::encode::write_sint(&mut buf, resp.tx_eid)?;
     Ok(buf)
@@ -728,41 +728,44 @@ pub fn encode_db_opened_response(resp: &DbOpenedResponse) -> Result<Vec<u8>> {
 
 pub fn decode_db_opened_response(data: &[u8]) -> Result<DbOpenedResponse> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let db_id = take_i64(&mut map, "db_id")?;
+    let tx_id = take_i64(&mut map, "tx_id")?;
+    let system_time = take_timestamp(&mut map, "system_time")?;
     let tx_eid = take_i64(&mut map, "tx_eid")?;
-    if db_id < 0 || db_id > u32::MAX as i64 {
-        bail!("db_id out of u32 range: {db_id}");
-    }
     Ok(DbOpenedResponse {
-        db_id: db_id as u32,
+        tx_id,
+        system_time,
         tx_eid,
     })
 }
 
-/// Encode a DbClosed response: `{"db_id": int}`.
-pub fn encode_db_closed_response(resp: &DbClosedResponse) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 1)?;
-    rmp::encode::write_str(&mut buf, "db_id")?;
-    rmp::encode::write_uint(&mut buf, resp.db_id as u64)?;
-    Ok(buf)
+fn write_tx_basis<W: Write>(w: &mut W, basis: &TxBasis) -> Result<()> {
+    rmp::encode::write_map_len(w, 3)?;
+    rmp::encode::write_str(w, "tx_id")?;
+    rmp::encode::write_sint(w, basis.tx_key.tx_id)?;
+    rmp::encode::write_str(w, "system_time")?;
+    write_timestamp(w, &basis.tx_key.system_time)?;
+    rmp::encode::write_str(w, "tx_eid")?;
+    rmp::encode::write_sint(w, basis.tx_eid)?;
+    Ok(())
 }
 
-pub fn decode_db_closed_response(data: &[u8]) -> Result<DbClosedResponse> {
-    let mut map = map_from_value(read_body_value(data)?)?;
-    let db_id = take_i64(&mut map, "db_id")?;
-    if db_id < 0 || db_id > u32::MAX as i64 {
-        bail!("db_id out of u32 range: {db_id}");
-    }
-    Ok(DbClosedResponse {
-        db_id: db_id as u32,
+fn tx_basis_from_value(value: Value) -> Result<TxBasis> {
+    let mut map = map_from_value(value)?;
+    Ok(TxBasis {
+        tx_key: TxKey {
+            tx_id: take_i64(&mut map, "tx_id")?,
+            system_time: take_timestamp(&mut map, "system_time")?,
+        },
+        tx_eid: take_i64(&mut map, "tx_eid")?,
     })
 }
 
-/// Encode a Query request: `{"query": str, "args": [QueryArg, ...]}`.
+/// Encode a Query request: `{"db": TxBasis, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 2)?;
+    rmp::encode::write_map_len(&mut buf, 3)?;
+    rmp::encode::write_str(&mut buf, "db")?;
+    write_tx_basis(&mut buf, &req.db)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -775,6 +778,7 @@ pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
 
 pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
+    let db = tx_basis_from_value(take_field(&mut map, "db")?)?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -784,7 +788,7 @@ pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     for item in arr {
         args.push(query_arg_from_value(item)?);
     }
-    Ok(QueryRequest { query, args })
+    Ok(QueryRequest { db, query, args })
 }
 
 /// Encode a query response: `{"columns": [...], "rows": [[...], ...]}`.
@@ -1285,8 +1289,10 @@ mod tests {
 
     #[test]
     fn round_trip_db_opened_response_body() {
+        let system_time = Utc.timestamp_opt(1_700_000_001, 0).unwrap();
         let response = DbOpenedResponse {
-            db_id: 7,
+            tx_id: 7,
+            system_time,
             tx_eid: 12345,
         };
         let buf = encode_db_opened_response(&response).unwrap();
@@ -1294,15 +1300,15 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_db_closed_response_body() {
-        let response = DbClosedResponse { db_id: 11 };
-        let buf = encode_db_closed_response(&response).unwrap();
-        assert_eq!(decode_db_closed_response(&buf).unwrap(), response);
-    }
-
-    #[test]
     fn round_trip_query_request_body() {
         let q = "{:find [?n] :where [[?e :name ?n]]}";
+        let db = TxBasis {
+            tx_key: TxKey {
+                tx_id: 42,
+                system_time: Utc.timestamp_opt(1_700_000_002, 0).unwrap(),
+            },
+            tx_eid: 100,
+        };
         let args = vec![
             QueryArg::Scalar(DataType::Long(7)),
             QueryArg::Collection(vec![
@@ -1311,6 +1317,7 @@ mod tests {
             ]),
         ];
         let request = QueryRequest {
+            db,
             query: q.into(),
             args,
         };
@@ -1439,23 +1446,23 @@ mod tests {
 
     #[test]
     fn decode_db_opened_rejects_wrong_type() {
-        // {"db_id": "not an int", "tx_eid": 7}
+        // {"tx_id": "not an int", "system_time": ts, "tx_eid": 7}
         let body = pack(Value::Map(vec![
-            (Value::String("db_id".into()), Value::String("nope".into())),
+            (Value::String("tx_id".into()), Value::String("nope".into())),
+            (
+                Value::String("system_time".into()),
+                Value::Ext(EXT_TIMESTAMP, vec![0, 0, 0, 0]),
+            ),
             (Value::String("tx_eid".into()), Value::Integer(7.into())),
         ]));
         assert!(decode_db_opened_response(&body).is_err());
     }
 
     #[test]
-    fn decode_db_opened_rejects_db_id_overflow() {
-        // db_id > u32::MAX
+    fn decode_db_opened_rejects_missing_system_time() {
         let body = pack(Value::Map(vec![
-            (
-                Value::String("db_id".into()),
-                Value::Integer((u64::from(u32::MAX) + 1).into()),
-            ),
-            (Value::String("tx_eid".into()), Value::Integer(0.into())),
+            (Value::String("tx_id".into()), Value::Integer(1.into())),
+            (Value::String("tx_eid".into()), Value::Integer(2.into())),
         ]));
         assert!(decode_db_opened_response(&body).is_err());
     }
@@ -1545,13 +1552,15 @@ mod tests {
     #[test]
     fn decode_body_rejects_trailing_bytes() {
         // Two consecutive valid maps — only one body is allowed.
-        let one = pack(Value::Map(vec![(
-            Value::String("db_id".into()),
-            Value::Integer(7.into()),
-        )]));
+        let one = encode_open_db_request(&OpenDbRequest {
+            tx_id: None,
+            system_time: None,
+            tx_eid: None,
+        })
+        .unwrap();
         let mut two = one.clone();
         two.extend_from_slice(&one);
-        assert!(decode_db_closed_response(&two).is_err());
+        assert!(decode_open_db_request(&two).is_err());
     }
 
     #[test]

--- a/triplox-client/src/protocol.rs
+++ b/triplox-client/src/protocol.rs
@@ -86,8 +86,6 @@ pub enum ErrorCode {
     InvalidMessageType = 4002,
     QueryCancelled = 4003,
     ServerShuttingDown = 4004,
-    // DB handle errors (5xxx)
-    InvalidDbHandle = 5000,
 }
 
 impl ErrorCode {
@@ -107,7 +105,6 @@ impl ErrorCode {
             4002 => Ok(ErrorCode::InvalidMessageType),
             4003 => Ok(ErrorCode::QueryCancelled),
             4004 => Ok(ErrorCode::ServerShuttingDown),
-            5000 => Ok(ErrorCode::InvalidDbHandle),
             _ => bail!("Unknown error code: {}", code),
         }
     }

--- a/triplox-jvm/dev/dev.clj
+++ b/triplox-jvm/dev/dev.clj
@@ -12,11 +12,11 @@
   (t/transact conn [{:db/id 1001 :person/name "alice" :person/age 30}
                     {:db/id 1002 :person/name "bob" :person/age 25}])
 
-  ;; Open a DB handle and query
-  (with-open [db (t/db conn)]
-    (t/q db '{:find [?name ?age]
-                   :where [[?e :person/name ?name]
-                           [?e :person/age ?age]]}))
+  ;; Open a DB value and query
+  (def db (t/db conn))
+  (t/q db '{:find [?name ?age]
+            :where [[?e :person/name ?name]
+                    [?e :person/age ?age]]})
 
   ;; Clean up
   (.close conn)

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -10,7 +10,7 @@
   (TriploxNode/connect host (int port)))
 
 (defn db
-  "Open a DB handle. Returns a Db (AutoCloseable)."
+  "Open a DB value. Returns a Db."
   (^Db [conn]
    (db conn nil))
   (^Db [conn {:keys [tx-basis] :as _opts}]

--- a/triplox-jvm/src/main/java/xyz/triplox/client/BackendMessage.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/BackendMessage.java
@@ -6,8 +6,9 @@ import java.time.Instant;
  * Decoded HTTP response bodies. Used internally by {@link WireCodec}.
  */
 public sealed interface BackendMessage {
-    record DbOpened(int dbId, long txEid) implements BackendMessage {}
-    record DbClosed(int dbId) implements BackendMessage {}
+    record DbOpened(long txId, Instant systemTime, long txEid) implements BackendMessage {
+        public TxBasis basis() { return new TxBasis(txId, systemTime, txEid); }
+    }
     record TxKey(long txId, Instant systemTime) implements BackendMessage {}
     record TxResult(byte status, long txId, Instant systemTime, long txEid, String errorMessage)
             implements BackendMessage {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
@@ -17,7 +17,7 @@ public class Db {
         this.basis = basis;
     }
 
-    TxBasis basis() { return basis; }
+    public TxBasis basis() { return basis; }
     public long txEid() { return basis.txEid(); }
 
     /**

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
@@ -4,24 +4,21 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Handle to an open DB read basis on the server.
+ * Immutable DB read basis.
  *
- * <p>Obtained via {@link TriploxNode#openDb()}. Provides query execution
- * and must be closed when no longer needed to release server resources.</p>
+ * <p>Obtained via {@link TriploxNode#openDb()}. Provides query execution.</p>
  */
-public class Db implements AutoCloseable {
+public class Db {
     private final TriploxNode node;
-    private final int dbId;
-    private final long txEid;
+    private final TxBasis basis;
 
-    Db(TriploxNode node, int dbId, long txEid) {
+    Db(TriploxNode node, TxBasis basis) {
         this.node = node;
-        this.dbId = dbId;
-        this.txEid = txEid;
+        this.basis = basis;
     }
 
-    int dbId() { return dbId; }
-    public long txEid() { return txEid; }
+    TxBasis basis() { return basis; }
+    public long txEid() { return basis.txEid(); }
 
     /**
      * Execute a Datalog query against this DB read basis.
@@ -35,13 +32,5 @@ public class Db implements AutoCloseable {
      */
     public List<List<Object>> query(String edn, List<QueryArg> args) throws IOException {
         return node.queryInternal(this, edn, args).rows();
-    }
-
-    /**
-     * Release this DB handle on the server.
-     */
-    @Override
-    public void close() throws IOException {
-        node.closeDbInternal(this);
     }
 }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
@@ -37,14 +37,14 @@ public class TriploxNode implements AutoCloseable {
     }
 
     /**
-     * Open a DB read handle at the latest indexed transaction.
+     * Open a DB value at the latest indexed transaction.
      */
     public Db openDb() throws IOException {
         return openDbInternal(null);
     }
 
     /**
-     * Open a DB read handle at a specific indexed transaction basis.
+     * Open a DB value at a specific indexed transaction basis.
      */
     public Db openDbAsOf(TxBasis basis) throws IOException {
         return openDbInternal(basis);
@@ -54,18 +54,11 @@ public class TriploxNode implements AutoCloseable {
         byte[] body = WireCodec.encodeOpenDbBody(basis);
         byte[] responseBody = postBinary("/db/open", body);
         var opened = WireCodec.decodeDbOpened(responseBody);
-        return new Db(this, opened.dbId(), opened.txEid());
+        return new Db(this, opened.basis());
     }
 
     /**
-     * Release a previously opened DB read handle.
-     */
-    void closeDbInternal(Db db) throws IOException {
-        deleteBinary("/db/" + db.dbId());
-    }
-
-    /**
-     * Execute a Datalog query against an open DB read handle.
+     * Execute a Datalog query against a DB value.
      */
     QueryResult queryInternal(Db db, String edn) throws IOException {
         return queryInternal(db, edn, List.of());
@@ -75,8 +68,8 @@ public class TriploxNode implements AutoCloseable {
      * Execute a Datalog query with input binding arguments.
      */
     QueryResult queryInternal(Db db, String edn, List<QueryArg> args) throws IOException {
-        byte[] body = WireCodec.encodeQueryBody(edn, args);
-        byte[] responseBody = postBinary("/db/" + db.dbId() + "/query", body);
+        byte[] body = WireCodec.encodeQueryBody(db.basis(), edn, args);
+        byte[] responseBody = postBinary("/db/query", body);
         return WireCodec.decodeQueryResponse(responseBody);
     }
 
@@ -132,14 +125,6 @@ public class TriploxNode implements AutoCloseable {
                 .uri(URI.create(baseUrl + path))
                 .header("Content-Type", CONTENT_TYPE)
                 .POST(HttpRequest.BodyPublishers.ofByteArray(body))
-                .build();
-        return sendAndCheck(request);
-    }
-
-    private byte[] deleteBinary(String path) throws IOException {
-        var request = HttpRequest.newBuilder()
-                .uri(URI.create(baseUrl + path))
-                .DELETE()
                 .build();
         return sendAndCheck(request);
     }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TxBasis.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TxBasis.java
@@ -3,6 +3,6 @@ package xyz.triplox.client;
 import java.time.Instant;
 
 /**
- * Indexed transaction basis for opening an as-of DB read handle.
+ * Indexed transaction basis for an as-of DB value.
  */
 public record TxBasis(long txId, Instant systemTime, long txEid) {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -57,11 +57,12 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/{id}/query} body: {@code {"query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/query} body: {@code {"db": TxBasis, "query": str, "args": [QueryArg, ...]}}.
      */
-    public static byte[] encodeQueryBody(String query, List<QueryArg> args) throws IOException {
+    public static byte[] encodeQueryBody(TxBasis basis, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(2);
+            packer.packMapHeader(3);
+            packer.packString("db"); packTxBasis(packer, basis);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -85,15 +86,10 @@ public final class WireCodec {
 
     public static BackendMessage.DbOpened decodeDbOpened(byte[] body) throws IOException {
         var fields = readFields(body);
-        long dbId = expectLong(fields, "db_id");
+        long txId = expectLong(fields, "tx_id");
+        Instant systemTime = expectInstant(fields, "system_time");
         long txEid = expectLong(fields, "tx_eid");
-        return new BackendMessage.DbOpened(toInt(dbId), txEid);
-    }
-
-    public static BackendMessage.DbClosed decodeDbClosed(byte[] body) throws IOException {
-        var fields = readFields(body);
-        long dbId = expectLong(fields, "db_id");
-        return new BackendMessage.DbClosed(toInt(dbId));
+        return new BackendMessage.DbOpened(txId, systemTime, txEid);
     }
 
     public static QueryResult decodeQueryResponse(byte[] body) throws IOException {
@@ -189,6 +185,13 @@ public final class WireCodec {
     // ---------------------------------------------------------------
     // Field-map helpers
     // ---------------------------------------------------------------
+
+    private static void packTxBasis(MessagePacker packer, TxBasis basis) throws IOException {
+        packer.packMapHeader(3);
+        packer.packString("tx_id"); packer.packLong(basis.txId());
+        packer.packString("system_time"); packer.packTimestamp(basis.systemTime());
+        packer.packString("tx_eid"); packer.packLong(basis.txEid());
+    }
 
     private static Map<String, Object> readFields(byte[] body) throws IOException {
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -34,17 +34,17 @@
 (use-fixtures :each with-conn with-people-schema)
 
 (defn q
-  "Open a DB, run query, close DB, return results as a set.
+  "Open a DB, run query, return results as a set.
   Additional arguments bind `:in` variables as scalars."
   [query-edn & args]
-  (with-open [db (tc/db *conn*)]
+  (let [db (tc/db *conn*)]
     (set (apply tc/q db query-edn args))))
 
 (defn q-ordered
-  "Open a DB, run query, close DB, return results as a vector (preserves order)."
+  "Open a DB, run query, return results as a vector (preserves order)."
   ([query-edn] (q-ordered *conn* query-edn))
   ([conn query-edn]
-   (with-open [db (tc/db conn)]
+   (let [db (tc/db conn)]
      (vec (tc/q db query-edn)))))
 
 ;; ---------------------------------------------------------------------------

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -57,9 +57,18 @@ class WireCodecTest {
 
     @Test
     void testEncodeQueryBody() throws IOException {
-        byte[] body = WireCodec.encodeQueryBody("{:find [?e]}", List.of());
+        Instant now = Instant.ofEpochSecond(1_700_000_000L);
+        byte[] body = WireCodec.encodeQueryBody(new TxBasis(42L, now, 100L), "{:find [?e]}", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
-            assertEquals(2, unpacker.unpackMapHeader());
+            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals("db", unpacker.unpackString());
+            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals("tx_id", unpacker.unpackString());
+            assertEquals(42L, unpacker.unpackLong());
+            assertEquals("system_time", unpacker.unpackString());
+            assertEquals(now, unpacker.unpackTimestamp());
+            assertEquals("tx_eid", unpacker.unpackString());
+            assertEquals(100L, unpacker.unpackLong());
             assertEquals("query", unpacker.unpackString());
             assertEquals("{:find [?e]}", unpacker.unpackString());
             assertEquals("args", unpacker.unpackString());
@@ -89,17 +98,20 @@ class WireCodecTest {
 
     @Test
     void testDecodeDbOpened() throws IOException {
-        byte[] body = packMap2("db_id", 5L, "tx_eid", 42L);
+        Instant now = Instant.ofEpochSecond(1_700_000_000L);
+        byte[] body;
+        try (var packer = MessagePack.newDefaultBufferPacker()) {
+            packer.packMapHeader(3);
+            packer.packString("tx_id"); packer.packLong(5);
+            packer.packString("system_time"); packer.packTimestamp(now);
+            packer.packString("tx_eid"); packer.packLong(42);
+            body = packer.toByteArray();
+        }
         var opened = WireCodec.decodeDbOpened(body);
-        assertEquals(5, opened.dbId());
+        assertEquals(5L, opened.txId());
+        assertEquals(now, opened.systemTime());
         assertEquals(42L, opened.txEid());
-    }
-
-    @Test
-    void testDecodeDbClosed() throws IOException {
-        byte[] body = packMap1("db_id", 5L);
-        var closed = WireCodec.decodeDbClosed(body);
-        assertEquals(5, closed.dbId());
+        assertEquals(new TxBasis(5L, now, 42L), opened.basis());
     }
 
     @Test
@@ -233,20 +245,4 @@ class WireCodecTest {
         packer.packString("type"); packer.packLong(Byte.toUnsignedLong(type));
     }
 
-    private static byte[] packMap1(String k1, long v1) throws IOException {
-        try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(1);
-            packer.packString(k1); packer.packLong(v1);
-            return packer.toByteArray();
-        }
-    }
-
-    private static byte[] packMap2(String k1, long v1, String k2, long v2) throws IOException {
-        try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(2);
-            packer.packString(k1); packer.packLong(v1);
-            packer.packString(k2); packer.packLong(v2);
-            return packer.toByteArray();
-        }
-    }
 }

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/TriploxNodeTest.java
@@ -33,11 +33,10 @@ class TriploxNodeTest {
             assertTrue(txResult.isCommitted());
 
             // Query
-            try (var db = node.openDb()) {
-                var rows = db.query("{:find [?name] :where [[?e :name ?name]]}");
-                assertEquals(1, rows.size());
-                assertEquals("alice", rows.get(0).get(0));
-            }
+            var db = node.openDb();
+            var rows = db.query("{:find [?name] :where [[?e :name ?name]]}");
+            assertEquals(1, rows.size());
+            assertEquals("alice", rows.get(0).get(0));
         }
     }
 
@@ -55,10 +54,9 @@ class TriploxNodeTest {
             var tx2 = node.executeTx(List.of(new TxOp.Put(map(":historical-name", "bob"))));
             assertTrue(tx2.isCommitted());
 
-            try (var db = node.openDbAsOf(tx1.basis())) {
-                var rows = db.query("{:find [?name] :where [[?e :historical-name ?name]]}");
-                assertEquals(List.of(List.of("alice")), rows);
-            }
+            var db = node.openDbAsOf(tx1.basis());
+            var rows = db.query("{:find [?name] :where [[?e :historical-name ?name]]}");
+            assertEquals(List.of(List.of("alice")), rows);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove server-side remote DB handle allocation, close, connection cleanup, and TTL reaping
- make query requests stateless via `POST /db/query` with the DB basis in the request body
- update Rust, Java, and Clojure clients/tests/examples so DB values do not need to be closed

## Testing
- `cargo fmt`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- `cd triplox-jvm && ./gradlew test --rerun-tasks`

Autogenerated by GPT-5.