### PR TITLE
feat: support non-db schema ident aliases

### DIFF
--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -25,7 +25,7 @@ A **schema attribute** defines a named attribute that can appear on data entitie
 
 | Property    | Key                | Value Type | Required | Description                                                        |
 |-------------|--------------------|------------|----------|--------------------------------------------------------------------|
-| Ident       | `db/ident`         | Keyword    | yes      | The attribute's name, e.g. `:person/name`                          |
+| Ident       | `db/ident`         | Keyword    | yes      | The attribute's name or alias, e.g. `:person/name`                  |
 | Value type  | `db/valueType`     | Ref        | yes      | Entity reference to a value type enum, e.g. `:db.type/string`      |
 | Cardinality | `db/cardinality`   | Ref        | yes      | Entity reference to `:db.cardinality/one` or `:db.cardinality/many` |
 | Unique      | `db/unique`        | Ref        | no       | Entity reference to `:db.unique/value` or `:db.unique/identity`     |
@@ -81,7 +81,7 @@ A fresh database is initialized with a bootstrap transaction (tx_id=0) that inst
 
 | Ident              | Value Type | Cardinality | Unique   |
 |--------------------|------------|-------------|----------|
-| `db/ident`         | keyword    | one         | identity |
+| `db/ident`         | keyword    | many        | identity |
 | `db/valueType`     | ref        | one         |          |
 | `db/cardinality`   | ref        | one         |          |
 | `db/unique`        | ref        | one         |          |
@@ -158,6 +158,8 @@ Schema attributes are **immutable** once installed. The following operations are
 | `Delete`   | entity ID belongs to a schema entity                          | "Cannot delete schema entity"        |
 | `Erase`    | entity ID belongs to a schema entity                          | "Cannot erase schema entity"         |
 
+Adding a new `db/ident` assertion to an existing non-`db/*` schema attribute is allowed as an alias. The existing ident remains valid, the new ident resolves to the same attribute entity, and schema constraints such as `db/valueType`, `db/cardinality`, and `db/unique` remain immutable. Schema attributes with any known ident in the `db` namespace cannot receive ident aliases.
+
 In its final form we likely reject any modifications to bootstrap schema attributes, but allow changes to user defined attributes.
 We still strive for a deprecation guided schema evolution.
 
@@ -174,5 +176,5 @@ We still strive for a deprecation guided schema evolution.
 - `db/unique` is optional. If present, it must be either `:db.unique/value` or `:db.unique/identity`.
 - These attributes can be defined with `Put` or `Add` statements (or combinations thereof) as long as the
   final set of required attributes is met.
-- Updating or deleting a schema attribute is rejected.
+- Updating or deleting a schema attribute is rejected, except for additive `db/ident` aliases on non-`db/*` schema attributes.
 - Attribute id resolution always works against the head of the db (basis-t in Datomic slang).

--- a/src/node.rs
+++ b/src/node.rs
@@ -1722,6 +1722,55 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_schema_attribute_ident_alias_can_be_used_for_transactions_and_queries() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        let name_id = node
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let alias_result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::Id(name_id),
+                attribute: kw!(:db/ident),
+                value: DataType::Keyword(kw!(:person/name)),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(alias_result, TransactionResult::TxCommited(_)));
+
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:person/name),
+            value: "Alice".into(),
+        }])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let alias_result = db
+            .query("[:find ?name :where [?e :person/name ?name]]")
+            .await
+            .unwrap();
+        assert_eq!(alias_result, vec![vec![DataType::String("Alice".into())]]);
+
+        let canonical_result = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
+        assert_eq!(
+            canonical_result,
+            vec![vec![DataType::String("Alice".into())]]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_keyword_value_comparison_name_first() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -102,7 +102,7 @@ static V1_ATTRIBUTES: LazyLock<Vec<(Keyword, Keyword, Keyword, Option<Keyword>)>
             (
                 kw!(:db/ident),
                 kw!(:db.type/keyword),
-                kw!(:db.cardinality/one),
+                kw!(:db.cardinality/many),
                 Some(kw!(:db.unique/identity)),
             ),
             (
@@ -441,6 +441,10 @@ fn is_schema_attribute(attribute: &Keyword) -> bool {
     )
 }
 
+fn is_db_ident(ident: &Keyword) -> bool {
+    ident.components().0 == "db"
+}
+
 /// The schema: bidirectional ident/entid maps + attribute definitions.
 #[derive(Debug, Clone, Default)]
 pub struct Schema {
@@ -465,6 +469,14 @@ impl Schema {
     /// Check if an entity ID is a schema attribute (has an entry in attribute_map).
     pub fn is_schema_entity(&self, entity_id: Entid) -> bool {
         self.attribute_map.contains_key(&entity_id)
+    }
+
+    fn has_db_ident(&self, entity_id: Entid) -> bool {
+        self.entid_map.get(&entity_id).is_some_and(is_db_ident)
+            || self
+                .ident_map
+                .iter()
+                .any(|(ident, eid)| *eid == entity_id && is_db_ident(ident))
     }
 
     /// Validate finalized transaction datoms against the current schema.
@@ -529,6 +541,21 @@ impl Schema {
             }
 
             if self.is_schema_entity(datom.entity) {
+                if datom.attribute == kw!(:db/ident) && datom.op == DatomOp::Assert {
+                    let ident = match &datom.value {
+                        DataType::Keyword(kw) => kw.clone(),
+                        _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
+                    };
+                    if self.has_db_ident(datom.entity) {
+                        return Err(anyhow::anyhow!(
+                            "Cannot add db/ident alias to db-prefixed schema entity {}",
+                            datom.entity
+                        ));
+                    }
+                    ident_updates.push((datom.entity, ident));
+                    continue;
+                }
+
                 let ident = self
                     .entid_map
                     .get(&datom.entity)
@@ -719,7 +746,7 @@ impl Schema {
     pub fn apply_schema_update(&mut self, update: SchemaUpdate) {
         for (eid, ident) in update.idents {
             self.ident_map.insert(ident.clone(), eid);
-            self.entid_map.insert(eid, ident);
+            self.entid_map.entry(eid).or_insert(ident);
         }
         for (eid, attr) in update.attributes {
             self.attribute_map.insert(eid, attr);
@@ -899,7 +926,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             other => panic!("Expected Keyword for ident, got {:?}", other),
         };
         schema.ident_map.insert(ident.clone(), entity_id);
-        schema.entid_map.insert(entity_id, ident);
+        schema.entid_map.entry(entity_id).or_insert(ident);
     }
 
     let mut unique_map = HashMap::new();
@@ -1095,6 +1122,7 @@ mod tests {
         let (eid, attr) = schema.get_attribute(&kw!(:db/ident)).unwrap();
         assert_eq!(eid, DB_IDENT);
         assert_eq!(attr.value_type, ValueType::Keyword);
+        assert!(attr.multival);
 
         let (eid, attr) = schema.get_attribute(&kw!(:db/valueType)).unwrap();
         assert_eq!(eid, DB_VALUE_TYPE);
@@ -1123,6 +1151,27 @@ mod tests {
 
         let (_eid, attr) = schema.get_attribute(&kw!(:name)).unwrap();
         assert_eq!(attr.value_type, ValueType::String);
+    }
+
+    #[test]
+    fn test_apply_schema_update_adds_alias_to_user_attribute() {
+        let mut schema = bootstrapped_schema_with_person_name();
+        let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
+
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(name_id),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:person/name)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+
+        assert_eq!(schema.ident_map[&kw!(:name)], name_id);
+        assert_eq!(schema.ident_map[&kw!(:person/name)], name_id);
+        assert_eq!(schema.entid_map[&name_id], kw!(:name));
     }
 
     #[test]
@@ -1197,6 +1246,42 @@ mod tests {
         assert!(validation.schema_changes_detected);
         let err = schema.prepare_schema_update(&datoms).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
+    }
+
+    #[test]
+    fn test_prepare_schema_update_rejects_alias_for_db_attribute() {
+        let schema = bootstrapped_schema();
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(DB_TX_ERROR),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:triplox/tx-error)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let err = schema.prepare_schema_update(&datoms).unwrap_err();
+        assert!(err.to_string().contains("Cannot add db/ident alias"));
+    }
+
+    #[test]
+    fn test_prepare_schema_update_rejects_alias_for_user_defined_db_namespace_attribute() {
+        let mut schema = bootstrapped_schema();
+        let ops = [schema_attribute(kw!(:db/custom), "string")];
+        let datoms = to_datoms(&ops, &schema);
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+        let (custom_id, _) = schema.get_attribute(&kw!(:db/custom)).unwrap();
+
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(custom_id),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:custom)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let err = schema.prepare_schema_update(&datoms).unwrap_err();
+        assert!(err.to_string().contains("Cannot add db/ident alias"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `:db/ident` cardinality-many while preserving `:db.unique/identity`
- allow additive `:db/ident` aliases for schema attributes without any known `db` namespace ident
- keep schema constraints immutable and preserve the original reverse ident as canonical
- document the alias behavior and `db/*` restriction

## Tests
- `cargo test -p triplox schema::tests::`
- `cargo test -p triplox node::tests::test_schema_attribute_ident_alias_can_be_used_for_transactions_and_queries`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt --check`
- `git diff --check`

Closes #324

Autogenerated by Codex (GPT-5).