### PR TITLE
Support `or` in incremental queries

### DIFF
--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -20,8 +20,15 @@ pub(crate) struct IncrementalQueryPlan {
     pub find_vars: Vec<Variable>,
     pub variables: Vec<Variable>,
     pub where_terms: Vec<WhereTermPlan>,
-    pub patterns: Vec<PatternPlan>,
     pub joins: Vec<JoinPlan>,
+}
+
+impl IncrementalQueryPlan {
+    pub(crate) fn leaf_patterns(&self) -> Vec<&PatternPlan> {
+        let mut patterns = Vec::new();
+        collect_leaf_patterns(&self.where_terms, &mut patterns);
+        patterns
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -83,9 +90,6 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
         bail!("Incremental queries require at least one triple pattern");
     }
 
-    let mut patterns = Vec::new();
-    collect_leaf_patterns(&where_terms, &mut patterns);
-
     let variables = collect_variables(&where_terms);
     for var in &find_vars {
         if !variables.contains(var) {
@@ -102,7 +106,6 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
         find_vars,
         variables,
         where_terms,
-        patterns,
         joins,
     })
 }
@@ -319,10 +322,10 @@ fn collect_variables(terms: &[WhereTermPlan]) -> Vec<Variable> {
     variables
 }
 
-fn collect_leaf_patterns(terms: &[WhereTermPlan], patterns: &mut Vec<PatternPlan>) {
+fn collect_leaf_patterns<'a>(terms: &'a [WhereTermPlan], patterns: &mut Vec<&'a PatternPlan>) {
     for term in terms {
         match term {
-            WhereTermPlan::Pattern(pattern) => patterns.push(pattern.clone()),
+            WhereTermPlan::Pattern(pattern) => patterns.push(pattern),
             WhereTermPlan::Or(or) => collect_leaf_patterns(&or.branches, patterns),
         }
     }
@@ -428,11 +431,12 @@ mod tests {
 
         assert_eq!(plan.find_vars, vec!["?e".to_var(), "?name".to_var()]);
         assert_eq!(plan.variables, vec!["?e".to_var(), "?name".to_var()]);
-        assert_eq!(plan.patterns.len(), 1);
-        assert_eq!(plan.patterns[0].attribute, 10);
+        let leaf_patterns = plan.leaf_patterns();
+        assert_eq!(leaf_patterns.len(), 1);
+        assert_eq!(leaf_patterns[0].attribute, 10);
         assert_eq!(
-            plan.patterns[0].output_vars,
-            vec!["?e".to_var(), "?name".to_var()]
+            &leaf_patterns[0].output_vars,
+            &vec!["?e".to_var(), "?name".to_var()]
         );
         assert!(plan.joins.is_empty());
     }
@@ -494,12 +498,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.patterns[0].value, encoded_string("Alice"));
+        let leaf_patterns = plan.leaf_patterns();
+        assert_eq!(&leaf_patterns[0].value, &encoded_string("Alice"));
         assert_eq!(
-            plan.patterns[1].entity,
-            PatternSlot::Variable("?other".to_var())
+            &leaf_patterns[1].entity,
+            &PatternSlot::Variable("?other".to_var())
         );
-        assert_eq!(plan.patterns[1].value, encoded_long(30));
+        assert_eq!(&leaf_patterns[1].value, &encoded_long(30));
     }
 
     #[test]
@@ -527,11 +532,12 @@ mod tests {
 
         assert_eq!(plan.find_vars, vec!["?e".to_var()]);
         assert_eq!(plan.variables, vec!["?e".to_var()]);
-        assert_eq!(plan.patterns.len(), 2);
-        assert_eq!(plan.patterns[0].attribute, 10);
-        assert_eq!(plan.patterns[0].value, encoded_string("Alice"));
-        assert_eq!(plan.patterns[1].attribute, 10);
-        assert_eq!(plan.patterns[1].value, encoded_string("Bob"));
+        let leaf_patterns = plan.leaf_patterns();
+        assert_eq!(leaf_patterns.len(), 2);
+        assert_eq!(leaf_patterns[0].attribute, 10);
+        assert_eq!(&leaf_patterns[0].value, &encoded_string("Alice"));
+        assert_eq!(leaf_patterns[1].attribute, 10);
+        assert_eq!(&leaf_patterns[1].value, &encoded_string("Bob"));
     }
 
     #[test]
@@ -546,7 +552,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.variables, vec!["?e".to_var()]);
-        assert_eq!(plan.patterns.len(), 3);
+        assert_eq!(plan.leaf_patterns().len(), 3);
         assert!(plan.joins.is_empty());
         assert!(matches!(plan.where_terms[0], WhereTermPlan::Or(_)));
     }
@@ -580,7 +586,7 @@ mod tests {
         let schema = test_schema();
         let plan = plan_query(&parse_query("[:find ?e :where [?e 10 ?name]]"), &schema).unwrap();
 
-        assert_eq!(plan.patterns[0].attribute, 10);
+        assert_eq!(plan.leaf_patterns()[0].attribute, 10);
     }
 
     #[test]

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -19,31 +19,28 @@ use crate::schema::Schema;
 pub(crate) struct IncrementalQueryPlan {
     pub find_vars: Vec<Variable>,
     pub variables: Vec<Variable>,
-    pub where_terms: Vec<WhereTermPlan>,
-    pub joins: Vec<JoinPlan>,
+    pub where_plan: RelPlan,
 }
 
 impl IncrementalQueryPlan {
     pub(crate) fn leaf_patterns(&self) -> Vec<&PatternPlan> {
         let mut patterns = Vec::new();
-        collect_leaf_patterns(&self.where_terms, &mut patterns);
+        collect_leaf_patterns(&self.where_plan, &mut patterns);
         patterns
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum WhereTermPlan {
-    Pattern(PatternPlan),
-    Or(OrPlan),
+pub(crate) struct RelPlan {
+    pub output_vars: Vec<Variable>,
+    pub kind: RelPlanKind,
 }
 
-impl WhereTermPlan {
-    pub(crate) fn output_vars(&self) -> &[Variable] {
-        match self {
-            WhereTermPlan::Pattern(pattern) => &pattern.output_vars,
-            WhereTermPlan::Or(or) => &or.output_vars,
-        }
-    }
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RelPlanKind {
+    Pattern(PatternPlan),
+    Join(JoinPlan),
+    Union(UnionPlan),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -61,14 +58,19 @@ pub(crate) struct PatternPlan {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct OrPlan {
-    pub branches: Vec<WhereTermPlan>,
-    pub output_vars: Vec<Variable>,
+pub(crate) struct UnionPlan {
+    pub branches: Vec<RelPlan>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JoinPlan {
-    pub right_term_index: usize,
+    pub inputs: Vec<RelPlan>,
+    pub steps: Vec<JoinStep>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct JoinStep {
+    pub right_input_index: usize,
     pub left_vars: Vec<Variable>,
     pub right_vars: Vec<Variable>,
     pub key_vars: Vec<Variable>,
@@ -80,17 +82,8 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
     let find_vars = find_vars(&query.find_spec)?;
     validate_query(query, &[])?;
 
-    let where_terms = query
-        .where_clauses
-        .iter()
-        .map(|clause| plan_where_clause(clause, schema))
-        .collect::<Result<Vec<_>>>()?;
-
-    if where_terms.is_empty() {
-        bail!("Incremental queries require at least one triple pattern");
-    }
-
-    let variables = collect_variables(&where_terms);
+    let where_plan = plan_where_clauses(&query.where_clauses, schema)?;
+    let variables = collect_variables(&where_plan);
     for var in &find_vars {
         if !variables.contains(var) {
             bail!(
@@ -100,13 +93,10 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
         }
     }
 
-    let joins = plan_joins(&where_terms);
-
     Ok(IncrementalQueryPlan {
         find_vars,
         variables,
-        where_terms,
-        joins,
+        where_plan,
     })
 }
 
@@ -266,7 +256,7 @@ fn plan_pattern(pattern: &Pattern, schema: &Schema) -> Result<PatternPlan> {
     })
 }
 
-fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
+fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<RelPlan> {
     let branches = or
         .clauses
         .iter()
@@ -274,16 +264,16 @@ fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
         .collect::<Result<Vec<_>>>()?;
     let output_vars = branches
         .first()
-        .map(|branch| branch.output_vars().to_vec())
+        .map(|branch| branch.output_vars.clone())
         .ok_or_else(|| anyhow!("OR clause must have at least one branch"))?;
 
-    Ok(WhereTermPlan::Or(OrPlan {
-        branches,
+    Ok(RelPlan {
         output_vars,
-    }))
+        kind: RelPlanKind::Union(UnionPlan { branches }),
+    })
 }
 
-fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<RelPlan> {
     match branch {
         OrWhereClause::Clause(clause) => plan_where_clause(clause, schema),
         OrWhereClause::And(_) => {
@@ -292,43 +282,84 @@ fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPl
     }
 }
 
-fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<RelPlan> {
     match clause {
-        WhereClause::Pattern(pattern) => Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?)),
+        WhereClause::Pattern(pattern) => {
+            let pattern = plan_pattern(pattern, schema)?;
+            Ok(RelPlan {
+                output_vars: pattern.output_vars.clone(),
+                kind: RelPlanKind::Pattern(pattern),
+            })
+        }
         WhereClause::OrJoin(or) => plan_or_join(or, schema),
         _ => unreachable!("unsupported clauses are rejected before planning"),
     }
 }
 
-fn collect_variables(terms: &[WhereTermPlan]) -> Vec<Variable> {
+fn plan_where_clauses(clauses: &[WhereClause], schema: &Schema) -> Result<RelPlan> {
+    let inputs = clauses
+        .iter()
+        .map(|clause| plan_where_clause(clause, schema))
+        .collect::<Result<Vec<_>>>()?;
+    plan_inputs(inputs)
+}
+
+fn plan_inputs(mut inputs: Vec<RelPlan>) -> Result<RelPlan> {
+    if inputs.is_empty() {
+        bail!("Incremental queries require at least one triple pattern");
+    }
+    if inputs.len() == 1 {
+        return Ok(inputs.remove(0));
+    }
+
+    let steps = plan_join_steps(&inputs);
+    let output_vars = steps
+        .last()
+        .map(|step| step.output_vars.clone())
+        .expect("multi-input join plan must have at least one step");
+
+    Ok(RelPlan {
+        output_vars,
+        kind: RelPlanKind::Join(JoinPlan { inputs, steps }),
+    })
+}
+
+fn collect_variables(plan: &RelPlan) -> Vec<Variable> {
     let mut variables = Vec::new();
     let mut seen = HashSet::new();
-    for term in terms {
-        for var in term.output_vars() {
-            if seen.insert(var.clone()) {
-                variables.push(var.clone());
-            }
+    for var in &plan.output_vars {
+        if seen.insert(var.clone()) {
+            variables.push(var.clone());
         }
     }
     variables
 }
 
-fn collect_leaf_patterns<'a>(terms: &'a [WhereTermPlan], patterns: &mut Vec<&'a PatternPlan>) {
-    for term in terms {
-        match term {
-            WhereTermPlan::Pattern(pattern) => patterns.push(pattern),
-            WhereTermPlan::Or(or) => collect_leaf_patterns(&or.branches, patterns),
+fn collect_leaf_patterns<'a>(plan: &'a RelPlan, patterns: &mut Vec<&'a PatternPlan>) {
+    match &plan.kind {
+        RelPlanKind::Pattern(pattern) => patterns.push(pattern),
+        RelPlanKind::Join(join) => {
+            for input in &join.inputs {
+                collect_leaf_patterns(input, patterns);
+            }
+        }
+        RelPlanKind::Union(union) => {
+            for branch in &union.branches {
+                collect_leaf_patterns(branch, patterns);
+            }
         }
     }
 }
 
-fn plan_joins(terms: &[WhereTermPlan]) -> Vec<JoinPlan> {
-    let mut joins = Vec::new();
-    let mut left_vars = terms[0].output_vars().to_vec();
+// This plans a very naive left-deep join plan, always joining on the intersection
+// of left (the accumulate so far) and right.
+fn plan_join_steps(inputs: &[RelPlan]) -> Vec<JoinStep> {
+    let mut steps = Vec::new();
+    let mut left_vars = inputs[0].output_vars.clone();
     let mut bound: HashSet<Variable> = left_vars.iter().cloned().collect();
 
-    for (right_term_index, term) in terms.iter().enumerate().skip(1) {
-        let right_vars = term.output_vars().to_vec();
+    for (right_input_index, input) in inputs.iter().enumerate().skip(1) {
+        let right_vars = input.output_vars.clone();
         let right_set: HashSet<Variable> = right_vars.iter().cloned().collect();
         // Note: Not using intersection to preserve ordering from left_vars
         let key_vars = left_vars
@@ -344,8 +375,8 @@ fn plan_joins(terms: &[WhereTermPlan]) -> Vec<JoinPlan> {
             }
         }
 
-        joins.push(JoinPlan {
-            right_term_index,
+        steps.push(JoinStep {
+            right_input_index,
             left_vars,
             right_vars,
             key_vars,
@@ -354,7 +385,7 @@ fn plan_joins(terms: &[WhereTermPlan]) -> Vec<JoinPlan> {
         left_vars = output_vars;
     }
 
-    joins
+    steps
 }
 
 #[cfg(test)]
@@ -411,6 +442,27 @@ mod tests {
         );
     }
 
+    fn pattern_rel(plan: &RelPlan) -> &PatternPlan {
+        let RelPlanKind::Pattern(pattern) = &plan.kind else {
+            panic!("expected pattern plan, got {:?}", plan.kind);
+        };
+        pattern
+    }
+
+    fn join_rel(plan: &RelPlan) -> &JoinPlan {
+        let RelPlanKind::Join(join) = &plan.kind else {
+            panic!("expected join plan, got {:?}", plan.kind);
+        };
+        join
+    }
+
+    fn union_rel(plan: &RelPlan) -> &UnionPlan {
+        let RelPlanKind::Union(union) = &plan.kind else {
+            panic!("expected union plan, got {:?}", plan.kind);
+        };
+        union
+    }
+
     #[test]
     fn plans_single_fixed_attribute_pattern() {
         let schema = test_schema();
@@ -429,7 +481,7 @@ mod tests {
             &leaf_patterns[0].output_vars,
             &vec!["?e".to_var(), "?name".to_var()]
         );
-        assert!(plan.joins.is_empty());
+        assert_eq!(pattern_rel(&plan.where_plan).attribute, 10);
     }
 
     #[test]
@@ -441,11 +493,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.joins.len(), 1);
-        assert_eq!(plan.joins[0].right_term_index, 1);
-        assert_eq!(plan.joins[0].key_vars, vec!["?e".to_var()]);
+        let join = join_rel(&plan.where_plan);
+        assert_eq!(join.inputs.len(), 2);
+        assert_eq!(join.steps.len(), 1);
+        assert_eq!(join.steps[0].right_input_index, 1);
+        assert_eq!(join.steps[0].key_vars, vec!["?e".to_var()]);
         assert_eq!(
-            plan.joins[0].output_vars,
+            join.steps[0].output_vars,
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var()]
         );
     }
@@ -461,8 +515,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.joins[0].right_term_index, 1);
-        assert_eq!(plan.joins[0].key_vars, vec!["?friend".to_var()]);
+        let join = join_rel(&plan.where_plan);
+        assert_eq!(join.steps[0].right_input_index, 1);
+        assert_eq!(join.steps[0].key_vars, vec!["?friend".to_var()]);
     }
 
     #[test]
@@ -474,10 +529,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.joins.len(), 3);
-        assert_eq!(plan.joins[0].key_vars, vec!["?e".to_var()]);
-        assert_eq!(plan.joins[1].key_vars, vec!["?friend".to_var()]);
-        assert_eq!(plan.joins[2].key_vars, vec!["?friend".to_var()]);
+        let join = join_rel(&plan.where_plan);
+        assert_eq!(join.steps.len(), 3);
+        assert_eq!(join.steps[0].key_vars, vec!["?e".to_var()]);
+        assert_eq!(join.steps[1].key_vars, vec!["?friend".to_var()]);
+        assert_eq!(join.steps[2].key_vars, vec!["?friend".to_var()]);
     }
 
     #[test]
@@ -507,9 +563,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.joins.len(), 1);
-        assert_eq!(plan.joins[0].right_term_index, 1);
-        assert!(plan.joins[0].key_vars.is_empty());
+        let join = join_rel(&plan.where_plan);
+        assert_eq!(join.steps.len(), 1);
+        assert_eq!(join.steps[0].right_input_index, 1);
+        assert!(join.steps[0].key_vars.is_empty());
     }
 
     #[test]
@@ -523,6 +580,10 @@ mod tests {
 
         assert_eq!(plan.find_vars, vec!["?e".to_var()]);
         assert_eq!(plan.variables, vec!["?e".to_var()]);
+        let union = union_rel(&plan.where_plan);
+        assert_eq!(union.branches.len(), 2);
+        assert!(matches!(union.branches[0].kind, RelPlanKind::Pattern(_)));
+        assert!(matches!(union.branches[1].kind, RelPlanKind::Pattern(_)));
         let leaf_patterns = plan.leaf_patterns();
         assert_eq!(leaf_patterns.len(), 2);
         assert_eq!(leaf_patterns[0].attribute, 10);
@@ -544,8 +605,10 @@ mod tests {
 
         assert_eq!(plan.variables, vec!["?e".to_var()]);
         assert_eq!(plan.leaf_patterns().len(), 3);
-        assert!(plan.joins.is_empty());
-        assert!(matches!(plan.where_terms[0], WhereTermPlan::Or(_)));
+        let union = union_rel(&plan.where_plan);
+        assert_eq!(union.branches.len(), 2);
+        assert!(matches!(union.branches[0].kind, RelPlanKind::Pattern(_)));
+        assert!(matches!(union.branches[1].kind, RelPlanKind::Union(_)));
     }
 
     #[test]
@@ -558,18 +621,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.variables, vec!["?e".to_var(), "?v".to_var()]);
-        let WhereTermPlan::Or(or) = &plan.where_terms[0] else {
-            panic!("expected or term");
-        };
-        assert_eq!(or.output_vars, vec!["?e".to_var(), "?v".to_var()]);
+        let or = union_rel(&plan.where_plan);
         assert_eq!(
-            or.branches[0].output_vars(),
-            &["?e".to_var(), "?v".to_var()]
+            plan.where_plan.output_vars,
+            vec!["?e".to_var(), "?v".to_var()]
         );
-        assert_eq!(
-            or.branches[1].output_vars(),
-            &["?v".to_var(), "?e".to_var()]
-        );
+        assert_eq!(or.branches[0].output_vars, &["?e".to_var(), "?v".to_var()]);
+        assert_eq!(or.branches[1].output_vars, &["?v".to_var(), "?e".to_var()]);
     }
 
     #[test]

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use anyhow::{anyhow, bail, Result};
 use edn::query::{
     Element, FindSpec, Limit, OrJoin, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace,
-    PatternValuePlace, UnifyVars, Variable, WhereClause,
+    PatternValuePlace, Variable, WhereClause,
 };
 
 use crate::codec::Encode;
@@ -101,9 +101,6 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
 }
 
 fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
-    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
-        bail!("Incremental queries do not support explicit or-join");
-    }
     for branch in &or.clauses {
         reject_unsupported_or_branch(branch)?;
     }
@@ -114,7 +111,7 @@ fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
     match branch {
         OrWhereClause::Clause(clause) => reject_unsupported_where_clause(clause),
         OrWhereClause::And(_) => {
-            bail!("Incremental querys currently do not support `and` patterns!")
+            bail!("Incremental queries currently do not support `and` patterns!")
         }
     }
 }
@@ -277,7 +274,7 @@ fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<RelPlan> {
     match branch {
         OrWhereClause::Clause(clause) => plan_where_clause(clause, schema),
         OrWhereClause::And(_) => {
-            unreachable!("Incremental querys currently do not support `and` patterns!")
+            unreachable!("Incremental queries currently do not support `and` patterns!")
         }
     }
 }

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -198,69 +198,6 @@ fn find_vars(find_spec: &FindSpec) -> Result<Vec<Variable>> {
         .collect()
 }
 
-fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermPlan> {
-    match clause {
-        WhereClause::Pattern(pattern) => Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?)),
-        WhereClause::OrJoin(or) => plan_or_join(or, schema),
-        _ => unreachable!("unsupported clauses are rejected before planning"),
-    }
-}
-
-fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
-    let branches = or
-        .clauses
-        .iter()
-        .map(|branch| plan_or_branch(branch, schema))
-        .collect::<Result<Vec<_>>>()?;
-    let output_vars = branches
-        .first()
-        .map(|branch| branch.output_vars().to_vec())
-        .ok_or_else(|| anyhow!("OR clause must have at least one branch"))?;
-
-    Ok(WhereTermPlan::Or(OrPlan {
-        branches,
-        output_vars,
-    }))
-}
-
-fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPlan> {
-    match branch {
-        OrWhereClause::Clause(WhereClause::Pattern(pattern)) => {
-            Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?))
-        }
-        OrWhereClause::Clause(WhereClause::OrJoin(or)) => plan_or_join(or, schema),
-        OrWhereClause::Clause(_) | OrWhereClause::And(_) => {
-            bail!("Incremental query or branches currently support only triple patterns or nested or clauses")
-        }
-    }
-}
-
-fn plan_pattern(pattern: &Pattern, schema: &Schema) -> Result<PatternPlan> {
-    let attribute = match &pattern.attribute {
-        PatternNonValuePlace::Ident(ident) => {
-            schema
-                .get_attribute(ident.as_ref())
-                .ok_or_else(|| anyhow!("Unknown attribute: {}", ident))?
-                .0
-        }
-        PatternNonValuePlace::Entid(entid) => *entid,
-        PatternNonValuePlace::Variable(_) | PatternNonValuePlace::Placeholder => {
-            unreachable!("variable and placeholder attributes are rejected before planning")
-        }
-    };
-
-    let entity = non_value_slot(&pattern.entity);
-    let value = value_slot(&pattern.value)?;
-    let output_vars = pattern_output_vars(&entity, &value);
-
-    Ok(PatternPlan {
-        attribute,
-        entity,
-        value,
-        output_vars,
-    })
-}
-
 fn non_value_slot(place: &PatternNonValuePlace) -> PatternSlot {
     match place {
         PatternNonValuePlace::Variable(var) => PatternSlot::Variable(var.clone()),
@@ -308,6 +245,69 @@ fn pattern_output_vars(entity: &PatternSlot, value: &PatternSlot) -> Vec<Variabl
     }
     vars
 }
+
+fn plan_pattern(pattern: &Pattern, schema: &Schema) -> Result<PatternPlan> {
+    let attribute = match &pattern.attribute {
+        PatternNonValuePlace::Ident(ident) => {
+            schema
+                .get_attribute(ident.as_ref())
+                .ok_or_else(|| anyhow!("Unknown attribute: {}", ident))?
+                .0
+        }
+        PatternNonValuePlace::Entid(entid) => *entid,
+        PatternNonValuePlace::Variable(_) | PatternNonValuePlace::Placeholder => {
+            unreachable!("variable and placeholder attributes are rejected before planning")
+        }
+    };
+
+    let entity = non_value_slot(&pattern.entity);
+    let value = value_slot(&pattern.value)?;
+    let output_vars = pattern_output_vars(&entity, &value);
+
+    Ok(PatternPlan {
+        attribute,
+        entity,
+        value,
+        output_vars,
+    })
+}
+
+fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
+    let branches = or
+        .clauses
+        .iter()
+        .map(|branch| plan_or_branch(branch, schema))
+        .collect::<Result<Vec<_>>>()?;
+    let output_vars = branches
+        .first()
+        .map(|branch| branch.output_vars().to_vec())
+        .ok_or_else(|| anyhow!("OR clause must have at least one branch"))?;
+
+    Ok(WhereTermPlan::Or(OrPlan {
+        branches,
+        output_vars,
+    }))
+}
+
+fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+    match branch {
+        OrWhereClause::Clause(clause) => {
+            plan_where_clause(clause, schema)
+        }
+        OrWhereClause::And(_) => {
+            unreachable!("Incremental querys currently do not support `and` patterns!")
+        }
+    }
+}
+
+fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+    match clause {
+        WhereClause::Pattern(pattern) => Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?)),
+        WhereClause::OrJoin(or) => plan_or_join(or, schema),
+        _ => unreachable!("unsupported clauses are rejected before planning"),
+    }
+}
+
 
 fn collect_variables(terms: &[WhereTermPlan]) -> Vec<Variable> {
     let mut variables = Vec::new();
@@ -640,7 +640,7 @@ mod tests {
         );
         assert_plan_err(
             r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#,
-            "do not support `and` patterns",
+            "or branches currently support only triple patterns or nested or clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -60,13 +60,11 @@ pub(crate) struct PatternPlan {
     pub output_vars: Vec<Variable>,
 }
 
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct OrPlan {
     pub branches: Vec<WhereTermPlan>,
     pub output_vars: Vec<Variable>,
 }
-
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JoinPlan {
@@ -112,7 +110,6 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
     })
 }
 
-
 fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
     if !matches!(&or.unify_vars, UnifyVars::Implicit) {
         bail!("Incremental queries do not support explicit or-join");
@@ -125,9 +122,7 @@ fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
 
 fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
     match branch {
-        OrWhereClause::Clause(clause) => {
-            reject_unsupported_where_clause(clause)
-        }
+        OrWhereClause::Clause(clause) => reject_unsupported_where_clause(clause),
         OrWhereClause::And(_) => {
             bail!("Incremental querys currently do not support `and` patterns!")
         }
@@ -179,7 +174,6 @@ fn reject_unsupported_query_shape(query: &ParsedQuery) -> Result<()> {
     }
     Ok(())
 }
-
 
 fn find_vars(find_spec: &FindSpec) -> Result<Vec<Variable>> {
     let elements = match find_spec {
@@ -291,9 +285,7 @@ fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
 
 fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPlan> {
     match branch {
-        OrWhereClause::Clause(clause) => {
-            plan_where_clause(clause, schema)
-        }
+        OrWhereClause::Clause(clause) => plan_where_clause(clause, schema),
         OrWhereClause::And(_) => {
             unreachable!("Incremental querys currently do not support `and` patterns!")
         }
@@ -308,12 +300,12 @@ fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermP
     }
 }
 
-
 fn collect_variables(terms: &[WhereTermPlan]) -> Vec<Variable> {
     let mut variables = Vec::new();
+    let mut seen = HashSet::new();
     for term in terms {
         for var in term.output_vars() {
-            if !variables.contains(var) {
+            if seen.insert(var.clone()) {
                 variables.push(var.clone());
             }
         }

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -47,9 +47,9 @@ impl WhereTermPlan {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct OrPlan {
-    pub branches: Vec<WhereTermPlan>,
-    pub output_vars: Vec<Variable>,
+pub(crate) enum PatternSlot {
+    Variable(Variable),
+    Constant(EncodedValue),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -60,11 +60,13 @@ pub(crate) struct PatternPlan {
     pub output_vars: Vec<Variable>,
 }
 
+
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum PatternSlot {
-    Variable(Variable),
-    Constant(EncodedValue),
+pub(crate) struct OrPlan {
+    pub branches: Vec<WhereTermPlan>,
+    pub output_vars: Vec<Variable>,
 }
+
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JoinPlan {
@@ -110,6 +112,54 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
     })
 }
 
+
+fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
+    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
+        bail!("Incremental queries do not support explicit or-join");
+    }
+    for branch in &or.clauses {
+        reject_unsupported_or_branch(branch)?;
+    }
+    Ok(())
+}
+
+fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
+    match branch {
+        OrWhereClause::Clause(clause) => {
+            reject_unsupported_where_clause(clause)
+        }
+        OrWhereClause::And(_) => {
+            bail!("Incremental querys currently do not support `and` patterns!")
+        }
+    }
+}
+
+fn reject_unsupported_pattern_shape(pattern: &Pattern) -> Result<()> {
+    if pattern.source.is_some() {
+        bail!("Incremental query patterns do not support source variables");
+    }
+    if !matches!(pattern.tx, PatternNonValuePlace::Placeholder) {
+        bail!("Incremental query patterns do not support tx positions");
+    }
+    if !matches!(
+        pattern.attribute,
+        PatternNonValuePlace::Ident(_) | PatternNonValuePlace::Entid(_)
+    ) {
+        bail!("Incremental query pattern attributes must be constant idents or entids");
+    }
+    Ok(())
+}
+
+fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
+    match clause {
+        WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
+        WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
+        _ => bail!(
+            "Incremental queries currently support only triple patterns and or clauses in :where"
+        ),
+    }
+}
+
 // TODO: Delete this when incremental queries reach one-shot query parity.
 fn reject_unsupported_query_shape(query: &ParsedQuery) -> Result<()> {
     if !query.with.is_empty() {
@@ -130,53 +180,6 @@ fn reject_unsupported_query_shape(query: &ParsedQuery) -> Result<()> {
     Ok(())
 }
 
-fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
-    match clause {
-        WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
-        WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
-        _ => bail!(
-            "Incremental queries currently support only triple patterns and or clauses in :where"
-        ),
-    }
-}
-
-fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
-    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
-        bail!("Incremental queries do not support explicit or-join");
-    }
-    for branch in &or.clauses {
-        reject_unsupported_or_branch(branch)?;
-    }
-    Ok(())
-}
-
-fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
-    match branch {
-        OrWhereClause::Clause(WhereClause::Pattern(pattern)) => {
-            reject_unsupported_pattern_shape(pattern)
-        }
-        OrWhereClause::Clause(WhereClause::OrJoin(or)) => reject_unsupported_or_join(or),
-        OrWhereClause::Clause(_) | OrWhereClause::And(_) => {
-            bail!("Incremental query or branches currently support only triple patterns or nested or clauses")
-        }
-    }
-}
-
-fn reject_unsupported_pattern_shape(pattern: &Pattern) -> Result<()> {
-    if pattern.source.is_some() {
-        bail!("Incremental query patterns do not support source variables");
-    }
-    if !matches!(pattern.tx, PatternNonValuePlace::Placeholder) {
-        bail!("Incremental query patterns do not support tx positions");
-    }
-    if !matches!(
-        pattern.attribute,
-        PatternNonValuePlace::Ident(_) | PatternNonValuePlace::Entid(_)
-    ) {
-        bail!("Incremental query pattern attributes must be constant idents or entids");
-    }
-    Ok(())
-}
 
 fn find_vars(find_spec: &FindSpec) -> Result<Vec<Variable>> {
     let elements = match find_spec {

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -207,10 +207,6 @@ fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermP
 }
 
 fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
-    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
-        bail!("Incremental queries do not support explicit or-join");
-    }
-
     let branches = or
         .clauses
         .iter()

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -640,7 +640,7 @@ mod tests {
         );
         assert_plan_err(
             r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#,
-            "or branches currently support only triple patterns or nested or clauses",
+            "do not support `and` patterns",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -442,27 +442,6 @@ mod tests {
         );
     }
 
-    fn pattern_rel(plan: &RelPlan) -> &PatternPlan {
-        let RelPlanKind::Pattern(pattern) = &plan.kind else {
-            panic!("expected pattern plan, got {:?}", plan.kind);
-        };
-        pattern
-    }
-
-    fn join_rel(plan: &RelPlan) -> &JoinPlan {
-        let RelPlanKind::Join(join) = &plan.kind else {
-            panic!("expected join plan, got {:?}", plan.kind);
-        };
-        join
-    }
-
-    fn union_rel(plan: &RelPlan) -> &UnionPlan {
-        let RelPlanKind::Union(union) = &plan.kind else {
-            panic!("expected union plan, got {:?}", plan.kind);
-        };
-        union
-    }
-
     #[test]
     fn plans_single_fixed_attribute_pattern() {
         let schema = test_schema();
@@ -481,7 +460,10 @@ mod tests {
             &leaf_patterns[0].output_vars,
             &vec!["?e".to_var(), "?name".to_var()]
         );
-        assert_eq!(pattern_rel(&plan.where_plan).attribute, 10);
+        let RelPlanKind::Pattern(pattern) = &plan.where_plan.kind else {
+            panic!("expected pattern plan, got {:?}", &plan.where_plan.kind);
+        };
+        assert_eq!(pattern.attribute, 10);
     }
 
     #[test]
@@ -493,7 +475,9 @@ mod tests {
         )
         .unwrap();
 
-        let join = join_rel(&plan.where_plan);
+        let RelPlanKind::Join(join) = &plan.where_plan.kind else {
+            panic!("expected join plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(join.inputs.len(), 2);
         assert_eq!(join.steps.len(), 1);
         assert_eq!(join.steps[0].right_input_index, 1);
@@ -515,7 +499,9 @@ mod tests {
         )
         .unwrap();
 
-        let join = join_rel(&plan.where_plan);
+        let RelPlanKind::Join(join) = &plan.where_plan.kind else {
+            panic!("expected join plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(join.steps[0].right_input_index, 1);
         assert_eq!(join.steps[0].key_vars, vec!["?friend".to_var()]);
     }
@@ -529,7 +515,9 @@ mod tests {
         )
         .unwrap();
 
-        let join = join_rel(&plan.where_plan);
+        let RelPlanKind::Join(join) = &plan.where_plan.kind else {
+            panic!("expected join plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(join.steps.len(), 3);
         assert_eq!(join.steps[0].key_vars, vec!["?e".to_var()]);
         assert_eq!(join.steps[1].key_vars, vec!["?friend".to_var()]);
@@ -563,7 +551,9 @@ mod tests {
         )
         .unwrap();
 
-        let join = join_rel(&plan.where_plan);
+        let RelPlanKind::Join(join) = &plan.where_plan.kind else {
+            panic!("expected join plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(join.steps.len(), 1);
         assert_eq!(join.steps[0].right_input_index, 1);
         assert!(join.steps[0].key_vars.is_empty());
@@ -580,7 +570,9 @@ mod tests {
 
         assert_eq!(plan.find_vars, vec!["?e".to_var()]);
         assert_eq!(plan.variables, vec!["?e".to_var()]);
-        let union = union_rel(&plan.where_plan);
+        let RelPlanKind::Union(union) = &plan.where_plan.kind else {
+            panic!("expected union plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(union.branches.len(), 2);
         assert!(matches!(union.branches[0].kind, RelPlanKind::Pattern(_)));
         assert!(matches!(union.branches[1].kind, RelPlanKind::Pattern(_)));
@@ -605,7 +597,9 @@ mod tests {
 
         assert_eq!(plan.variables, vec!["?e".to_var()]);
         assert_eq!(plan.leaf_patterns().len(), 3);
-        let union = union_rel(&plan.where_plan);
+        let RelPlanKind::Union(union) = &plan.where_plan.kind else {
+            panic!("expected union plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(union.branches.len(), 2);
         assert!(matches!(union.branches[0].kind, RelPlanKind::Pattern(_)));
         assert!(matches!(union.branches[1].kind, RelPlanKind::Union(_)));
@@ -621,7 +615,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.variables, vec!["?e".to_var(), "?v".to_var()]);
-        let or = union_rel(&plan.where_plan);
+        let RelPlanKind::Union(or) = &plan.where_plan.kind else {
+            panic!("expected union plan, got {:?}", &plan.where_plan.kind);
+        };
         assert_eq!(
             plan.where_plan.output_vars,
             vec!["?e".to_var(), "?v".to_var()]

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -4,8 +4,8 @@ use std::collections::HashSet;
 
 use anyhow::{anyhow, bail, Result};
 use edn::query::{
-    Element, FindSpec, Limit, ParsedQuery, Pattern, PatternNonValuePlace, PatternValuePlace,
-    Variable, WhereClause,
+    Element, FindSpec, Limit, OrJoin, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace,
+    PatternValuePlace, UnifyVars, Variable, WhereClause,
 };
 
 use crate::codec::Encode;
@@ -19,8 +19,30 @@ use crate::schema::Schema;
 pub(crate) struct IncrementalQueryPlan {
     pub find_vars: Vec<Variable>,
     pub variables: Vec<Variable>,
+    pub where_terms: Vec<WhereTermPlan>,
     pub patterns: Vec<PatternPlan>,
     pub joins: Vec<JoinPlan>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum WhereTermPlan {
+    Pattern(PatternPlan),
+    Or(OrPlan),
+}
+
+impl WhereTermPlan {
+    pub(crate) fn output_vars(&self) -> &[Variable] {
+        match self {
+            WhereTermPlan::Pattern(pattern) => &pattern.output_vars,
+            WhereTermPlan::Or(or) => &or.output_vars,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OrPlan {
+    pub branches: Vec<WhereTermPlan>,
+    pub output_vars: Vec<Variable>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -39,7 +61,7 @@ pub(crate) enum PatternSlot {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JoinPlan {
-    pub right_pattern_index: usize,
+    pub right_term_index: usize,
     pub left_vars: Vec<Variable>,
     pub right_vars: Vec<Variable>,
     pub key_vars: Vec<Variable>,
@@ -48,23 +70,23 @@ pub(crate) struct JoinPlan {
 
 pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<IncrementalQueryPlan> {
     reject_unsupported_query_shape(query)?;
+    let find_vars = find_vars(&query.find_spec)?;
     validate_query(query, &[])?;
 
-    let find_vars = find_vars(&query.find_spec);
-    let patterns = query
+    let where_terms = query
         .where_clauses
         .iter()
-        .map(|clause| match clause {
-            WhereClause::Pattern(pattern) => plan_pattern(pattern, schema),
-            _ => unreachable!("non-pattern clauses are rejected before planning"),
-        })
+        .map(|clause| plan_where_clause(clause, schema))
         .collect::<Result<Vec<_>>>()?;
 
-    if patterns.is_empty() {
+    if where_terms.is_empty() {
         bail!("Incremental queries require at least one triple pattern");
     }
 
-    let variables = collect_variables(&patterns);
+    let mut patterns = Vec::new();
+    collect_leaf_patterns(&where_terms, &mut patterns);
+
+    let variables = collect_variables(&where_terms);
     for var in &find_vars {
         if !variables.contains(var) {
             bail!(
@@ -74,11 +96,12 @@ pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<Increme
         }
     }
 
-    let joins = plan_joins(&patterns);
+    let joins = plan_joins(&where_terms);
 
     Ok(IncrementalQueryPlan {
         find_vars,
         variables,
+        where_terms,
         patterns,
         joins,
     })
@@ -98,51 +121,116 @@ fn reject_unsupported_query_shape(query: &ParsedQuery) -> Result<()> {
     if query.order.is_some() {
         bail!("Incremental queries do not support :order");
     }
-    match &query.find_spec {
-        FindSpec::FindRel(elements) => {
-            for element in elements {
-                if !matches!(element, Element::Variable(_)) {
-                    bail!("Incremental queries support only variables in :find");
-                }
-            }
-        }
-        _ => bail!("Incremental queries support only relational :find"),
-    }
     for clause in &query.where_clauses {
-        match clause {
-            WhereClause::Pattern(pattern) => {
-                if pattern.source.is_some() {
-                    bail!("Incremental query patterns do not support source variables");
-                }
-                if !matches!(pattern.tx, PatternNonValuePlace::Placeholder) {
-                    bail!("Incremental query patterns do not support tx positions");
-                }
-                if !matches!(
-                    pattern.attribute,
-                    PatternNonValuePlace::Ident(_) | PatternNonValuePlace::Entid(_)
-                ) {
-                    bail!("Incremental query pattern attributes must be constant idents or entids");
-                }
-            }
-            _ => bail!("Incremental queries currently support only triple patterns in :where"),
-        }
+        reject_unsupported_where_clause(clause)?;
     }
     Ok(())
 }
 
-fn find_vars(find_spec: &FindSpec) -> Vec<Variable> {
+fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
+    match clause {
+        WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
+        WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
+        _ => bail!(
+            "Incremental queries currently support only triple patterns and or clauses in :where"
+        ),
+    }
+}
+
+fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
+    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
+        bail!("Incremental queries do not support explicit or-join");
+    }
+    for branch in &or.clauses {
+        reject_unsupported_or_branch(branch)?;
+    }
+    Ok(())
+}
+
+fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
+    match branch {
+        OrWhereClause::Clause(WhereClause::Pattern(pattern)) => {
+            reject_unsupported_pattern_shape(pattern)
+        }
+        OrWhereClause::Clause(WhereClause::OrJoin(or)) => reject_unsupported_or_join(or),
+        OrWhereClause::Clause(_) | OrWhereClause::And(_) => {
+            bail!("Incremental query or branches currently support only triple patterns or nested or clauses")
+        }
+    }
+}
+
+fn reject_unsupported_pattern_shape(pattern: &Pattern) -> Result<()> {
+    if pattern.source.is_some() {
+        bail!("Incremental query patterns do not support source variables");
+    }
+    if !matches!(pattern.tx, PatternNonValuePlace::Placeholder) {
+        bail!("Incremental query patterns do not support tx positions");
+    }
+    if !matches!(
+        pattern.attribute,
+        PatternNonValuePlace::Ident(_) | PatternNonValuePlace::Entid(_)
+    ) {
+        bail!("Incremental query pattern attributes must be constant idents or entids");
+    }
+    Ok(())
+}
+
+fn find_vars(find_spec: &FindSpec) -> Result<Vec<Variable>> {
     let elements = match find_spec {
         FindSpec::FindRel(elements) => elements,
-        _ => unreachable!("non-relational :find is rejected before planning"),
+        _ => bail!("Incremental queries support only relational :find"),
     };
 
     elements
         .iter()
         .map(|element| match element {
-            Element::Variable(var) => var.clone(),
-            _ => unreachable!("non-variable :find elements are rejected before planning"),
+            Element::Variable(var) => Ok(var.clone()),
+            _ => Err(anyhow!(
+                "Incremental queries support only variables in :find"
+            )),
         })
         .collect()
+}
+
+fn plan_where_clause(clause: &WhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+    match clause {
+        WhereClause::Pattern(pattern) => Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?)),
+        WhereClause::OrJoin(or) => plan_or_join(or, schema),
+        _ => unreachable!("unsupported clauses are rejected before planning"),
+    }
+}
+
+fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<WhereTermPlan> {
+    if !matches!(&or.unify_vars, UnifyVars::Implicit) {
+        bail!("Incremental queries do not support explicit or-join");
+    }
+
+    let branches = or
+        .clauses
+        .iter()
+        .map(|branch| plan_or_branch(branch, schema))
+        .collect::<Result<Vec<_>>>()?;
+    let output_vars = branches
+        .first()
+        .map(|branch| branch.output_vars().to_vec())
+        .ok_or_else(|| anyhow!("OR clause must have at least one branch"))?;
+
+    Ok(WhereTermPlan::Or(OrPlan {
+        branches,
+        output_vars,
+    }))
+}
+
+fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<WhereTermPlan> {
+    match branch {
+        OrWhereClause::Clause(WhereClause::Pattern(pattern)) => {
+            Ok(WhereTermPlan::Pattern(plan_pattern(pattern, schema)?))
+        }
+        OrWhereClause::Clause(WhereClause::OrJoin(or)) => plan_or_join(or, schema),
+        OrWhereClause::Clause(_) | OrWhereClause::And(_) => {
+            bail!("Incremental query or branches currently support only triple patterns or nested or clauses")
+        }
+    }
 }
 
 fn plan_pattern(pattern: &Pattern, schema: &Schema) -> Result<PatternPlan> {
@@ -219,10 +307,10 @@ fn pattern_output_vars(entity: &PatternSlot, value: &PatternSlot) -> Vec<Variabl
     vars
 }
 
-fn collect_variables(patterns: &[PatternPlan]) -> Vec<Variable> {
+fn collect_variables(terms: &[WhereTermPlan]) -> Vec<Variable> {
     let mut variables = Vec::new();
-    for pattern in patterns {
-        for var in &pattern.output_vars {
+    for term in terms {
+        for var in term.output_vars() {
             if !variables.contains(var) {
                 variables.push(var.clone());
             }
@@ -231,13 +319,22 @@ fn collect_variables(patterns: &[PatternPlan]) -> Vec<Variable> {
     variables
 }
 
-fn plan_joins(patterns: &[PatternPlan]) -> Vec<JoinPlan> {
+fn collect_leaf_patterns(terms: &[WhereTermPlan], patterns: &mut Vec<PatternPlan>) {
+    for term in terms {
+        match term {
+            WhereTermPlan::Pattern(pattern) => patterns.push(pattern.clone()),
+            WhereTermPlan::Or(or) => collect_leaf_patterns(&or.branches, patterns),
+        }
+    }
+}
+
+fn plan_joins(terms: &[WhereTermPlan]) -> Vec<JoinPlan> {
     let mut joins = Vec::new();
-    let mut left_vars = patterns[0].output_vars.clone();
+    let mut left_vars = terms[0].output_vars().to_vec();
     let mut bound: HashSet<Variable> = left_vars.iter().cloned().collect();
 
-    for (right_pattern_index, pattern) in patterns.iter().enumerate().skip(1) {
-        let right_vars = pattern.output_vars.clone();
+    for (right_term_index, term) in terms.iter().enumerate().skip(1) {
+        let right_vars = term.output_vars().to_vec();
         let right_set: HashSet<Variable> = right_vars.iter().cloned().collect();
         // Note: Not using intersection to preserve ordering from left_vars
         let key_vars = left_vars
@@ -254,7 +351,7 @@ fn plan_joins(patterns: &[PatternPlan]) -> Vec<JoinPlan> {
         }
 
         joins.push(JoinPlan {
-            right_pattern_index,
+            right_term_index,
             left_vars,
             right_vars,
             key_vars,
@@ -350,7 +447,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.joins.len(), 1);
-        assert_eq!(plan.joins[0].right_pattern_index, 1);
+        assert_eq!(plan.joins[0].right_term_index, 1);
         assert_eq!(plan.joins[0].key_vars, vec!["?e".to_var()]);
         assert_eq!(
             plan.joins[0].output_vars,
@@ -369,7 +466,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(plan.joins[0].right_pattern_index, 1);
+        assert_eq!(plan.joins[0].right_term_index, 1);
         assert_eq!(plan.joins[0].key_vars, vec!["?friend".to_var()]);
     }
 
@@ -415,8 +512,67 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.joins.len(), 1);
-        assert_eq!(plan.joins[0].right_pattern_index, 1);
+        assert_eq!(plan.joins[0].right_term_index, 1);
         assert!(plan.joins[0].key_vars.is_empty());
+    }
+
+    #[test]
+    fn plans_flat_or_clause() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(r#"[:find ?e :where (or [?e :name "Alice"] [?e :name "Bob"])]"#),
+            &schema,
+        )
+        .unwrap();
+
+        assert_eq!(plan.find_vars, vec!["?e".to_var()]);
+        assert_eq!(plan.variables, vec!["?e".to_var()]);
+        assert_eq!(plan.patterns.len(), 2);
+        assert_eq!(plan.patterns[0].attribute, 10);
+        assert_eq!(plan.patterns[0].value, encoded_string("Alice"));
+        assert_eq!(plan.patterns[1].attribute, 10);
+        assert_eq!(plan.patterns[1].value, encoded_string("Bob"));
+    }
+
+    #[test]
+    fn plans_nested_or_clause() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                r#"[:find ?e :where (or [?e :name "Alice"] (or [?e :name "Bob"] [?e :name "Cara"]))]"#,
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        assert_eq!(plan.variables, vec!["?e".to_var()]);
+        assert_eq!(plan.patterns.len(), 3);
+        assert!(plan.joins.is_empty());
+        assert!(matches!(plan.where_terms[0], WhereTermPlan::Or(_)));
+    }
+
+    #[test]
+    fn plans_or_clause_with_branch_specific_variable_order() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(r#"[:find ?e ?v :where (or [?e :name ?v] [?v :follows ?e])]"#),
+            &schema,
+        )
+        .unwrap();
+
+        assert_eq!(plan.variables, vec!["?e".to_var(), "?v".to_var()]);
+        let WhereTermPlan::Or(or) = &plan.where_terms[0] else {
+            panic!("expected or term");
+        };
+        assert_eq!(or.output_vars, vec!["?e".to_var(), "?v".to_var()]);
+        assert_eq!(
+            or.branches[0].output_vars(),
+            &["?e".to_var(), "?v".to_var()]
+        );
+        assert_eq!(
+            or.branches[1].output_vars(),
+            &["?v".to_var(), "?e".to_var()]
+        );
     }
 
     #[test]
@@ -470,16 +626,20 @@ mod tests {
     #[test]
     fn rejects_unsupported_where_forms() {
         assert_plan_err(
-            r#"[:find ?e :where [?e :name "Alice"] [(< ?e 2)]]"#,
-            "only triple patterns",
-        );
-        assert_plan_err(
-            r#"[:find ?e :where (or [?e :name "Alice"] [?e :name "Bob"])]"#,
-            "only triple patterns",
+            r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#,
+            "only triple patterns and or clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] (not [?e :age 30])]"#,
-            "only triple patterns",
+            "only triple patterns and or clauses",
+        );
+        assert_plan_err(
+            r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#,
+            "or branches currently support only triple patterns or nested or clauses",
+        );
+        assert_plan_err(
+            r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,
+            "explicit or-join",
         );
     }
 

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -510,7 +510,7 @@ mod tests {
 
     use super::*;
     use crate::codec::Encode;
-    use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot, WhereTermPlan};
+    use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot, RelPlan, RelPlanKind};
 
     #[test]
     fn unregister_removes_query_storage() {
@@ -845,8 +845,10 @@ mod tests {
         IncrementalQueryPlan {
             find_vars: vec!["?name".to_var()],
             variables: vec!["?e".to_var(), "?name".to_var()],
-            where_terms: vec![WhereTermPlan::Pattern(pattern.clone())],
-            joins: vec![],
+            where_plan: RelPlan {
+                output_vars: pattern.output_vars.clone(),
+                kind: RelPlanKind::Pattern(pattern),
+            },
         }
     }
 

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -847,7 +847,6 @@ mod tests {
             variables: vec!["?e".to_var(), "?name".to_var()],
             where_terms: vec![WhereTermPlan::Pattern(pattern.clone())],
             joins: vec![],
-            patterns: vec![pattern],
         }
     }
 

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -510,7 +510,7 @@ mod tests {
 
     use super::*;
     use crate::codec::Encode;
-    use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot};
+    use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot, WhereTermPlan};
 
     #[test]
     fn unregister_removes_query_storage() {
@@ -845,6 +845,7 @@ mod tests {
         IncrementalQueryPlan {
             find_vars: vec!["?name".to_var()],
             variables: vec!["?e".to_var(), "?name".to_var()],
+            where_terms: vec![WhereTermPlan::Pattern(pattern.clone())],
             joins: vec![],
             patterns: vec![pattern],
         }

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -145,6 +145,7 @@ pub(crate) async fn scan_current_triples<D>(
 where
     D: slatedb::DbReadOps + Sync,
 {
+    // TODO: maybe this should be become a function on IncrementalQueryPlan
     let attributes = plan
         .leaf_patterns()
         .into_iter()

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -146,8 +146,8 @@ where
     D: slatedb::DbReadOps + Sync,
 {
     let attributes = plan
-        .patterns
-        .iter()
+        .leaf_patterns()
+        .into_iter()
         .map(|pattern| pattern.attribute)
         .collect::<HashSet<_>>();
     let mut latest_by_triple: HashMap<EncodedTriple, (i64, u8)> = HashMap::new();

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -475,75 +475,6 @@ mod tests {
         )
     }
 
-    fn flat_or_plan() -> IncrementalQueryPlan {
-        let alice = PatternPlan {
-            attribute: 10,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
-            output_vars: vec!["?e".to_var()],
-        };
-        let bob = PatternPlan {
-            attribute: 10,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Constant(DataType::String("Bob".to_string()).encode()),
-            output_vars: vec!["?e".to_var()],
-        };
-        IncrementalQueryPlan {
-            find_vars: vec!["?e".to_var()],
-            variables: vec!["?e".to_var()],
-            where_plan: union_rel(
-                vec!["?e".to_var()],
-                vec![pattern_rel(alice.clone()), pattern_rel(bob.clone())],
-            ),
-        }
-    }
-
-    fn overlapping_or_plan() -> IncrementalQueryPlan {
-        let named = PatternPlan {
-            attribute: 10,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
-            output_vars: vec!["?e".to_var()],
-        };
-        let typed = PatternPlan {
-            attribute: 13,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Constant(DataType::Keyword(kw!(:person)).encode()),
-            output_vars: vec!["?e".to_var()],
-        };
-        IncrementalQueryPlan {
-            find_vars: vec!["?e".to_var()],
-            variables: vec!["?e".to_var()],
-            where_plan: union_rel(
-                vec!["?e".to_var()],
-                vec![pattern_rel(named.clone()), pattern_rel(typed.clone())],
-            ),
-        }
-    }
-
-    fn reordered_branch_or_plan() -> IncrementalQueryPlan {
-        let name = PatternPlan {
-            attribute: 10,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Variable("?v".to_var()),
-            output_vars: vec!["?e".to_var(), "?v".to_var()],
-        };
-        let follows = PatternPlan {
-            attribute: 12,
-            entity: PatternSlot::Variable("?v".to_var()),
-            value: PatternSlot::Variable("?e".to_var()),
-            output_vars: vec!["?v".to_var(), "?e".to_var()],
-        };
-        IncrementalQueryPlan {
-            find_vars: vec!["?e".to_var(), "?v".to_var()],
-            variables: vec!["?e".to_var(), "?v".to_var()],
-            where_plan: union_rel(
-                vec!["?e".to_var(), "?v".to_var()],
-                vec![pattern_rel(name.clone()), pattern_rel(follows.clone())],
-            ),
-        }
-    }
-
     fn reordered_join_plan() -> IncrementalQueryPlan {
         let patterns = vec![
             PatternPlan {
@@ -771,8 +702,28 @@ mod tests {
 
     #[test]
     fn or_stream_emits_disjoint_union() {
+        let alice = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let bob = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Bob".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let plan = IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var()],
+            variables: vec!["?e".to_var()],
+            where_plan: union_rel(
+                vec!["?e".to_var()],
+                vec![pattern_rel(alice), pattern_rel(bob)],
+            ),
+        };
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, flat_or_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -794,8 +745,28 @@ mod tests {
 
     #[test]
     fn or_stream_collapses_overlapping_branches() {
+        let named = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let typed = PatternPlan {
+            attribute: 13,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::Keyword(kw!(:person)).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let plan = IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var()],
+            variables: vec!["?e".to_var()],
+            where_plan: union_rel(
+                vec!["?e".to_var()],
+                vec![pattern_rel(named), pattern_rel(typed)],
+            ),
+        };
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, overlapping_or_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -832,8 +803,28 @@ mod tests {
 
     #[test]
     fn or_stream_normalizes_branch_row_order() {
+        let name = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Variable("?v".to_var()),
+            output_vars: vec!["?e".to_var(), "?v".to_var()],
+        };
+        let follows = PatternPlan {
+            attribute: 12,
+            entity: PatternSlot::Variable("?v".to_var()),
+            value: PatternSlot::Variable("?e".to_var()),
+            output_vars: vec!["?v".to_var(), "?e".to_var()],
+        };
+        let plan = IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var(), "?v".to_var()],
+            variables: vec!["?e".to_var(), "?v".to_var()],
+            where_plan: union_rel(
+                vec!["?e".to_var(), "?v".to_var()],
+                vec![pattern_rel(name), pattern_rel(follows)],
+            ),
+        };
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, reordered_branch_or_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -11,7 +11,7 @@ use dbsp::{
 use edn::query::Variable;
 
 use crate::codec::Decode;
-use crate::inc_query::{IncrementalQueryPlan, JoinPlan, PatternPlan, PatternSlot};
+use crate::inc_query::{IncrementalQueryPlan, JoinPlan, PatternPlan, PatternSlot, WhereTermPlan};
 use crate::incremental::{EncodedRow, EncodedTriple};
 use crate::ops::DataType;
 
@@ -144,17 +144,55 @@ pub(crate) struct PlannedWhereStream {
     vars: Vec<Variable>,
 }
 
+fn project_stream(
+    rows: Stream<RootCircuit, RowZSet>,
+    source_vars: &[Variable],
+    target_vars: &[Variable],
+) -> Stream<RootCircuit, RowZSet> {
+    let selected_positions = positions(source_vars, target_vars);
+    rows.map(move |row| select_row_positions(row, &selected_positions))
+}
+
+fn term_stream(
+    input: &Stream<RootCircuit, OrdZSet<EncodedTriple>>,
+    term: &WhereTermPlan,
+) -> PlannedWhereStream {
+    match term {
+        WhereTermPlan::Pattern(pattern) => PlannedWhereStream {
+            rows: pattern_stream(input, pattern.clone()),
+            vars: pattern.output_vars.clone(),
+        },
+        WhereTermPlan::Or(or) => {
+            let mut branches = or
+                .branches
+                .iter()
+                .map(|branch| {
+                    let branch = term_stream(input, branch);
+                    project_stream(branch.rows, &branch.vars, &or.output_vars)
+                })
+                .collect::<Vec<_>>();
+            let first = branches.remove(0);
+            let rows = first.sum(branches.iter()).distinct();
+            PlannedWhereStream {
+                rows,
+                vars: or.output_vars.clone(),
+            }
+        }
+    }
+}
+
 // Creates the DBSP stream of joined where rows for the whole incremental query plan.
 pub(crate) fn query_where_stream(
     input: &Stream<RootCircuit, OrdZSet<EncodedTriple>>,
     plan: &IncrementalQueryPlan,
 ) -> PlannedWhereStream {
-    let mut rows = pattern_stream(input, plan.patterns[0].clone());
-    let mut vars = plan.patterns[0].output_vars.clone();
+    let first = term_stream(input, &plan.where_terms[0]);
+    let mut rows = first.rows;
+    let mut vars = first.vars;
 
     for join in &plan.joins {
-        let right = pattern_stream(input, plan.patterns[join.right_pattern_index].clone());
-        rows = join_rows(rows, right, join);
+        let right = term_stream(input, &plan.where_terms[join.right_term_index]);
+        rows = join_rows(rows, right.rows, join);
         vars = join.output_vars.clone();
     }
 
@@ -261,12 +299,13 @@ mod tests {
     use dbsp::{
         utils::Tup2, DBSPHandle, OrdZSet, OutputHandle, RootCircuit, Runtime, ZSetHandle, ZWeight,
     };
+    use edn::kw;
     use edn::query::ToVariable;
     use tempfile::TempDir;
 
     use super::*;
     use crate::codec::Encode;
-    use crate::inc_query::{IncrementalQueryPlan, JoinPlan, PatternSlot};
+    use crate::inc_query::{IncrementalQueryPlan, JoinPlan, OrPlan, PatternSlot, WhereTermPlan};
     use crate::ops::DataType;
 
     fn build_pattern_circuit(
@@ -356,6 +395,26 @@ mod tests {
         }
     }
 
+    fn plan_from_patterns(
+        find_vars: Vec<Variable>,
+        variables: Vec<Variable>,
+        patterns: Vec<PatternPlan>,
+        joins: Vec<JoinPlan>,
+    ) -> IncrementalQueryPlan {
+        let where_terms = patterns
+            .iter()
+            .cloned()
+            .map(WhereTermPlan::Pattern)
+            .collect();
+        IncrementalQueryPlan {
+            find_vars,
+            variables,
+            where_terms,
+            patterns,
+            joins,
+        }
+    }
+
     fn entity_join_plan() -> IncrementalQueryPlan {
         let patterns = vec![
             PatternPlan {
@@ -371,17 +430,101 @@ mod tests {
                 output_vars: vec!["?e".to_var(), "?age".to_var()],
             },
         ];
-        IncrementalQueryPlan {
-            find_vars: vec!["?name".to_var(), "?age".to_var()],
-            variables: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-            joins: vec![JoinPlan {
-                right_pattern_index: 1,
+        plan_from_patterns(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            patterns.clone(),
+            vec![JoinPlan {
+                right_term_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec!["?e".to_var()],
                 output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
             }],
-            patterns,
+        )
+    }
+
+    fn flat_or_plan() -> IncrementalQueryPlan {
+        let alice = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let bob = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Bob".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var()],
+            variables: vec!["?e".to_var()],
+            where_terms: vec![WhereTermPlan::Or(OrPlan {
+                branches: vec![
+                    WhereTermPlan::Pattern(alice.clone()),
+                    WhereTermPlan::Pattern(bob.clone()),
+                ],
+                output_vars: vec!["?e".to_var()],
+            })],
+            patterns: vec![alice, bob],
+            joins: vec![],
+        }
+    }
+
+    fn overlapping_or_plan() -> IncrementalQueryPlan {
+        let named = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::String("Alice".to_string()).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        let typed = PatternPlan {
+            attribute: 13,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Constant(DataType::Keyword(kw!(:person)).encode()),
+            output_vars: vec!["?e".to_var()],
+        };
+        IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var()],
+            variables: vec!["?e".to_var()],
+            where_terms: vec![WhereTermPlan::Or(OrPlan {
+                branches: vec![
+                    WhereTermPlan::Pattern(named.clone()),
+                    WhereTermPlan::Pattern(typed.clone()),
+                ],
+                output_vars: vec!["?e".to_var()],
+            })],
+            patterns: vec![named, typed],
+            joins: vec![],
+        }
+    }
+
+    fn reordered_branch_or_plan() -> IncrementalQueryPlan {
+        let name = PatternPlan {
+            attribute: 10,
+            entity: PatternSlot::Variable("?e".to_var()),
+            value: PatternSlot::Variable("?v".to_var()),
+            output_vars: vec!["?e".to_var(), "?v".to_var()],
+        };
+        let follows = PatternPlan {
+            attribute: 12,
+            entity: PatternSlot::Variable("?v".to_var()),
+            value: PatternSlot::Variable("?e".to_var()),
+            output_vars: vec!["?v".to_var(), "?e".to_var()],
+        };
+        IncrementalQueryPlan {
+            find_vars: vec!["?e".to_var(), "?v".to_var()],
+            variables: vec!["?e".to_var(), "?v".to_var()],
+            where_terms: vec![WhereTermPlan::Or(OrPlan {
+                branches: vec![
+                    WhereTermPlan::Pattern(name.clone()),
+                    WhereTermPlan::Pattern(follows.clone()),
+                ],
+                output_vars: vec!["?e".to_var(), "?v".to_var()],
+            })],
+            patterns: vec![name, follows],
+            joins: vec![],
         }
     }
 
@@ -406,24 +549,25 @@ mod tests {
                 output_vars: vec!["?e".to_var(), "?friend".to_var()],
             },
         ];
-        IncrementalQueryPlan {
-            find_vars: vec!["?friend".to_var(), "?age".to_var()],
-            variables: vec![
+        plan_from_patterns(
+            vec!["?friend".to_var(), "?age".to_var()],
+            vec![
                 "?e".to_var(),
                 "?name".to_var(),
                 "?age".to_var(),
                 "?friend".to_var(),
             ],
-            joins: vec![
+            patterns.clone(),
+            vec![
                 JoinPlan {
-                    right_pattern_index: 2,
+                    right_term_index: 2,
                     left_vars: patterns[0].output_vars.clone(),
                     right_vars: patterns[2].output_vars.clone(),
                     key_vars: vec!["?e".to_var()],
                     output_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
                 },
                 JoinPlan {
-                    right_pattern_index: 1,
+                    right_term_index: 1,
                     left_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
                     right_vars: patterns[1].output_vars.clone(),
                     key_vars: vec!["?e".to_var()],
@@ -435,8 +579,7 @@ mod tests {
                     ],
                 },
             ],
-            patterns,
-        }
+        )
     }
 
     #[test]
@@ -611,6 +754,95 @@ mod tests {
     }
 
     #[test]
+    fn or_stream_emits_disjoint_union() {
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(|circuit| build_find_circuit(circuit, flat_or_plan()));
+
+        append(
+            &handle,
+            [
+                (triple(1, 10, DataType::String("Alice".to_string())), 1),
+                (triple(2, 10, DataType::String("Bob".to_string())), 1),
+                (triple(3, 10, DataType::String("Charlie".to_string())), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+
+        let mut rows = decode_output_rows(&output.consolidate()).unwrap();
+        rows.sort_by_key(|row| format!("{:?}", row));
+        assert_eq!(
+            rows,
+            vec![(vec![DataType::Long(1)], 1), (vec![DataType::Long(2)], 1),]
+        );
+    }
+
+    #[test]
+    fn or_stream_collapses_overlapping_branches() {
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(|circuit| build_find_circuit(circuit, overlapping_or_plan()));
+
+        append(
+            &handle,
+            [
+                (triple(1, 10, DataType::String("Alice".to_string())), 1),
+                (triple(1, 13, DataType::Keyword(kw!(:person))), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::Long(1)], 1)]
+        );
+
+        append(
+            &handle,
+            [(triple(1, 10, DataType::String("Alice".to_string())), -1)],
+        );
+        circuit.transaction().unwrap();
+        assert!(decode_output_rows(&output.consolidate())
+            .unwrap()
+            .is_empty());
+
+        append(
+            &handle,
+            [(triple(1, 13, DataType::Keyword(kw!(:person))), -1)],
+        );
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::Long(1)], -1)]
+        );
+    }
+
+    #[test]
+    fn or_stream_normalizes_branch_row_order() {
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(|circuit| build_find_circuit(circuit, reordered_branch_or_plan()));
+
+        append(
+            &handle,
+            [
+                (triple(1, 10, DataType::String("Alice".to_string())), 1),
+                (triple(2, 12, DataType::Long(1)), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+
+        let mut rows = decode_output_rows(&output.consolidate()).unwrap();
+        rows.sort_by_key(|row| format!("{:?}", row));
+        assert_eq!(
+            rows,
+            vec![
+                (vec![DataType::Long(1), DataType::Long(2)], 1),
+                (
+                    vec![DataType::Long(1), DataType::String("Alice".to_string())],
+                    1,
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn joins_through_ref_value() {
         let patterns = vec![
             PatternPlan {
@@ -626,18 +858,18 @@ mod tests {
                 output_vars: vec!["?friend".to_var(), "?friend-name".to_var()],
             },
         ];
-        let plan = IncrementalQueryPlan {
-            find_vars: vec!["?friend-name".to_var()],
-            variables: vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
-            joins: vec![JoinPlan {
-                right_pattern_index: 1,
+        let plan = plan_from_patterns(
+            vec!["?friend-name".to_var()],
+            vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
+            patterns.clone(),
+            vec![JoinPlan {
+                right_term_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec!["?friend".to_var()],
                 output_vars: vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
             }],
-            patterns,
-        };
+        );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
 
@@ -666,14 +898,17 @@ mod tests {
     #[test]
     fn joins_three_pattern_chain() {
         let mut plan = entity_join_plan();
-        plan.patterns.push(PatternPlan {
+        let follows_pattern = PatternPlan {
             attribute: 12,
             entity: PatternSlot::Variable("?e".to_var()),
             value: PatternSlot::Variable("?friend".to_var()),
             output_vars: vec!["?e".to_var(), "?friend".to_var()],
-        });
+        };
+        plan.patterns.push(follows_pattern.clone());
+        plan.where_terms
+            .push(WhereTermPlan::Pattern(follows_pattern));
         plan.joins.push(JoinPlan {
-            right_pattern_index: 2,
+            right_term_index: 2,
             left_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
             right_vars: vec!["?e".to_var(), "?friend".to_var()],
             key_vars: vec!["?e".to_var()],
@@ -728,16 +963,17 @@ mod tests {
                 output_vars: vec!["?other".to_var(), "?age".to_var()],
             },
         ];
-        let plan = IncrementalQueryPlan {
-            find_vars: vec!["?name".to_var(), "?age".to_var()],
-            variables: vec![
+        let plan = plan_from_patterns(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec![
                 "?e".to_var(),
                 "?name".to_var(),
                 "?other".to_var(),
                 "?age".to_var(),
             ],
-            joins: vec![JoinPlan {
-                right_pattern_index: 1,
+            patterns.clone(),
+            vec![JoinPlan {
+                right_term_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec![],
@@ -748,8 +984,7 @@ mod tests {
                     "?age".to_var(),
                 ],
             }],
-            patterns,
-        };
+        );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
 

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -427,106 +427,16 @@ mod tests {
         }
     }
 
-    fn plan_from_patterns(
+    fn query_plan(
         find_vars: Vec<Variable>,
         variables: Vec<Variable>,
-        patterns: Vec<PatternPlan>,
-        steps: Vec<JoinStep>,
+        where_plan: RelPlan,
     ) -> IncrementalQueryPlan {
-        let mut inputs = patterns.into_iter().map(pattern_rel).collect::<Vec<_>>();
-        let where_plan = if inputs.len() == 1 {
-            inputs.remove(0)
-        } else {
-            join_rel(inputs, steps)
-        };
         IncrementalQueryPlan {
             find_vars,
             variables,
             where_plan,
         }
-    }
-
-    fn entity_join_plan() -> IncrementalQueryPlan {
-        let patterns = vec![
-            PatternPlan {
-                attribute: 10,
-                entity: PatternSlot::Variable("?e".to_var()),
-                value: PatternSlot::Variable("?name".to_var()),
-                output_vars: vec!["?e".to_var(), "?name".to_var()],
-            },
-            PatternPlan {
-                attribute: 11,
-                entity: PatternSlot::Variable("?e".to_var()),
-                value: PatternSlot::Variable("?age".to_var()),
-                output_vars: vec!["?e".to_var(), "?age".to_var()],
-            },
-        ];
-        plan_from_patterns(
-            vec!["?name".to_var(), "?age".to_var()],
-            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-            patterns.clone(),
-            vec![JoinStep {
-                right_input_index: 1,
-                left_vars: patterns[0].output_vars.clone(),
-                right_vars: patterns[1].output_vars.clone(),
-                key_vars: vec!["?e".to_var()],
-                output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-            }],
-        )
-    }
-
-    fn reordered_join_plan() -> IncrementalQueryPlan {
-        let patterns = vec![
-            PatternPlan {
-                attribute: 10,
-                entity: PatternSlot::Variable("?e".to_var()),
-                value: PatternSlot::Variable("?name".to_var()),
-                output_vars: vec!["?e".to_var(), "?name".to_var()],
-            },
-            PatternPlan {
-                attribute: 11,
-                entity: PatternSlot::Variable("?e".to_var()),
-                value: PatternSlot::Variable("?age".to_var()),
-                output_vars: vec!["?e".to_var(), "?age".to_var()],
-            },
-            PatternPlan {
-                attribute: 12,
-                entity: PatternSlot::Variable("?e".to_var()),
-                value: PatternSlot::Variable("?friend".to_var()),
-                output_vars: vec!["?e".to_var(), "?friend".to_var()],
-            },
-        ];
-        plan_from_patterns(
-            vec!["?friend".to_var(), "?age".to_var()],
-            vec![
-                "?e".to_var(),
-                "?name".to_var(),
-                "?age".to_var(),
-                "?friend".to_var(),
-            ],
-            patterns.clone(),
-            vec![
-                JoinStep {
-                    right_input_index: 2,
-                    left_vars: patterns[0].output_vars.clone(),
-                    right_vars: patterns[2].output_vars.clone(),
-                    key_vars: vec!["?e".to_var()],
-                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
-                },
-                JoinStep {
-                    right_input_index: 1,
-                    left_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
-                    right_vars: patterns[1].output_vars.clone(),
-                    key_vars: vec!["?e".to_var()],
-                    output_vars: vec![
-                        "?e".to_var(),
-                        "?name".to_var(),
-                        "?friend".to_var(),
-                        "?age".to_var(),
-                    ],
-                },
-            ],
-        )
     }
 
     #[test]
@@ -535,8 +445,39 @@ mod tests {
         let storage_path = dir.path().join("query-1");
         std::fs::create_dir_all(&storage_path).unwrap();
         std::fs::write(storage_path.join("stale"), b"stale").unwrap();
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                }],
+            ),
+        );
 
-        let mut circuit = QueryCircuit::build(entity_join_plan(), &storage_path).unwrap();
+        let mut circuit = QueryCircuit::build(plan, &storage_path).unwrap();
         circuit
             .prime(vec![
                 Tup2(triple(42, 10, DataType::String("Alice".to_string())), 1),
@@ -624,8 +565,39 @@ mod tests {
 
     #[test]
     fn joins_two_patterns_on_entity() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                }],
+            ),
+        );
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_where_circuit(circuit, entity_join_plan()));
+            build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -652,8 +624,65 @@ mod tests {
 
     #[test]
     fn query_rows_follow_join_plan_order() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+            PatternPlan {
+                attribute: 12,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?friend".to_var()),
+                output_vars: vec!["?e".to_var(), "?friend".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?friend".to_var(), "?age".to_var()],
+            vec![
+                "?e".to_var(),
+                "?name".to_var(),
+                "?age".to_var(),
+                "?friend".to_var(),
+            ],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                    pattern_rel(patterns[2].clone()),
+                ],
+                vec![
+                    JoinStep {
+                        right_input_index: 2,
+                        left_vars: patterns[0].output_vars.clone(),
+                        right_vars: patterns[2].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
+                    },
+                    JoinStep {
+                        right_input_index: 1,
+                        left_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
+                        right_vars: patterns[1].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec![
+                            "?e".to_var(),
+                            "?name".to_var(),
+                            "?friend".to_var(),
+                            "?age".to_var(),
+                        ],
+                    },
+                ],
+            ),
+        );
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_where_circuit(circuit, reordered_join_plan()));
+            build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -681,8 +710,65 @@ mod tests {
 
     #[test]
     fn find_projection_uses_planned_output_order() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+            PatternPlan {
+                attribute: 12,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?friend".to_var()),
+                output_vars: vec!["?e".to_var(), "?friend".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?friend".to_var(), "?age".to_var()],
+            vec![
+                "?e".to_var(),
+                "?name".to_var(),
+                "?age".to_var(),
+                "?friend".to_var(),
+            ],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                    pattern_rel(patterns[2].clone()),
+                ],
+                vec![
+                    JoinStep {
+                        right_input_index: 2,
+                        left_vars: patterns[0].output_vars.clone(),
+                        right_vars: patterns[2].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
+                    },
+                    JoinStep {
+                        right_input_index: 1,
+                        left_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
+                        right_vars: patterns[1].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec![
+                            "?e".to_var(),
+                            "?name".to_var(),
+                            "?friend".to_var(),
+                            "?age".to_var(),
+                        ],
+                    },
+                ],
+            ),
+        );
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, reordered_join_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -851,7 +937,7 @@ mod tests {
 
     #[test]
     fn joins_through_ref_value() {
-        let patterns = vec![
+        let patterns = [
             PatternPlan {
                 attribute: 12,
                 entity: PatternSlot::Variable("?e".to_var()),
@@ -865,17 +951,22 @@ mod tests {
                 output_vars: vec!["?friend".to_var(), "?friend-name".to_var()],
             },
         ];
-        let plan = plan_from_patterns(
+        let plan = query_plan(
             vec!["?friend-name".to_var()],
             vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
-            patterns.clone(),
-            vec![JoinStep {
-                right_input_index: 1,
-                left_vars: patterns[0].output_vars.clone(),
-                right_vars: patterns[1].output_vars.clone(),
-                key_vars: vec!["?friend".to_var()],
-                output_vars: vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
-            }],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?friend".to_var()],
+                    output_vars: vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
+                }],
+            ),
         );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
@@ -904,7 +995,7 @@ mod tests {
 
     #[test]
     fn joins_three_pattern_chain() {
-        let patterns = vec![
+        let patterns = [
             PatternPlan {
                 attribute: 10,
                 entity: PatternSlot::Variable("?e".to_var()),
@@ -924,7 +1015,7 @@ mod tests {
                 output_vars: vec!["?e".to_var(), "?friend".to_var()],
             },
         ];
-        let plan = plan_from_patterns(
+        let plan = query_plan(
             vec!["?name".to_var(), "?age".to_var(), "?friend".to_var()],
             vec![
                 "?e".to_var(),
@@ -932,28 +1023,34 @@ mod tests {
                 "?age".to_var(),
                 "?friend".to_var(),
             ],
-            patterns.clone(),
-            vec![
-                JoinStep {
-                    right_input_index: 1,
-                    left_vars: patterns[0].output_vars.clone(),
-                    right_vars: patterns[1].output_vars.clone(),
-                    key_vars: vec!["?e".to_var()],
-                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-                },
-                JoinStep {
-                    right_input_index: 2,
-                    left_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-                    right_vars: patterns[2].output_vars.clone(),
-                    key_vars: vec!["?e".to_var()],
-                    output_vars: vec![
-                        "?e".to_var(),
-                        "?name".to_var(),
-                        "?age".to_var(),
-                        "?friend".to_var(),
-                    ],
-                },
-            ],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                    pattern_rel(patterns[2].clone()),
+                ],
+                vec![
+                    JoinStep {
+                        right_input_index: 1,
+                        left_vars: patterns[0].output_vars.clone(),
+                        right_vars: patterns[1].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                    },
+                    JoinStep {
+                        right_input_index: 2,
+                        left_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                        right_vars: patterns[2].output_vars.clone(),
+                        key_vars: vec!["?e".to_var()],
+                        output_vars: vec![
+                            "?e".to_var(),
+                            "?name".to_var(),
+                            "?age".to_var(),
+                            "?friend".to_var(),
+                        ],
+                    },
+                ],
+            ),
         );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
@@ -984,7 +1081,7 @@ mod tests {
 
     #[test]
     fn cartesian_product_when_patterns_share_no_variables() {
-        let patterns = vec![
+        let patterns = [
             PatternPlan {
                 attribute: 10,
                 entity: PatternSlot::Variable("?e".to_var()),
@@ -998,7 +1095,7 @@ mod tests {
                 output_vars: vec!["?other".to_var(), "?age".to_var()],
             },
         ];
-        let plan = plan_from_patterns(
+        let plan = query_plan(
             vec!["?name".to_var(), "?age".to_var()],
             vec![
                 "?e".to_var(),
@@ -1006,19 +1103,24 @@ mod tests {
                 "?other".to_var(),
                 "?age".to_var(),
             ],
-            patterns.clone(),
-            vec![JoinStep {
-                right_input_index: 1,
-                left_vars: patterns[0].output_vars.clone(),
-                right_vars: patterns[1].output_vars.clone(),
-                key_vars: vec![],
-                output_vars: vec![
-                    "?e".to_var(),
-                    "?name".to_var(),
-                    "?other".to_var(),
-                    "?age".to_var(),
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
                 ],
-            }],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec![],
+                    output_vars: vec![
+                        "?e".to_var(),
+                        "?name".to_var(),
+                        "?other".to_var(),
+                        "?age".to_var(),
+                    ],
+                }],
+            ),
         );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
@@ -1060,8 +1162,39 @@ mod tests {
 
     #[test]
     fn projects_rows_to_find_order_and_decodes() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                }],
+            ),
+        );
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, entity_join_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -1083,8 +1216,39 @@ mod tests {
 
     #[test]
     fn preserves_negative_delta_weights() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                }],
+            ),
+        );
         let (mut circuit, (handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, entity_join_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         append(
             &handle,
@@ -1106,8 +1270,39 @@ mod tests {
 
     #[test]
     fn empty_steps_decode_to_no_rows() {
+        let patterns = [
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+        ];
+        let plan = query_plan(
+            vec!["?name".to_var(), "?age".to_var()],
+            vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+            join_rel(
+                vec![
+                    pattern_rel(patterns[0].clone()),
+                    pattern_rel(patterns[1].clone()),
+                ],
+                vec![JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                }],
+            ),
+        );
         let (mut circuit, (_handle, output), _storage) =
-            build_test_circuit(|circuit| build_find_circuit(circuit, entity_join_plan()));
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
 
         circuit.transaction().unwrap();
 

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -11,7 +11,9 @@ use dbsp::{
 use edn::query::Variable;
 
 use crate::codec::Decode;
-use crate::inc_query::{IncrementalQueryPlan, JoinPlan, PatternPlan, PatternSlot, WhereTermPlan};
+use crate::inc_query::{
+    IncrementalQueryPlan, JoinStep, PatternPlan, PatternSlot, RelPlan, RelPlanKind,
+};
 use crate::incremental::{EncodedRow, EncodedTriple};
 use crate::ops::DataType;
 
@@ -97,7 +99,7 @@ fn merge_rows(left: &EncodedRow, right: &EncodedRow, sources: &[RowSource]) -> E
 fn join_rows(
     left: Stream<RootCircuit, RowZSet>,
     right: Stream<RootCircuit, RowZSet>,
-    join: &JoinPlan,
+    join: &JoinStep,
 ) -> Stream<RootCircuit, RowZSet> {
     let left_key_positions = positions(&join.left_vars, &join.key_vars);
     let right_key_positions = positions(&join.right_vars, &join.key_vars);
@@ -153,29 +155,42 @@ fn project_stream(
     rows.map(move |row| select_row_positions(row, &selected_positions))
 }
 
-fn term_stream(
+fn rel_stream(
     input: &Stream<RootCircuit, OrdZSet<EncodedTriple>>,
-    term: &WhereTermPlan,
+    plan: &RelPlan,
 ) -> PlannedWhereStream {
-    match term {
-        WhereTermPlan::Pattern(pattern) => PlannedWhereStream {
+    match &plan.kind {
+        RelPlanKind::Pattern(pattern) => PlannedWhereStream {
             rows: pattern_stream(input, pattern.clone()),
             vars: pattern.output_vars.clone(),
         },
-        WhereTermPlan::Or(or) => {
-            let mut branches = or
+        RelPlanKind::Join(join) => {
+            let first = rel_stream(input, &join.inputs[0]);
+            let mut rows = first.rows;
+            let mut vars = first.vars;
+
+            for step in &join.steps {
+                let right = rel_stream(input, &join.inputs[step.right_input_index]);
+                rows = join_rows(rows, right.rows, step);
+                vars = step.output_vars.clone();
+            }
+
+            PlannedWhereStream { rows, vars }
+        }
+        RelPlanKind::Union(union) => {
+            let mut branches = union
                 .branches
                 .iter()
                 .map(|branch| {
-                    let branch = term_stream(input, branch);
-                    project_stream(branch.rows, &branch.vars, &or.output_vars)
+                    let branch = rel_stream(input, branch);
+                    project_stream(branch.rows, &branch.vars, &plan.output_vars)
                 })
                 .collect::<Vec<_>>();
             let first = branches.remove(0);
             let rows = first.sum(branches.iter()).distinct();
             PlannedWhereStream {
                 rows,
-                vars: or.output_vars.clone(),
+                vars: plan.output_vars.clone(),
             }
         }
     }
@@ -186,17 +201,7 @@ pub(crate) fn query_where_stream(
     input: &Stream<RootCircuit, OrdZSet<EncodedTriple>>,
     plan: &IncrementalQueryPlan,
 ) -> PlannedWhereStream {
-    let first = term_stream(input, &plan.where_terms[0]);
-    let mut rows = first.rows;
-    let mut vars = first.vars;
-
-    for join in &plan.joins {
-        let right = term_stream(input, &plan.where_terms[join.right_term_index]);
-        rows = join_rows(rows, right.rows, join);
-        vars = join.output_vars.clone();
-    }
-
-    PlannedWhereStream { rows, vars }
+    rel_stream(input, &plan.where_plan)
 }
 
 // Creates the DBSP stream of rows projected to the query find variables.
@@ -305,7 +310,9 @@ mod tests {
 
     use super::*;
     use crate::codec::Encode;
-    use crate::inc_query::{IncrementalQueryPlan, JoinPlan, OrPlan, PatternSlot, WhereTermPlan};
+    use crate::inc_query::{
+        IncrementalQueryPlan, JoinPlan, JoinStep, PatternSlot, RelPlan, RelPlanKind, UnionPlan,
+    };
     use crate::ops::DataType;
 
     fn build_pattern_circuit(
@@ -395,22 +402,47 @@ mod tests {
         }
     }
 
+    fn pattern_rel(pattern: PatternPlan) -> RelPlan {
+        RelPlan {
+            output_vars: pattern.output_vars.clone(),
+            kind: RelPlanKind::Pattern(pattern),
+        }
+    }
+
+    fn join_rel(inputs: Vec<RelPlan>, steps: Vec<JoinStep>) -> RelPlan {
+        RelPlan {
+            output_vars: steps
+                .last()
+                .expect("join plan must have at least one step")
+                .output_vars
+                .clone(),
+            kind: RelPlanKind::Join(JoinPlan { inputs, steps }),
+        }
+    }
+
+    fn union_rel(output_vars: Vec<Variable>, branches: Vec<RelPlan>) -> RelPlan {
+        RelPlan {
+            output_vars,
+            kind: RelPlanKind::Union(UnionPlan { branches }),
+        }
+    }
+
     fn plan_from_patterns(
         find_vars: Vec<Variable>,
         variables: Vec<Variable>,
         patterns: Vec<PatternPlan>,
-        joins: Vec<JoinPlan>,
+        steps: Vec<JoinStep>,
     ) -> IncrementalQueryPlan {
-        let where_terms = patterns
-            .iter()
-            .cloned()
-            .map(WhereTermPlan::Pattern)
-            .collect();
+        let mut inputs = patterns.into_iter().map(pattern_rel).collect::<Vec<_>>();
+        let where_plan = if inputs.len() == 1 {
+            inputs.remove(0)
+        } else {
+            join_rel(inputs, steps)
+        };
         IncrementalQueryPlan {
             find_vars,
             variables,
-            where_terms,
-            joins,
+            where_plan,
         }
     }
 
@@ -433,8 +465,8 @@ mod tests {
             vec!["?name".to_var(), "?age".to_var()],
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
             patterns.clone(),
-            vec![JoinPlan {
-                right_term_index: 1,
+            vec![JoinStep {
+                right_input_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec!["?e".to_var()],
@@ -459,14 +491,10 @@ mod tests {
         IncrementalQueryPlan {
             find_vars: vec!["?e".to_var()],
             variables: vec!["?e".to_var()],
-            where_terms: vec![WhereTermPlan::Or(OrPlan {
-                branches: vec![
-                    WhereTermPlan::Pattern(alice.clone()),
-                    WhereTermPlan::Pattern(bob.clone()),
-                ],
-                output_vars: vec!["?e".to_var()],
-            })],
-            joins: vec![],
+            where_plan: union_rel(
+                vec!["?e".to_var()],
+                vec![pattern_rel(alice.clone()), pattern_rel(bob.clone())],
+            ),
         }
     }
 
@@ -486,14 +514,10 @@ mod tests {
         IncrementalQueryPlan {
             find_vars: vec!["?e".to_var()],
             variables: vec!["?e".to_var()],
-            where_terms: vec![WhereTermPlan::Or(OrPlan {
-                branches: vec![
-                    WhereTermPlan::Pattern(named.clone()),
-                    WhereTermPlan::Pattern(typed.clone()),
-                ],
-                output_vars: vec!["?e".to_var()],
-            })],
-            joins: vec![],
+            where_plan: union_rel(
+                vec!["?e".to_var()],
+                vec![pattern_rel(named.clone()), pattern_rel(typed.clone())],
+            ),
         }
     }
 
@@ -513,14 +537,10 @@ mod tests {
         IncrementalQueryPlan {
             find_vars: vec!["?e".to_var(), "?v".to_var()],
             variables: vec!["?e".to_var(), "?v".to_var()],
-            where_terms: vec![WhereTermPlan::Or(OrPlan {
-                branches: vec![
-                    WhereTermPlan::Pattern(name.clone()),
-                    WhereTermPlan::Pattern(follows.clone()),
-                ],
-                output_vars: vec!["?e".to_var(), "?v".to_var()],
-            })],
-            joins: vec![],
+            where_plan: union_rel(
+                vec!["?e".to_var(), "?v".to_var()],
+                vec![pattern_rel(name.clone()), pattern_rel(follows.clone())],
+            ),
         }
     }
 
@@ -555,15 +575,15 @@ mod tests {
             ],
             patterns.clone(),
             vec![
-                JoinPlan {
-                    right_term_index: 2,
+                JoinStep {
+                    right_input_index: 2,
                     left_vars: patterns[0].output_vars.clone(),
                     right_vars: patterns[2].output_vars.clone(),
                     key_vars: vec!["?e".to_var()],
                     output_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
                 },
-                JoinPlan {
-                    right_term_index: 1,
+                JoinStep {
+                    right_input_index: 1,
                     left_vars: vec!["?e".to_var(), "?name".to_var(), "?friend".to_var()],
                     right_vars: patterns[1].output_vars.clone(),
                     key_vars: vec!["?e".to_var()],
@@ -858,8 +878,8 @@ mod tests {
             vec!["?friend-name".to_var()],
             vec!["?e".to_var(), "?friend".to_var(), "?friend-name".to_var()],
             patterns.clone(),
-            vec![JoinPlan {
-                right_term_index: 1,
+            vec![JoinStep {
+                right_input_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec!["?friend".to_var()],
@@ -893,28 +913,57 @@ mod tests {
 
     #[test]
     fn joins_three_pattern_chain() {
-        let mut plan = entity_join_plan();
-        let follows_pattern = PatternPlan {
-            attribute: 12,
-            entity: PatternSlot::Variable("?e".to_var()),
-            value: PatternSlot::Variable("?friend".to_var()),
-            output_vars: vec!["?e".to_var(), "?friend".to_var()],
-        };
-        plan.where_terms
-            .push(WhereTermPlan::Pattern(follows_pattern));
-        plan.joins.push(JoinPlan {
-            right_term_index: 2,
-            left_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
-            right_vars: vec!["?e".to_var(), "?friend".to_var()],
-            key_vars: vec!["?e".to_var()],
-            output_vars: vec![
+        let patterns = vec![
+            PatternPlan {
+                attribute: 10,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?name".to_var()),
+                output_vars: vec!["?e".to_var(), "?name".to_var()],
+            },
+            PatternPlan {
+                attribute: 11,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?age".to_var()),
+                output_vars: vec!["?e".to_var(), "?age".to_var()],
+            },
+            PatternPlan {
+                attribute: 12,
+                entity: PatternSlot::Variable("?e".to_var()),
+                value: PatternSlot::Variable("?friend".to_var()),
+                output_vars: vec!["?e".to_var(), "?friend".to_var()],
+            },
+        ];
+        let plan = plan_from_patterns(
+            vec!["?name".to_var(), "?age".to_var(), "?friend".to_var()],
+            vec![
                 "?e".to_var(),
                 "?name".to_var(),
                 "?age".to_var(),
                 "?friend".to_var(),
             ],
-        });
-        plan.variables.push("?friend".to_var());
+            patterns.clone(),
+            vec![
+                JoinStep {
+                    right_input_index: 1,
+                    left_vars: patterns[0].output_vars.clone(),
+                    right_vars: patterns[1].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                },
+                JoinStep {
+                    right_input_index: 2,
+                    left_vars: vec!["?e".to_var(), "?name".to_var(), "?age".to_var()],
+                    right_vars: patterns[2].output_vars.clone(),
+                    key_vars: vec!["?e".to_var()],
+                    output_vars: vec![
+                        "?e".to_var(),
+                        "?name".to_var(),
+                        "?age".to_var(),
+                        "?friend".to_var(),
+                    ],
+                },
+            ],
+        );
         let (mut circuit, (handle, output), _storage) =
             build_test_circuit(move |circuit| build_where_circuit(circuit, plan.clone()));
 
@@ -967,8 +1016,8 @@ mod tests {
                 "?age".to_var(),
             ],
             patterns.clone(),
-            vec![JoinPlan {
-                right_term_index: 1,
+            vec![JoinStep {
+                right_input_index: 1,
                 left_vars: patterns[0].output_vars.clone(),
                 right_vars: patterns[1].output_vars.clone(),
                 key_vars: vec![],

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -410,7 +410,6 @@ mod tests {
             find_vars,
             variables,
             where_terms,
-            patterns,
             joins,
         }
     }
@@ -467,7 +466,6 @@ mod tests {
                 ],
                 output_vars: vec!["?e".to_var()],
             })],
-            patterns: vec![alice, bob],
             joins: vec![],
         }
     }
@@ -495,7 +493,6 @@ mod tests {
                 ],
                 output_vars: vec!["?e".to_var()],
             })],
-            patterns: vec![named, typed],
             joins: vec![],
         }
     }
@@ -523,7 +520,6 @@ mod tests {
                 ],
                 output_vars: vec!["?e".to_var(), "?v".to_var()],
             })],
-            patterns: vec![name, follows],
             joins: vec![],
         }
     }
@@ -904,7 +900,6 @@ mod tests {
             value: PatternSlot::Variable("?friend".to_var()),
             output_vars: vec!["?e".to_var(), "?friend".to_var()],
         };
-        plan.patterns.push(follows_pattern.clone());
         plan.where_terms
             .push(WhereTermPlan::Pattern(follows_pattern));
         plan.joins.push(JoinPlan {

--- a/src/node.rs
+++ b/src/node.rs
@@ -2702,38 +2702,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_primed_incremental_or_query_uses_existing_branch_rows() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-        execute_and_flush(
-            &node,
-            vec![TxOp::Add {
-                entity: EntityRef::Id(100),
-                attribute: kw!(:email),
-                value: DataType::String("alice@example.com".to_string()),
-            }],
-        )
-        .await;
-        let query = r#"[:find ?age :where (or [?e :name "Alice"] [?e :email "alice@example.com"]) [?e :age ?age]]"#;
-        let mut subscription = node
-            .register_incremental_query(parse_query(query), &[])
-            .await
-            .unwrap();
-        let mut rows = Vec::new();
-
-        let basis = execute_and_flush(
-            &node,
-            vec![TxOp::Add {
-                entity: EntityRef::Id(100),
-                attribute: kw!(:age),
-                value: DataType::Long(30),
-            }],
-        )
-        .await;
-        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
-    }
-
-    #[tokio::test]
     async fn test_register_incremental_query_rejects_unsupported_query() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/node.rs
+++ b/src/node.rs
@@ -2575,6 +2575,165 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_incremental_equivalence_flat_or() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        flush_wal(&node).await;
+        let query = r#"[:find ?e :where (or [?e :name "Alice"] [?e :name "Bob"])]"#;
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:name),
+                value: DataType::String("Alice".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(101),
+                attribute: kw!(:name),
+                value: DataType::String("Charlie".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(102),
+                attribute: kw!(:name),
+                value: DataType::String("Bob".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+    }
+
+    #[tokio::test]
+    async fn test_incremental_equivalence_or_joined_with_outer_pattern() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        flush_wal(&node).await;
+        let query =
+            r#"[:find ?age :where (or [?e :name "Alice"] [?e :name "Bob"]) [?e :age ?age]]"#;
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:name),
+                value: DataType::String("Alice".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:age),
+                value: DataType::Long(30),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![
+                TxOp::Add {
+                    entity: EntityRef::Id(101),
+                    attribute: kw!(:name),
+                    value: DataType::String("Bob".to_string()),
+                },
+                TxOp::Add {
+                    entity: EntityRef::Id(101),
+                    attribute: kw!(:age),
+                    value: DataType::Long(40),
+                },
+            ],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+    }
+
+    #[tokio::test]
+    async fn test_incremental_equivalence_nested_or() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        flush_wal(&node).await;
+        let query =
+            r#"[:find ?e :where (or [?e :name "Alice"] (or [?e :name "Bob"] [?e :name "Cara"]))]"#;
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        for (entity, name) in [(100, "Alice"), (101, "Bob"), (102, "Cara")] {
+            let basis = execute_and_flush(
+                &node,
+                vec![TxOp::Add {
+                    entity: EntityRef::Id(entity),
+                    attribute: kw!(:name),
+                    value: DataType::String(name.to_string()),
+                }],
+            )
+            .await;
+            assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_primed_incremental_or_query_uses_existing_branch_rows() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:email),
+                value: DataType::String("alice@example.com".to_string()),
+            }],
+        )
+        .await;
+        let query = r#"[:find ?age :where (or [?e :name "Alice"] [?e :email "alice@example.com"]) [?e :age ?age]]"#;
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:age),
+                value: DataType::Long(30),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+    }
+
+    #[tokio::test]
     async fn test_register_incremental_query_rejects_unsupported_query() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -411,6 +411,18 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_rejects_explicit_or_join() {
+        let parsed =
+            parse_query(r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#);
+        let err = validate_query(&parsed, &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("explicit or-join"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
     fn test_validate_rejects_nested_or_mismatched_branch_variables() {
         let parsed = parse_query(
             r#"[:find ?e :where (or [?e :name "A"] (or [?e :name "B"] [?v :name "C"]))]"#,

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::{Error, bail};
+use anyhow::{bail, Error};
 use edn::query::{
-    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace, PatternValuePlace, UnifyVars, Variable, WhereClause
+    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace,
+    PatternValuePlace, UnifyVars, Variable, WhereClause,
 };
 
 use crate::expr::expr_variables;

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -1,9 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::Error;
+use anyhow::{Error, bail};
 use edn::query::{
-    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace,
-    PatternValuePlace, Variable, WhereClause,
+    Binding, Element, FindSpec, Limit, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace, PatternValuePlace, UnifyVars, Variable, WhereClause
 };
 
 use crate::expr::expr_variables;
@@ -37,6 +36,9 @@ where
     validate_clause(clause)?;
     match clause {
         WhereClause::OrJoin(oj) => {
+            if !matches!(&oj.unify_vars, UnifyVars::Implicit) {
+                bail!("Incremental queries do not support explicit or-join");
+            }
             for branch in &oj.clauses {
                 validate_or_branch_recursively(branch, validate_clause)?;
             }

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -37,7 +37,7 @@ where
     match clause {
         WhereClause::OrJoin(oj) => {
             if !matches!(&oj.unify_vars, UnifyVars::Implicit) {
-                bail!("Incremental queries do not support explicit or-join");
+                bail!("Queries (currently) do not support explicit or-join");
             }
             for branch in &oj.clauses {
                 validate_or_branch_recursively(branch, validate_clause)?;

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -243,7 +243,7 @@
 (deftest test-or-joined-with-outer-pattern-retraction
   (with-open [conn (connect)]
     (api/transact conn people-schema)
-    (api/transact conn [{:name "Alice" :city "Paris"}
+    (api/transact conn [{:name "Alice" :city "Berlin"}
                         {:name "Bob" :city "Berlin"}
                         {:name "Carol" :city "Rome"}])
     (let [bob-id (single-value conn '{:find [?e]

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -225,6 +225,37 @@
         (api/transact conn [[:db/retract alice-id :city "NYC"]])
         (is (= [[["NYC"] -1]] (take-delta! sub)))))))
 
+(deftest test-or-retraction
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (api/transact conn [{:name "Alice"}
+                        {:name "Bob"}
+                        {:name "Carol"}])
+    (let [bob-id (single-value conn '{:find [?e]
+                                      :where [[?e :name "Bob"]]})]
+      (with-open [sub (api/subscribe conn '{:find [?e]
+                                            :where [(or [?e :name "Alice"]
+                                                        [?e :name "Bob"])]})]
+        (api/transact conn [[:db/retract bob-id :name "Bob"]])
+        (is (= [[[bob-id] -1]]
+               (take-delta! sub)))))))
+
+(deftest test-or-joined-with-outer-pattern-retraction
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (api/transact conn [{:name "Alice" :city "Paris"}
+                        {:name "Bob" :city "Berlin"}
+                        {:name "Carol" :city "Rome"}])
+    (let [bob-id (single-value conn '{:find [?e]
+                                      :where [[?e :name "Bob"]]})]
+      (with-open [sub (api/subscribe conn '{:find [?city]
+                                            :where [(or [?e :name "Alice"]
+                                                        [?e :name "Bob"])
+                                                    [?e :city ?city]]})]
+        (api/transact conn [[:db/retract bob-id :name "Bob"]])
+        (is (= [[["Berlin"] -1]]
+               (take-delta! sub)))))))
+
 (deftest test-prefix-stable-extension-addition
   (with-open [conn (connect)]
     (api/transact conn triangle-relation-schema)


### PR DESCRIPTION
## Summary
- add recursive incremental where-term planning for implicit `or` clauses
- compile branch streams with DBSP sum plus distinct semantics
- add planner, circuit, and node-level coverage for flat, nested, joined, overlapping, and primed `or` queries

## Verification
- `cargo fmt --check`
- `cargo test -p triplox`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated by Codex (GPT-5).