### PR TITLE
Fix CdcStream immutable WAL file polling

### DIFF
--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -9,7 +9,10 @@ use crate::indexer::eav_key_to_parts;
 use crate::ops::{DataType, Datom, DatomOp};
 use crate::schema::Schema;
 
-/// Tracks position in the WAL stream for resumability.
+/// Tracks the CDC stream position.
+///
+/// `last_seq` is the exclusive lower bound for rows yielded by the stream.
+/// `wal_id` is a WAL discovery hint and is updated to the last opened WAL file.
 #[derive(Debug, Default, Clone)]
 pub struct CdcCursor {
     pub wal_id: u64,
@@ -30,7 +33,6 @@ pub struct CdcStream {
     current_iter: Option<WalFileIterator>,
     buffered: Option<RowEntry>,
     cursor: CdcCursor,
-    next_wal_id_to_list: u64,
     poll_interval: Duration,
     cancel: CancellationToken,
 }
@@ -47,8 +49,7 @@ impl CdcStream {
         poll_interval: Duration,
         cancel: CancellationToken,
     ) -> Result<Self, slatedb::Error> {
-        let next_wal_id_to_list = cursor.wal_id;
-        let wal_files: VecDeque<WalFile> = wal_reader.list(next_wal_id_to_list..).await?.into();
+        let wal_files: VecDeque<WalFile> = wal_reader.list(cursor.wal_id..).await?.into();
 
         let mut stream = CdcStream {
             wal_reader,
@@ -56,7 +57,6 @@ impl CdcStream {
             current_iter: None,
             buffered: None,
             cursor,
-            next_wal_id_to_list,
             poll_interval,
             cancel,
         };
@@ -125,7 +125,7 @@ impl CdcStream {
             loop {
                 let new_files: VecDeque<WalFile> = self
                     .wal_reader
-                    .list(self.next_wal_id_to_list..)
+                    .list((self.cursor.wal_id + 1)..)
                     .await?
                     .into();
 
@@ -165,7 +165,6 @@ impl CdcStream {
     async fn advance_to_next_file(&mut self) -> Result<bool, slatedb::Error> {
         if let Some(file) = self.wal_files.pop_front() {
             self.cursor.wal_id = file.id;
-            self.next_wal_id_to_list = file.id + 1;
             self.current_iter = Some(file.iterator().await?);
             Ok(true)
         } else {
@@ -591,6 +590,53 @@ mod tests {
             txs.len()
         );
         db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cdc_cursor_last_seq_skips_old_wals_then_polls_next_wal() {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let (db, object_store) = setup_db("/test_cursor_seq_start_then_live").await;
+
+            db.put(b"k1", b"v1").await.unwrap();
+            db.flush_with_options(flush_opts()).await.unwrap();
+            db.put(b"k2", b"v2").await.unwrap();
+            db.flush_with_options(flush_opts()).await.unwrap();
+
+            let current_seq = db.status().durable_seq;
+            let wal_reader = WalReader::new("/test_cursor_seq_start_then_live", object_store);
+            let cancel = CancellationToken::new();
+            let mut stream = CdcStream::new(
+                wal_reader,
+                CdcCursor {
+                    wal_id: 0,
+                    last_seq: current_seq,
+                },
+                Duration::from_millis(10),
+                cancel,
+            )
+            .await
+            .unwrap();
+
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                db.put(b"k3", b"v3").await.unwrap();
+                db.flush_with_options(flush_opts()).await.unwrap();
+            });
+
+            let tx = stream
+                .next_transaction()
+                .await
+                .unwrap()
+                .expect("stream should skip old WALs and yield the next live transaction");
+
+            assert!(tx.seq > current_seq);
+            assert!(tx.entries.iter().any(|entry| {
+                entry.key.as_ref() == b"k3"
+                    && matches!(&entry.value, ValueDeletable::Value(value) if value.as_ref() == b"v3")
+            }));
+        })
+        .await
+        .expect("test_cdc_cursor_last_seq_skips_old_wals_then_polls_next_wal timed out");
     }
 
     #[tokio::test]

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -30,6 +30,7 @@ pub struct CdcStream {
     current_iter: Option<WalFileIterator>,
     buffered: Option<RowEntry>,
     cursor: CdcCursor,
+    next_wal_id_to_list: u64,
     poll_interval: Duration,
     cancel: CancellationToken,
 }
@@ -46,7 +47,8 @@ impl CdcStream {
         poll_interval: Duration,
         cancel: CancellationToken,
     ) -> Result<Self, slatedb::Error> {
-        let wal_files: VecDeque<WalFile> = wal_reader.list(cursor.wal_id..).await?.into();
+        let next_wal_id_to_list = cursor.wal_id;
+        let wal_files: VecDeque<WalFile> = wal_reader.list(next_wal_id_to_list..).await?.into();
 
         let mut stream = CdcStream {
             wal_reader,
@@ -54,6 +56,7 @@ impl CdcStream {
             current_iter: None,
             buffered: None,
             cursor,
+            next_wal_id_to_list,
             poll_interval,
             cancel,
         };
@@ -76,9 +79,9 @@ impl CdcStream {
         let seq = first.seq;
         let mut entries = vec![first];
 
-        // Accumulate entries with the same seq.
+        // Accumulate entries with the same seq inside the current WAL file.
         loop {
-            match self.next_entry().await? {
+            match self.next_entry_in_current_file().await? {
                 Some(entry) if entry.seq == seq => {
                     entries.push(entry);
                 }
@@ -88,7 +91,8 @@ impl CdcStream {
                     break;
                 }
                 None => {
-                    // Cancelled or no more data — yield what we have.
+                    // WAL files are immutable and transactions do not cross file
+                    // boundaries, so EOF completes the current transaction.
                     break;
                 }
             }
@@ -107,16 +111,9 @@ impl CdcStream {
             return Ok(Some(entry));
         }
 
-        let skip_seq = self.cursor.last_seq;
-
         loop {
-            // Try reading from current iterator, skipping already-processed entries.
-            if let Some(ref mut iter) = self.current_iter {
-                while let Some(entry) = iter.next().await? {
-                    if entry.seq > skip_seq {
-                        return Ok(Some(entry));
-                    }
-                }
+            if let Some(entry) = self.next_entry_in_current_file().await? {
+                return Ok(Some(entry));
             }
 
             // Current file exhausted — try next file.
@@ -128,7 +125,7 @@ impl CdcStream {
             loop {
                 let new_files: VecDeque<WalFile> = self
                     .wal_reader
-                    .list((self.cursor.wal_id + 1)..)
+                    .list(self.next_wal_id_to_list..)
                     .await?
                     .into();
 
@@ -138,7 +135,7 @@ impl CdcStream {
                     break;
                 }
 
-                // Wait for new data or cancellation.
+                // Wait for a newly visible immutable WAL file or cancellation.
                 tokio::select! {
                     _ = tokio::time::sleep(self.poll_interval) => continue,
                     _ = self.cancel.cancelled() => return Ok(None),
@@ -147,11 +144,28 @@ impl CdcStream {
         }
     }
 
+    /// Get the next entry from the already-open WAL file.
+    /// Returns None when that immutable file is exhausted.
+    async fn next_entry_in_current_file(&mut self) -> Result<Option<RowEntry>, slatedb::Error> {
+        let Some(ref mut iter) = self.current_iter else {
+            return Ok(None);
+        };
+
+        while let Some(entry) = iter.next().await? {
+            if entry.seq > self.cursor.last_seq {
+                return Ok(Some(entry));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Pop the next WAL file from the queue and open its iterator.
     /// Returns true if a new file was opened, false if queue is empty.
     async fn advance_to_next_file(&mut self) -> Result<bool, slatedb::Error> {
         if let Some(file) = self.wal_files.pop_front() {
             self.cursor.wal_id = file.id;
+            self.next_wal_id_to_list = file.id + 1;
             self.current_iter = Some(file.iterator().await?);
             Ok(true)
         } else {
@@ -635,6 +649,50 @@ mod tests {
         })
         .await
         .expect("test_cdc_cursor_waits_for_live_transactions timed out");
+    }
+
+    #[tokio::test]
+    async fn test_cdc_cursor_yields_transaction_at_wal_file_eof_without_cancellation() {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let (db, object_store) = setup_db("/test_cursor_wal_file_eof").await;
+
+            db.put(b"k1", b"v1").await.unwrap();
+            db.flush_with_options(flush_opts()).await.unwrap();
+
+            let current_seq = db.status().durable_seq;
+            let wal_reader = WalReader::new("/test_cursor_wal_file_eof", object_store);
+            let cancel = CancellationToken::new();
+            let mut stream = CdcStream::new(
+                wal_reader,
+                CdcCursor {
+                    wal_id: 0,
+                    last_seq: current_seq,
+                },
+                Duration::from_millis(10),
+                cancel,
+            )
+            .await
+            .unwrap();
+
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                db.put(b"k2", b"v2").await.unwrap();
+                db.flush_with_options(flush_opts()).await.unwrap();
+            });
+
+            let tx = stream
+                .next_transaction()
+                .await
+                .unwrap()
+                .expect("transaction at WAL file EOF should be yielded without cancellation");
+
+            assert!(tx.seq > current_seq);
+            assert_eq!(tx.entries.len(), 1);
+        })
+        .await
+        .expect(
+            "test_cdc_cursor_yields_transaction_at_wal_file_eof_without_cancellation timed out",
+        );
     }
 
     #[tokio::test]

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -12,11 +12,20 @@ use crate::schema::Schema;
 /// Tracks the CDC stream position.
 ///
 /// `last_seq` is the exclusive lower bound for rows yielded by the stream.
-/// `wal_id` is a WAL discovery hint and is updated to the last opened WAL file.
-#[derive(Debug, Default, Clone)]
+/// `wal_id` is the WAL file currently being read, or the next WAL id to discover.
+#[derive(Debug, Clone)]
 pub struct CdcCursor {
     pub wal_id: u64,
     pub last_seq: u64,
+}
+
+impl Default for CdcCursor {
+    fn default() -> Self {
+        Self {
+            wal_id: 1,
+            last_seq: 0,
+        }
+    }
 }
 
 /// A single CDC transaction: all RowEntries sharing one seq number.
@@ -121,13 +130,10 @@ impl CdcStream {
                 continue;
             }
 
-            // No more files — poll for new WAL files (after the one we already processed).
+            // No more files — poll for the current cursor WAL or later.
             loop {
-                let new_files: VecDeque<WalFile> = self
-                    .wal_reader
-                    .list((self.cursor.wal_id + 1)..)
-                    .await?
-                    .into();
+                let new_files: VecDeque<WalFile> =
+                    self.wal_reader.list(self.cursor.wal_id..).await?.into();
 
                 if !new_files.is_empty() {
                     self.wal_files = new_files;
@@ -157,6 +163,8 @@ impl CdcStream {
             }
         }
 
+        self.cursor.wal_id += 1;
+        self.current_iter = None;
         Ok(None)
     }
 
@@ -593,23 +601,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cdc_cursor_last_seq_skips_old_wals_then_polls_next_wal() {
-        tokio::time::timeout(Duration::from_secs(5), async {
-            let (db, object_store) = setup_db("/test_cursor_seq_start_then_live").await;
+    async fn test_cdc_cursor_polls_cursor_wal_when_initial_list_is_empty() {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            let (db, object_store) = setup_db("/test_cursor_empty_initial_list").await;
 
-            db.put(b"k1", b"v1").await.unwrap();
-            db.flush_with_options(flush_opts()).await.unwrap();
-            db.put(b"k2", b"v2").await.unwrap();
-            db.flush_with_options(flush_opts()).await.unwrap();
+            let wal_reader = WalReader::new("/test_cursor_empty_initial_list", object_store);
+            let next_wal_id = wal_reader
+                .list(..)
+                .await
+                .unwrap()
+                .last()
+                .map(|file| file.id + 1)
+                .unwrap_or(1);
+            assert!(wal_reader.list(next_wal_id..).await.unwrap().is_empty());
 
-            let current_seq = db.status().durable_seq;
-            let wal_reader = WalReader::new("/test_cursor_seq_start_then_live", object_store);
             let cancel = CancellationToken::new();
             let mut stream = CdcStream::new(
                 wal_reader,
                 CdcCursor {
-                    wal_id: 0,
-                    last_seq: current_seq,
+                    wal_id: next_wal_id,
+                    last_seq: 0,
                 },
                 Duration::from_millis(10),
                 cancel,
@@ -619,7 +630,7 @@ mod tests {
 
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(50)).await;
-                db.put(b"k3", b"v3").await.unwrap();
+                db.put(b"k1", b"v1").await.unwrap();
                 db.flush_with_options(flush_opts()).await.unwrap();
             });
 
@@ -627,30 +638,29 @@ mod tests {
                 .next_transaction()
                 .await
                 .unwrap()
-                .expect("stream should skip old WALs and yield the next live transaction");
+                .expect("stream should poll the cursor WAL id after an empty initial list");
 
-            assert!(tx.seq > current_seq);
             assert!(tx.entries.iter().any(|entry| {
-                entry.key.as_ref() == b"k3"
-                    && matches!(&entry.value, ValueDeletable::Value(value) if value.as_ref() == b"v3")
+                entry.key.as_ref() == b"k1"
+                    && matches!(&entry.value, ValueDeletable::Value(value) if value.as_ref() == b"v1")
             }));
         })
         .await
-        .expect("test_cdc_cursor_last_seq_skips_old_wals_then_polls_next_wal timed out");
+        .expect("test_cdc_cursor_polls_cursor_wal_when_initial_list_is_empty timed out");
     }
 
     #[tokio::test]
-    async fn test_cdc_cursor_waits_for_live_transactions() {
+    async fn test_cdc_cursor_skips_old_wals_then_reads_live_transactions() {
         tokio::time::timeout(Duration::from_secs(5), async {
-            let (db, object_store) = setup_db("/test_cursor_live").await;
+            let (db, object_store) = setup_db("/test_cursor_skip_then_live").await;
 
             db.put(b"k1", b"v1").await.unwrap();
             db.flush_with_options(flush_opts()).await.unwrap();
+            db.put(b"k2", b"v2").await.unwrap();
+            db.flush_with_options(flush_opts()).await.unwrap();
 
             let current_seq = db.status().durable_seq;
-
-            // Create stream BEFORE new transactions exist.
-            let wal_reader = WalReader::new("/test_cursor_live", object_store);
+            let wal_reader = WalReader::new("/test_cursor_skip_then_live", object_store);
             let cancel = CancellationToken::new();
             let cancel_clone = cancel.clone();
             let mut stream = CdcStream::new(
@@ -665,13 +675,12 @@ mod tests {
             .await
             .unwrap();
 
-            // Spawn background task to write new transactions then cancel.
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(50)).await;
-                db.put(b"k2", b"v2").await.unwrap();
+                db.put(b"k3", b"v3").await.unwrap();
                 db.flush_with_options(flush_opts()).await.unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;
-                db.put(b"k3", b"v3").await.unwrap();
+                db.put(b"k4", b"v4").await.unwrap();
                 db.flush_with_options(flush_opts()).await.unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 cancel_clone.cancel();
@@ -692,9 +701,21 @@ mod tests {
                 "expected at least 2 live transactions, got {}",
                 txs.len()
             );
+            assert!(txs.iter().any(|tx| {
+                tx.entries.iter().any(|entry| {
+                    entry.key.as_ref() == b"k3"
+                        && matches!(&entry.value, ValueDeletable::Value(value) if value.as_ref() == b"v3")
+                })
+            }));
+            assert!(txs.iter().any(|tx| {
+                tx.entries.iter().any(|entry| {
+                    entry.key.as_ref() == b"k4"
+                        && matches!(&entry.value, ValueDeletable::Value(value) if value.as_ref() == b"v4")
+                })
+            }));
         })
         .await
-        .expect("test_cdc_cursor_waits_for_live_transactions timed out");
+        .expect("test_cdc_cursor_skips_old_wals_then_reads_live_transactions timed out");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- treat visible SlateDB WAL files as immutable while grouping CDC transactions
- yield the final transaction in a WAL file at file EOF without waiting for cancellation or a later transaction boundary
- keep `next_transaction()` parked only while waiting for the first row of the next transaction or a newly visible WAL file
- remove the current-file reopen logic and the extra row-state enum from the earlier version of this PR

## Verification

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/triplox-cdc-stream-target CARGO_INCREMENTAL=0 cargo test -p triplox slate::cdc`
- `CARGO_TARGET_DIR=/tmp/triplox-cdc-stream-target CARGO_INCREMENTAL=0 cargo test --workspace`
- `CARGO_TARGET_DIR=/tmp/triplox-cdc-stream-target CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features`
