### PR TITLE
Add tx pipeline error-scenario integration tests

### DIFF
--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/tx_test.clj
@@ -9,7 +9,19 @@
     :db/cardinality :db.cardinality/one}
    {:db/ident :tx/follows
     :db/valueType :db.type/ref
-    :db/cardinality :db.cardinality/one}])
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :tx/email
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value}
+   {:db/ident :tx/handle
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :tx/spouse
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}])
 
 (defn with-tx-schema [f]
   (api/transact *conn* tx-schema)
@@ -35,3 +47,79 @@
   (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:tx/name "Bob" :tx/follows 11111}])]
     (is (false? committed?))
     (is (some? (re-find #"^unallocated entity id \d+$" error-message)))))
+
+(deftest rejects-unknown-attribute
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:tx/nonexistent "Ivan"}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Unknown attribute" error-message)))))
+
+(deftest rejects-type-mismatch
+  ;; :tx/name is :db.type/string but a long is supplied
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:tx/name 42}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Type mismatch for attribute" error-message)))))
+
+(deftest rejects-unknown-ident-entity
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [[:db/add :tx/does-not-exist :tx/name "Ivan"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Unknown ident:" error-message)))))
+
+(deftest rejects-unknown-ident-in-ref-value
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [{:tx/name "Bob" :tx/follows :tx/nope}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Unknown ident in ref value position" error-message)))))
+
+(deftest rejects-cardinality-one-multiple-values
+  ;; both ops share tempid "e", so they assert two values for a card-one attr on one entity
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [[:db/add "e" :tx/name "Ivan"]
+                              [:db/add "e" :tx/name "Petr"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Transaction cannot assert multiple values" error-message)))))
+
+(deftest rejects-retract-of-unupserted-tempid
+  (let [{:keys [committed? error-message] :as _tx-res} (api/transact *conn* [[:db/retract "e" :tx/name "Ivan"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"referenced tempid that did not upsert" error-message)))))
+
+(deftest rejects-lookup-ref-on-non-identity-attribute
+  ;; :tx/email is :db.unique/value; lookup refs require :db.unique/identity
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [[:db/add [:tx/email "ivan@example.com"] :tx/name "Ivan"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"must be :db.unique/identity" error-message)))))
+
+(deftest rejects-lookup-ref-with-no-match
+  ;; :tx/handle is :db.unique/identity but no entity owns this handle
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [[:db/add [:tx/handle "ghost"] :tx/name "Ivan"]])]
+    (is (false? committed?))
+    (is (some? (re-find #"^No entity found for lookup ref" error-message)))))
+
+(deftest rejects-unique-value-violation-within-tx
+  ;; two distinct entities asserting the same :db.unique/value in one tx
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [{:tx/email "dup@example.com"}
+                              {:tx/email "dup@example.com"}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Unique constraint violation" error-message)))))
+
+(deftest rejects-unique-value-violation-against-stored
+  (api/transact *conn* [{:tx/email "taken@example.com"}])
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [{:tx/email "taken@example.com"}])]
+    (is (false? committed?))
+    (is (some? (re-find #"already owns it" error-message)))))
+
+(deftest rejects-conflicting-upserts
+  ;; "t1" upserts to one entity via :tx/handle in step 0, then to a *different*
+  ;; entity via the ref-identity :tx/spouse in step 1 (once "t2" is known),
+  ;; so the two generations disagree on what "t1" resolves to.
+  (api/transact *conn* [{:tx/handle "h1"}])                ; => E1
+  (api/transact *conn* [{:tx/handle "t2h"}])               ; => T2 (the spouse target)
+  (api/transact *conn* [{:tx/spouse [:tx/handle "t2h"]}])  ; => E2, identified by spouse=T2
+  (let [{:keys [committed? error-message] :as _tx-res}
+        (api/transact *conn* [{:db/id "t1" :tx/handle "h1" :tx/spouse "t2"}
+                              {:db/id "t2" :tx/handle "t2h"}])]
+    (is (false? committed?))
+    (is (some? (re-find #"^Conflicting upserts" error-message)))))


### PR DESCRIPTION
## Summary

Adds integration tests in `tx_test.clj` covering the semantic error paths in the transaction pipeline (`src/indexer.rs` and its `tx` / `tempids` / `upsert_resolution` / `schema` helpers), following the existing `rejects-explicit-unallocated-id` pattern (`committed?` false + `re-find` on `error-message`).

### New tests

| Test | Pipeline stage | Asserted message |
|------|----------------|------------------|
| `rejects-unknown-attribute` | cross-cutting | `^Unknown attribute` |
| `rejects-type-mismatch` | `validate_datoms` | `^Type mismatch for attribute` |
| `rejects-unknown-ident-entity` | `expand_tx_ops` | `^Unknown ident:` |
| `rejects-unknown-ident-in-ref-value` | `expand_tx_ops` | `^Unknown ident in ref value position` |
| `rejects-cardinality-one-multiple-values` | `validate_datoms` | `^Transaction cannot assert multiple values` |
| `rejects-retract-of-unupserted-tempid` | `resolve_tempids` | `referenced tempid that did not upsert` |
| `rejects-lookup-ref-on-non-identity-attribute` | `resolve_lookup_refs` | `must be :db.unique/identity` |
| `rejects-lookup-ref-with-no-match` | `resolve_lookup_refs` | `^No entity found for lookup ref` |
| `rejects-unique-value-violation-within-tx` | `validate_unique_constraints` | `^Unique constraint violation` |
| `rejects-unique-value-violation-against-stored` | `validate_unique_constraints` | `already owns it` |
| `rejects-conflicting-upserts` | `resolve_tempids` (cross-generation) | `^Conflicting upserts` |

### Schema changes

Extends `tx-schema` with `:tx/email` (`:db.unique/value`), `:tx/handle` and `:tx/spouse` (both `:db.unique/identity`, the latter ref-typed) to drive the uniqueness, lookup-ref, and multi-step upsert resolution paths.

## Notes

All cases are semantic errors that flow through the aborted-tx branch, so the result is `committed? false` with the message in `:error-message`. `rejects-conflicting-upserts` is the most intricate — it relies on the ref-identity `:tx/spouse` attribute to make a single tempid resolve to two different entities across two evolution generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)