### PR TITLE
Reject query placeholders in validation

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -474,6 +474,42 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_rejects_entity_placeholder() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let db = node.db().await.unwrap();
+        let err = db
+            .query("[:find ?name :where [_ :name ?name]]")
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("entity position"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_rejects_value_placeholder() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let db = node.db().await.unwrap();
+        let err = db
+            .query("[:find ?e :where [?e :name _]]")
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("value position"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_two_patterns_join() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -2,7 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Error;
 use edn::query::{
-    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, Variable, WhereClause,
+    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace,
+    PatternValuePlace, Variable, WhereClause,
 };
 
 use crate::expr::expr_variables;
@@ -77,6 +78,17 @@ fn validate_pattern_variables_in_clause(clause: &WhereClause) -> Result<(), Erro
 }
 
 fn validate_single_pattern_variables(pattern: &Pattern) -> Result<(), Error> {
+    if matches!(&pattern.entity, PatternNonValuePlace::Placeholder) {
+        return Err(anyhow::anyhow!(
+            "Placeholders in entity position are not supported"
+        ));
+    }
+    if matches!(&pattern.value, PatternValuePlace::Placeholder) {
+        return Err(anyhow::anyhow!(
+            "Placeholders in value position are not supported"
+        ));
+    }
+
     let mut seen = HashSet::new();
     for var in pattern_variables(pattern) {
         if !seen.insert(var.clone()) {


### PR DESCRIPTION
## Summary
- reject `_` placeholders in query entity and value positions during validation
- add end-to-end `db.query` tests for both rejected placeholder positions

## Verification
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated by GPT-5 Codex.
