### PR TITLE
Reject unallocated explicit entity IDs

### DIFF
--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -35,26 +35,31 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - Converts DatomExpanded -> DatomWithTempids (eliminates LookupRef variants)
    - Errors if any lookup ref has no matching entity
                                 ↓
-4. Resolve tempids/upserts      tempids::resolve_tempids(...)
+4. Validate explicit IDs        tx::validate_allocated_entity_ids(...)
+   - Concrete entity IDs must already be allocated in their partition
+   - Ref-typed Long values must point to already allocated entity IDs
+   - Tempids remain deferred and can still allocate within this transaction
+                                ↓
+5. Resolve tempids/upserts      tempids::resolve_tempids(...)
    - Splits DatomWithTempids into Mentat-style Generation populations
    - Resolves :db.unique/identity tempids against unique-only VAE
    - Evolves complex upserts until no simple upserts remain
    - Allocates remaining tempids, coalescing unresolved identity matches
    Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
                                 ↓
-5. Cardinality resolution       finalize_datoms_for_commit (EAV scan for card-one auto-retract)
+6. Cardinality resolution       finalize_datoms_for_commit (EAV scan for card-one auto-retract)
                                 ↓
-6. Validate                     validate_unique_constraints + schema.validate_datoms(datoms)
+7. Validate                     validate_unique_constraints + schema.validate_datoms(datoms)
    - Unique checks for :db.unique/value and :db.unique/identity
    - Type checking: value type matches attribute's value_type
    - Unknown attribute errors
    - Detects schema changes
                                 ↓
-7. Write indices + commit       let mut batch = WriteBatch::new();
+8. Write indices + commit       let mut batch = WriteBatch::new();
                                 write_index_entries(&mut batch, ...);
                                 slatedb.write_with_options(batch, ...)
                                 ↓
-8. Apply on success only:
+9. Apply on success only:
    - self.metadata.partition_map = pending_pm    (counter reservation committed)
    - self.metadata.schema.apply_schema_update(schema_update)  (infallible)
    - self.metadata.advance_generation()
@@ -72,6 +77,8 @@ TxOp (EntityRef + DataType)
 DatomExpanded (EntityExpanded + ValueExpanded)   may contain LookupRef + TempId
     ↓ resolve_lookup_refs (async, unique-only VAE index)
 DatomWithTempids (IdOrTempId + ValueWithTempIds) only TempId remains
+    ↓ validate_allocated_entity_ids (sync, partition map)
+DatomWithTempids                                explicit IDs checked
     ↓ tempids::resolve_tempids (async, VAE + partition map)
 Datom (i64 + DataType)                           fully concrete
 ```

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -310,7 +310,14 @@ impl Indexer {
         let with_tempids =
             tx::resolve_lookup_refs(expanded, &self.metadata.schema, &self.slatedb).await?;
 
-        // 4. Resolve tempids, including identity upserts, then build tx entity datoms
+        // 4. Validate explicit entity IDs before tempids become concrete IDs
+        tx::validate_allocated_entity_ids(
+            &with_tempids,
+            &self.metadata.schema,
+            &self.metadata.partition_map,
+        )?;
+
+        // 5. Resolve tempids, including identity upserts, then build tx entity datoms
         let mut datoms = tempids::resolve_tempids(
             with_tempids,
             &self.metadata.schema,
@@ -320,28 +327,28 @@ impl Indexer {
         .await?;
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
-        // 5. Finalize datoms (card-one rewrite) against current storage state
+        // 6. Finalize datoms (card-one rewrite) against current storage state
         let datoms = self.finalize_datoms_for_commit(datoms).await?;
 
-        // 6. Unique + general validation
+        // 7. Unique + general validation
         self.validate_unique_constraints(&datoms).await?;
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
 
-        // 7. Prepare schema update before writing to avoid leaking rejected datoms
+        // 8. Prepare schema update before writing to avoid leaking rejected datoms
         let schema_update = if validation.schema_changes_detected {
             Some(self.metadata.schema.prepare_schema_update(&datoms)?)
         } else {
             None
         };
 
-        // 8. Write indices + commit
+        // 9. Write indices + commit
         let mut batch = WriteBatch::new();
         write_index_entries(&mut batch, &datoms, &self.metadata.schema, tx_eid)?;
         self.slatedb
             .write_with_options(batch, &DEFAULT_WRITE_OPTIONS)
             .await?;
 
-        // 9. Apply on success only
+        // 10. Apply on success only
         self.metadata.partition_map = pending_pm;
         if let Some(schema_update) = schema_update.filter(|update| !update.is_empty()) {
             self.metadata.schema.apply_schema_update(schema_update);

--- a/src/node.rs
+++ b/src/node.rs
@@ -3327,7 +3327,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_explicit_unallocated_db_id_aborts() {
+    async fn test_explicit_unallocated_ids_abort() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
@@ -3340,12 +3340,6 @@ mod tests {
             .unwrap();
 
         assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
-    }
-
-    #[tokio::test]
-    async fn test_explicit_unallocated_entity_ref_aborts() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
 
         let result = node
             .execute_tx(vec![TxOp::Add {
@@ -3357,12 +3351,6 @@ mod tests {
             .unwrap();
 
         assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
-    }
-
-    #[tokio::test]
-    async fn test_unallocated_ref_value_aborts() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
 
         let result = node
             .execute_tx(vec![TxOp::put(vec![

--- a/src/node.rs
+++ b/src/node.rs
@@ -420,6 +420,7 @@ mod tests {
     };
     use edn::kw;
     use edn::Keyword;
+    use regex::Regex;
     use slatedb::config::{FlushOptions, FlushType};
     use triplox_client::transaction::TransactionResult;
 
@@ -427,6 +428,15 @@ mod tests {
     async fn define_test_schema(node: &impl SubmitNode) {
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
         assert!(matches!(result, TransactionResult::TxCommited(_)));
+    }
+
+    fn assert_aborted_with_error_matching(result: TransactionResult, pattern: &str) {
+        let TransactionResult::TxAborted(_, error) = result else {
+            panic!("transaction should abort, got {:?}", result);
+        };
+        let error = error.to_string();
+        let re = Regex::new(pattern).expect("valid regex");
+        assert!(re.is_match(&error), "unexpected error: {}", error);
     }
 
     fn parse_query(input: &str) -> ParsedQuery {
@@ -3313,6 +3323,64 @@ mod tests {
             matches!(result, TransactionResult::TxAborted(_, _)),
             "tempids that appear only in value position must abort, got {:?}",
             result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_unallocated_db_id_aborts() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:db/id), DataType::Long(11111)),
+                (kw!(:name), "Ivan".into()),
+            ])])
+            .await
+            .unwrap();
+
+        assert_aborted_with_error_matching(
+            result,
+            r"^Explicit entity id \d+ has not been allocated$",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_unallocated_entity_ref_aborts() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: EntityRef::Id(11111),
+                attribute: kw!(:name),
+                value: "Ivan".into(),
+            }])
+            .await
+            .unwrap();
+
+        assert_aborted_with_error_matching(
+            result,
+            r"^Explicit entity id \d+ has not been allocated$",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unallocated_ref_value_aborts() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        let result = node
+            .execute_tx(vec![TxOp::put(vec![
+                (kw!(:name), "Bob".into()),
+                (kw!(:follows), DataType::Long(11111)),
+            ])])
+            .await
+            .unwrap();
+
+        assert_aborted_with_error_matching(
+            result,
+            r"^Ref value for attribute :follows points to unallocated entity id \d+$",
         );
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -3339,10 +3339,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_aborted_with_error_matching(
-            result,
-            r"^Explicit entity id \d+ has not been allocated$",
-        );
+        assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
     }
 
     #[tokio::test]
@@ -3359,10 +3356,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_aborted_with_error_matching(
-            result,
-            r"^Explicit entity id \d+ has not been allocated$",
-        );
+        assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
     }
 
     #[tokio::test]
@@ -3378,10 +3372,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_aborted_with_error_matching(
-            result,
-            r"^Ref value for attribute :follows points to unallocated entity id \d+$",
-        );
+        assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
     }
 
     /// Cross-iteration EV→E resolution where the second-iteration store

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -7,6 +7,7 @@ use edn::symbols::Keyword;
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
 use crate::indexer::vae_key_to_parts;
 use crate::iterator::slate_key_iterator::SlateKeyIterator;
+use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::schema::{Schema, Unique, ValueType};
 use crate::util::{concat_bytes, next_prefix};
@@ -402,6 +403,41 @@ pub async fn resolve_lookup_refs(
         });
     }
     Ok(result)
+}
+
+pub(crate) fn validate_allocated_entity_ids(
+    datoms: &[DatomWithTempids],
+    schema: &Schema,
+    partition_map: &PartitionMap,
+) -> Result<()> {
+    for datom in datoms {
+        let (_, attr) = schema
+            .get_attribute(&datom.attribute)
+            .ok_or_else(|| anyhow::anyhow!("Unknown attribute: {}", datom.attribute))?;
+
+        if let IdOrTempId::Id(id) = datom.entity {
+            if !partition_map.contains_entid(id) {
+                return Err(anyhow::anyhow!(
+                    "Explicit entity id {} has not been allocated",
+                    id
+                ));
+            }
+        }
+
+        if attr.value_type == ValueType::Ref {
+            if let ValueWithTempIds::Data(DataType::Long(id)) = datom.value {
+                if !partition_map.contains_entid(id) {
+                    return Err(anyhow::anyhow!(
+                        "Ref value for attribute {} points to unallocated entity id {}",
+                        datom.attribute,
+                        id
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -417,27 +417,24 @@ pub(crate) fn validate_allocated_entity_ids(
 
         if let IdOrTempId::Id(id) = datom.entity {
             if !partition_map.contains_entid(id) {
-                return Err(anyhow::anyhow!(
-                    "Explicit entity id {} has not been allocated",
-                    id
-                ));
+                return Err(unallocated_entity_id_error(id));
             }
         }
 
         if attr.value_type == ValueType::Ref {
             if let ValueWithTempIds::Data(DataType::Long(id)) = datom.value {
                 if !partition_map.contains_entid(id) {
-                    return Err(anyhow::anyhow!(
-                        "Ref value for attribute {} points to unallocated entity id {}",
-                        datom.attribute,
-                        id
-                    ));
+                    return Err(unallocated_entity_id_error(id));
                 }
             }
         }
     }
 
     Ok(())
+}
+
+fn unallocated_entity_id_error(id: Entid) -> anyhow::Error {
+    anyhow::anyhow!("unallocated entity id {}", id)
 }
 
 #[cfg(test)]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -405,6 +405,10 @@ pub async fn resolve_lookup_refs(
     Ok(result)
 }
 
+fn unallocated_entity_id_error(id: Entid) -> anyhow::Error {
+    anyhow::anyhow!("unallocated entity id {}", id)
+}
+
 pub(crate) fn validate_allocated_entity_ids(
     datoms: &[DatomWithTempids],
     schema: &Schema,
@@ -431,10 +435,6 @@ pub(crate) fn validate_allocated_entity_ids(
     }
 
     Ok(())
-}
-
-fn unallocated_entity_id_error(id: Entid) -> anyhow::Error {
-    anyhow::anyhow!("unallocated entity id {}", id)
 }
 
 #[cfg(test)]

--- a/triplox-jvm/.gitignore
+++ b/triplox-jvm/.gitignore
@@ -2,6 +2,9 @@
 build
 .idea
 .lsp
+!.lsp/
+.lsp/*
+!.lsp/config.edn
 .clj-kondo
 **/.nrepl-port
 .cpcache

--- a/triplox-jvm/.lsp/config.edn
+++ b/triplox-jvm/.lsp/config.edn
@@ -1,0 +1,3 @@
+{:source-paths ["src/main/clojure"
+                "src/test/clojure"
+                "dev"]}

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx.clj
@@ -1,0 +1,37 @@
+(ns xyz.triplox.integration.tx
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [xyz.triplox.api :as api]
+            [xyz.triplox.integration.query-test :as query-test :refer [*conn*]]))
+
+(def tx-schema
+  [{:db/ident :tx/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :tx/follows
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one}])
+
+(defn with-tx-schema [f]
+  (api/transact *conn* tx-schema)
+  (f))
+
+(use-fixtures :each query-test/with-conn with-tx-schema)
+
+(deftest tx-commited
+  (is (true? (:committed? (api/transact *conn* [{:tx/name "Ivan"}])))))
+
+(deftest rejects-explicit-unallocated-id
+  ;; db/id
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:db/id 11111 :tx/name "Ivan"}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^unallocated entity id \d+$" error-message))))
+
+  ;; entity-id
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [[:db/add 11111 :tx/name "Ivan"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"^unallocated entity id \d+$" error-message))))
+
+  ;; ref
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:tx/name "Bob" :tx/follows 11111}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^unallocated entity id \d+$" error-message)))))

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx_test.clj
@@ -1,4 +1,4 @@
-(ns xyz.triplox.integration.tx
+(ns xyz.triplox.integration.tx-test
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [xyz.triplox.api :as api]
             [xyz.triplox.integration.query-test :as query-test :refer [*conn*]]))


### PR DESCRIPTION
## Summary
- reject explicit numeric entity IDs before tempid allocation when their partition counter has not allocated them
- reject ref-typed Long values that point at unallocated entity IDs
- add node regression tests for map-form `:db/id`, vector-form entity IDs, and ref-typed Long values
- document the explicit-ID validation stage in the tx pipeline

Fixes #361.

## Verification
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated by Codex (GPT-5).
