### PR TITLE
Bootstrap via empty log transaction

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,7 +1,9 @@
 use anyhow::{bail, Context, Result};
+use std::sync::LazyLock;
 
+use crate::clock::st_from_unix_epoch;
 use crate::codec;
-use crate::indexer::write_index_entries;
+use crate::indexer::{build_tx_entity_datoms, write_index_entries};
 use crate::metadata::{Metadata, PartitionMap};
 use crate::partition::{
     extract_counter, partition_entity_prefix, COUNTER_BITS, DB_PARTITION, TX_PARTITION,
@@ -10,6 +12,7 @@ use crate::partition::{
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
 use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
+use crate::transaction::{TxBasis, TxKey};
 use crate::tx;
 use crate::util::concat_bytes;
 use slatedb::{Db, WriteBatch};
@@ -24,6 +27,17 @@ const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 /// Entity ID for the bootstrap transaction (TX_PARTITION, counter 0).
 /// Matches `make_entity_id(TX_PARTITION, 0)`.
 pub(crate) const BOOTSTRAP_TX_EID: i64 = (TX_PARTITION as i64) << COUNTER_BITS;
+
+/// TxKey reserved for the bootstrap transaction and the initial empty log record.
+pub(crate) static BOOTSTRAP_TX_KEY: LazyLock<TxKey> = LazyLock::new(|| TxKey {
+    tx_id: 0,
+    system_time: st_from_unix_epoch(0),
+});
+
+pub(crate) static BOOTSTRAP_TX_BASIS: LazyLock<TxBasis> = LazyLock::new(|| TxBasis {
+    tx_key: *BOOTSTRAP_TX_KEY,
+    tx_eid: BOOTSTRAP_TX_EID,
+});
 
 /// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
 /// With descending encoding, the first entity per partition has the highest counter.
@@ -66,8 +80,9 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> Result<PartitionMap
 
 /// Initialize the database and return ready `Metadata`.
 ///
-/// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries,
-///   writes the version, and returns populated metadata.
+/// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries
+///   including a transaction entity directly to SlateDB, writes the version, and
+///   returns populated metadata.
 /// - **Existing DB**: loads the schema from indices via the Datalog query engine,
 ///   derives counters by scanning the EAV index.
 pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
@@ -89,7 +104,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
-            let tx_eid = BOOTSTRAP_TX_EID;
+            let basis = *BOOTSTRAP_TX_BASIS;
             let mut boot_pm = PartitionMap::new();
 
             // Same normalization and tempid-resolution stages as the indexer.
@@ -101,6 +116,12 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
                 tempids::resolve_tempids(with_tempids, &bootstrap_schema, &slate.db, &mut boot_pm)
                     .await
                     .unwrap();
+            datoms.extend(build_tx_entity_datoms(
+                basis.tx_eid,
+                basis.tx_key,
+                true,
+                None,
+            ));
 
             // Validate against pre-built schema, then derive the bootstrap schema delta.
             let validation = bootstrap_schema.validate_datoms(&datoms).unwrap();
@@ -120,7 +141,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             );
 
             let mut batch = WriteBatch::new();
-            write_index_entries(&mut batch, &datoms, &bootstrap_schema, tx_eid).unwrap();
+            write_index_entries(&mut batch, &datoms, &bootstrap_schema, basis.tx_eid).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             batch.put(&version_key, version.as_bytes());
@@ -166,7 +187,7 @@ mod tests {
             metadata.partition_map[&DB_PARTITION],
             DB_PARTITION_COUNTER_FLOOR
         );
-        assert_eq!(metadata.partition_map[&TX_PARTITION], 0);
+        assert_eq!(metadata.partition_map[&TX_PARTITION], 1);
         assert_eq!(metadata.partition_map[&USER_PARTITION], 0);
         // Enum entities are in ident_map but not attribute_map
         assert!(metadata

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,9 +1,7 @@
 use anyhow::{bail, Context, Result};
-use std::sync::LazyLock;
 
-use crate::clock::st_from_unix_epoch;
 use crate::codec;
-use crate::indexer::{build_tx_entity_datoms, write_index_entries};
+use crate::indexer::write_index_entries;
 use crate::metadata::{Metadata, PartitionMap};
 use crate::partition::{
     extract_counter, partition_entity_prefix, COUNTER_BITS, DB_PARTITION, TX_PARTITION,
@@ -12,7 +10,6 @@ use crate::partition::{
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
 use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
-use crate::transaction::TxKey;
 use crate::tx;
 use crate::util::concat_bytes;
 use slatedb::{Db, WriteBatch};
@@ -25,16 +22,8 @@ const META_KEY_VERSION: &[u8] = b"version";
 const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 
 /// Entity ID for the bootstrap transaction (TX_PARTITION, counter 0).
-/// Matches `make_entity_id(TX_PARTITION, 0)`; expressed as a const so
-/// `node::from_slate_and_log` can compare without recomputing.
+/// Matches `make_entity_id(TX_PARTITION, 0)`.
 pub(crate) const BOOTSTRAP_TX_EID: i64 = (TX_PARTITION as i64) << COUNTER_BITS;
-
-/// TxKey written for the bootstrap transaction. `tx_id=0` and `system_time=epoch`
-/// collide with the first FileLog tx today; see TODO(#97).
-pub(crate) static BOOTSTRAP_TX_KEY: LazyLock<TxKey> = LazyLock::new(|| TxKey {
-    tx_id: 0,
-    system_time: st_from_unix_epoch(0),
-});
 
 /// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
 /// With descending encoding, the first entity per partition has the highest counter.
@@ -77,9 +66,8 @@ pub(crate) async fn scan_partition_counters(slatedb: &Db) -> Result<PartitionMap
 
 /// Initialize the database and return ready `Metadata`.
 ///
-/// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries
-///   including a transaction entity directly to SlateDB, writes the version, and
-///   returns populated metadata.
+/// - **Fresh DB**: processes the bootstrap schema transaction, writes index entries,
+///   writes the version, and returns populated metadata.
 /// - **Existing DB**: loads the schema from indices via the Datalog query engine,
 ///   derives counters by scanning the EAV index.
 pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
@@ -101,7 +89,6 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
-            let tx_key = *BOOTSTRAP_TX_KEY;
             let tx_eid = BOOTSTRAP_TX_EID;
             let mut boot_pm = PartitionMap::new();
 
@@ -114,7 +101,6 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
                 tempids::resolve_tempids(with_tempids, &bootstrap_schema, &slate.db, &mut boot_pm)
                     .await
                     .unwrap();
-            datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
             // Validate against pre-built schema, then derive the bootstrap schema delta.
             let validation = bootstrap_schema.validate_datoms(&datoms).unwrap();
@@ -180,7 +166,7 @@ mod tests {
             metadata.partition_map[&DB_PARTITION],
             DB_PARTITION_COUNTER_FLOOR
         );
-        assert_eq!(metadata.partition_map[&TX_PARTITION], 1);
+        assert_eq!(metadata.partition_map[&TX_PARTITION], 0);
         assert_eq!(metadata.partition_map[&USER_PARTITION], 0);
         // Enum entities are in ident_map but not attribute_map
         assert!(metadata

--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -1,5 +1,5 @@
 use crate::clock::SystemTimeSource;
-use crate::log::{Record, TxId, TxLog, TxLogReader, TxLogWriter};
+use crate::log::{Record, TxId, TxLog, TxLogReader, TxLogWriter, BOOTSTRAP_RECORD};
 use crate::transaction::TxKey;
 use anyhow::Result;
 use log::warn;
@@ -38,12 +38,11 @@ impl FileLog {
             tx_sender: broadcast::channel(1024).0,
         })
     }
+}
 
-    pub(crate) async fn ensure_bootstrap_record(&self) -> Result<()> {
-        let bootstrap_record = Record {
-            tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
-            record: Vec::new(),
-        };
+impl TxLog for FileLog {
+    async fn ensure_bootstrap_record(&self) -> Result<()> {
+        let bootstrap_record = BOOTSTRAP_RECORD.clone();
 
         match self.read_txs_after(None, 1).await?.first() {
             Some(record) if record == &bootstrap_record => return Ok(()),
@@ -130,8 +129,6 @@ impl TxLogWriter for FileLog {
         record.tx_key
     }
 }
-
-impl TxLog for FileLog {}
 
 #[cfg(test)]
 mod tests {

--- a/src/file_log.rs
+++ b/src/file_log.rs
@@ -38,6 +38,35 @@ impl FileLog {
             tx_sender: broadcast::channel(1024).0,
         })
     }
+
+    pub(crate) async fn ensure_bootstrap_record(&self) -> Result<()> {
+        let bootstrap_record = Record {
+            tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
+            record: Vec::new(),
+        };
+
+        match self.read_txs_after(None, 1).await?.first() {
+            Some(record) if record == &bootstrap_record => return Ok(()),
+            Some(record) => {
+                return Err(anyhow::anyhow!(
+                    "file log starts with non-bootstrap record {:?}",
+                    record.tx_key
+                ));
+            }
+            None => {}
+        }
+
+        let mut state = self.state.lock().await;
+        if state.file.stream_position()? != 0 {
+            return Err(anyhow::anyhow!(
+                "file log has bytes but no readable bootstrap record"
+            ));
+        }
+        bincode::serialize_into(&mut state.file, &bootstrap_record)?;
+        state.file.flush()?;
+        state.file.get_ref().sync_data()?;
+        Ok(())
+    }
 }
 
 impl TxLogReader for FileLog {

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -142,11 +142,7 @@ impl IncrementalQueryService {
         let _registration_guard = self.registration_gate.lock().await;
         let (basis, schema) = {
             let indexer = indexer.read().await;
-            let basis = indexer.latest_tx_basis().ok_or_else(|| {
-                // TODO(#278, #134): make initialized nodes always expose a latest indexed basis.
-                anyhow!("Indexer has no latest indexed transaction basis")
-            })?;
-            (basis, indexer.metadata().schema.clone())
+            (indexer.latest_tx_basis(), indexer.metadata().schema.clone())
         };
         let plan = plan_query(&query, &schema)?;
         let initial_triples = scan_current_triples(db, &plan, basis.tx_eid).await?;

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -93,9 +93,10 @@ where
         let seq = tx.seq;
         let schema = node.schema().await;
         let datoms = crate::slate::cdc::datoms_from_cdc_transaction(&tx, &schema)?;
-        let Some(basis) = tx_basis_from_datoms(&datoms) else {
+        if datoms.is_empty() {
             continue;
-        };
+        }
+        let basis = tx_basis_from_datoms(&datoms)?;
         let tuples = datoms_to_tuples(&datoms, &schema)?;
         let _registration_guard = registration_gate.lock().await;
         service.apply_triples(Some(basis), seq, tuples).await?;
@@ -106,7 +107,7 @@ where
     Ok(())
 }
 
-pub(crate) fn tx_basis_from_datoms(datoms: &[Datom]) -> Option<TxBasis> {
+pub(crate) fn tx_basis_from_datoms(datoms: &[Datom]) -> Result<TxBasis> {
     let mut by_entity: HashMap<i64, (Option<i64>, Option<crate::clock::Instant>)> = HashMap::new();
     for datom in datoms {
         let entry = by_entity.entry(datom.entity).or_default();
@@ -123,15 +124,17 @@ pub(crate) fn tx_basis_from_datoms(datoms: &[Datom]) -> Option<TxBasis> {
 
     by_entity
         .into_iter()
-        .find_map(|(tx_eid, (tx_id, instant))| {
-            Some(TxBasis {
+        .find_map(|(tx_eid, (tx_id, instant))| match (tx_id, instant) {
+            (Some(tx_id), Some(instant)) => Some(TxBasis {
                 tx_key: TxKey {
-                    tx_id: tx_id?,
-                    system_time: instant?,
+                    tx_id,
+                    system_time: instant,
                 },
                 tx_eid,
-            })
+            }),
+            _ => None,
         })
+        .ok_or_else(|| anyhow::anyhow!("CDC transaction datoms missing transaction basis"))
 }
 
 pub(crate) async fn scan_current_triples<D>(
@@ -202,6 +205,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::clock::st_from_unix_epoch;
     use crate::indexer::Indexer;
     use crate::metadata::{Metadata, PartitionMap};
     use crate::schema::{Attribute, Schema, ValueType};
@@ -271,6 +275,54 @@ mod tests {
             ident_map,
             attribute_map,
         }
+    }
+
+    #[test]
+    fn tx_basis_from_datoms_extracts_transaction_basis() {
+        let instant = st_from_unix_epoch(123);
+        let datoms = [
+            Datom {
+                entity: 99,
+                attribute: kw!(:db/txId),
+                value: DataType::Long(42),
+                op: DatomOp::Assert,
+            },
+            Datom {
+                entity: 99,
+                attribute: kw!(:db/txInstant),
+                value: DataType::Instant(instant),
+                op: DatomOp::Assert,
+            },
+        ];
+
+        let basis = tx_basis_from_datoms(&datoms).unwrap();
+
+        assert_eq!(
+            basis,
+            TxBasis {
+                tx_key: TxKey {
+                    tx_id: 42,
+                    system_time: instant,
+                },
+                tx_eid: 99,
+            }
+        );
+    }
+
+    #[test]
+    fn tx_basis_from_datoms_errors_without_transaction_basis() {
+        let datoms = [Datom {
+            entity: 42,
+            attribute: kw!(:name),
+            value: DataType::String("Alice".to_string()),
+            op: DatomOp::Assert,
+        }];
+
+        let err = tx_basis_from_datoms(&datoms).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("CDC transaction datoms missing transaction basis"));
     }
 
     #[test]

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -212,7 +212,7 @@ mod tests {
         let indexer = Arc::new(RwLock::new(Indexer::new(
             slate.db.clone(),
             Metadata::new(test_schema(), PartitionMap::new()),
-            None,
+            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
         )));
         let service = IncrementalQueryService::new(
             tempfile::tempdir().unwrap().path().to_path_buf(),

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -93,10 +93,12 @@ where
         let seq = tx.seq;
         let schema = node.schema().await;
         let datoms = crate::slate::cdc::datoms_from_cdc_transaction(&tx, &schema)?;
-        let basis = tx_basis_from_datoms(&datoms);
+        let Some(basis) = tx_basis_from_datoms(&datoms) else {
+            continue;
+        };
         let tuples = datoms_to_tuples(&datoms, &schema)?;
         let _registration_guard = registration_gate.lock().await;
-        service.apply_triples(basis, seq, tuples).await?;
+        service.apply_triples(Some(basis), seq, tuples).await?;
         // The registration gate is released before polling the next WAL transaction.
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -30,7 +30,7 @@ type TxCompletionMessage = (TxKey, Option<TxBasis>, Result<(), Arc<Error>>);
 pub struct Indexer {
     slatedb: Arc<Db>,
     metadata: Metadata,
-    latest_indexed_tx: Option<TxBasis>,
+    latest_indexed_tx: TxBasis,
     tx_completion_sender: broadcast::Sender<TxCompletionMessage>,
 }
 
@@ -247,7 +247,7 @@ pub(crate) fn build_tx_entity_datoms(
 }
 
 impl Indexer {
-    pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: Option<TxBasis>) -> Self {
+    pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: TxBasis) -> Self {
         let (tx_completion_sender, _) = broadcast::channel(1024);
         Indexer {
             slatedb,
@@ -261,7 +261,7 @@ impl Indexer {
         &self.metadata
     }
 
-    pub(crate) fn latest_tx_basis(&self) -> Option<TxBasis> {
+    pub(crate) fn latest_tx_basis(&self) -> TxBasis {
         self.latest_indexed_tx
     }
 
@@ -361,7 +361,7 @@ impl Indexer {
 
         // Update latest indexed tx and broadcast completion
         let basis = TxBasis { tx_key, tx_eid };
-        self.latest_indexed_tx = Some(basis);
+        self.latest_indexed_tx = basis;
 
         if let Err(e) = self
             .tx_completion_sender
@@ -581,7 +581,7 @@ impl Indexer {
         // No need to advance generation for aborted transactions
         self.metadata.partition_map = pending_pm;
         let basis = TxBasis { tx_key, tx_eid };
-        self.latest_indexed_tx = Some(basis);
+        self.latest_indexed_tx = basis;
         Ok(basis)
     }
 }
@@ -591,7 +591,7 @@ impl Indexer {
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
 /// no messages are missed between subscription and the actual wait.
 pub(crate) struct TxWaiter {
-    latest_tx: Option<TxBasis>,
+    latest_tx: TxBasis,
     rx: broadcast::Receiver<TxCompletionMessage>,
 }
 
@@ -605,20 +605,18 @@ impl TxWaiter {
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {
         // Fast path: already indexed at subscription time
-        if let Some(latest_basis) = self.latest_tx {
-            if tx_key == latest_basis.tx_key {
-                return Ok(TxCompletion {
-                    basis: Some(latest_basis),
-                    // TODO: We are not filling in the error here if there was a semantic error.
-                    result: Ok(()),
-                });
-            }
-            if tx_key < latest_basis.tx_key {
-                return Ok(TxCompletion {
-                    basis: None,
-                    result: Ok(()),
-                });
-            }
+        if tx_key == self.latest_tx.tx_key {
+            return Ok(TxCompletion {
+                basis: Some(self.latest_tx),
+                // TODO: We are not filling in the error here if there was a semantic error.
+                result: Ok(()),
+            });
+        }
+        if tx_key < self.latest_tx.tx_key {
+            return Ok(TxCompletion {
+                basis: None,
+                result: Ok(()),
+            });
         }
 
         // TODO: The >= check can return a different tx's result if the
@@ -654,10 +652,8 @@ impl TxWaiter {
     /// Wait until indexing has reached `tx_key`, regardless of whether that
     /// transaction committed or aborted.
     pub async fn await_indexed(mut self, tx_key: TxKey) -> Result<(), Error> {
-        if let Some(latest_basis) = self.latest_tx {
-            if tx_key.tx_id <= latest_basis.tx_key.tx_id {
-                return Ok(());
-            }
+        if tx_key.tx_id <= self.latest_tx.tx_key.tx_id {
+            return Ok(());
         }
 
         loop {
@@ -808,7 +804,11 @@ mod tests {
     /// Returns the indexer ready for test data at tx_id=1+.
     async fn bootstrapped_indexer(slate: &SlateComponents) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate).await.unwrap();
-        let mut indexer = Indexer::new(slate.db.clone(), metadata, None);
+        let mut indexer = Indexer::new(
+            slate.db.clone(),
+            metadata,
+            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+        );
         let tx_key_0 = TxKey {
             tx_id: 0,
             system_time: st_from_unix_epoch(1),
@@ -1053,7 +1053,7 @@ mod tests {
         let indexer = Indexer::new(
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
-            None,
+            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
         );
 
         let tx_key = TxKey {
@@ -1142,7 +1142,7 @@ mod tests {
         let mut indexer = Indexer::new(
             components.db.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
-            None,
+            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
         );
         let tx_key = TxKey {
             tx_id: 1,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -139,8 +139,10 @@ pub(crate) fn write_index_entries(
 /// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
 /// system_time from `db/txInstant` value.
 ///
-/// Returns `Ok(None)` if no transaction entity has been indexed yet.
-pub async fn maybe_latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<Option<TxBasis>>
+/// Errors if no TX_PARTITION entity exists (an initialized DB always has the
+/// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
+/// `:db/txInstant`.
+pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
 where
     D: DbReadOps + Sync,
 {
@@ -174,31 +176,18 @@ where
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok(Some(TxBasis {
+        (Some(eid), Some(tid), Some(st)) => Ok(TxBasis {
             tx_key: TxKey {
                 tx_id: tid,
                 system_time: st,
             },
             tx_eid: eid,
-        })),
-        (None, _, _) => Ok(None),
+        }),
+        (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
         (Some(eid), tid, st) => {
             bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
         }
     }
-}
-
-/// Scan EAV entries for TX_PARTITION entities and return (tx_eid, TxKey) for the latest tx.
-///
-/// Errors if no TX_PARTITION entity exists or if the latest tx entity is
-/// missing `:db/txId` or `:db/txInstant`.
-pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
-where
-    D: DbReadOps + Sync,
-{
-    maybe_latest_tx_basis_from_sdb(sdb)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("TX_PARTITION is empty; database not initialized"))
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -139,10 +139,8 @@ pub(crate) fn write_index_entries(
 /// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
 /// system_time from `db/txInstant` value.
 ///
-/// Errors if no TX_PARTITION entity exists (an initialized DB always has the
-/// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
-/// `:db/txInstant`.
-pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
+/// Returns `Ok(None)` if no transaction entity has been indexed yet.
+pub async fn maybe_latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<Option<TxBasis>>
 where
     D: DbReadOps + Sync,
 {
@@ -176,18 +174,31 @@ where
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok(TxBasis {
+        (Some(eid), Some(tid), Some(st)) => Ok(Some(TxBasis {
             tx_key: TxKey {
                 tx_id: tid,
                 system_time: st,
             },
             tx_eid: eid,
-        }),
-        (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
+        })),
+        (None, _, _) => Ok(None),
         (Some(eid), tid, st) => {
             bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
         }
     }
+}
+
+/// Scan EAV entries for TX_PARTITION entities and return (tx_eid, TxKey) for the latest tx.
+///
+/// Errors if no TX_PARTITION entity exists or if the latest tx entity is
+/// missing `:db/txId` or `:db/txInstant`.
+pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
+where
+    D: DbReadOps + Sync,
+{
+    maybe_latest_tx_basis_from_sdb(sdb)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("TX_PARTITION is empty; database not initialized"))
 }
 
 /// Build datoms for a first-class transaction entity in TX_PARTITION.

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::Result;
 use log::{error, info, trace, warn};
@@ -16,6 +16,11 @@ pub struct Record {
     pub tx_key: TxKey,
     pub record: Vec<u8>,
 }
+
+pub(crate) static BOOTSTRAP_RECORD: LazyLock<Record> = LazyLock::new(|| Record {
+    tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
+    record: Vec::new(),
+});
 
 #[allow(async_fn_in_trait)]
 pub(crate) trait Subscriber: Send + Sync {
@@ -152,7 +157,9 @@ pub trait TxLogWriter: Send + Sync + 'static {
     fn append_tx(&self, record: Vec<u8>) -> impl Future<Output = TxKey> + Send;
 }
 
-pub trait TxLog: TxLogReader + TxLogWriter {}
+pub trait TxLog: TxLogReader + TxLogWriter {
+    fn ensure_bootstrap_record(&self) -> impl Future<Output = Result<()>> + Send;
+}
 
 // Mock subscriber for testing
 #[allow(unused)]

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -5,7 +5,7 @@ use std::cmp::min;
 use crate::clock::SystemTimeSource;
 use crate::error::TriploxError;
 use crate::log::TxId;
-use crate::log::{Record, TxLog, TxLogReader, TxLogWriter};
+use crate::log::{Record, TxLog, TxLogReader, TxLogWriter, BOOTSTRAP_RECORD};
 use crate::logging::init;
 use crate::transaction::TxKey;
 use anyhow::Result;
@@ -29,12 +29,11 @@ impl MemoryLog {
             tx_sender: broadcast::channel(1024).0,
         }
     }
+}
 
-    pub(crate) async fn ensure_bootstrap_record(&self) -> Result<()> {
-        let bootstrap_record = Record {
-            tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
-            record: Vec::new(),
-        };
+impl TxLog for MemoryLog {
+    async fn ensure_bootstrap_record(&self) -> Result<()> {
+        let bootstrap_record = BOOTSTRAP_RECORD.clone();
         let mut state = self.state.write().await;
         match state.txs.first() {
             Some(record) if record == &bootstrap_record => Ok(()),
@@ -92,8 +91,6 @@ impl TxLogWriter for MemoryLog {
         tx_key
     }
 }
-
-impl TxLog for MemoryLog {}
 
 #[cfg(test)]
 mod tests {

--- a/src/memory_log.rs
+++ b/src/memory_log.rs
@@ -29,6 +29,25 @@ impl MemoryLog {
             tx_sender: broadcast::channel(1024).0,
         }
     }
+
+    pub(crate) async fn ensure_bootstrap_record(&self) -> Result<()> {
+        let bootstrap_record = Record {
+            tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
+            record: Vec::new(),
+        };
+        let mut state = self.state.write().await;
+        match state.txs.first() {
+            Some(record) if record == &bootstrap_record => Ok(()),
+            Some(record) => Err(anyhow::anyhow!(
+                "memory log starts with non-bootstrap record {:?}",
+                record.tx_key
+            )),
+            None => {
+                state.txs.push(bootstrap_record);
+                Ok(())
+            }
+        }
+    }
 }
 
 impl TxLogReader for MemoryLog {

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,7 +12,7 @@ use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
 };
-use crate::indexer::{latest_tx_basis_from_sdb, maybe_latest_tx_basis_from_sdb, Indexer};
+use crate::indexer::{latest_tx_basis_from_sdb, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
@@ -147,42 +147,25 @@ impl SchemaProvider for tokio::sync::RwLock<Indexer> {
     }
 }
 
-fn serialize_empty_tx() -> Result<Vec<u8>, Error> {
-    Ok(bincode::serialize(&Vec::<TxOp>::new())?)
-}
-
-async fn append_empty_bootstrap_tx<L: TxLog>(
-    log: Arc<L>,
-    indexer: Arc<tokio::sync::RwLock<Indexer>>,
-) -> Result<TxBasis, Error> {
-    let waiter = indexer.read().await.tx_waiter();
-    // TODO: Handle crashes after schema index writes but before this empty bootstrap tx is indexed.
-    let tx_key = log.append_tx(serialize_empty_tx()?).await;
-    let completion = waiter.await_tx(tx_key).await?;
-    completion.result.map_err(|e| anyhow::anyhow!("{:#}", e))?;
-    completion.basis.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Indexer did not return TxBasis for bootstrap tx {}",
-            tx_key.tx_id
-        )
-    })
-}
-
 impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slate = in_memory_slate().await;
         let metadata = crate::bootstrap::init_db(&slate).await.unwrap();
+        let bootstrap_basis = *crate::bootstrap::BOOTSTRAP_TX_BASIS;
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
             metadata,
-            None,
+            Some(bootstrap_basis),
         )));
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
+        log.ensure_bootstrap_record().await.unwrap();
 
-        let subscription = subscribe(log.clone(), None, indexer.clone()).await;
-        append_empty_bootstrap_tx(log.clone(), indexer.clone())
-            .await
-            .unwrap();
+        let subscription = subscribe(
+            log.clone(),
+            Some(bootstrap_basis.tx_key.tx_id),
+            indexer.clone(),
+        )
+        .await;
         let incremental = IncrementalQueryService::new(
             std::env::temp_dir().join(format!(
                 "triplox-dbsp-incremental-{}",
@@ -214,38 +197,32 @@ impl Node<FileLog> {
     ) -> Result<Self, Error> {
         let metadata = crate::bootstrap::init_db(&slate).await?;
 
-        // Restore the latest indexed tx if one exists; otherwise the empty
-        // bootstrap tx below creates the initial basis through the normal log path.
-        let latest_indexed_tx = maybe_latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
+        let latest_indexed = latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
+        let log = Arc::new(FileLog::new(log_file, Box::new(clock::SystemClock))?);
+        if latest_indexed == *crate::bootstrap::BOOTSTRAP_TX_BASIS {
+            log.ensure_bootstrap_record().await?;
+        }
+        let latest_indexed_tx = Some(latest_indexed);
 
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
             metadata,
             latest_indexed_tx,
         )));
-        let log = Arc::new(FileLog::new(log_file, Box::new(clock::SystemClock))?);
 
-        let after_tx_id = latest_indexed_tx.map(|b| b.tx_key.tx_id);
+        let after_tx_id = Some(latest_indexed.tx_key.tx_id);
 
-        let (last_tx_key, waiter) = if latest_indexed_tx.is_some() {
-            // Read the last tx_key from the log before subscribing (for catch-up awaiting)
-            let records = log.read_txs_after(after_tx_id, u16::MAX).await?;
-            let last_tx_key = records.last().map(|r| r.tx_key);
-            let waiter = match last_tx_key {
-                Some(_) => Some(indexer.read().await.tx_waiter()),
-                None => None,
-            };
-            (last_tx_key, waiter)
-        } else {
-            (None, None)
+        // Read the last tx_key from the log before subscribing (for catch-up awaiting)
+        let records = log.read_txs_after(after_tx_id, u16::MAX).await?;
+        let last_tx_key = records.last().map(|r| r.tx_key);
+
+        // Create a waiter for catch-up completion
+        let waiter = match last_tx_key {
+            Some(_) => Some(indexer.read().await.tx_waiter()),
+            None => None,
         };
 
         let subscription = subscribe(log.clone(), after_tx_id, indexer.clone()).await;
-
-        if latest_indexed_tx.is_none() {
-            append_empty_bootstrap_tx(log.clone(), indexer.clone()).await?;
-        }
-
         let incremental = IncrementalQueryService::new(
             incremental_storage_path,
             Handle::current(),
@@ -1261,6 +1238,33 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_node_bootstrap_log_marker_is_empty_and_not_duplicated() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().to_path_buf();
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        let records = node.log.read_txs_after(None, u16::MAX).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].tx_key,
+            crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key
+        );
+        assert!(records[0].record.is_empty());
+        node.close().await.unwrap();
+
+        let node = Node::local_node(&root_path).await.unwrap();
+        let records = node.log.read_txs_after(None, u16::MAX).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].tx_key,
+            crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key
+        );
+        assert!(records[0].record.is_empty());
+
+        node.close().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_local_node_restart_skips_already_indexed_first_log_tx() {
         let dir = tempfile::tempdir().unwrap();
         let root_path = dir.path().to_path_buf();
@@ -1465,18 +1469,14 @@ mod tests {
         };
         assert_eq!(extract_partition(tx_eid), TX_PARTITION);
         assert_eq!(result[0][1], DataType::Long(0));
-        assert!(
-            matches!(result[0][2], DataType::Instant(_)),
-            "expected bootstrap tx instant, got {:?}",
-            result[0][2]
-        );
+        assert_eq!(result[0][2], DataType::Instant(st_from_unix_epoch(0)));
         assert_eq!(result[0][3], DataType::Keyword(kw!(:db.tx/committed)));
 
         node.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_first_submitted_tx_has_distinct_tx_id() {
+    async fn test_first_submitted_tx_does_not_share_bootstrap_tx_id() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,7 +12,7 @@ use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
 };
-use crate::indexer::{latest_tx_basis_from_sdb, Indexer};
+use crate::indexer::{latest_tx_basis_from_sdb, maybe_latest_tx_basis_from_sdb, Indexer};
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
@@ -147,6 +147,27 @@ impl SchemaProvider for tokio::sync::RwLock<Indexer> {
     }
 }
 
+fn serialize_empty_tx() -> Result<Vec<u8>, Error> {
+    Ok(bincode::serialize(&Vec::<TxOp>::new())?)
+}
+
+async fn append_empty_bootstrap_tx<L: TxLog>(
+    log: Arc<L>,
+    indexer: Arc<tokio::sync::RwLock<Indexer>>,
+) -> Result<TxBasis, Error> {
+    let waiter = indexer.read().await.tx_waiter();
+    // TODO: Handle crashes after schema index writes but before this empty bootstrap tx is indexed.
+    let tx_key = log.append_tx(serialize_empty_tx()?).await;
+    let completion = waiter.await_tx(tx_key).await?;
+    completion.result.map_err(|e| anyhow::anyhow!("{:#}", e))?;
+    completion.basis.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Indexer did not return TxBasis for bootstrap tx {}",
+            tx_key.tx_id
+        )
+    })
+}
+
 impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slate = in_memory_slate().await;
@@ -159,6 +180,9 @@ impl Node<MemoryLog> {
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
 
         let subscription = subscribe(log.clone(), None, indexer.clone()).await;
+        append_empty_bootstrap_tx(log.clone(), indexer.clone())
+            .await
+            .unwrap();
         let incremental = IncrementalQueryService::new(
             std::env::temp_dir().join(format!(
                 "triplox-dbsp-incremental-{}",
@@ -190,19 +214,9 @@ impl Node<FileLog> {
     ) -> Result<Self, Error> {
         let metadata = crate::bootstrap::init_db(&slate).await?;
 
-        // Determine the latest already-indexed tx_id so we skip replaying it
-        // and restore the indexer's in-memory state for TxWaiter fast-path.
-        let latest_indexed = latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
-        // Bootstrap and the first FileLog transaction both currently use tx_id=0,
-        // so we can't disambiguate them by tx_id alone. Use the entity ID instead:
-        // only advance the log cursor past tx_id=0 once a tx entity beyond bootstrap
-        // has been indexed; otherwise replay the log from the start so the first
-        // user tx isn't skipped.
-        let latest_indexed_tx = if latest_indexed.tx_eid > crate::bootstrap::BOOTSTRAP_TX_EID {
-            Some(latest_indexed)
-        } else {
-            None
-        };
+        // Restore the latest indexed tx if one exists; otherwise the empty
+        // bootstrap tx below creates the initial basis through the normal log path.
+        let latest_indexed_tx = maybe_latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
 
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
@@ -213,17 +227,25 @@ impl Node<FileLog> {
 
         let after_tx_id = latest_indexed_tx.map(|b| b.tx_key.tx_id);
 
-        // Read the last tx_key from the log before subscribing (for catch-up awaiting)
-        let records = log.read_txs_after(after_tx_id, u16::MAX).await?;
-        let last_tx_key = records.last().map(|r| r.tx_key);
-
-        // Create a waiter for catch-up completion
-        let waiter = match last_tx_key {
-            Some(_) => Some(indexer.read().await.tx_waiter()),
-            None => None,
+        let (last_tx_key, waiter) = if latest_indexed_tx.is_some() {
+            // Read the last tx_key from the log before subscribing (for catch-up awaiting)
+            let records = log.read_txs_after(after_tx_id, u16::MAX).await?;
+            let last_tx_key = records.last().map(|r| r.tx_key);
+            let waiter = match last_tx_key {
+                Some(_) => Some(indexer.read().await.tx_waiter()),
+                None => None,
+            };
+            (last_tx_key, waiter)
+        } else {
+            (None, None)
         };
 
         let subscription = subscribe(log.clone(), after_tx_id, indexer.clone()).await;
+
+        if latest_indexed_tx.is_none() {
+            append_empty_bootstrap_tx(log.clone(), indexer.clone()).await?;
+        }
+
         let incremental = IncrementalQueryService::new(
             incremental_storage_path,
             Handle::current(),
@@ -454,7 +476,7 @@ mod tests {
 
         // submit_tx returns immediately with a TxKey
         let tx_key = node.submit_tx(tx_ops).await.unwrap();
-        assert_eq!(tx_key.tx_id, 1);
+        assert_eq!(tx_key.tx_id, 2);
 
         // Wait for indexer to process the transaction
         waiter
@@ -1253,7 +1275,7 @@ mod tests {
             .query("[:find ?tx :where [?tx :db/txId 0]]")
             .await
             .unwrap();
-        assert_eq!(txs.len(), 2);
+        assert_eq!(txs.len(), 1);
 
         node.close().await.unwrap();
     }
@@ -1443,14 +1465,18 @@ mod tests {
         };
         assert_eq!(extract_partition(tx_eid), TX_PARTITION);
         assert_eq!(result[0][1], DataType::Long(0));
-        assert_eq!(result[0][2], DataType::Instant(st_from_unix_epoch(0)));
+        assert!(
+            matches!(result[0][2], DataType::Instant(_)),
+            "expected bootstrap tx instant, got {:?}",
+            result[0][2]
+        );
         assert_eq!(result[0][3], DataType::Keyword(kw!(:db.tx/committed)));
 
         node.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_first_submitted_tx_temporarily_shares_bootstrap_tx_id() {
+    async fn test_first_submitted_tx_has_distinct_tx_id() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -1460,7 +1486,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.len(), 2);
+        assert_eq!(result.len(), 1);
 
         node.close().await.unwrap();
     }
@@ -1928,7 +1954,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires bootstrap latest_tx_basis to be visible through the indexer"]
     async fn test_incremental_schema_query_before_user_tx_observes_schema_changes() {
         let node = Node::memory_node().await;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -155,7 +155,7 @@ impl Node<MemoryLog> {
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
             metadata,
-            Some(bootstrap_basis),
+            bootstrap_basis,
         )));
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
         log.ensure_bootstrap_record().await.unwrap();
@@ -202,12 +202,10 @@ impl Node<FileLog> {
         if latest_indexed == *crate::bootstrap::BOOTSTRAP_TX_BASIS {
             log.ensure_bootstrap_record().await?;
         }
-        let latest_indexed_tx = Some(latest_indexed);
-
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
             metadata,
-            latest_indexed_tx,
+            latest_indexed,
         )));
 
         let after_tx_id = Some(latest_indexed.tx_key.tx_id);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1236,33 +1236,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_local_node_bootstrap_log_marker_is_empty_and_not_duplicated() {
-        let dir = tempfile::tempdir().unwrap();
-        let root_path = dir.path().to_path_buf();
-
-        let node = Node::local_node(&root_path).await.unwrap();
-        let records = node.log.read_txs_after(None, u16::MAX).await.unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(
-            records[0].tx_key,
-            crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key
-        );
-        assert!(records[0].record.is_empty());
-        node.close().await.unwrap();
-
-        let node = Node::local_node(&root_path).await.unwrap();
-        let records = node.log.read_txs_after(None, u16::MAX).await.unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(
-            records[0].tx_key,
-            crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key
-        );
-        assert!(records[0].record.is_empty());
-
-        node.close().await.unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn test_local_node_restart_skips_already_indexed_first_log_tx() {
         let dir = tempfile::tempdir().unwrap();
         let root_path = dir.path().to_path_buf();


### PR DESCRIPTION
## Summary
- stop writing the bootstrap tx entity directly from init_db
- start the normal subscriber first, then append and await an empty bootstrap transaction to establish the initial TxBasis
- detect fresh stores by absence of indexed tx entities and skip basis-less bootstrap schema CDC entries

## Testing
- cargo fmt
- cargo test -p triplox
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features

Autogenerated with Codex (GPT-5).
