### PR TITLE
fix: detect conflicting identity upserts on a single tempid

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -3588,6 +3588,63 @@ mod tests {
         }
     }
 
+    /// A single tempid asserting two different `:db.unique/identity`
+    /// attributes that resolve to two different existing entities must abort
+    /// as a conflicting upsert naming the tempid and both candidates — not as
+    /// a downstream unique-constraint violation against a nondeterministically
+    /// chosen winner (#380).
+    #[tokio::test]
+    async fn test_conflicting_identity_upserts_single_tempid_rejects_tx() {
+        let node = Node::memory_node().await;
+        node.execute_tx(vec![
+            unique_identity_schema_attribute(kw!(:user/email), "string"),
+            unique_identity_schema_attribute(kw!(:user/ssn), "string"),
+        ])
+        .await
+        .unwrap();
+
+        node.execute_tx(vec![
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("alice".into())),
+                (kw!(:user/email), "a@x".into()),
+            ]),
+            TxOp::put(vec![
+                (kw!(:db/id), DataType::String("bob".into())),
+                (kw!(:user/ssn), "123".into()),
+            ]),
+        ])
+        .await
+        .unwrap();
+
+        let result = node
+            .execute_tx(vec![
+                TxOp::Add {
+                    entity: "t".into(),
+                    attribute: kw!(:user/email),
+                    value: "a@x".into(),
+                },
+                TxOp::Add {
+                    entity: "t".into(),
+                    attribute: kw!(:user/ssn),
+                    value: "123".into(),
+                },
+            ])
+            .await
+            .unwrap();
+
+        match result {
+            TransactionResult::TxAborted(_, err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("Conflicting upserts"),
+                    "expected 'Conflicting upserts', got: {}",
+                    msg
+                );
+            }
+            TransactionResult::TxCommited(_) => panic!("expected TxAborted, got TxCommited"),
+        }
+    }
+
     /// In-tx ownership transfer of a unique-identity ref attribute.
     ///
     /// The user retracts carol's `(:user/primary-friend, bob)` ownership and

--- a/src/tempids.rs
+++ b/src/tempids.rs
@@ -203,26 +203,9 @@ mod tests {
         (resolved, pm)
     }
 
-    async fn seed_datom(
-        db: &slatedb::Db,
-        schema: &Schema,
-        entity: Entid,
-        attribute: edn::symbols::Keyword,
-        value: DataType,
-    ) {
+    async fn seed_datom(db: &slatedb::Db, schema: &Schema, datom: Datom) {
         let mut batch = WriteBatch::new();
-        write_index_entries(
-            &mut batch,
-            &[Datom {
-                entity,
-                attribute,
-                value,
-                op: DatomOp::Assert,
-            }],
-            schema,
-            1,
-        )
-        .unwrap();
+        write_index_entries(&mut batch, &[datom], schema, 1).unwrap();
         db.write_with_options(batch, &DEFAULT_WRITE_OPTIONS)
             .await
             .unwrap();
@@ -234,7 +217,17 @@ mod tests {
         entity: Entid,
         ident: edn::symbols::Keyword,
     ) {
-        seed_datom(db, schema, entity, kw!(:db/ident), DataType::Keyword(ident)).await;
+        seed_datom(
+            db,
+            schema,
+            Datom {
+                entity,
+                attribute: kw!(:db/ident),
+                value: DataType::Keyword(ident),
+                op: DatomOp::Assert,
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -285,17 +278,23 @@ mod tests {
         seed_datom(
             slate.db.as_ref(),
             &schema,
-            42,
-            kw!(:email),
-            DataType::String("a@x".to_string()),
+            Datom {
+                entity: 42,
+                attribute: kw!(:email),
+                value: DataType::String("a@x".to_string()),
+                op: DatomOp::Assert,
+            },
         )
         .await;
         seed_datom(
             slate.db.as_ref(),
             &schema,
-            43,
-            kw!(:ssn),
-            DataType::String("123".to_string()),
+            Datom {
+                entity: 43,
+                attribute: kw!(:ssn),
+                value: DataType::String("123".to_string()),
+                op: DatomOp::Assert,
+            },
         )
         .await;
         let datoms = vec![
@@ -338,17 +337,23 @@ mod tests {
         seed_datom(
             slate.db.as_ref(),
             &schema,
-            42,
-            kw!(:email),
-            DataType::String("a@x".to_string()),
+            Datom {
+                entity: 42,
+                attribute: kw!(:email),
+                value: DataType::String("a@x".to_string()),
+                op: DatomOp::Assert,
+            },
         )
         .await;
         seed_datom(
             slate.db.as_ref(),
             &schema,
-            42,
-            kw!(:ssn),
-            DataType::String("123".to_string()),
+            Datom {
+                entity: 42,
+                attribute: kw!(:ssn),
+                value: DataType::String("123".to_string()),
+                op: DatomOp::Assert,
+            },
         )
         .await;
         let datoms = vec![

--- a/src/tempids.rs
+++ b/src/tempids.rs
@@ -16,28 +16,38 @@ use crate::schema::Schema;
 use crate::tx::{self, DatomWithTempids, IdOrTempId};
 use crate::upsert_resolution::{Generation, TempIdMap, UniqueLookup};
 
+fn conflicting_upserts(conflicts: BTreeMap<String, BTreeSet<Entid>>) -> anyhow::Error {
+    anyhow::anyhow!("Conflicting upserts: {:?}", conflicts)
+}
+
 async fn resolve_temp_id_avs(
     tempid_avs: &[(String, UniqueLookup)],
     db: &slatedb::Db,
 ) -> Result<TempIdMap> {
-    let mut unique_lookups: HashMap<UniqueLookup, Vec<String>> = HashMap::new();
-    for (tempid, lookup) in tempid_avs {
-        unique_lookups
-            .entry(lookup.clone())
-            .or_default()
-            .push(tempid.clone());
-    }
-
-    let lookups: Vec<UniqueLookup> = unique_lookups.keys().cloned().collect();
+    let lookups: Vec<UniqueLookup> = tempid_avs.iter().map(|(_, l)| l.clone()).collect();
     let resolved = tx::batch_lookup_unique_eids(db, &lookups).await?;
 
-    let mut temp_id_map = HashMap::new();
-    for (lookup, tempids) in unique_lookups {
-        if let Some(&eid) = resolved.get(&lookup) {
-            for tempid in tempids {
-                temp_id_map.insert(tempid, eid);
-            }
+    // A tempid may carry several identity assertions; collect every entid they
+    // resolve to so that disagreement aborts instead of one binding silently
+    // winning by iteration order.
+    let mut candidates: BTreeMap<String, BTreeSet<Entid>> = BTreeMap::new();
+    for (tempid, lookup) in tempid_avs {
+        if let Some(&eid) = resolved.get(lookup) {
+            candidates.entry(tempid.clone()).or_default().insert(eid);
         }
+    }
+
+    let mut temp_id_map = TempIdMap::new();
+    let mut conflicts: BTreeMap<String, BTreeSet<Entid>> = BTreeMap::new();
+    for (tempid, eids) in candidates {
+        if eids.len() == 1 {
+            temp_id_map.insert(tempid, eids.into_iter().next().unwrap());
+        } else {
+            conflicts.insert(tempid, eids);
+        }
+    }
+    if !conflicts.is_empty() {
+        return Err(conflicting_upserts(conflicts));
     }
     Ok(temp_id_map)
 }
@@ -59,7 +69,7 @@ fn record_resolutions(
     }
 
     if !conflicts.is_empty() {
-        return Err(anyhow::anyhow!("Conflicting upserts: {:?}", conflicts));
+        return Err(conflicting_upserts(conflicts));
     }
     Ok(())
 }
@@ -166,6 +176,8 @@ mod tests {
             (kw!(:name), 100, ValueType::String, None),
             (kw!(:age), 101, ValueType::Long, None),
             (kw!(:follows), 102, ValueType::Ref, None),
+            (kw!(:email), 103, ValueType::String, Some(Unique::Identity)),
+            (kw!(:ssn), 104, ValueType::String, Some(Unique::Identity)),
         ] {
             schema.ident_map.insert(kw.clone(), eid);
             schema.entid_map.insert(eid, kw);
@@ -191,19 +203,20 @@ mod tests {
         (resolved, pm)
     }
 
-    async fn seed_ident(
+    async fn seed_datom(
         db: &slatedb::Db,
         schema: &Schema,
         entity: Entid,
-        ident: edn::symbols::Keyword,
+        attribute: edn::symbols::Keyword,
+        value: DataType,
     ) {
         let mut batch = WriteBatch::new();
         write_index_entries(
             &mut batch,
             &[Datom {
                 entity,
-                attribute: kw!(:db/ident),
-                value: DataType::Keyword(ident),
+                attribute,
+                value,
                 op: DatomOp::Assert,
             }],
             schema,
@@ -213,6 +226,15 @@ mod tests {
         db.write_with_options(batch, &DEFAULT_WRITE_OPTIONS)
             .await
             .unwrap();
+    }
+
+    async fn seed_ident(
+        db: &slatedb::Db,
+        schema: &Schema,
+        entity: Entid,
+        ident: edn::symbols::Keyword,
+    ) {
+        seed_datom(db, schema, entity, kw!(:db/ident), DataType::Keyword(ident)).await;
     }
 
     #[tokio::test]
@@ -253,6 +275,107 @@ mod tests {
         ];
         let (resolved, _) = resolve(datoms).await;
         assert_ne!(resolved[0].entity, resolved[1].entity);
+    }
+
+    #[tokio::test]
+    async fn test_conflicting_identity_upserts_on_single_tempid_errors() {
+        let slate = in_memory_slate().await;
+        let schema = tempid_test_schema();
+        let mut pm = PartitionMap::new();
+        seed_datom(
+            slate.db.as_ref(),
+            &schema,
+            42,
+            kw!(:email),
+            DataType::String("a@x".to_string()),
+        )
+        .await;
+        seed_datom(
+            slate.db.as_ref(),
+            &schema,
+            43,
+            kw!(:ssn),
+            DataType::String("123".to_string()),
+        )
+        .await;
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t".to_string()),
+                attribute: kw!(:email),
+                value: ValueWithTempIds::Data(DataType::String("a@x".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t".to_string()),
+                attribute: kw!(:ssn),
+                value: ValueWithTempIds::Data(DataType::String("123".to_string())),
+                op: DatomOp::Assert,
+            },
+        ];
+
+        let msg = resolve_tempids(datoms, &schema, &slate.db, &mut pm)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            msg.contains("Conflicting upserts"),
+            "expected 'Conflicting upserts', got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("\"t\"") && msg.contains("42") && msg.contains("43"),
+            "error should name the tempid and both candidate entids, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_identity_upserts_same_entity_succeeds() {
+        let slate = in_memory_slate().await;
+        let schema = tempid_test_schema();
+        let mut pm = PartitionMap::new();
+        seed_datom(
+            slate.db.as_ref(),
+            &schema,
+            42,
+            kw!(:email),
+            DataType::String("a@x".to_string()),
+        )
+        .await;
+        seed_datom(
+            slate.db.as_ref(),
+            &schema,
+            42,
+            kw!(:ssn),
+            DataType::String("123".to_string()),
+        )
+        .await;
+        let datoms = vec![
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t".to_string()),
+                attribute: kw!(:email),
+                value: ValueWithTempIds::Data(DataType::String("a@x".to_string())),
+                op: DatomOp::Assert,
+            },
+            DatomWithTempids {
+                entity: IdOrTempId::TempId("t".to_string()),
+                attribute: kw!(:ssn),
+                value: ValueWithTempIds::Data(DataType::String("123".to_string())),
+                op: DatomOp::Assert,
+            },
+        ];
+
+        let resolved = resolve_tempids(datoms, &schema, &slate.db, &mut pm)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.len(), 2);
+        assert!(resolved.iter().all(|d| d.entity == 42));
+        assert!(
+            pm.is_empty(),
+            "upserted tempid should not allocate a new entid"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #380.

When one tempid asserted two different `:db.unique/identity` attributes that resolved to two different existing entities, `resolve_temp_id_avs` silently overwrote the first binding with the second — the winner was determined by `HashMap` iteration order. The transaction still aborted, but only downstream in `validate_unique_constraints`, with a misleading "Unique constraint violation" naming a nondeterministically chosen entity.

## Changes

- `resolve_temp_id_avs` now collects every entid each tempid resolves to into a `BTreeMap<String, BTreeSet<Entid>>` and aborts with a deterministic `Conflicting upserts: {"t": {42, 43}}` error when a tempid has more than one candidate. This restores the within-generation check Mentat performs in its `resolve_temp_id_avs` (`db/src/tx.rs`), complementing the existing cross-generation check in `record_resolutions`.
- Dropped the lookup-grouping `HashMap` — `batch_lookup_unique_eids` already dedupes lookups internally via its prefix `BTreeMap`.
- Extracted a shared `conflicting_upserts` error constructor so both conflict paths emit an identical format.

## Tests

- `tempids.rs`: conflict case asserts the error names the tempid and both candidate entids; agreement case (both identity attributes owned by the same entity) asserts both datoms resolve to it with no allocation. Test schema gained `:email`/`:ssn` identity attributes and a generalized `seed_datom` helper.
- `node.rs`: end-to-end `test_conflicting_identity_upserts_single_tempid_rejects_tx` reproduces the issue scenario and asserts `TxAborted` with "Conflicting upserts".

Full suite passes (510 passed, 1 pre-existing ignored); `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)