### PR TITLE
fix: don't fail node restart on a trailing aborted tx

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -585,6 +585,10 @@ pub(crate) struct TxCompletion {
 }
 
 impl TxWaiter {
+    // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
+    // await_indexed answers "Are we there yet?" without knowing anything about the result.
+
+
     /// Wait until `tx_key` has been indexed. Returns the indexed basis and status,
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -588,7 +588,6 @@ impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
 
-
     /// Wait until `tx_key` has been indexed. Returns the indexed basis and status,
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -197,8 +197,7 @@ impl<L: TxLog> Node<L> {
 
         // Wait for catch-up to complete if there are un-indexed transactions
         if let Some((tx_key, waiter)) = last_tx_key.zip(waiter) {
-            let completion = waiter.await_tx(tx_key).await?;
-            completion.result.map_err(|e| anyhow::anyhow!("{:#}", e))?;
+            waiter.await_indexed(tx_key).await?;
         }
 
         Ok(Node {
@@ -1404,6 +1403,56 @@ mod tests {
             "tx_waiter should not timeout for an already-indexed tx"
         );
         result.unwrap().expect("await_tx should succeed");
+
+        node.close().await.unwrap();
+    }
+
+    // Restarting after a trailing semantic error should not result in node startup failure.
+    // A semantic error is just transaction history.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_node_restart_over_trailing_aborted_tx() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = dir.path().to_path_buf();
+
+        // First node: bootstrap + define schema, then shut down cleanly so the
+        // schema tx is indexed into SlateDB.
+        let node = Node::local_node(&root_path).await.unwrap();
+        define_test_schema(&node).await;
+        node.close().await.unwrap();
+
+        // Append a fact using a non-existant attribute
+        let aborting_ops = collect_tx_ops(vec![TxOp::Add {
+            entity: "e".into(),
+            attribute: kw!(:nonexistent_attr),
+            value: "oops".into(),
+        }])
+        .unwrap();
+        let serialized = bincode::serialize(&aborting_ops).unwrap();
+        {
+            let log = FileLog::new(&root_path.join("log"), Box::new(clock::SystemClock)).unwrap();
+            log.append_tx(serialized).await.unwrap();
+        }
+
+        // Restart: catch-up replays the un-indexed aborting tx as the last log
+        // record. The node must still come up.
+        let node = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            Node::local_node(&root_path),
+        )
+        .await
+        .expect("restart should not hang")
+        .expect("node should restart over a trailing aborted tx");
+
+        // The node is usable afterwards and the abort is recorded as history.
+        let result = node
+            .execute_tx(vec![TxOp::Add {
+                entity: "alice".into(),
+                attribute: kw!(:name),
+                value: "alice".into(),
+            }])
+            .await
+            .unwrap();
+        assert!(matches!(result, TransactionResult::TxCommited(_)));
 
         node.close().await.unwrap();
     }


### PR DESCRIPTION
## Problem

`Node::from_slate_and_tx_log` gates startup catch-up on `await_tx(last_tx).result` (`src/node.rs`). `await_tx` returns the trailing transaction's **semantic commit/abort outcome**, so an aborted last tx makes node startup fail.

This bites in the realistic crash-recovery scenario: a tx is durably appended to the log but the process dies before the indexer persists it to SlateDB. On the next startup, catch-up replays that tx; if it's a semantic abort (e.g. an unknown attribute), the `Err` propagates out of node construction and the node refuses to start — even though a recorded abort is perfectly valid history.

A graceful close doesn't expose this (the abort gets persisted, so catch-up skips it); only an *un-indexed* trailing abort triggers it.

## Fix

Gate startup on `await_indexed`, which waits for indexing to *reach* the last tx without inspecting its commit/abort result — the read/progress semantics this path actually wants. Genuine indexer-shutdown/technical failures still surface via its `Closed` error.

Also adds a short comment on `TxWaiter` documenting the `await_tx` (outcome) vs `await_indexed` (progress) distinction.

## Test

`test_local_node_restart_over_trailing_aborted_tx` reproduces the crash: it appends an aborting tx straight to the `FileLog` (bypassing indexing) and asserts the node restarts and stays usable. The test fails on the old `await_tx` gate (`Unknown attribute: :nonexistent_attr`) and passes with the fix.

## Verification

- `cargo test --workspace` — all green
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)