### PR TITLE
Reject incremental query args at node boundary

### DIFF
--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -296,10 +296,10 @@ the server remains healthy.
 
 Registers an incremental query and streams its result deltas. `db` is reserved
 for future historical replay and **MUST be `nil`/omitted** in this version (a
-non-nil `db` is rejected with HTTP 400 / `InvalidQuery`). `query` and `args` are
-as in [§4.4](#44-query-request--post-dbquery); queries the incremental engine
-does not yet support currently mirror one-shot query failures and are rejected
-with HTTP 500 / `QueryError` (code 2001).
+non-nil `db` is rejected with HTTP 400 / `InvalidQuery`). `args` is reserved for
+future incremental `:in` bindings and **MUST be empty** in this version. Queries
+or args the incremental engine does not yet support currently mirror one-shot
+query failures and are rejected with HTTP 500 / `QueryError` (code 2001).
 
 On success the response is **HTTP 200** with `Content-Type:
 application/vnd.triplox+msgpack` and a body that is a **frame stream** (§4.12),

--- a/src/node.rs
+++ b/src/node.rs
@@ -332,7 +332,14 @@ impl<L: TxLog> Node<L> {
     pub(crate) async fn register_incremental_query(
         &self,
         query: ParsedQuery,
+        args: &[QueryArg],
     ) -> Result<IncrementalQuerySubscription, Error> {
+        if !args.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Incremental query args are not supported yet"
+            ));
+        }
+
         self.incremental
             .register_query(self.slate.db.as_ref(), query, self.indexer.clone())
             .await
@@ -406,7 +413,7 @@ mod tests {
     use super::*;
     use crate::clock::st_from_unix_epoch;
     use crate::error::TriploxError;
-    use crate::ops::{DataType, EntityRef, TxOp};
+    use crate::ops::{DataType, EntityRef, QueryArg, TxOp};
     use crate::partition::{extract_partition, TX_PARTITION};
     use crate::schema::{
         test_schema_tx, unique_identity_schema_attribute, unique_value_schema_attribute,
@@ -1913,7 +1920,7 @@ mod tests {
         let expected_basis = *node.db().await.unwrap().tx_basis();
 
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
 
@@ -1925,11 +1932,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_register_incremental_query_rejects_non_empty_args() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let err = node
+            .register_incremental_query(
+                parse_query("[:find ?name :where [?e :name ?name]]"),
+                &[QueryArg::Scalar("Alice".into())],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Incremental query args are not supported yet"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
     async fn test_incremental_schema_query_before_user_tx_observes_schema_changes() {
         let node = Node::memory_node().await;
 
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?ident :where [?e :db/ident ?ident]]"))
+            .register_incremental_query(
+                parse_query("[:find ?ident :where [?e :db/ident ?ident]]"),
+                &[],
+            )
             .await
             .unwrap();
         let basis = match node.execute_tx(test_schema_tx()).await.unwrap() {
@@ -1968,7 +1999,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
 
@@ -1993,9 +2024,10 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         let mut subscription = node
-            .register_incremental_query(parse_query(
-                "[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]",
-            ))
+            .register_incremental_query(
+                parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]"),
+                &[],
+            )
             .await
             .unwrap();
         let future_basis = match node
@@ -2029,7 +2061,7 @@ mod tests {
         define_test_schema(&node).await;
         flush_wal(&node).await;
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let basis = match node
@@ -2073,7 +2105,7 @@ mod tests {
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         assert_eq!(subscription.basis, first_basis);
@@ -2112,7 +2144,7 @@ mod tests {
         define_test_schema(&node).await;
         flush_wal(&node).await;
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let basis = match node
@@ -2164,7 +2196,7 @@ mod tests {
         assert!(matches!(result, TransactionResult::TxCommited(_)));
         flush_wal(&node).await;
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let basis = match node
@@ -2200,9 +2232,10 @@ mod tests {
         define_test_schema(&node).await;
         flush_wal(&node).await;
         let mut subscription = node
-            .register_incremental_query(parse_query(
-                "[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]",
-            ))
+            .register_incremental_query(
+                parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]"),
+                &[],
+            )
             .await
             .unwrap();
         let mut rows = Vec::new();
@@ -2268,7 +2301,7 @@ mod tests {
         let mut subscription = node
             .register_incremental_query(parse_query(
                 "[:find ?name ?friend-name ?age :where [?e :name ?name] [?e :follows ?friend] [?friend :name ?friend-name] [?friend :age ?age]]",
-            ))
+            ), &[])
             .await
             .unwrap();
         let mut rows = Vec::new();
@@ -2344,7 +2377,7 @@ mod tests {
         let mut subscription = node
             .register_incremental_query(parse_query(
                 r#"[:find ?name ?age :where [?e :name ?name] [?other :age ?age] [?e :name "Alice"]]"#,
-            ))
+            ), &[])
             .await
             .unwrap();
         let mut rows = Vec::new();
@@ -2407,7 +2440,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let err = node
-            .register_incremental_query(parse_query("[:find ?name :where [_ :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [_ :name ?name]]"), &[])
             .await
             .unwrap_err();
 
@@ -2424,7 +2457,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let err = node
-            .register_incremental_query(parse_query("[:find ?e :where [?e :name _]]"))
+            .register_incremental_query(parse_query("[:find ?e :where [?e :name _]]"), &[])
             .await
             .unwrap_err();
 
@@ -2442,7 +2475,7 @@ mod tests {
         flush_wal(&node).await;
         let query = "[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]";
         let mut subscription = node
-            .register_incremental_query(parse_query(query))
+            .register_incremental_query(parse_query(query), &[])
             .await
             .unwrap();
         let mut rows = Vec::new();
@@ -2495,7 +2528,7 @@ mod tests {
         flush_wal(&node).await;
         let query = "[:find ?name ?age :where [?e :name ?name] [?other :age ?age]]";
         let mut subscription = node
-            .register_incremental_query(parse_query(query))
+            .register_incremental_query(parse_query(query), &[])
             .await
             .unwrap();
         let mut rows = Vec::new();
@@ -2540,7 +2573,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let err = node
-            .register_incremental_query(parse_query("[:find ?e :where [?e ?a ?v]]"))
+            .register_incremental_query(parse_query("[:find ?e :where [?e ?a ?v]]"), &[])
             .await
             .unwrap_err();
 
@@ -2555,7 +2588,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let mut subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let handle = subscription.handle;
@@ -2571,7 +2604,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let handle = subscription.handle;
@@ -2588,7 +2621,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
         let handle = subscription.handle;
@@ -2606,7 +2639,7 @@ mod tests {
         let storage_path = dir.path().join("dbsp-incremental").join("query-1");
 
         let _subscription = node
-            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"))
+            .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -334,7 +334,7 @@ async fn subscribe<L: TxLog + 'static>(
 
     let subscription = state
         .node
-        .register_incremental_query(parsed)
+        .register_incremental_query(parsed, &request.args)
         .await
         .map_err(|e| ApiError::internal(ErrorCode::QueryError, e.to_string()))?;
 
@@ -631,17 +631,22 @@ async fn serve_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::{DataType, QueryArg};
     use futures::StreamExt;
     use triplox_client::msgpack_codec::{
         decode_subscription_frame, encode_subscribe_request, SubscribeRequest,
     };
 
     fn subscribe_body(query: &str, db: Option<TxBasis>) -> Bytes {
+        subscribe_body_with_args(query, db, vec![])
+    }
+
+    fn subscribe_body_with_args(query: &str, db: Option<TxBasis>, args: Vec<QueryArg>) -> Bytes {
         Bytes::from(
             encode_subscribe_request(&SubscribeRequest {
                 db,
                 query: query.to_string(),
-                args: vec![],
+                args,
             })
             .expect("encode subscribe request"),
         )
@@ -689,6 +694,29 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(err.code, ErrorCode::QueryError);
+    }
+
+    #[tokio::test]
+    async fn subscribe_rejects_non_empty_args() {
+        let server = Arc::new(Server::new(Arc::new(Node::memory_node().await)));
+        let err = subscribe(
+            State(server),
+            subscribe_body_with_args(
+                "[:find ?n :where [?e :name ?n]]",
+                None,
+                vec![QueryArg::Scalar(DataType::String("Ivan".to_string()))],
+            ),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.code, ErrorCode::QueryError);
+        assert!(
+            err.message
+                .contains("Incremental query args are not supported yet"),
+            "unexpected error: {}",
+            err.message
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- thread subscribe request args into node-level incremental query registration
- reject non-empty incremental query args until incremental `:in` support exists
- document that subscribe args are reserved and must be empty for now

Closes #363

## Tests
- `cargo fmt`
- `cargo test -p triplox rejects_non_empty_args`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated with GPT-5 Codex.