### PR TITLE
Support schema ident aliases

### DIFF
--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -158,7 +158,7 @@ Schema attributes are **immutable** once installed. The following operations are
 | `Delete`   | entity ID belongs to a schema entity                          | "Cannot delete schema entity"        |
 | `Erase`    | entity ID belongs to a schema entity                          | "Cannot erase schema entity"         |
 
-Adding a new `db/ident` assertion to an existing non-`db/*` schema attribute is allowed as an alias. The existing ident remains valid, the new ident resolves to the same attribute entity, and schema constraints such as `db/valueType`, `db/cardinality`, and `db/unique` remain immutable. Schema attributes with any known ident in the `db` namespace cannot receive ident aliases.
+Adding a new `db/ident` assertion to an existing schema attribute is allowed as an alias. Existing idents remain valid, the new ident resolves to the same attribute entity, and schema constraints such as `db/valueType`, `db/cardinality`, and `db/unique` remain immutable. Runtime reverse lookups use the lexicographically smallest ident as the canonical display form until query support can choose the latest ident by transaction entity.
 
 In its final form we likely reject any modifications to bootstrap schema attributes, but allow changes to user defined attributes.
 We still strive for a deprecation guided schema evolution.
@@ -176,5 +176,5 @@ We still strive for a deprecation guided schema evolution.
 - `db/unique` is optional. If present, it must be either `:db.unique/value` or `:db.unique/identity`.
 - These attributes can be defined with `Put` or `Add` statements (or combinations thereof) as long as the
   final set of required attributes is met.
-- Updating or deleting a schema attribute is rejected, except for additive `db/ident` aliases on non-`db/*` schema attributes.
+- Updating or deleting a schema attribute is rejected, except for additive `db/ident` aliases.
 - Attribute id resolution always works against the head of the db (basis-t in Datomic slang).

--- a/design/SCHEMA.md
+++ b/design/SCHEMA.md
@@ -25,7 +25,7 @@ A **schema attribute** defines a named attribute that can appear on data entitie
 
 | Property    | Key                | Value Type | Required | Description                                                        |
 |-------------|--------------------|------------|----------|--------------------------------------------------------------------|
-| Ident       | `db/ident`         | Keyword    | yes      | The attribute's name, e.g. `:person/name`                          |
+| Ident       | `db/ident`         | Keyword    | yes      | The attribute's name or alias, e.g. `:person/name`                  |
 | Value type  | `db/valueType`     | Ref        | yes      | Entity reference to a value type enum, e.g. `:db.type/string`      |
 | Cardinality | `db/cardinality`   | Ref        | yes      | Entity reference to `:db.cardinality/one` or `:db.cardinality/many` |
 | Unique      | `db/unique`        | Ref        | no       | Entity reference to `:db.unique/value` or `:db.unique/identity`     |
@@ -81,7 +81,7 @@ A fresh database is initialized with a bootstrap transaction (tx_id=0) that inst
 
 | Ident              | Value Type | Cardinality | Unique   |
 |--------------------|------------|-------------|----------|
-| `db/ident`         | keyword    | one         | identity |
+| `db/ident`         | keyword    | many        | identity |
 | `db/valueType`     | ref        | one         |          |
 | `db/cardinality`   | ref        | one         |          |
 | `db/unique`        | ref        | one         |          |
@@ -158,6 +158,8 @@ Schema attributes are **immutable** once installed. The following operations are
 | `Delete`   | entity ID belongs to a schema entity                          | "Cannot delete schema entity"        |
 | `Erase`    | entity ID belongs to a schema entity                          | "Cannot erase schema entity"         |
 
+Adding a new `db/ident` assertion to an existing non-`db/*` schema attribute is allowed as an alias. The existing ident remains valid, the new ident resolves to the same attribute entity, and schema constraints such as `db/valueType`, `db/cardinality`, and `db/unique` remain immutable. Schema attributes with any known ident in the `db` namespace cannot receive ident aliases.
+
 In its final form we likely reject any modifications to bootstrap schema attributes, but allow changes to user defined attributes.
 We still strive for a deprecation guided schema evolution.
 
@@ -174,5 +176,5 @@ We still strive for a deprecation guided schema evolution.
 - `db/unique` is optional. If present, it must be either `:db.unique/value` or `:db.unique/identity`.
 - These attributes can be defined with `Put` or `Add` statements (or combinations thereof) as long as the
   final set of required attributes is met.
-- Updating or deleting a schema attribute is rejected.
+- Updating or deleting a schema attribute is rejected, except for additive `db/ident` aliases on non-`db/*` schema attributes.
 - Attribute id resolution always works against the head of the db (basis-t in Datomic slang).

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -329,7 +329,15 @@ impl Indexer {
 
         // 7. Prepare schema update before writing to avoid leaking rejected datoms
         let schema_update = if validation.schema_changes_detected {
-            Some(self.metadata.schema.prepare_schema_update(&datoms)?)
+            Some(
+                self.metadata
+                    .schema
+                    .prepare_schema_update_with_partition_maps(
+                        &datoms,
+                        &self.metadata.partition_map,
+                        &pending_pm,
+                    )?,
+            )
         } else {
             None
         };
@@ -1474,6 +1482,47 @@ mod tests {
                 "rejected schema update must not be written to EAV"
             );
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_schema_install_with_unallocated_explicit_id_rejected_in_pipeline(
+    ) -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let explicit_id = crate::partition::make_entity_id(crate::partition::DB_PARTITION, 10_000);
+
+        let tx = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
+        let waiter = indexer.tx_waiter();
+        let basis = indexer
+            .transact_tx(
+                tx,
+                vec![TxOp::put(vec![
+                    (kw!(:db/id), DataType::Long(explicit_id)),
+                    (kw!(:db/ident), DataType::Keyword(kw!(:explicit/schema))),
+                    (kw!(:db/valueType), DataType::Long(DB_TYPE_LONG)),
+                    (kw!(:db/cardinality), DataType::Long(DB_CARDINALITY_ONE)),
+                ])],
+            )
+            .await?;
+
+        assert_eq!(basis.tx_key, tx);
+        let completion = waiter.await_tx(tx).await?;
+        assert_eq!(completion.basis.map(|basis| basis.tx_key), Some(tx));
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("unallocated schema entity"));
+        assert!(indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:explicit/schema))
+            .is_none());
 
         Ok(())
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1722,6 +1722,55 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_schema_attribute_ident_alias_can_be_used_for_transactions_and_queries() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        let name_id = node
+            .indexer
+            .read()
+            .await
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let alias_result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::Id(name_id),
+                attribute: kw!(:db/ident),
+                value: DataType::Keyword(kw!(:person/name)),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(alias_result, TransactionResult::TxCommited(_)));
+
+        node.execute_tx(vec![TxOp::Add {
+            entity: "alice".into(),
+            attribute: kw!(:person/name),
+            value: "Alice".into(),
+        }])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let alias_result = db
+            .query("[:find ?name :where [?e :person/name ?name]]")
+            .await
+            .unwrap();
+        assert_eq!(alias_result, vec![vec![DataType::String("Alice".into())]]);
+
+        let canonical_result = db
+            .query("[:find ?name :where [?e :name ?name]]")
+            .await
+            .unwrap();
+        assert_eq!(
+            canonical_result,
+            vec![vec![DataType::String("Alice".into())]]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_keyword_value_comparison_name_first() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,6 +6,7 @@ use edn::kw;
 use edn::symbols::Keyword;
 use tokio::runtime::Handle;
 
+use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::query::execute_query;
 use edn::query::ParsedQuery;
@@ -441,8 +442,23 @@ fn is_schema_attribute(attribute: &Keyword) -> bool {
     )
 }
 
-fn is_db_ident(ident: &Keyword) -> bool {
-    ident.components().0 == "db"
+fn set_canonical_ident(entid_map: &mut EntidMap, eid: Entid, ident: Keyword) {
+    match entid_map.get_mut(&eid) {
+        Some(current) if ident.to_string() < current.to_string() => {
+            *current = ident;
+        }
+        Some(_) => {}
+        None => {
+            entid_map.insert(eid, ident);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntityAllocationStatus {
+    Existing,
+    AllocatedInTx,
+    Unallocated,
 }
 
 /// The schema: bidirectional ident/entid maps + attribute definitions.
@@ -469,14 +485,6 @@ impl Schema {
     /// Check if an entity ID is a schema attribute (has an entry in attribute_map).
     pub fn is_schema_entity(&self, entity_id: Entid) -> bool {
         self.attribute_map.contains_key(&entity_id)
-    }
-
-    fn has_db_ident(&self, entity_id: Entid) -> bool {
-        self.entid_map.get(&entity_id).is_some_and(is_db_ident)
-            || self
-                .ident_map
-                .iter()
-                .any(|(ident, eid)| *eid == entity_id && is_db_ident(ident))
     }
 
     /// Validate finalized transaction datoms against the current schema.
@@ -532,6 +540,23 @@ impl Schema {
     /// This step is responsible only for schema-related assertions and mutation
     /// rules. It assumes general datom validation has already succeeded.
     pub fn prepare_schema_update(&self, datoms: &[Datom]) -> Result<SchemaUpdate> {
+        self.prepare_schema_update_inner(datoms, None)
+    }
+
+    pub(crate) fn prepare_schema_update_with_partition_maps(
+        &self,
+        datoms: &[Datom],
+        committed_pm: &PartitionMap,
+        pending_pm: &PartitionMap,
+    ) -> Result<SchemaUpdate> {
+        self.prepare_schema_update_inner(datoms, Some((committed_pm, pending_pm)))
+    }
+
+    fn prepare_schema_update_inner(
+        &self,
+        datoms: &[Datom],
+        partition_maps: Option<(&PartitionMap, &PartitionMap)>,
+    ) -> Result<SchemaUpdate> {
         let mut ident_updates: Vec<(Entid, Keyword)> = Vec::new();
         let mut builders: HashMap<Entid, AttributeBuilder> = HashMap::new();
 
@@ -540,18 +565,33 @@ impl Schema {
                 continue;
             }
 
-            if self.is_schema_entity(datom.entity) {
+            let allocation_status = partition_maps.map(|(committed_pm, pending_pm)| {
+                if committed_pm.contains_entid(datom.entity) {
+                    EntityAllocationStatus::Existing
+                } else if pending_pm.contains_entid(datom.entity) {
+                    EntityAllocationStatus::AllocatedInTx
+                } else {
+                    EntityAllocationStatus::Unallocated
+                }
+            });
+
+            if allocation_status == Some(EntityAllocationStatus::Unallocated) {
+                return Err(anyhow::anyhow!(
+                    "Cannot apply schema datom {} to unallocated schema entity {}",
+                    datom.attribute,
+                    datom.entity
+                ));
+            }
+
+            let existing_entity = allocation_status == Some(EntityAllocationStatus::Existing)
+                || (allocation_status.is_none() && self.is_schema_entity(datom.entity));
+
+            if existing_entity {
                 if datom.attribute == kw!(:db/ident) && datom.op == DatomOp::Assert {
                     let ident = match &datom.value {
                         DataType::Keyword(kw) => kw.clone(),
                         _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
                     };
-                    if self.has_db_ident(datom.entity) {
-                        return Err(anyhow::anyhow!(
-                            "Cannot add db/ident alias to db-prefixed schema entity {}",
-                            datom.entity
-                        ));
-                    }
                     ident_updates.push((datom.entity, ident));
                     continue;
                 }
@@ -746,7 +786,7 @@ impl Schema {
     pub fn apply_schema_update(&mut self, update: SchemaUpdate) {
         for (eid, ident) in update.idents {
             self.ident_map.insert(ident.clone(), eid);
-            self.entid_map.entry(eid).or_insert(ident);
+            set_canonical_ident(&mut self.entid_map, eid, ident);
         }
         for (eid, attr) in update.attributes {
             self.attribute_map.insert(eid, attr);
@@ -926,7 +966,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             other => panic!("Expected Keyword for ident, got {:?}", other),
         };
         schema.ident_map.insert(ident.clone(), entity_id);
-        schema.entid_map.entry(entity_id).or_insert(ident);
+        set_canonical_ident(&mut schema.entid_map, entity_id, ident);
     }
 
     let mut unique_map = HashMap::new();
@@ -1161,7 +1201,7 @@ mod tests {
         let ops = [TxOp::Add {
             entity: EntityRef::Id(name_id),
             attribute: kw!(:db/ident),
-            value: DataType::Keyword(kw!(:person/name)),
+            value: DataType::Keyword(kw!(:aaa/name)),
         }];
         let datoms = to_datoms(&ops, &schema);
         let validation = schema.validate_datoms(&datoms).unwrap();
@@ -1170,8 +1210,8 @@ mod tests {
         schema.apply_schema_update(update);
 
         assert_eq!(schema.ident_map[&kw!(:name)], name_id);
-        assert_eq!(schema.ident_map[&kw!(:person/name)], name_id);
-        assert_eq!(schema.entid_map[&name_id], kw!(:name));
+        assert_eq!(schema.ident_map[&kw!(:aaa/name)], name_id);
+        assert_eq!(schema.entid_map[&name_id], kw!(:aaa/name));
     }
 
     #[test]
@@ -1249,8 +1289,8 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_schema_update_rejects_alias_for_db_attribute() {
-        let schema = bootstrapped_schema();
+    fn test_prepare_schema_update_allows_alias_for_db_attribute() {
+        let mut schema = bootstrapped_schema();
         let ops = [TxOp::Add {
             entity: EntityRef::Id(DB_TX_ERROR),
             attribute: kw!(:db/ident),
@@ -1259,12 +1299,16 @@ mod tests {
         let datoms = to_datoms(&ops, &schema);
         let validation = schema.validate_datoms(&datoms).unwrap();
         assert!(validation.schema_changes_detected);
-        let err = schema.prepare_schema_update(&datoms).unwrap_err();
-        assert!(err.to_string().contains("Cannot add db/ident alias"));
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+
+        assert_eq!(schema.ident_map[&kw!(:db/txError)], DB_TX_ERROR);
+        assert_eq!(schema.ident_map[&kw!(:triplox/tx-error)], DB_TX_ERROR);
+        assert_eq!(schema.entid_map[&DB_TX_ERROR], kw!(:db/txError));
     }
 
     #[test]
-    fn test_prepare_schema_update_rejects_alias_for_user_defined_db_namespace_attribute() {
+    fn test_prepare_schema_update_allows_alias_for_user_defined_db_namespace_attribute() {
         let mut schema = bootstrapped_schema();
         let ops = [schema_attribute(kw!(:db/custom), "string")];
         let datoms = to_datoms(&ops, &schema);
@@ -1280,8 +1324,12 @@ mod tests {
         let datoms = to_datoms(&ops, &schema);
         let validation = schema.validate_datoms(&datoms).unwrap();
         assert!(validation.schema_changes_detected);
-        let err = schema.prepare_schema_update(&datoms).unwrap_err();
-        assert!(err.to_string().contains("Cannot add db/ident alias"));
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+
+        assert_eq!(schema.ident_map[&kw!(:db/custom)], custom_id);
+        assert_eq!(schema.ident_map[&kw!(:custom)], custom_id);
+        assert_eq!(schema.entid_map[&custom_id], kw!(:custom));
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -102,7 +102,7 @@ static V1_ATTRIBUTES: LazyLock<Vec<(Keyword, Keyword, Keyword, Option<Keyword>)>
             (
                 kw!(:db/ident),
                 kw!(:db.type/keyword),
-                kw!(:db.cardinality/one),
+                kw!(:db.cardinality/many),
                 Some(kw!(:db.unique/identity)),
             ),
             (
@@ -441,6 +441,10 @@ fn is_schema_attribute(attribute: &Keyword) -> bool {
     )
 }
 
+fn is_db_ident(ident: &Keyword) -> bool {
+    ident.components().0 == "db"
+}
+
 /// The schema: bidirectional ident/entid maps + attribute definitions.
 #[derive(Debug, Clone, Default)]
 pub struct Schema {
@@ -465,6 +469,14 @@ impl Schema {
     /// Check if an entity ID is a schema attribute (has an entry in attribute_map).
     pub fn is_schema_entity(&self, entity_id: Entid) -> bool {
         self.attribute_map.contains_key(&entity_id)
+    }
+
+    fn has_db_ident(&self, entity_id: Entid) -> bool {
+        self.entid_map.get(&entity_id).is_some_and(is_db_ident)
+            || self
+                .ident_map
+                .iter()
+                .any(|(ident, eid)| *eid == entity_id && is_db_ident(ident))
     }
 
     /// Validate finalized transaction datoms against the current schema.
@@ -529,6 +541,21 @@ impl Schema {
             }
 
             if self.is_schema_entity(datom.entity) {
+                if datom.attribute == kw!(:db/ident) && datom.op == DatomOp::Assert {
+                    let ident = match &datom.value {
+                        DataType::Keyword(kw) => kw.clone(),
+                        _ => return Err(anyhow::anyhow!("db/ident must be a Keyword")),
+                    };
+                    if self.has_db_ident(datom.entity) {
+                        return Err(anyhow::anyhow!(
+                            "Cannot add db/ident alias to db-prefixed schema entity {}",
+                            datom.entity
+                        ));
+                    }
+                    ident_updates.push((datom.entity, ident));
+                    continue;
+                }
+
                 let ident = self
                     .entid_map
                     .get(&datom.entity)
@@ -719,7 +746,7 @@ impl Schema {
     pub fn apply_schema_update(&mut self, update: SchemaUpdate) {
         for (eid, ident) in update.idents {
             self.ident_map.insert(ident.clone(), eid);
-            self.entid_map.insert(eid, ident);
+            self.entid_map.entry(eid).or_insert(ident);
         }
         for (eid, attr) in update.attributes {
             self.attribute_map.insert(eid, attr);
@@ -899,7 +926,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             other => panic!("Expected Keyword for ident, got {:?}", other),
         };
         schema.ident_map.insert(ident.clone(), entity_id);
-        schema.entid_map.insert(entity_id, ident);
+        schema.entid_map.entry(entity_id).or_insert(ident);
     }
 
     let mut unique_map = HashMap::new();
@@ -1095,6 +1122,7 @@ mod tests {
         let (eid, attr) = schema.get_attribute(&kw!(:db/ident)).unwrap();
         assert_eq!(eid, DB_IDENT);
         assert_eq!(attr.value_type, ValueType::Keyword);
+        assert!(attr.multival);
 
         let (eid, attr) = schema.get_attribute(&kw!(:db/valueType)).unwrap();
         assert_eq!(eid, DB_VALUE_TYPE);
@@ -1123,6 +1151,27 @@ mod tests {
 
         let (_eid, attr) = schema.get_attribute(&kw!(:name)).unwrap();
         assert_eq!(attr.value_type, ValueType::String);
+    }
+
+    #[test]
+    fn test_apply_schema_update_adds_alias_to_user_attribute() {
+        let mut schema = bootstrapped_schema_with_person_name();
+        let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
+
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(name_id),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:person/name)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+
+        assert_eq!(schema.ident_map[&kw!(:name)], name_id);
+        assert_eq!(schema.ident_map[&kw!(:person/name)], name_id);
+        assert_eq!(schema.entid_map[&name_id], kw!(:name));
     }
 
     #[test]
@@ -1197,6 +1246,42 @@ mod tests {
         assert!(validation.schema_changes_detected);
         let err = schema.prepare_schema_update(&datoms).unwrap_err();
         assert!(err.to_string().contains("Cannot modify schema entity"));
+    }
+
+    #[test]
+    fn test_prepare_schema_update_rejects_alias_for_db_attribute() {
+        let schema = bootstrapped_schema();
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(DB_TX_ERROR),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:triplox/tx-error)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let err = schema.prepare_schema_update(&datoms).unwrap_err();
+        assert!(err.to_string().contains("Cannot add db/ident alias"));
+    }
+
+    #[test]
+    fn test_prepare_schema_update_rejects_alias_for_user_defined_db_namespace_attribute() {
+        let mut schema = bootstrapped_schema();
+        let ops = [schema_attribute(kw!(:db/custom), "string")];
+        let datoms = to_datoms(&ops, &schema);
+        let update = schema.prepare_schema_update(&datoms).unwrap();
+        schema.apply_schema_update(update);
+        let (custom_id, _) = schema.get_attribute(&kw!(:db/custom)).unwrap();
+
+        let ops = [TxOp::Add {
+            entity: EntityRef::Id(custom_id),
+            attribute: kw!(:db/ident),
+            value: DataType::Keyword(kw!(:custom)),
+        }];
+        let datoms = to_datoms(&ops, &schema);
+        let validation = schema.validate_datoms(&datoms).unwrap();
+        assert!(validation.schema_changes_detected);
+        let err = schema.prepare_schema_update(&datoms).unwrap_err();
+        assert!(err.to_string().contains("Cannot add db/ident alias"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow additive `:db/ident` aliases on existing schema entities while keeping `:db/valueType`, `:db/unique`, and `:db/cardinality` immutable
- choose the lexicographically smallest ident as the canonical reverse lookup until tx-position ordering is available
- validate schema installs against committed and pending partition maps so explicit unallocated schema IDs are rejected before index writes

Closes #324

## Test plan

- `cargo test -p triplox`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt --check`

Generated with GPT-5 Codex.