### PR TITLE
Remove vector function args

### DIFF
--- a/edn/src/parse.rs
+++ b/edn/src/parse.rs
@@ -295,7 +295,6 @@ peg::parser! {
 
         rule fn_arg() -> query::FnArg
             = v:value() {? query::FnArg::from_value(&v).ok_or("expected query function argument") }
-            / __() "[" args:fn_arg()+ "]" __() { query::FnArg::Vector(args) }
 
         rule find_elem() -> query::Element
             = __() v:variable() __() { query::Element::Variable(v) }

--- a/edn/src/query.rs
+++ b/edn/src/query.rs
@@ -218,9 +218,6 @@ pub enum FnArg {
     EntidOrInteger(i64),
     IdentOrKeyword(Keyword),
     Constant(NonIntegerConstant),
-    // The collection values representable in EDN.  There's no advantage to destructuring up front,
-    // since consumers will need to handle arbitrarily nested EDN themselves anyway.
-    Vector(Vec<FnArg>),
 }
 
 impl FromValue<FnArg> for FnArg {
@@ -271,16 +268,6 @@ impl std::fmt::Display for FnArg {
             &FnArg::EntidOrInteger(entid) => write!(f, "{}", entid),
             FnArg::IdentOrKeyword(kw) => write!(f, "{}", kw),
             FnArg::Constant(constant) => write!(f, "{}", constant),
-            FnArg::Vector(vec) => {
-                write!(f, "[")?;
-                for (i, arg) in vec.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, " ")?;
-                    }
-                    write!(f, "{}", arg)?;
-                }
-                write!(f, "]")
-            }
         }
     }
 }

--- a/edn/tests/query_tests.rs
+++ b/edn/tests/query_tests.rs
@@ -345,6 +345,11 @@ fn round_trip_where_fn() {
 }
 
 #[test]
+fn rejects_vector_function_arg() {
+    assert!(parse_query("[:find ?x :where [(some_fn [?x 1])]]").is_err());
+}
+
+#[test]
 fn round_trip_simple_pattern() {
     assert_round_trip("[:find ?x ?y :where [?x :foo/bar ?y]]");
 }


### PR DESCRIPTION
## Summary
- remove the inherited `FnArg::Vector` branch from query function arguments
- stop parsing bracketed vector literals as function arguments
- add a parser regression test that rejects vector function args

## Verification
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated by GPT-5 Codex.
