### PR TITLE
Support h2c upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5479,6 +5479,7 @@ dependencies = [
  "feldera-macros",
  "feldera-size-of",
  "futures",
+ "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ remote-test = []
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "rustls"] }
+http-body-util = "0.1"
 tempfile = "3.14.0"
 testcontainers = { version = "0.25", features = ["http_wait"] }
 triplox = { path = ".", features = ["test-helpers"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,18 +8,24 @@
 //! - `POST /tx/submit`         — Submit a fire-and-forget transaction
 //! - `POST /tx/execute`        — Execute a transaction and wait for indexing
 
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Error, Result};
-use axum::body::Bytes;
+use axum::body::{Body, Bytes};
 use axum::extract::{DefaultBodyLimit, State};
-use axum::http::StatusCode;
+use axum::http::header::{CONNECTION, UPGRADE};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::Router;
+use futures::future::BoxFuture;
+use hyper::body::Incoming;
+use hyper::service::Service;
+use hyper::Request;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -458,9 +464,9 @@ async fn serve_connection(
     name: &'static str,
 ) {
     let io = TokioIo::new(stream);
-    let service = TowerToHyperService::new(router);
+    let service = h2c_upgrade_service(router, conn_id, name);
     let builder = Builder::new(TokioExecutor::new());
-    let conn = builder.serve_connection(io, service);
+    let conn = builder.serve_connection_with_upgrades(io, service);
     tokio::pin!(conn);
 
     tokio::select! {
@@ -475,4 +481,83 @@ async fn serve_connection(
             let _ = conn.await;
         }
     }
+}
+
+fn h2c_upgrade_service(router: Router, conn_id: u64, name: &'static str) -> H2cUpgradeService {
+    H2cUpgradeService {
+        router,
+        conn_id,
+        name,
+    }
+}
+
+#[derive(Clone)]
+struct H2cUpgradeService {
+    router: Router,
+    conn_id: u64,
+    name: &'static str,
+}
+
+impl Service<Request<Incoming>> for H2cUpgradeService {
+    type Response = Response;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn call(&self, req: Request<Incoming>) -> Self::Future {
+        let router = self.router.clone();
+        let conn_id = self.conn_id;
+        let name = self.name;
+        Box::pin(async move {
+            if is_h2c_upgrade_request(req.headers()) {
+                let on_upgrade = hyper::upgrade::on(req);
+                tokio::spawn(async move {
+                    match on_upgrade.await {
+                        Ok(upgraded) => {
+                            let service = TowerToHyperService::new(router);
+                            let builder = Builder::new(TokioExecutor::new()).http2_only();
+                            if let Err(err) = builder.serve_connection(upgraded, service).await {
+                                warn!(
+                                    "{} h2c upgraded connection {} error: {}",
+                                    name, conn_id, err
+                                );
+                            }
+                        }
+                        Err(err) => warn!(
+                            "{} h2c upgrade for connection {} failed: {}",
+                            name, conn_id, err
+                        ),
+                    }
+                });
+
+                let response = Response::builder()
+                    .status(StatusCode::SWITCHING_PROTOCOLS)
+                    .header(CONNECTION, "Upgrade")
+                    .header(UPGRADE, "h2c")
+                    .body(Body::empty())
+                    .expect("h2c upgrade response is valid");
+                Ok(response)
+            } else {
+                TowerToHyperService::new(router).call(req).await
+            }
+        })
+    }
+}
+
+fn is_h2c_upgrade_request(headers: &HeaderMap) -> bool {
+    header_contains_token(headers, CONNECTION, "upgrade")
+        && header_contains_token(headers, UPGRADE, "h2c")
+        && headers.contains_key("http2-settings")
+}
+
+fn header_contains_token(
+    headers: &HeaderMap,
+    name: axum::http::header::HeaderName,
+    token: &str,
+) -> bool {
+    headers
+        .get_all(name)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|value| value.trim().eq_ignore_ascii_case(token))
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -1,5 +1,10 @@
 use std::sync::Arc;
 
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::Request;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
@@ -7,6 +12,7 @@ use chrono::TimeZone;
 use edn::kw;
 use edn::symbols::Keyword;
 use triplox::client::ClientNode;
+use triplox::msgpack_codec::{decode_db_opened_response, encode_open_db_request, OpenDbRequest};
 use triplox::node::{Database, Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, EntityRef, TxOp};
 use triplox::schema::test_schema_tx;
@@ -41,6 +47,78 @@ async fn start_test_server() -> (String, CancellationToken) {
 async fn test_client_connect() {
     let (addr, token) = start_test_server().await;
     let _client = ClientNode::connect(&addr).await.unwrap();
+    token.cancel();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_h2c_upgrade_then_http2_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let node = Arc::new(Node::memory_node().await);
+    let server = Server::new(node);
+
+    let token = CancellationToken::new();
+    let server_token = token.clone();
+    tokio::spawn(async move {
+        let _ = server.listen_on(listener, server_token).await;
+    });
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(
+            concat!(
+                "OPTIONS * HTTP/1.1\r\n",
+                "Host: localhost\r\n",
+                "Connection: Upgrade, HTTP2-Settings\r\n",
+                "Upgrade: h2c\r\n",
+                "HTTP2-Settings: AAMAAABkAAQAAP__\r\n",
+                "\r\n"
+            )
+            .as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let mut response = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        let n = stream.read(&mut byte).await.unwrap();
+        assert!(n > 0, "server closed before sending h2c upgrade response");
+        response.push(byte[0]);
+        if response.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let response = String::from_utf8(response).unwrap();
+    assert!(response.starts_with("HTTP/1.1 101 Switching Protocols"));
+    assert!(response.to_ascii_lowercase().contains("upgrade: h2c"));
+
+    let io = TokioIo::new(stream);
+    let (mut sender, connection) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+        .handshake(io)
+        .await
+        .unwrap();
+    tokio::spawn(connection);
+
+    let body = encode_open_db_request(&OpenDbRequest {
+        tx_id: None,
+        system_time: None,
+        tx_eid: None,
+    })
+    .unwrap();
+    let request = Request::post("/db/open")
+        .header("Content-Type", "application/vnd.triplox+msgpack")
+        .body(Full::new(Bytes::from(body)))
+        .unwrap();
+
+    let response = sender.send_request(request).await.unwrap();
+    assert_eq!(response.status(), hyper::StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let opened = decode_db_opened_response(&body).unwrap();
+    assert_eq!(opened.tx_id, 0);
+
     token.cancel();
 }
 


### PR DESCRIPTION
## Summary
- accept HTTP/1.1 `Upgrade: h2c` handshakes in the Triplox server
- continue upgraded sockets as HTTP/2 connections while preserving prior-knowledge h2c
- add an integration test that performs the h2c upgrade and sends a real HTTP/2 `/db/open` request

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated with Codex (GPT-5).