### PR TITLE
fix: recover exact tx outcome in TxWaiter after broadcast lag

### DIFF
--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -217,6 +217,7 @@ mod tests {
             slate.db.clone(),
             Metadata::new(test_schema(), PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            1024,
         )));
         let service = IncrementalQueryService::new(
             tempfile::tempdir().unwrap().path().to_path_buf(),

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -206,7 +206,7 @@ mod tests {
 
     use super::*;
     use crate::clock::st_from_unix_epoch;
-    use crate::indexer::Indexer;
+    use crate::indexer::{Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
     use crate::metadata::{Metadata, PartitionMap};
     use crate::schema::{Attribute, Schema, ValueType};
 
@@ -217,7 +217,7 @@ mod tests {
             slate.db.clone(),
             Metadata::new(test_schema(), PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
-            1024,
+            DEFAULT_TX_COMPLETION_CAPACITY,
         )));
         let service = IncrementalQueryService::new(
             tempfile::tempdir().unwrap().path().to_path_buf(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -627,12 +627,8 @@ impl TxWaiter {
                     }
                 }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
-                    // Our notification may have been dropped. Check storage. If no completion was found, continue.
-                    if let Some(completion) =
-                        tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await?
-                    {
-                        return Ok(completion);
-                    }
+                    // Our notification may have been dropped. We just continue because 
+                    // we deal with the correct resolution in the branch above eventually. 
                     continue;
                 }
                 Err(broadcast::error::RecvError::Closed) => {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1371,67 +1371,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_await_tx_fast_path_latest_aborted() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let mut indexer = bootstrapped_indexer(&components).await;
-        let tx_key = test_tx_key(1);
-
-        let basis = indexer.transact_tx(tx_key, aborting_op()).await?;
-
-        // Waiter created after indexing: fast path must report the real abort
-        let completion = indexer.tx_waiter().await_tx(tx_key).await?;
-        assert_eq!(completion.basis, Some(basis));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown attribute"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_await_tx_fast_path_earlier_tx_returns_real_result() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let mut indexer = bootstrapped_indexer(&components).await;
-        let tx_key_1 = test_tx_key(1);
-
-        let basis_1 = indexer.transact_tx(tx_key_1, add_op("alice")).await?;
-        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
-
-        let completion = indexer.tx_waiter().await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, Some(basis_1));
-        assert!(completion.result.is_ok());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_await_tx_fast_path_earlier_missing_tx() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let mut indexer = bootstrapped_indexer(&components).await;
-        let tx_key_1 = test_tx_key(1);
-
-        indexer
-            .accept(Record {
-                tx_key: tx_key_1,
-                record: vec![0xff],
-            })
-            .await;
-        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
-
-        // Fast path over an earlier tx that left no entity: await_tx errors
-        // because the outcome can't be recovered from storage.
-        let err = match indexer.tx_waiter().await_tx(tx_key_1).await {
-            Ok(_) => panic!("expected await_tx to error for an unrecoverable tx"),
-            Err(e) => e,
-        };
-        assert!(err.to_string().contains("failed or could not be recovered"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_await_tx_ordering() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let slate = components.db.clone();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -28,6 +28,8 @@ use crate::util::concat_bytes;
 
 type TxCompletionMessage = (TxKey, Option<TxBasis>, Result<(), Arc<Error>>);
 
+pub const DEFAULT_TX_COMPLETION_CAPACITY: usize = 1024;
+
 pub struct Indexer {
     slatedb: Arc<Db>,
     metadata: Metadata,
@@ -817,7 +819,7 @@ mod tests {
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
     /// Returns the indexer ready for test data at tx_id=1+.
     async fn bootstrapped_indexer(slate: &SlateComponents) -> Indexer {
-        bootstrapped_indexer_with_capacity(slate, 1024).await
+        bootstrapped_indexer_with_capacity(slate, DEFAULT_TX_COMPLETION_CAPACITY).await
     }
 
     /// Like `bootstrapped_indexer` with an explicit completion-channel capacity
@@ -1105,7 +1107,7 @@ mod tests {
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
-            1024,
+            DEFAULT_TX_COMPLETION_CAPACITY,
         );
 
         let tx_key = TxKey {
@@ -1195,7 +1197,7 @@ mod tests {
             components.db.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
-            1024,
+            DEFAULT_TX_COMPLETION_CAPACITY,
         );
         let tx_key = TxKey {
             tx_id: 1,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1326,6 +1326,32 @@ mod tests {
         }]
     }
 
+    // Distinct from the committed lagged test below: only a semantically
+    // aborted tx exercises lookup_tx_completion's DB_TX_ABORTED -> Err(Arc)
+    // reconstruction flowing back through await_tx as Ok(TxCompletion) with an
+    // error result. The committed path returns Ok(Ok(())) and never hits it.
+    #[tokio::test]
+    async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
+        let tx_key_1 = test_tx_key(1);
+        let waiter = indexer.tx_waiter();
+
+        let basis_1 = indexer.transact_tx(tx_key_1, aborting_op()).await?;
+        // The second completion evicts the first from the capacity-1 channel
+        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+
+        let completion = waiter.await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, Some(basis_1));
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown attribute"));
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_await_tx_lagged_committed_tx_recovers_from_storage() -> Result<(), Error> {
         let components = in_memory_slate().await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -619,9 +619,7 @@ impl TxWaiter {
                                 result,
                             });
                         }
-                        // The indexer broadcasts exactly one message per log
-                        // record in order, so seeing a later tx first means our
-                        // message was dropped during a lag.
+                        // Seeing a later tx first means we were lagging at some point.
                         std::cmp::Ordering::Greater => {
                             return self.completion_from_storage(tx_key).await;
                         }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -599,23 +599,6 @@ impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
 
-    /// Recover an already-indexed transaction's outcome from storage. Missing
-    /// tx entity means the tx failed without persisting an outcome (technical
-    /// abort, deserialize failure); mirror the live notification shape for
-    /// those: no basis, an error result.
-    async fn completion_from_storage(&self, tx_key: TxKey) -> Result<TxCompletion, Error> {
-        match tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
-            Some(completion) => Ok(completion),
-            None => Ok(TxCompletion {
-                basis: None,
-                result: Err(Arc::new(anyhow::anyhow!(
-                    "Transaction {} left no tx entity; it failed with a non-recoverable error whose details were lost",
-                    tx_key.tx_id
-                ))),
-            }),
-        }
-    }
-
     /// Wait until `tx_key` has been indexed. Returns the indexed basis and status,
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {
@@ -686,6 +669,19 @@ impl TxWaiter {
                         tx_key.tx_id
                     ));
                 }
+            }
+        }
+    }
+
+    /// Recover an already-indexed transaction's outcome from storage. 
+    /// A missing tx entity means a technical failure. 
+    async fn completion_from_storage(&self, tx_key: TxKey) -> Result<TxCompletion, Error> {
+        match tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
+            Some(completion) => Ok(completion),
+            // TODO: Deal with proper error escalation here. See #118.
+            None => { 
+                error!("Transaction {} failed or could not be recovered!", tx_key.tx_id);
+                Err(anyhow::anyhow!("Transaction {} failed or could not be recovered!", tx_key.tx_id))
             }
         }
     }
@@ -1384,13 +1380,13 @@ mod tests {
             .await;
         indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
 
-        let completion = waiter.await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, None);
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("left no tx entity"));
+        // No tx entity persisted: completion can't be recovered, so await_tx
+        // itself errors rather than returning a completion with an error result.
+        let err = match waiter.await_tx(tx_key_1).await {
+            Ok(_) => panic!("expected await_tx to error for an unrecoverable tx"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("failed or could not be recovered"));
 
         Ok(())
     }
@@ -1445,13 +1441,13 @@ mod tests {
             .await;
         indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
 
-        let completion = indexer.tx_waiter().await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, None);
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("left no tx entity"));
+        // Fast path over an earlier tx that left no entity: await_tx errors
+        // because the outcome can't be recovered from storage.
+        let err = match indexer.tx_waiter().await_tx(tx_key_1).await {
+            Ok(_) => panic!("expected await_tx to error for an unrecoverable tx"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("failed or could not be recovered"));
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -237,19 +237,15 @@ pub(crate) fn build_tx_entity_datoms(
 }
 
 impl Indexer {
-    pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: TxBasis) -> Self {
-        Self::with_channel_capacity(slatedb, metadata, latest_indexed_tx, 1024)
-    }
-
-    /// Like `new` with an explicit completion-channel capacity, so tests can
-    /// force broadcast lag deterministically.
-    pub(crate) fn with_channel_capacity(
+    /// `tx_completion_capacity` sizes the tx-completion broadcast channel;
+    /// tests use small values to force broadcast lag deterministically.
+    pub fn new(
         slatedb: Arc<Db>,
         metadata: Metadata,
         latest_indexed_tx: TxBasis,
-        capacity: usize,
+        tx_completion_capacity: usize,
     ) -> Self {
-        let (tx_completion_sender, _) = broadcast::channel(capacity);
+        let (tx_completion_sender, _) = broadcast::channel(tx_completion_capacity);
         Indexer {
             slatedb,
             metadata,
@@ -597,87 +593,6 @@ pub(crate) struct TxCompletion {
     pub result: Result<(), Arc<anyhow::Error>>,
 }
 
-/// Look up a transaction's persisted outcome via the AVE index on `:db/txId`,
-/// reading `:db/txResult`/`:db/txError` from the tx entity.
-///
-/// Returns `None` if no tx entity exists: the tx is either not yet indexed or
-/// failed without persisting an outcome (technical abort, deserialize failure).
-pub(crate) async fn lookup_tx_completion<D>(
-    sdb: &D,
-    tx_key: TxKey,
-) -> Result<Option<TxCompletion>, Error>
-where
-    D: DbReadOps + Sync,
-{
-    // Keyed on tx_id only; the log assigns system_time together with tx_id.
-    let mut value_buf = Vec::new();
-    encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_buf);
-    let ave_prefix = concat_bytes(&[
-        &[codec::AVE],
-        &encode_i64_bytes(crate::schema::DB_TX_ID),
-        &value_buf,
-    ]);
-    let mut iter = sdb
-        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
-    let mut tx_eid: Option<i64> = None;
-    while let Some(kv) = iter.next().await? {
-        let (_attribute, _value, entity, _tx_eid, op) = ave_key_to_parts(kv.key)?;
-        if op == codec::RETRACT {
-            continue;
-        }
-        match entity {
-            DataType::Long(eid) => {
-                tx_eid = Some(eid);
-                break;
-            }
-            other => bail!("Expected Long entity ID in AVE key, got {:?}", other),
-        }
-    }
-    let Some(tx_eid) = tx_eid else {
-        return Ok(None);
-    };
-
-    let mut entity_buf = Vec::new();
-    encode_datatype(&DataType::Long(tx_eid), &mut entity_buf);
-    let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_buf]);
-    let mut iter = sdb
-        .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
-        .await?;
-    let mut tx_result: Option<i64> = None;
-    let mut tx_error: Option<String> = None;
-    while let Some(kv) = iter.next().await? {
-        let (_entity, attribute, value, _tx_eid, op) = eav_key_to_parts(kv.key)?;
-        if op == codec::RETRACT {
-            continue;
-        }
-        if attribute == crate::schema::DB_TX_RESULT {
-            if let DataType::Long(result) = value {
-                tx_result = Some(result);
-            }
-        }
-        if attribute == crate::schema::DB_TX_ERROR {
-            if let DataType::String(err) = value {
-                tx_error = Some(err);
-            }
-        }
-    }
-
-    let result = match tx_result {
-        Some(DB_TX_COMMITTED) => Ok(()),
-        Some(DB_TX_ABORTED) => Err(Arc::new(anyhow::anyhow!(
-            "{}",
-            tx_error.unwrap_or_else(|| format!("Transaction {} aborted", tx_key.tx_id))
-        ))),
-        Some(other) => bail!("Tx entity {tx_eid} has unknown :db/txResult {other}"),
-        None => bail!("Tx entity {tx_eid} missing :db/txResult"),
-    };
-    Ok(Some(TxCompletion {
-        basis: Some(TxBasis { tx_key, tx_eid }),
-        result,
-    }))
-}
-
 impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
@@ -687,7 +602,7 @@ impl TxWaiter {
     /// abort, deserialize failure); mirror the live notification shape for
     /// those: no basis, an error result.
     async fn completion_from_storage(&self, tx_key: TxKey) -> Result<TxCompletion, Error> {
-        match lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
+        match tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
             Some(completion) => Ok(completion),
             None => Ok(TxCompletion {
                 basis: None,
@@ -732,7 +647,7 @@ impl TxWaiter {
                     // found means the tx is still pending or left no entity — a
                     // later tx's message will resolve it via the Greater branch.
                     if let Some(completion) =
-                        lookup_tx_completion(self.slatedb.as_ref(), tx_key).await?
+                        tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await?
                     {
                         return Ok(completion);
                     }
@@ -912,7 +827,7 @@ mod tests {
         capacity: usize,
     ) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate).await.unwrap();
-        let mut indexer = Indexer::with_channel_capacity(
+        let mut indexer = Indexer::new(
             slate.db.clone(),
             metadata,
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
@@ -1190,6 +1105,7 @@ mod tests {
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            1024,
         );
 
         let tx_key = TxKey {
@@ -1279,6 +1195,7 @@ mod tests {
             components.db.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            1024,
         );
         let tx_key = TxKey {
             tx_id: 1,
@@ -1331,7 +1248,7 @@ mod tests {
             )
             .await?;
 
-        let completion = lookup_tx_completion(components.db.as_ref(), tx_key)
+        let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("tx entity should exist");
         assert_eq!(completion.basis, Some(basis));
@@ -1359,7 +1276,7 @@ mod tests {
             )
             .await?;
 
-        let completion = lookup_tx_completion(components.db.as_ref(), tx_key)
+        let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("aborted tx entity should exist");
         assert_eq!(completion.basis, Some(basis));
@@ -1380,7 +1297,7 @@ mod tests {
             tx_id: 42,
             system_time: st_from_unix_epoch(2),
         };
-        assert!(lookup_tx_completion(components.db.as_ref(), tx_key)
+        assert!(tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .is_none());
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -238,7 +238,18 @@ pub(crate) fn build_tx_entity_datoms(
 
 impl Indexer {
     pub fn new(slatedb: Arc<Db>, metadata: Metadata, latest_indexed_tx: TxBasis) -> Self {
-        let (tx_completion_sender, _) = broadcast::channel(1024);
+        Self::with_channel_capacity(slatedb, metadata, latest_indexed_tx, 1024)
+    }
+
+    /// Like `new` with an explicit completion-channel capacity, so tests can
+    /// force broadcast lag deterministically.
+    pub(crate) fn with_channel_capacity(
+        slatedb: Arc<Db>,
+        metadata: Metadata,
+        latest_indexed_tx: TxBasis,
+        capacity: usize,
+    ) -> Self {
+        let (tx_completion_sender, _) = broadcast::channel(capacity);
         Indexer {
             slatedb,
             metadata,
@@ -268,7 +279,7 @@ impl Indexer {
     ) -> Result<TxBasis, Error> {
         match self.transact_tx_inner(tx_key, tx_ops).await {
             Ok(basis) => Ok(basis),
-            Err(e) => match self.write_aborted_tx(tx_key, e.to_string()).await {
+            Err(e) => match self.write_aborted_tx(tx_key, format!("{:#}", e)).await {
                 // semantic error
                 Ok(basis) => {
                     let err = Arc::new(e);
@@ -549,6 +560,7 @@ impl Indexer {
         TxWaiter {
             latest_tx: self.latest_indexed_tx,
             rx: self.tx_completion_sender.subscribe(),
+            slatedb: self.slatedb.clone(),
         }
     }
 
@@ -577,6 +589,7 @@ impl Indexer {
 pub(crate) struct TxWaiter {
     latest_tx: TxBasis,
     rx: broadcast::Receiver<TxCompletionMessage>,
+    slatedb: Arc<Db>,
 }
 
 pub(crate) struct TxCompletion {
@@ -584,46 +597,145 @@ pub(crate) struct TxCompletion {
     pub result: Result<(), Arc<anyhow::Error>>,
 }
 
+/// Look up a transaction's persisted outcome via the AVE index on `:db/txId`,
+/// reading `:db/txResult`/`:db/txError` from the tx entity.
+///
+/// Returns `None` if no tx entity exists: the tx is either not yet indexed or
+/// failed without persisting an outcome (technical abort, deserialize failure).
+pub(crate) async fn lookup_tx_completion<D>(
+    sdb: &D,
+    tx_key: TxKey,
+) -> Result<Option<TxCompletion>, Error>
+where
+    D: DbReadOps + Sync,
+{
+    // Keyed on tx_id only; the log assigns system_time together with tx_id.
+    let mut value_buf = Vec::new();
+    encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_buf);
+    let ave_prefix = concat_bytes(&[
+        &[codec::AVE],
+        &encode_i64_bytes(crate::schema::DB_TX_ID),
+        &value_buf,
+    ]);
+    let mut iter = sdb
+        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    let mut tx_eid: Option<i64> = None;
+    while let Some(kv) = iter.next().await? {
+        let (_attribute, _value, entity, _tx_eid, op) = ave_key_to_parts(kv.key)?;
+        if op == codec::RETRACT {
+            continue;
+        }
+        match entity {
+            DataType::Long(eid) => {
+                tx_eid = Some(eid);
+                break;
+            }
+            other => bail!("Expected Long entity ID in AVE key, got {:?}", other),
+        }
+    }
+    let Some(tx_eid) = tx_eid else {
+        return Ok(None);
+    };
+
+    let mut entity_buf = Vec::new();
+    encode_datatype(&DataType::Long(tx_eid), &mut entity_buf);
+    let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_buf]);
+    let mut iter = sdb
+        .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    let mut tx_result: Option<i64> = None;
+    let mut tx_error: Option<String> = None;
+    while let Some(kv) = iter.next().await? {
+        let (_entity, attribute, value, _tx_eid, op) = eav_key_to_parts(kv.key)?;
+        if op == codec::RETRACT {
+            continue;
+        }
+        if attribute == crate::schema::DB_TX_RESULT {
+            if let DataType::Long(result) = value {
+                tx_result = Some(result);
+            }
+        }
+        if attribute == crate::schema::DB_TX_ERROR {
+            if let DataType::String(err) = value {
+                tx_error = Some(err);
+            }
+        }
+    }
+
+    let result = match tx_result {
+        Some(DB_TX_COMMITTED) => Ok(()),
+        Some(DB_TX_ABORTED) => Err(Arc::new(anyhow::anyhow!(
+            "{}",
+            tx_error.unwrap_or_else(|| format!("Transaction {} aborted", tx_key.tx_id))
+        ))),
+        Some(other) => bail!("Tx entity {tx_eid} has unknown :db/txResult {other}"),
+        None => bail!("Tx entity {tx_eid} missing :db/txResult"),
+    };
+    Ok(Some(TxCompletion {
+        basis: Some(TxBasis { tx_key, tx_eid }),
+        result,
+    }))
+}
+
 impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
 
+    /// Recover an already-indexed transaction's outcome from storage. Missing
+    /// tx entity means the tx failed without persisting an outcome (technical
+    /// abort, deserialize failure); mirror the live notification shape for
+    /// those: no basis, an error result.
+    async fn completion_from_storage(&self, tx_key: TxKey) -> Result<TxCompletion, Error> {
+        match lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
+            Some(completion) => Ok(completion),
+            None => Ok(TxCompletion {
+                basis: None,
+                result: Err(Arc::new(anyhow::anyhow!(
+                    "Transaction {} left no tx entity; it failed with a non-recoverable error whose details were lost",
+                    tx_key.tx_id
+                ))),
+            }),
+        }
+    }
+
     /// Wait until `tx_key` has been indexed. Returns the indexed basis and status,
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {
-        // Fast path: already indexed at subscription time
-        if tx_key == self.latest_tx.tx_key {
-            return Ok(TxCompletion {
-                basis: Some(self.latest_tx),
-                // TODO: We are not filling in the error here if there was a semantic error.
-                result: Ok(()),
-            });
-        }
-        if tx_key < self.latest_tx.tx_key {
-            return Ok(TxCompletion {
-                basis: None,
-                result: Ok(()),
-            });
+        // Fast path: already indexed at subscription time; storage is the
+        // authoritative record of its outcome.
+        if tx_key <= self.latest_tx.tx_key {
+            return self.completion_from_storage(tx_key).await;
         }
 
-        // TODO: The >= check can return a different tx's result if the
-        // broadcast channel lags. Will be revisited when the log is removed and we
-        // ingest directly into Slate.
         loop {
             match self.rx.recv().await {
                 Ok((completed_tx_key, completed_basis, result)) => {
-                    if completed_tx_key >= tx_key {
-                        return Ok(TxCompletion {
-                            basis: completed_basis,
-                            result,
-                        });
+                    match completed_tx_key.cmp(&tx_key) {
+                        std::cmp::Ordering::Less => continue,
+                        std::cmp::Ordering::Equal => {
+                            return Ok(TxCompletion {
+                                basis: completed_basis,
+                                result,
+                            });
+                        }
+                        // The indexer broadcasts exactly one message per log
+                        // record in order, so seeing a later tx first means our
+                        // message was dropped during a lag.
+                        std::cmp::Ordering::Greater => {
+                            return self.completion_from_storage(tx_key).await;
+                        }
                     }
-                    // Keep waiting for higher tx_id
                 }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
-                    // TODO(#282): recover exact tx outcome or fail instead of risking a later tx's result.
-                    // Channel overflowed. Just continue waiting - we'll eventually
-                    // get the notification or the channel will close.
+                    // Our notification may have been dropped; check storage. Not
+                    // found means the tx is still pending or left no entity — a
+                    // later tx's message will resolve it via the Greater branch.
+                    if let Some(completion) =
+                        lookup_tx_completion(self.slatedb.as_ref(), tx_key).await?
+                    {
+                        return Ok(completion);
+                    }
                     continue;
                 }
                 Err(broadcast::error::RecvError::Closed) => {
@@ -790,11 +902,21 @@ mod tests {
     /// Uses init_db for bootstrap, then transacts test schema via the indexer.
     /// Returns the indexer ready for test data at tx_id=1+.
     async fn bootstrapped_indexer(slate: &SlateComponents) -> Indexer {
+        bootstrapped_indexer_with_capacity(slate, 1024).await
+    }
+
+    /// Like `bootstrapped_indexer` with an explicit completion-channel capacity
+    /// (capacity 1 forces broadcast lag with two transactions).
+    async fn bootstrapped_indexer_with_capacity(
+        slate: &SlateComponents,
+        capacity: usize,
+    ) -> Indexer {
         let metadata = crate::bootstrap::init_db(slate).await.unwrap();
-        let mut indexer = Indexer::new(
+        let mut indexer = Indexer::with_channel_capacity(
             slate.db.clone(),
             metadata,
             *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            capacity,
         );
         let tx_key_0 = TxKey {
             tx_id: 0,
@@ -1186,6 +1308,231 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Failed to write aborted tx entity"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tx_completion_committed() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
+        let basis = indexer
+            .transact_tx(
+                tx_key,
+                vec![TxOp::Add {
+                    entity: "alice".into(),
+                    attribute: kw!(:name),
+                    value: "alice".into(),
+                }],
+            )
+            .await?;
+
+        let completion = lookup_tx_completion(components.db.as_ref(), tx_key)
+            .await?
+            .expect("tx entity should exist");
+        assert_eq!(completion.basis, Some(basis));
+        assert!(completion.result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tx_completion_aborted() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let tx_key = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(2),
+        };
+        let basis = indexer
+            .transact_tx(
+                tx_key,
+                vec![TxOp::Add {
+                    entity: "e".into(),
+                    attribute: kw!(:nonexistent),
+                    value: "x".into(),
+                }],
+            )
+            .await?;
+
+        let completion = lookup_tx_completion(components.db.as_ref(), tx_key)
+            .await?
+            .expect("aborted tx entity should exist");
+        assert_eq!(completion.basis, Some(basis));
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown attribute"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tx_completion_missing() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        bootstrapped_indexer(&components).await;
+        let tx_key = TxKey {
+            tx_id: 42,
+            system_time: st_from_unix_epoch(2),
+        };
+        assert!(lookup_tx_completion(components.db.as_ref(), tx_key)
+            .await?
+            .is_none());
+
+        Ok(())
+    }
+
+    fn test_tx_key(tx_id: i64) -> TxKey {
+        TxKey {
+            tx_id,
+            system_time: st_from_unix_epoch(tx_id as u64 * 100),
+        }
+    }
+
+    fn add_op(name: &str) -> Vec<TxOp> {
+        vec![TxOp::Add {
+            entity: name.into(),
+            attribute: kw!(:name),
+            value: name.into(),
+        }]
+    }
+
+    fn aborting_op() -> Vec<TxOp> {
+        vec![TxOp::Add {
+            entity: "e".into(),
+            attribute: kw!(:nonexistent),
+            value: "x".into(),
+        }]
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
+        let tx_key_1 = test_tx_key(1);
+        let waiter = indexer.tx_waiter();
+
+        let basis_1 = indexer.transact_tx(tx_key_1, aborting_op()).await?;
+        // The second completion evicts the first from the capacity-1 channel
+        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+
+        let completion = waiter.await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, Some(basis_1));
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown attribute"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_lagged_committed_tx_recovers_from_storage() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
+        let tx_key_1 = test_tx_key(1);
+        let waiter = indexer.tx_waiter();
+
+        let basis_1 = indexer.transact_tx(tx_key_1, add_op("alice")).await?;
+        indexer.transact_tx(test_tx_key(2), aborting_op()).await?;
+
+        let completion = waiter.await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, Some(basis_1));
+        assert!(completion.result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_lagged_technical_abort_returns_error() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
+        let tx_key_1 = test_tx_key(1);
+        let waiter = indexer.tx_waiter();
+
+        // Deserialize failure: notifies without persisting a tx entity
+        indexer
+            .accept(Record {
+                tx_key: tx_key_1,
+                record: vec![0xff],
+            })
+            .await;
+        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+
+        let completion = waiter.await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, None);
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("left no tx entity"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_fast_path_latest_aborted() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let tx_key = test_tx_key(1);
+
+        let basis = indexer.transact_tx(tx_key, aborting_op()).await?;
+
+        // Waiter created after indexing: fast path must report the real abort
+        let completion = indexer.tx_waiter().await_tx(tx_key).await?;
+        assert_eq!(completion.basis, Some(basis));
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown attribute"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_fast_path_earlier_tx_returns_real_result() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let tx_key_1 = test_tx_key(1);
+
+        let basis_1 = indexer.transact_tx(tx_key_1, add_op("alice")).await?;
+        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+
+        let completion = indexer.tx_waiter().await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, Some(basis_1));
+        assert!(completion.result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_await_tx_fast_path_earlier_missing_tx() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let tx_key_1 = test_tx_key(1);
+
+        indexer
+            .accept(Record {
+                tx_key: tx_key_1,
+                record: vec![0xff],
+            })
+            .await;
+        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+
+        let completion = indexer.tx_waiter().await_tx(tx_key_1).await?;
+        assert_eq!(completion.basis, None);
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("left no tx entity"));
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1326,10 +1326,6 @@ mod tests {
         }]
     }
 
-    // Distinct from the committed lagged test below: only a semantically
-    // aborted tx exercises lookup_tx_completion's DB_TX_ABORTED -> Err(Arc)
-    // reconstruction flowing back through await_tx as Ok(TxCompletion) with an
-    // error result. The committed path returns Ok(Ok(())) and never hits it.
     #[tokio::test]
     async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
         let components = in_memory_slate().await;
@@ -1348,23 +1344,6 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Unknown attribute"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_await_tx_lagged_committed_tx_recovers_from_storage() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
-        let tx_key_1 = test_tx_key(1);
-        let waiter = indexer.tx_waiter();
-
-        let basis_1 = indexer.transact_tx(tx_key_1, add_op("alice")).await?;
-        indexer.transact_tx(test_tx_key(2), aborting_op()).await?;
-
-        let completion = waiter.await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, Some(basis_1));
-        assert!(completion.result.is_ok());
 
         Ok(())
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -585,9 +585,7 @@ impl Indexer {
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
 /// no messages are missed between subscription and the actual wait.
 pub(crate) struct TxWaiter {
-    /// Latest indexed tx captured when this waiter subscribed; the fast-path
-    /// boundary. A `tx_key` at or below it was already indexed at subscription
-    /// time, so its outcome is read from storage rather than awaited.
+    /// Latest indexed tx captured when this waiter subscribed.
     baseline: TxBasis,
     rx: broadcast::Receiver<TxCompletionMessage>,
     slatedb: Arc<Db>,
@@ -674,15 +672,19 @@ impl TxWaiter {
         }
     }
 
-    /// Recover an already-indexed transaction's outcome from storage. 
-    /// A missing tx entity means a technical failure. 
+    /// Recover an already-indexed transaction's outcome from storage.
+    /// A missing tx entity means a technical failure.
     async fn completion_from_storage(&self, tx_key: TxKey) -> Result<TxCompletion, Error> {
         match tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await? {
             Some(completion) => Ok(completion),
             // TODO: Deal with proper error escalation here. See #118.
-            None => { 
-                error!("Transaction {} failed or could not be recovered!", tx_key.tx_id);
-                Err(anyhow::anyhow!("Transaction {} failed or could not be recovered!", tx_key.tx_id))
+            None => {
+                let msg = format!(
+                    "Transaction {} failed or could not be recovered!",
+                    tx_key.tx_id
+                );
+                error!("{msg}");
+                Err(anyhow::anyhow!(msg))
             }
         }
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -627,8 +627,8 @@ impl TxWaiter {
                     }
                 }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
-                    // Our notification may have been dropped. We just continue because 
-                    // we deal with the correct resolution in the branch above eventually. 
+                    // Our notification may have been dropped. We just continue because
+                    // we deal with the correct resolution in the branch above eventually.
                     continue;
                 }
                 Err(broadcast::error::RecvError::Closed) => {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -627,9 +627,7 @@ impl TxWaiter {
                     }
                 }
                 Err(broadcast::error::RecvError::Lagged(_count)) => {
-                    // Our notification may have been dropped; check storage. Not
-                    // found means the tx is still pending or left no entity — a
-                    // later tx's message will resolve it via the Greater branch.
+                    // Our notification may have been dropped. Check storage. If no completion was found, continue.
                     if let Some(completion) =
                         tx::lookup_tx_completion(self.slatedb.as_ref(), tx_key).await?
                     {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1327,28 +1327,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
-        let tx_key_1 = test_tx_key(1);
-        let waiter = indexer.tx_waiter();
-
-        let basis_1 = indexer.transact_tx(tx_key_1, aborting_op()).await?;
-        // The second completion evicts the first from the capacity-1 channel
-        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
-
-        let completion = waiter.await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, Some(basis_1));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown attribute"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_await_tx_lagged_committed_tx_recovers_from_storage() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -556,7 +556,7 @@ impl Indexer {
     /// ```
     pub(crate) fn tx_waiter(&self) -> TxWaiter {
         TxWaiter {
-            latest_tx: self.latest_indexed_tx,
+            baseline: self.latest_indexed_tx,
             rx: self.tx_completion_sender.subscribe(),
             slatedb: self.slatedb.clone(),
         }
@@ -585,7 +585,10 @@ impl Indexer {
 /// Created by `Indexer::tx_waiter()`. Holds a broadcast receiver so that
 /// no messages are missed between subscription and the actual wait.
 pub(crate) struct TxWaiter {
-    latest_tx: TxBasis,
+    /// Latest indexed tx captured when this waiter subscribed; the fast-path
+    /// boundary. A `tx_key` at or below it was already indexed at subscription
+    /// time, so its outcome is read from storage rather than awaited.
+    baseline: TxBasis,
     rx: broadcast::Receiver<TxCompletionMessage>,
     slatedb: Arc<Db>,
 }
@@ -604,7 +607,7 @@ impl TxWaiter {
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {
         // Fast path: already indexed at subscription time; storage is the
         // authoritative record of its outcome.
-        if tx_key <= self.latest_tx.tx_key {
+        if tx_key <= self.baseline.tx_key {
             return self.completion_from_storage(tx_key).await;
         }
 
@@ -649,7 +652,7 @@ impl TxWaiter {
     /// Wait until indexing has reached `tx_key`, regardless of whether that
     /// transaction committed or aborted.
     pub async fn await_indexed(mut self, tx_key: TxKey) -> Result<(), Error> {
-        if tx_key.tx_id <= self.latest_tx.tx_key.tx_id {
+        if tx_key.tx_id <= self.baseline.tx_key.tx_id {
             return Ok(());
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,7 +15,7 @@ use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
 };
-use crate::indexer::{latest_tx_basis_from_sdb, Indexer};
+use crate::indexer::{latest_tx_basis_from_sdb, Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
 #[cfg(feature = "kafka")]
 use crate::kafka_log::KafkaLog;
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
@@ -170,7 +170,7 @@ impl<L: TxLog> Node<L> {
             slate.db.clone(),
             metadata,
             latest_indexed,
-            1024,
+            DEFAULT_TX_COMPLETION_CAPACITY,
         )));
 
         let after_tx_id = Some(latest_indexed.tx_key.tx_id);
@@ -220,7 +220,7 @@ impl Node<MemoryLog> {
             slate.db.clone(),
             metadata,
             bootstrap_basis,
-            1024,
+            DEFAULT_TX_COMPLETION_CAPACITY,
         )));
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
         log.ensure_bootstrap_record().await.unwrap();

--- a/src/node.rs
+++ b/src/node.rs
@@ -415,6 +415,7 @@ impl<L: TxLog> SubmitNode for Node<L> {
             Ok(()) => Ok(TransactionResult::TxCommited(basis)),
             Err(e) => Ok(TransactionResult::TxAborted(
                 basis,
+                // TODO: Assure identical errors on live and reconstruction path. See #393.
                 anyhow::anyhow!("{:#}", e).into(),
             )),
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -170,6 +170,7 @@ impl<L: TxLog> Node<L> {
             slate.db.clone(),
             metadata,
             latest_indexed,
+            1024,
         )));
 
         let after_tx_id = Some(latest_indexed.tx_key.tx_id);
@@ -219,6 +220,7 @@ impl Node<MemoryLog> {
             slate.db.clone(),
             metadata,
             bootstrap_basis,
+            1024,
         )));
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
         log.ensure_bootstrap_record().await.unwrap();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,15 +1,19 @@
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Error, Result};
 use edn::kw;
 use edn::symbols::Keyword;
+use slatedb::DbReadOps;
 
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
-use crate::indexer::vae_key_to_parts;
+use crate::indexer::{ave_key_to_parts, eav_key_to_parts, vae_key_to_parts, TxCompletion};
 use crate::iterator::slate_key_iterator::SlateKeyIterator;
 use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
-use crate::schema::{Schema, Unique, ValueType};
+use crate::schema::{Schema, Unique, ValueType, DB_TX_ABORTED, DB_TX_COMMITTED};
+use crate::slate::DEFAULT_SCAN_OPTIONS;
+use crate::transaction::{TxBasis, TxKey};
 use crate::util::{concat_bytes, next_prefix};
 
 // ---------------------------------------------------------------------------
@@ -453,6 +457,87 @@ pub(crate) fn validate_allocated_entity_ids(
     }
 
     Ok(())
+}
+
+/// Look up a transaction's persisted outcome via the AVE index on `:db/txId`,
+/// reading `:db/txResult`/`:db/txError` from the tx entity.
+///
+/// Returns `None` if no tx entity exists: the tx is either not yet indexed or
+/// failed without persisting an outcome (technical abort, deserialize failure).
+pub(crate) async fn lookup_tx_completion<D>(
+    sdb: &D,
+    tx_key: TxKey,
+) -> Result<Option<TxCompletion>, Error>
+where
+    D: DbReadOps + Sync,
+{
+    // Keyed on tx_id only; the log assigns system_time together with tx_id.
+    let mut value_buf = Vec::new();
+    encode_datatype(&DataType::Long(tx_key.tx_id), &mut value_buf);
+    let ave_prefix = concat_bytes(&[
+        &[codec::AVE],
+        &encode_i64_bytes(crate::schema::DB_TX_ID),
+        &value_buf,
+    ]);
+    let mut iter = sdb
+        .scan_prefix_with_options(&ave_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    let mut tx_eid: Option<i64> = None;
+    while let Some(kv) = iter.next().await? {
+        let (_attribute, _value, entity, _tx_eid, op) = ave_key_to_parts(kv.key)?;
+        if op == codec::RETRACT {
+            continue;
+        }
+        match entity {
+            DataType::Long(eid) => {
+                tx_eid = Some(eid);
+                break;
+            }
+            other => bail!("Expected Long entity ID in AVE key, got {:?}", other),
+        }
+    }
+    let Some(tx_eid) = tx_eid else {
+        return Ok(None);
+    };
+
+    let mut entity_buf = Vec::new();
+    encode_datatype(&DataType::Long(tx_eid), &mut entity_buf);
+    let eav_prefix = concat_bytes(&[&[codec::EAV], &entity_buf]);
+    let mut iter = sdb
+        .scan_prefix_with_options(&eav_prefix, &DEFAULT_SCAN_OPTIONS)
+        .await?;
+    let mut tx_result: Option<i64> = None;
+    let mut tx_error: Option<String> = None;
+    while let Some(kv) = iter.next().await? {
+        let (_entity, attribute, value, _tx_eid, op) = eav_key_to_parts(kv.key)?;
+        if op == codec::RETRACT {
+            continue;
+        }
+        if attribute == crate::schema::DB_TX_RESULT {
+            if let DataType::Long(result) = value {
+                tx_result = Some(result);
+            }
+        }
+        if attribute == crate::schema::DB_TX_ERROR {
+            if let DataType::String(err) = value {
+                tx_error = Some(err);
+            }
+        }
+    }
+
+    let result = match tx_result {
+        Some(DB_TX_COMMITTED) => Ok(()),
+        Some(DB_TX_ABORTED) => Err(Arc::new(anyhow::anyhow!(
+            "{}",
+            tx_error.unwrap_or_else(|| format!("Transaction {} aborted", tx_key.tx_id))
+        ))),
+        Some(other) => bail!("Tx entity {tx_eid} has unknown :db/txResult {other}"),
+        None => bail!("Tx entity {tx_eid} missing :db/txResult"),
+    };
+    Ok(Some(TxCompletion {
+        basis: Some(TxBasis { tx_key, tx_eid }),
+        result,
+    }))
 }
 
 #[cfg(test)]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -464,7 +464,7 @@ pub(crate) fn validate_allocated_entity_ids(
 ///
 /// Returns `None` if no tx entity exists: the tx is either not yet indexed or
 /// failed without persisting an outcome (technical abort, deserialize failure).
-/// 
+///
 /// TODO: I think this function can be replaced by an entity API call once we have
 /// simplified TxKey/TxBasis and an actual entity API.
 pub(crate) async fn lookup_tx_completion<D>(

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -464,6 +464,9 @@ pub(crate) fn validate_allocated_entity_ids(
 ///
 /// Returns `None` if no tx entity exists: the tx is either not yet indexed or
 /// failed without persisting an outcome (technical abort, deserialize failure).
+/// 
+/// TODO: I think this function can be replaced by an entity API call once we have
+/// simplified TxKey/TxBasis and an actual entity API.
 pub(crate) async fn lookup_tx_completion<D>(
     sdb: &D,
     tx_key: TxKey,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -527,6 +527,7 @@ where
 
     let result = match tx_result {
         Some(DB_TX_COMMITTED) => Ok(()),
+        // TODO: Assure identical errors on live and reconstruction path. See #393.
         Some(DB_TX_ABORTED) => Err(Arc::new(anyhow::anyhow!(
             "{}",
             tx_error.unwrap_or_else(|| format!("Transaction {} aborted", tx_key.tx_id))


### PR DESCRIPTION
## Summary

`TxWaiter::await_tx` returned the first completion message with `completed_tx_key >= tx_key`. When the broadcast channel (capacity 1024) lagged, the awaited tx's message could be dropped and the next message — belonging to a **later** transaction — was returned in its place, so `Node::execute_tx` could report the wrong commit/abort outcome with the wrong `tx_eid`. The fast paths had the same bug class: an already-indexed aborted tx was reported as `Ok(())` (old TODO), and earlier tx_keys returned `basis: None, Ok(())` unconditionally.

## Fix

Storage is the authoritative record of an outcome: every commit and semantic abort persists a tx entity with `:db/txId`, `:db/txResult`, and `:db/txError`. This PR:

- Adds `lookup_tx_completion`, which recovers a tx's outcome via an AVE prefix scan on `:db/txId` plus an EAV read of the tx entity.
- Rewrites `await_tx`: an exact `==` match returns the broadcast message as before (hot path, zero storage reads); seeing a later tx first (only possible after lag, since the indexer broadcasts exactly one in-order message per record) recovers the true outcome from storage; on `RecvError::Lagged` the waiter checks storage immediately. The already-indexed fast paths use the same recovery, so aborted transactions now report their real error and basis.
- A tx that left no entity (technical abort, deserialize failure) yields an explicit "left no tx entity" error instead of a fabricated result, mirroring the live notification shape (`basis: None`, error result).
- Stores the full error chain (`{:#}`) in aborted tx entities.
- Adds `Indexer::with_channel_capacity` so tests can force lag deterministically (capacity 1 + two transactions).

`await_indexed` is unchanged — `>=` is correct there since it only asks whether indexing has reached a point.

## Tests

Nine new tests in `src/indexer.rs`:
- `lookup_tx_completion` unit tests: committed, aborted (error string round-trips), missing.
- Lag regression: awaited tx aborted / later committed, awaited tx committed / later aborted, and a technical abort whose evidence surfaces via a later tx's message.
- Fast paths: latest tx aborted, earlier committed tx returns its real basis, earlier tx with no entity returns the explicit error.

All six behavior tests were verified to fail against the pre-fix logic. `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features`, and `cargo fmt` are clean.

Closes #131
Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)