### PR TITLE
fix: validate tx conflicts before card-one finalize rewrite

### DIFF
--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -15,7 +15,7 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
                                 (pipeline reads go directly against slatedb;
                                  index writes are buffered in a WriteBatch
-                                 committed atomically in step 7)
+                                 committed atomically in step 9)
                                 ↓
 2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) -> Vec<DatomExpanded>
    - TxOp::Put -> N DatomExpanded (one per attr)
@@ -47,19 +47,25 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
    - Allocates remaining tempids, coalescing unresolved identity matches
    Build tx entity datoms       build_tx_entity_datoms(tx_eid, tx_key, ...)
                                 ↓
-6. Cardinality resolution       finalize_datoms_for_commit (EAV scan for card-one auto-retract)
-                                ↓
-7. Validate                     validate_unique_constraints + schema.validate_datoms(datoms)
-   - Unique checks for :db.unique/value and :db.unique/identity
+6. Validate                     schema.validate_datoms(datoms)
+   - Runs on the user's datoms before finalize, so intra-tx conflicts
+     (add/retract overlap, card-one multi-assert) judge user intent
    - Type checking: value type matches attribute's value_type
    - Unknown attribute errors
    - Detects schema changes
                                 ↓
-8. Write indices + commit       let mut batch = WriteBatch::new();
+7. Cardinality resolution       finalize_datoms_for_commit (EAV scan for card-one auto-retract)
+   - Purely mechanical rewrite: cannot change tx semantics
+                                ↓
+8. Unique validation            validate_unique_constraints
+   - Unique checks for :db.unique/value and :db.unique/identity
+   - Runs post-finalize: must see auto-generated card-one retracts
+                                ↓
+9. Write indices + commit       let mut batch = WriteBatch::new();
                                 write_index_entries(&mut batch, ...);
                                 slatedb.write_with_options(batch, ...)
                                 ↓
-9. Apply on success only:
+10. Apply on success only:
    - self.metadata.partition_map = pending_pm    (counter reservation committed)
    - self.metadata.schema.apply_schema_update(schema_update)  (infallible)
    - self.metadata.advance_generation()

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -328,28 +328,30 @@ impl Indexer {
         .await?;
         datoms.extend(build_tx_entity_datoms(tx_eid, tx_key, true, None));
 
-        // 6. Finalize datoms (card-one rewrite) against current storage state
-        let datoms = self.finalize_datoms_for_commit(datoms).await?;
-
-        // 7. Unique + general validation
-        self.validate_unique_constraints(&datoms).await?;
+        // 6. Validate user datoms (intra-tx conflicts judge user intent, pre-finalize)
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
 
-        // 8. Prepare schema update before writing to avoid leaking rejected datoms
+        // 7. Finalize datoms (card-one rewrite) against current storage state
+        let datoms = self.finalize_datoms_for_commit(datoms).await?;
+
+        // 8. Unique validation (needs the auto-generated card-one retracts)
+        self.validate_unique_constraints(&datoms).await?;
+
+        // 9. Prepare schema update before writing to avoid leaking rejected datoms
         let schema_update = if validation.schema_changes_detected {
             Some(self.metadata.schema.prepare_schema_update(&datoms)?)
         } else {
             None
         };
 
-        // 9. Write indices + commit
+        // 10. Write indices + commit
         let mut batch = WriteBatch::new();
         write_index_entries(&mut batch, &datoms, &self.metadata.schema, tx_eid)?;
         self.slatedb
             .write_with_options(batch, &DEFAULT_WRITE_OPTIONS)
             .await?;
 
-        // 10. Apply on success only
+        // 11. Apply on success only
         self.metadata.partition_map = pending_pm;
         if let Some(schema_update) = schema_update.filter(|update| !update.is_empty()) {
             self.metadata.schema.apply_schema_update(schema_update);
@@ -1392,6 +1394,184 @@ mod tests {
             }
         }
         assert_eq!(add_count, 1, "Expected 1 ADD entry (second tx dropped)");
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries");
+
+        Ok(())
+    }
+
+    /// Find the first user-partition entity ID in the EAV index.
+    async fn find_user_entity_id(slate: &Db) -> Result<i64, Error> {
+        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
+            if let DataType::Long(id) = eid {
+                if id >= user_base {
+                    return Ok(id);
+                }
+            }
+        }
+        anyhow::bail!("Should have found user entity")
+    }
+
+    /// Count (ADD, RETRACT) EAV entries for a given entity and attribute.
+    async fn count_eav_ops(
+        slate: &Db,
+        entity_id: i64,
+        attr_id: Entid,
+    ) -> Result<(u32, u32), Error> {
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        let mut add_count = 0;
+        let mut retract_count = 0;
+        while let Some(kv) = iter.next().await? {
+            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if eid != DataType::Long(entity_id) || attribute != attr_id {
+                continue;
+            }
+            match op {
+                codec::ADD => add_count += 1,
+                codec::RETRACT => retract_count += 1,
+                _ => {}
+            }
+        }
+        Ok((add_count, retract_count))
+    }
+
+    // Regression test for #379 consequence 1: retract + re-assert of the stored
+    // value must abort as an add/retract conflict instead of silently retracting.
+    #[tokio::test]
+    async fn test_retract_and_reassert_stored_value_aborts() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let slate = components.db.clone();
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
+        indexer
+            .transact_tx(
+                tx1,
+                vec![TxOp::Add {
+                    entity: "alice".into(),
+                    attribute: kw!(:name),
+                    value: "alice".into(),
+                }],
+            )
+            .await?;
+        let entity_id = find_user_entity_id(&slate).await?;
+
+        // Second tx: retract + re-assert the stored value — must abort, not retract
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        let waiter = indexer.tx_waiter();
+        indexer
+            .transact_tx(
+                tx2,
+                vec![
+                    TxOp::Retract {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "alice".into(),
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "alice".into(),
+                    },
+                ],
+            )
+            .await?;
+        let completion = waiter.await_tx(tx2).await?;
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot both assert and retract"));
+
+        // The stored value must survive: 1 ADD, no RETRACTs
+        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
+        assert_eq!(add_count, 1, "Expected the original ADD to survive");
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries");
+
+        Ok(())
+    }
+
+    // Regression test for #379 consequence 2: two asserts for a card-one attribute
+    // must abort even when one of them equals the stored value.
+    #[tokio::test]
+    async fn test_card_one_two_asserts_abort_even_when_one_matches_stored() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let slate = components.db.clone();
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
+        indexer
+            .transact_tx(
+                tx1,
+                vec![TxOp::Add {
+                    entity: "alice".into(),
+                    attribute: kw!(:name),
+                    value: "alice".into(),
+                }],
+            )
+            .await?;
+        let entity_id = find_user_entity_id(&slate).await?;
+
+        // Second tx: assert stored value + a different value — must abort, not let "bob" win
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        let waiter = indexer.tx_waiter();
+        indexer
+            .transact_tx(
+                tx2,
+                vec![
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "alice".into(),
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "bob".into(),
+                    },
+                ],
+            )
+            .await?;
+        let completion = waiter.await_tx(tx2).await?;
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot assert multiple values"));
+
+        // Storage unchanged: only the original ADD, no "bob", no RETRACTs
+        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
+        assert_eq!(add_count, 1, "Expected only the original ADD");
         assert_eq!(retract_count, 0, "Expected no RETRACT entries");
 
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -332,6 +332,10 @@ impl Indexer {
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
 
         // 7. Finalize datoms (card-one rewrite) against current storage state
+        // The reason this step can-t invalidate the datom set is that this can only ever do two things:
+        // - Drop an assert those value is already stored. No conflict possible.
+        // - Add a retract for a stored value. By construction it's valid and validation assured 
+        //   that there is at most one assert per (entity, card-one attribute) pair. 
         let datoms = self.finalize_datoms_for_commit(datoms).await?;
 
         // 8. Unique validation (needs the auto-generated card-one retracts)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -805,7 +805,7 @@ mod tests {
     }
 
     /// Find the first user-partition entity ID by scanning the EAV index.
-    async fn find_first_user_entity(slate: &Arc<slatedb::Db>) -> Result<i64, Error> {
+    async fn find_first_user_entity(slate: &Db) -> Result<i64, Error> {
         let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
         let mut iter = slate
             .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
@@ -818,7 +818,7 @@ mod tests {
                 }
             }
         }
-        panic!("No user-partition entity found in EAV index");
+        anyhow::bail!("No user-partition entity found in EAV index")
     }
 
     /// Count (ADD, RETRACT) EAV entries for a given entity and attribute.
@@ -912,7 +912,7 @@ mod tests {
         }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
-        // Verify an EAV entry in USER_PARTITION exists (panics if none found)
+        // Verify an EAV entry in USER_PARTITION exists (errors if none found)
         find_first_user_entity(&slate).await?;
 
         Ok(())

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1456,6 +1456,74 @@ mod tests {
         Ok(())
     }
 
+    // Regression test for #379 consequence 2: two asserts for a card-one attribute
+    // must abort even when one of them equals the stored value.
+    #[tokio::test]
+    async fn test_card_one_two_asserts_abort_even_when_one_matches_stored() -> Result<(), Error> {
+        let components = in_memory_slate().await;
+        let slate = components.db.clone();
+        let mut indexer = bootstrapped_indexer(&components).await;
+        let name_id = indexer
+            .metadata()
+            .schema
+            .get_attribute(&kw!(:name))
+            .unwrap()
+            .0;
+
+        let tx1 = TxKey {
+            tx_id: 1,
+            system_time: st_from_unix_epoch(100),
+        };
+        indexer
+            .transact_tx(
+                tx1,
+                vec![TxOp::Add {
+                    entity: "alice".into(),
+                    attribute: kw!(:name),
+                    value: "alice".into(),
+                }],
+            )
+            .await?;
+        let entity_id = find_first_user_entity(&slate).await?;
+
+        // Second tx: assert stored value + a different value — must abort, not let "bob" win
+        let tx2 = TxKey {
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
+        };
+        let waiter = indexer.tx_waiter();
+        indexer
+            .transact_tx(
+                tx2,
+                vec![
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "alice".into(),
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity_id),
+                        attribute: kw!(:name),
+                        value: "bob".into(),
+                    },
+                ],
+            )
+            .await?;
+        let completion = waiter.await_tx(tx2).await?;
+        assert!(completion
+            .result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot assert multiple values"));
+
+        // Storage unchanged: only the original ADD, no "bob", no RETRACTs
+        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
+        assert_eq!(add_count, 1, "Expected only the original ADD");
+        assert_eq!(retract_count, 0, "Expected no RETRACT entries");
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_schema_immutability_rejected_in_pipeline() -> Result<(), Error> {
         let components = in_memory_slate().await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -332,9 +332,9 @@ impl Indexer {
         let validation = self.metadata.schema.validate_datoms(&datoms)?;
 
         // 7. Finalize datoms (card-one rewrite) against current storage state
-        // The reason this step can-t invalidate the datom set is that this can only ever do two things:
-        // - Drop an assert those value is already stored. No conflict possible.
-        // - Add a retract for a stored value. By construction it's valid and validation assured
+        // This step can't invalidate the datom set because it can only ever do two things:
+        // - Drop an assert whose value is already stored. No conflict possible.
+        // - Add a retract for a stored value. By construction it's valid, and validation ensured
         //   that there is at most one assert per (entity, card-one attribute) pair.
         let datoms = self.finalize_datoms_for_commit(datoms).await?;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -334,8 +334,8 @@ impl Indexer {
         // 7. Finalize datoms (card-one rewrite) against current storage state
         // The reason this step can-t invalidate the datom set is that this can only ever do two things:
         // - Drop an assert those value is already stored. No conflict possible.
-        // - Add a retract for a stored value. By construction it's valid and validation assured 
-        //   that there is at most one assert per (entity, card-one attribute) pair. 
+        // - Add a retract for a stored value. By construction it's valid and validation assured
+        //   that there is at most one assert per (entity, card-one attribute) pair.
         let datoms = self.finalize_datoms_for_commit(datoms).await?;
 
         // 8. Unique validation (needs the auto-generated card-one retracts)
@@ -804,6 +804,48 @@ mod tests {
         indexer
     }
 
+    /// Find the first user-partition entity ID by scanning the EAV index.
+    async fn find_first_user_entity(slate: &Arc<slatedb::Db>) -> Result<i64, Error> {
+        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        while let Some(kv) = iter.next().await? {
+            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
+            if let DataType::Long(id) = eid {
+                if id >= user_base {
+                    return Ok(id);
+                }
+            }
+        }
+        panic!("No user-partition entity found in EAV index");
+    }
+
+    /// Count (ADD, RETRACT) EAV entries for a given entity and attribute.
+    async fn count_eav_ops(
+        slate: &Db,
+        entity_id: i64,
+        attr_id: Entid,
+    ) -> Result<(u32, u32), Error> {
+        let mut iter = slate
+            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
+            .await?;
+        let mut add_count = 0;
+        let mut retract_count = 0;
+        while let Some(kv) = iter.next().await? {
+            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
+            if eid != DataType::Long(entity_id) || attribute != attr_id {
+                continue;
+            }
+            match op {
+                codec::ADD => add_count += 1,
+                codec::RETRACT => retract_count += 1,
+                _ => {}
+            }
+        }
+        Ok((add_count, retract_count))
+    }
+
     #[tokio::test]
     async fn test_indexer() -> Result<(), Error> {
         let components = in_memory_slate().await;
@@ -870,23 +912,8 @@ mod tests {
         }];
         indexer.transact_tx(tx_key, tx_ops).await.unwrap();
 
-        // Verify an EAV entry in USER_PARTITION exists
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await
-            .unwrap();
-        let mut found = false;
-        while let Some(kv) = iter.next().await? {
-            let (entity_id, _, _, _, _) = eav_key_to_parts(kv.key).unwrap();
-            if let DataType::Long(eid) = entity_id {
-                if eid >= user_base {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        assert!(found, "Expected EAV entry to be written to the database");
+        // Verify an EAV entry in USER_PARTITION exists (panics if none found)
+        find_first_user_entity(&slate).await?;
 
         Ok(())
     }
@@ -1259,21 +1286,7 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find the auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
-            }
-        }
-        assert!(entity_id >= user_base, "Should have found user entity");
+        let entity_id = find_first_user_entity(&slate).await?;
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
         let tx2 = TxKey {
@@ -1349,20 +1362,7 @@ mod tests {
         indexer.transact_tx(tx1, tx_ops).await?;
 
         // Find auto-assigned entity ID
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut entity_id: i64 = 0;
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    entity_id = id;
-                    break;
-                }
-            }
-        }
+        let entity_id = find_first_user_entity(&slate).await?;
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey {
@@ -1381,68 +1381,11 @@ mod tests {
             .await?;
 
         // Count EAV entries for entity, name attr — should be 1 ADD, 0 RETRACTs
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        let mut add_count = 0;
-        let mut retract_count = 0;
-        while let Some(kv) = iter.next().await? {
-            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if eid != DataType::Long(entity_id) || attribute != name_id {
-                continue;
-            }
-            match op {
-                codec::ADD => add_count += 1,
-                codec::RETRACT => retract_count += 1,
-                _ => {}
-            }
-        }
+        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
         assert_eq!(add_count, 1, "Expected 1 ADD entry (second tx dropped)");
         assert_eq!(retract_count, 0, "Expected no RETRACT entries");
 
         Ok(())
-    }
-
-    /// Find the first user-partition entity ID in the EAV index.
-    async fn find_user_entity_id(slate: &Db) -> Result<i64, Error> {
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    return Ok(id);
-                }
-            }
-        }
-        anyhow::bail!("Should have found user entity")
-    }
-
-    /// Count (ADD, RETRACT) EAV entries for a given entity and attribute.
-    async fn count_eav_ops(
-        slate: &Db,
-        entity_id: i64,
-        attr_id: Entid,
-    ) -> Result<(u32, u32), Error> {
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        let mut add_count = 0;
-        let mut retract_count = 0;
-        while let Some(kv) = iter.next().await? {
-            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if eid != DataType::Long(entity_id) || attribute != attr_id {
-                continue;
-            }
-            match op {
-                codec::ADD => add_count += 1,
-                codec::RETRACT => retract_count += 1,
-                _ => {}
-            }
-        }
-        Ok((add_count, retract_count))
     }
 
     // Regression test for #379 consequence 1: retract + re-assert of the stored
@@ -1473,7 +1416,7 @@ mod tests {
                 }],
             )
             .await?;
-        let entity_id = find_user_entity_id(&slate).await?;
+        let entity_id = find_first_user_entity(&slate).await?;
 
         // Second tx: retract + re-assert the stored value — must abort, not retract
         let tx2 = TxKey {
@@ -1508,74 +1451,6 @@ mod tests {
         // The stored value must survive: 1 ADD, no RETRACTs
         let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
         assert_eq!(add_count, 1, "Expected the original ADD to survive");
-        assert_eq!(retract_count, 0, "Expected no RETRACT entries");
-
-        Ok(())
-    }
-
-    // Regression test for #379 consequence 2: two asserts for a card-one attribute
-    // must abort even when one of them equals the stored value.
-    #[tokio::test]
-    async fn test_card_one_two_asserts_abort_even_when_one_matches_stored() -> Result<(), Error> {
-        let components = in_memory_slate().await;
-        let slate = components.db.clone();
-        let mut indexer = bootstrapped_indexer(&components).await;
-        let name_id = indexer
-            .metadata()
-            .schema
-            .get_attribute(&kw!(:name))
-            .unwrap()
-            .0;
-
-        let tx1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
-        };
-        indexer
-            .transact_tx(
-                tx1,
-                vec![TxOp::Add {
-                    entity: "alice".into(),
-                    attribute: kw!(:name),
-                    value: "alice".into(),
-                }],
-            )
-            .await?;
-        let entity_id = find_user_entity_id(&slate).await?;
-
-        // Second tx: assert stored value + a different value — must abort, not let "bob" win
-        let tx2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
-        };
-        let waiter = indexer.tx_waiter();
-        indexer
-            .transact_tx(
-                tx2,
-                vec![
-                    TxOp::Add {
-                        entity: EntityRef::Id(entity_id),
-                        attribute: kw!(:name),
-                        value: "alice".into(),
-                    },
-                    TxOp::Add {
-                        entity: EntityRef::Id(entity_id),
-                        attribute: kw!(:name),
-                        value: "bob".into(),
-                    },
-                ],
-            )
-            .await?;
-        let completion = waiter.await_tx(tx2).await?;
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot assert multiple values"));
-
-        // Storage unchanged: only the original ADD, no "bob", no RETRACTs
-        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
-        assert_eq!(add_count, 1, "Expected only the original ADD");
         assert_eq!(retract_count, 0, "Expected no RETRACT entries");
 
         Ok(())
@@ -1649,23 +1524,6 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    /// Find the first user-partition entity ID by scanning the EAV index.
-    async fn find_first_user_entity(slate: &Arc<slatedb::Db>) -> Result<i64, Error> {
-        let user_base = crate::partition::USER_PARTITION as i64 * (1i64 << 42);
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        while let Some(kv) = iter.next().await? {
-            let (eid, _, _, _, _) = eav_key_to_parts(kv.key.clone())?;
-            if let DataType::Long(id) = eid {
-                if id >= user_base {
-                    return Ok(id);
-                }
-            }
-        }
-        panic!("No user-partition entity found in EAV index");
     }
 
     // TODO move this test to a proper node level test once we support historic queries
@@ -1911,22 +1769,7 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs, 0 RETRACTs
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        let mut add_count = 0;
-        let mut retract_count = 0;
-        while let Some(kv) = iter.next().await? {
-            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if eid != DataType::Long(entity_id) || attribute != tags_id {
-                continue;
-            }
-            match op {
-                codec::ADD => add_count += 1,
-                codec::RETRACT => retract_count += 1,
-                _ => {}
-            }
-        }
+        let (add_count, retract_count) = count_eav_ops(&slate, entity_id, tags_id).await?;
         assert_eq!(add_count, 2, "Expected 2 ADD entries for cardinality-many");
         assert_eq!(
             retract_count, 0,
@@ -1979,19 +1822,7 @@ mod tests {
         indexer.transact_tx(tx2, tx_ops2).await?;
 
         // Scan EAV for entity, tags attr — expect 2 ADDs (both written)
-        let mut iter = slate
-            .scan_prefix_with_options(&[codec::EAV], &ScanOptions::default())
-            .await?;
-        let mut add_count = 0;
-        while let Some(kv) = iter.next().await? {
-            let (eid, attribute, _value, _ts, op) = eav_key_to_parts(kv.key)?;
-            if eid != DataType::Long(entity_id) || attribute != tags_id {
-                continue;
-            }
-            if op == codec::ADD {
-                add_count += 1;
-            }
-        }
+        let (add_count, _retract_count) = count_eav_ops(&slate, entity_id, tags_id).await?;
         assert_eq!(
             add_count, 2,
             "Expected 2 ADD entries for same value on cardinality-many"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -467,8 +467,10 @@ impl Schema {
         self.attribute_map.contains_key(&entity_id)
     }
 
-    /// Validate finalized transaction datoms against the current schema.
+    /// Validate resolved transaction datoms against the current schema.
     ///
+    /// Runs before the card-one finalize rewrite so intra-tx conflicts are
+    /// judged on user intent, not on mechanically rewritten datoms (#379).
     /// This step does general transaction validation only. Schema-related datoms
     /// are merely witnessed so the caller can decide whether a schema delta must
     /// be prepared in a separate pass.


### PR DESCRIPTION
Fixes #379.

## Problem

`finalize_datoms_for_commit` (pipeline step 6) dropped no-op card-one asserts (assert whose value equals the stored value) **before** `validate_datoms` (step 7) checked intra-transaction conflicts. The drop could remove exactly the datom that would have triggered a conflict error:

1. **Silent retraction**: `retract(e,a,v)` + `assert(e,a,v)` where `v` is the stored value — finalize dropped the assert, `add_retract_conflicts` saw only the retract, and the value was silently deleted (Datomic rejects this tx).
2. **State-dependent conflicts**: two asserts for a card-one attribute aborted with `CardinalityOneAddConflict` — unless one equaled the stored value, in which case the other silently won.

## Fix

`schema.validate_datoms` now runs on the resolved user datoms **before** `finalize_datoms_for_commit`, so intra-tx conflicts judge user intent and finalize becomes a purely mechanical rewrite that cannot change semantics.

`validate_unique_constraints` deliberately stays post-finalize: it must see the auto-generated card-one retracts (e.g. moving a unique value between entities), and the no-op drop cannot change its outcome (asserting your own stored value resolves to `owner == entity`, which is allowed anyway).

Also updates `design/TX_PIPELINE.md` stages 6–8 and the `validate_datoms` doc comment to match.

## Tests

Two regression tests in the indexer test module, one per consequence:
- `test_retract_and_reassert_stored_value_aborts`
- `test_card_one_two_asserts_abort_even_when_one_matches_stored`

Both were verified to fail under the old ordering. `cargo test --workspace`, `cargo clippy --workspace --all-targets`, and `cargo fmt --check` all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)