### PR TITLE
Unify TxKey and TxBasis; derive tx_eid from tx_id

### DIFF
--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -92,7 +92,7 @@ Node::register_incremental_query
     delegates to IncrementalQueryService::register_query
 
 IncrementalQueryService::register_query
-    captures the latest indexed TxBasis and schema from the indexer
+    captures the latest indexed TxKey and schema from the indexer
     plans the query
     scans the initial triples
     captures the WAL cursor
@@ -160,7 +160,7 @@ CDC loop holds the same gate around each `apply_triples`. This makes the
 snapshot/register cutover atomic with respect to CDC application: a transaction
 after the registration basis cannot be consumed by the global CDC loop before the
 new query is present in the service registry. The cutover boundary itself is the
-registration `TxBasis` — the global CDC loop reads the WAL from the beginning and
+registration `TxKey` — the global CDC loop reads the WAL from the beginning and
 each query skips transactions at or before its own `tx_id`. I think in the future
 this serialization across WAL application, basis capture and circuit initialization
 is too restrictive and we need to built something more multi-threaded.
@@ -221,7 +221,7 @@ For each transaction:
 
 1. `CdcStream` yields one grouped WAL transaction.
 2. EAV entries are decoded into datoms.
-3. Transaction metadata is converted into a `TxBasis` when possible.
+3. Transaction metadata is converted into a `TxKey` when possible.
 4. Datoms become a weighted batch of encoded triples.
 5. The incremental service steps each registered query circuit that has not
    already advanced past this transaction.
@@ -235,7 +235,7 @@ For each transaction:
 Each registration returns:
 
 - a query handle,
-- the registration `TxBasis`, and
+- the registration `TxKey`, and
 - a bounded Tokio channel of result deltas.
 
 Queries can be explicitly unregistered. They are also cleaned up when their
@@ -266,7 +266,7 @@ The current tuning knobs:
 ## Direction
 
 Currently the incremental query API is very bare bones. There is no way to
-specify the `TxBasis` that a query should start at. There is now way
+specify the `TxKey` that a query should start at. There is now way
 to stop and restart a query without reinitializing the circuit. All these
 things are possible, but need more thought and careful analysis for the
 state management.

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -74,9 +74,26 @@ Each transaction is reified as an entity in this partition. The transaction enti
 | `db/txId`       | long       | The sequential tx_id assigned by the log                       |
 | `db/txError`    | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
 
-A transaction with counter value `t` has entity ID `(1 << 42) | t`. This transaction entity ID is the temporal read basis (`tx_eid`) used to bound historical reads: a DB opened at a given basis sees datoms whose transaction entity is at or before that `tx_eid`. Transaction entities appear in the E-leading indices like any other entity, enabling queries such as "find all transactions after time T" through the standard query engine.
+The transaction entity ID (`tx_eid`) is **not minted** by the partition map; it is a
+pure function of the log-assigned `tx_id`:
 
-Note: `db/txId` remains the sequential log position, while `tx_eid` is the transaction entity ID used by covering indices and temporal reads. They are related but intentionally distinct identifiers.
+```
+tx_eid = make_entity_id(TX_PARTITION, tx_id) = (1 << 42) | tx_id   (== mask ^ tx_id)
+tx_id  = extract_counter(tx_eid)
+```
+
+So a `TxKey { tx_id, system_time }` immediately identifies a database value: its
+`tx_eid` (the temporal read coordinate) is recovered by masking, with no storage
+lookup. A DB opened at a given `TxKey` sees datoms whose transaction entity is at or
+before `tx_eid`. Transaction entities appear in the E-leading indices like any other
+entity, enabling queries such as "find all transactions after time T" through the
+standard query engine.
+
+The indexer *sets* (rather than allocates) the `TX_PARTITION` counter from each
+incoming `tx_id`, asserting it is strictly greater than the previous one so `tx_eid`
+is strictly increasing. `tx_id` need not be dense — e.g. the file log uses byte
+offsets, so `tx_eid`s have gaps. `db/txId` is stored for queryability but is
+redundant with the entity id (`db/txId == extract_counter(tx_eid)`).
 
 ### 2.3 :db.part/user (partition 2)
 

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -67,12 +67,12 @@ Because partition 0 places no bits above the counter, entity IDs in this partiti
 
 Each transaction is reified as an entity in this partition. The transaction entity carries the following attributes:
 
-| Attribute      | Value Type | Description                                                    |
-|----------------|------------|----------------------------------------------------------------|
-| `db/txInstant`  | instant    | Wall-clock time of the transaction                             |
-| `db/txResult`   | ref        | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)      |
-| `db/txId`       | long       | The sequential tx_id assigned by the log                       |
-| `db/txError`    | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
+| Attribute      | Value Type | Description                                                         |
+|----------------|------------|---------------------------------------------------------------------|
+| `db/txInstant` | instant    | Wall-clock time of the transaction                                  |
+| `db/txResult`  | ref        | `:db.tx/committed` or `:db.tx/aborted` (see `SCHEMA.md`)            |
+| `db/txId`      | long       | The sequential tx_id assigned by the log                            |
+| `db/txError`   | string     | Error message (present only when `db/txResult` is `:db.tx/aborted`) |
 
 The transaction entity ID (`tx_eid`) is **not minted** by the partition map; it is a
 pure function of the log-assigned `tx_id`:

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -81,8 +81,8 @@ pure function of the log-assigned `tx_id`:
 tx_eid = make_entity_id(TX_PARTITION, tx_id) = (1 << 42) | tx_id   (== mask ^ tx_id)
 tx_id  = extract_counter(tx_eid)
 ```
-This has the nice property that we don't need to do a lookup any `tx_eid` for a given `TxKey` when
-querying, but simply derive a tx_eid via a mask. The indexer *sets* (rather than allocates) the `TX_PARTITION` counter
+This has the nice property that we don't need to look up a `tx_eid` for a given `TxKey` when
+querying; we can derive it with a mask instead. The indexer *sets* (rather than allocates) the `TX_PARTITION` counter
 from each incoming `tx_key.tx_id`. The semantics of the log assure that these ids are strictly increasing.
 `db/txId` is stored for queryability.
 

--- a/design/PARTITIONS.md
+++ b/design/PARTITIONS.md
@@ -81,19 +81,10 @@ pure function of the log-assigned `tx_id`:
 tx_eid = make_entity_id(TX_PARTITION, tx_id) = (1 << 42) | tx_id   (== mask ^ tx_id)
 tx_id  = extract_counter(tx_eid)
 ```
-
-So a `TxKey { tx_id, system_time }` immediately identifies a database value: its
-`tx_eid` (the temporal read coordinate) is recovered by masking, with no storage
-lookup. A DB opened at a given `TxKey` sees datoms whose transaction entity is at or
-before `tx_eid`. Transaction entities appear in the E-leading indices like any other
-entity, enabling queries such as "find all transactions after time T" through the
-standard query engine.
-
-The indexer *sets* (rather than allocates) the `TX_PARTITION` counter from each
-incoming `tx_id`, asserting it is strictly greater than the previous one so `tx_eid`
-is strictly increasing. `tx_id` need not be dense — e.g. the file log uses byte
-offsets, so `tx_eid`s have gaps. `db/txId` is stored for queryability but is
-redundant with the entity id (`db/txId == extract_counter(tx_eid)`).
+This has the nice property that we don't need to do a lookup any `tx_eid` for a given `TxKey` when
+querying, but simply derive a tx_eid via a mask. The indexer *sets* (rather than allocates) the `TX_PARTITION` counter
+from each incoming `tx_key.tx_id`. The semantics of the log assure that these ids are strictly increasing.
+`db/txId` is stored for queryability.
 
 ### 2.3 :db.part/user (partition 2)
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -325,18 +325,18 @@ Each frame is a map with a `kind` discriminator. Decoders **MUST reject unknown
 
 ```
 {"kind": "open",
- "basis":   {"tx_id": <int>, "system_time": <Timestamp>},
+ "tx_key":  {"tx_id": <int>, "system_time": <Timestamp>},
  "columns": [<ColumnDescription>, ...]}
 ```
 
-`basis` is the registration basis; deltas describe transactions strictly after
+`tx_key` is the registration basis; deltas describe transactions strictly after
 it. `columns` matches [QueryResponse](#46-queryresponse).
 
 #### `delta` frame — zero or more, one per affecting transaction
 
 ```
 {"kind": "delta",
- "basis":   {"tx_id": <int>, "system_time": <Timestamp>},
+ "tx_key":  {"tx_id": <int>, "system_time": <Timestamp>},
  "rows":    [[[<DataType>, ...], <int weight>], ...]}
 ```
 
@@ -344,7 +344,7 @@ Each entry of `rows` is a 2-element array `[values, weight]`: `values` has one
 `DataType` per column (positional, per the `open` frame), `weight` is a **raw
 signed multiplicity** (`> 0` added, `< 0` retracted; not limited to `±1`). A
 `delta` frame is emitted only for a transaction that produces a non-empty change
-(`rows` is never empty). `basis` is the transaction basis that produced the
+(`rows` is never empty). `tx_key` is the transaction basis that produced the
 delta.
 
 #### `error` frame — terminal

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -51,11 +51,12 @@ All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body)
 
 ### 1.2 DB Values
 
-DB values are immutable read bases. A DB value contains the transaction log key
-(`tx_id` + `system_time`) plus the transaction entity ID (`tx_eid`) that bounds
-temporal reads. The server does not allocate or retain per-DB resources. Query
-requests carry the DB value, and the server creates a transient read view from
-that basis when the query executes.
+DB values are immutable read bases. A DB value is the transaction log key
+(`tx_id` + `system_time`); the transaction entity ID that bounds temporal reads
+is derived from `tx_id` (`tx_eid = make_entity_id(TX_PARTITION, tx_id)`) and so
+never travels on the wire. The server does not allocate or retain per-DB
+resources. Query requests carry the DB value, and the server creates a transient
+read view from that basis when the query executes.
 
 DB values do not need to be closed.
 
@@ -195,25 +196,26 @@ than a single-member union.
 ### 4.2 OpenDb Request — `POST /db/open`
 
 ```
-{"tx_id": <int>|nil, "system_time": <Timestamp>|nil, "tx_eid": <int>|nil}
+{"tx_id": <int>|nil, "system_time": <Timestamp>|nil}
 ```
 
-Either all three fields are present (pinned transaction basis) or all three are
+Either both fields are present (pinned transaction basis) or both are
 `nil` (latest indexed). Mixing `nil` with a value is rejected with HTTP 400.
 
 ### 4.3 DbOpened Response
 
 ```
-{"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>}
+{"tx_id": <int>, "system_time": <Timestamp>}
 ```
 
-The response is the immutable DB read basis. `tx_eid` is the transaction entity
-ID that bounds temporal reads.
+The response is the immutable DB read basis. The bounding transaction entity ID
+is derived from `tx_id` (`tx_eid = make_entity_id(TX_PARTITION, tx_id)`) and is
+not carried on the wire.
 
 ### 4.4 Query Request — `POST /db/query`
 
 ```
-{"db": {"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>},
+{"db": {"tx_id": <int>, "system_time": <Timestamp>},
  "query": <str>,
  "args": [<QueryArg>, ...]}
 ```
@@ -323,7 +325,7 @@ Each frame is a map with a `kind` discriminator. Decoders **MUST reject unknown
 
 ```
 {"kind": "open",
- "basis":   {"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>},
+ "basis":   {"tx_id": <int>, "system_time": <Timestamp>},
  "columns": [<ColumnDescription>, ...]}
 ```
 
@@ -334,7 +336,7 @@ it. `columns` matches [QueryResponse](#46-queryresponse).
 
 ```
 {"kind": "delta",
- "basis":   {"tx_id": <int>, "system_time": <Timestamp>, "tx_eid": <int>},
+ "basis":   {"tx_id": <int>, "system_time": <Timestamp>},
  "rows":    [[[<DataType>, ...], <int weight>], ...]}
 ```
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -293,12 +293,16 @@ the server remains healthy.
 
 ### 4.11 Subscribe Request — `POST /db/subscribe`
 
-Takes the same body as a [Query Request](#44-query-request--post-dbquery), with two
-restrictions in this version: `tx_key` **MUST be `nil`/omitted** (reserved for
-future historical replay; a non-nil value is rejected with HTTP 400 / `InvalidQuery`)
-and `args` **MUST be empty** (reserved for future incremental `:in` bindings). Queries
-or args the incremental engine does not yet support mirror one-shot query failures and
-are rejected with HTTP 500 / `QueryError` (code 2001).
+```
+{"tx_key": <TxKey>|nil, "query": <str>, "args": [<QueryArg>, ...]}
+```
+
+The same `query`/`args` shape as a [Query Request](#44-query-request--post-dbquery),
+except `tx_key` is optional. In this version it **MUST be `nil`/omitted** (a non-nil
+value is rejected with HTTP 400 / `InvalidQuery`; it is reserved for future historical
+replay) and `args` **MUST be empty** (reserved for future incremental `:in` bindings).
+Queries or args the incremental engine does not yet support mirror one-shot query
+failures and are rejected with HTTP 500 / `QueryError` (code 2001).
 
 On success the response is **HTTP 200** with `Content-Type:
 application/vnd.triplox+msgpack` and a body that is a **frame stream** (§4.12),

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -200,25 +200,24 @@ than a single-member union.
 Either both fields are present (pinned transaction basis) or both are
 `nil` (latest indexed). Mixing `nil` with a value is rejected with HTTP 400.
 
-### 4.3 DbOpened Response
+### 4.3 OpenDb Response
 
 ```
 {"tx_id": <int>, "system_time": <Timestamp>}
 ```
 
-The response is the immutable DB read basis. The bounding transaction entity ID
-is derived from `tx_id` (`tx_eid = make_entity_id(TX_PARTITION, tx_id)`) and is
-not carried on the wire.
+The response is a `TxKey`, the immutable DB read basis is this TxKey. The bounding transaction entity ID
+is derived from `tx_id`.
 
 ### 4.4 Query Request — `POST /db/query`
 
 ```
-{"db": {"tx_id": <int>, "system_time": <Timestamp>},
+{"basis_tx_key": {"tx_id": <int>, "system_time": <Timestamp>},
  "query": <str>,
  "args": [<QueryArg>, ...]}
 ```
 
-`db` is a DB read basis returned by `DbOpened` or a previous transaction result.
+`basis_tx_key` is a DB read basis as returned by the `OpenDb` response or a previous transaction result.
 `query` is a Datalog query in EDN text. `args` provides values for variables
 declared in the query's `:in` clause; the number and order must match. For
 queries without `:in`, pass an empty array.

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -51,14 +51,12 @@ All non-200 responses carry an [ErrorResponse](#410-errorresponse--non-200-body)
 
 ### 1.2 DB Values
 
-DB values are immutable read bases. A DB value is the transaction log key
-(`tx_id` + `system_time`); the transaction entity ID that bounds temporal reads
-is derived from `tx_id` (`tx_eid = make_entity_id(TX_PARTITION, tx_id)`) and so
+DB values are immutable read bases. A DB value is pinned by the transaction log key
+(`tx_id` + `system_time`). The transaction entity ID that bounds temporal reads
+on a db value is derived from `tx_id` (`tx_eid = TX_PARTITION_MASK | tx_id`) and so
 never travels on the wire. The server does not allocate or retain per-DB
 resources. Query requests carry the DB value, and the server creates a transient
-read view from that basis when the query executes.
-
-DB values do not need to be closed.
+read view from that basis when the query executes. DB values do not need to be closed.
 
 ---
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -145,6 +145,18 @@ form as the ext-3 Keyword payload.
 
 > **Note**: Only Scalar bindings are currently implemented in the query engine.
 
+### 2.4 TxKey
+
+A `TxKey` identifies a transaction and the immutable DB read basis it pins:
+
+```
+{"tx_id": <int>, "system_time": <Timestamp>}
+```
+
+`tx_id` is the log-assigned sequence position and `system_time` its wall-clock
+timestamp. The transaction entity ID that bounds temporal reads is derived from
+`tx_id` (see [§1.2](#12-db-values)) and is not carried on the wire.
+
 ---
 
 ## 3. Data Type Tags
@@ -202,22 +214,17 @@ Either both fields are present (pinned transaction basis) or both are
 
 ### 4.3 OpenDb Response
 
-```
-{"tx_id": <int>, "system_time": <Timestamp>}
-```
-
-The response is a `TxKey`, the immutable DB read basis is this TxKey. The bounding transaction entity ID
-is derived from `tx_id`.
+The response body is a [`TxKey`](#24-txkey): the immutable DB read basis.
 
 ### 4.4 Query Request — `POST /db/query`
 
 ```
-{"basis_tx_key": {"tx_id": <int>, "system_time": <Timestamp>},
+{"basis_tx_key": <TxKey>,
  "query": <str>,
  "args": [<QueryArg>, ...]}
 ```
 
-`basis_tx_key` is a DB read basis as returned by the `OpenDb` response or a previous transaction result.
+`basis_tx_key` is a [`TxKey`](#24-txkey) DB read basis, as returned by the `OpenDb` response or a previous transaction result.
 `query` is a Datalog query in EDN text. `args` provides values for variables
 declared in the query's `:in` clause; the number and order must match. For
 queries without `:in`, pass an empty array.
@@ -244,12 +251,9 @@ Both endpoints take the same body. They differ in semantics:
 
 ### 4.8 TxKey Response
 
-```
-{"tx_id": <int>, "system_time": <Timestamp>}
-```
-
-Returned for `/tx/submit`. The server has accepted the transaction and will
-durably log it; `system_time` is its assigned timestamp.
+The response body is a [`TxKey`](#24-txkey). Returned for `/tx/submit`: the server
+has accepted the transaction and will durably log it; `system_time` is its
+assigned timestamp.
 
 ### 4.9 TxResult Response
 
@@ -289,16 +293,12 @@ the server remains healthy.
 
 ### 4.11 Subscribe Request — `POST /db/subscribe`
 
-```
-{"basis_tx_key": <TxKey>|nil, "query": <str>, "args": [<QueryArg>, ...]}
-```
-
-Registers an incremental query and streams its result deltas. `basis_tx_key` is reserved
-for future historical replay and **MUST be `nil`/omitted** in this version (a
-non-nil `basis_tx_key` is rejected with HTTP 400 / `InvalidQuery`). `args` is reserved for
-future incremental `:in` bindings and **MUST be empty** in this version. Queries
-or args the incremental engine does not yet support currently mirror one-shot
-query failures and are rejected with HTTP 500 / `QueryError` (code 2001).
+Takes the same body as a [Query Request](#44-query-request--post-dbquery), with two
+restrictions in this version: `basis_tx_key` **MUST be `nil`/omitted** (reserved for
+future historical replay; a non-nil value is rejected with HTTP 400 / `InvalidQuery`)
+and `args` **MUST be empty** (reserved for future incremental `:in` bindings). Queries
+or args the incremental engine does not yet support mirror one-shot query failures and
+are rejected with HTTP 500 / `QueryError` (code 2001).
 
 On success the response is **HTTP 200** with `Content-Type:
 application/vnd.triplox+msgpack` and a body that is a **frame stream** (§4.12),
@@ -322,7 +322,7 @@ Each frame is a map with a `kind` discriminator. Decoders **MUST reject unknown
 
 ```
 {"kind": "open",
- "tx_key":  {"tx_id": <int>, "system_time": <Timestamp>},
+ "tx_key":  <TxKey>,
  "columns": [<ColumnDescription>, ...]}
 ```
 
@@ -333,7 +333,7 @@ it. `columns` matches [QueryResponse](#46-queryresponse).
 
 ```
 {"kind": "delta",
- "tx_key":  {"tx_id": <int>, "system_time": <Timestamp>},
+ "tx_key":  <TxKey>,
  "rows":    [[[<DataType>, ...], <int weight>], ...]}
 ```
 

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -290,12 +290,12 @@ the server remains healthy.
 ### 4.11 Subscribe Request — `POST /db/subscribe`
 
 ```
-{"db": <DbBasis>|nil, "query": <str>, "args": [<QueryArg>, ...]}
+{"basis_tx_key": <TxKey>|nil, "query": <str>, "args": [<QueryArg>, ...]}
 ```
 
-Registers an incremental query and streams its result deltas. `db` is reserved
+Registers an incremental query and streams its result deltas. `basis_tx_key` is reserved
 for future historical replay and **MUST be `nil`/omitted** in this version (a
-non-nil `db` is rejected with HTTP 400 / `InvalidQuery`). `args` is reserved for
+non-nil `basis_tx_key` is rejected with HTTP 400 / `InvalidQuery`). `args` is reserved for
 future incremental `:in` bindings and **MUST be empty** in this version. Queries
 or args the incremental engine does not yet support currently mirror one-shot
 query failures and are rejected with HTTP 500 / `QueryError` (code 2001).

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -219,12 +219,12 @@ The response body is a [`TxKey`](#24-txkey): the immutable DB read basis.
 ### 4.4 Query Request — `POST /db/query`
 
 ```
-{"basis_tx_key": <TxKey>,
+{"tx_key": <TxKey>,
  "query": <str>,
  "args": [<QueryArg>, ...]}
 ```
 
-`basis_tx_key` is a [`TxKey`](#24-txkey) DB read basis, as returned by the `OpenDb` response or a previous transaction result.
+`tx_key` is a [`TxKey`](#24-txkey) DB read basis, as returned by the `OpenDb` response or a previous transaction result.
 `query` is a Datalog query in EDN text. `args` provides values for variables
 declared in the query's `:in` clause; the number and order must match. For
 queries without `:in`, pass an empty array.
@@ -294,7 +294,7 @@ the server remains healthy.
 ### 4.11 Subscribe Request — `POST /db/subscribe`
 
 Takes the same body as a [Query Request](#44-query-request--post-dbquery), with two
-restrictions in this version: `basis_tx_key` **MUST be `nil`/omitted** (reserved for
+restrictions in this version: `tx_key` **MUST be `nil`/omitted** (reserved for
 future historical replay; a non-nil value is rejected with HTTP 400 / `InvalidQuery`)
 and `args` **MUST be empty** (reserved for future incremental `:in` bindings). Queries
 or args the incremental engine does not yet support mirror one-shot query failures and

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -301,6 +301,7 @@ The same `query`/`args` shape as a [Query Request](#44-query-request--post-dbque
 except `tx_key` is optional. In this version it **MUST be `nil`/omitted** (a non-nil
 value is rejected with HTTP 400 / `InvalidQuery`; it is reserved for future historical
 replay) and `args` **MUST be empty** (reserved for future incremental `:in` bindings).
+At some point it might make sense to unify Query Request and Subscribe Request.
 Queries or args the incremental engine does not yet support mirror one-shot query
 failures and are rejected with HTTP 500 / `QueryError` (code 2001).
 

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -13,13 +13,8 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 ```
 1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
    Derive tx entity id          tx_eid = tx_eid_from_tx_id(tx_key.tx_id)
-   Set (not mint) TX counter    pending_pm.set_tx_counter(tx_key.tx_id)?
-                                (tx_eid is a pure function of the log-assigned
-                                 tx_id; set_tx_counter advances the TX_PARTITION
-                                 high-water mark and asserts strict monotonicity.
-                                 Pipeline reads go directly against slatedb;
-                                 index writes are buffered in a WriteBatch
-                                 committed atomically in step 9)
+                                pending_pm.set_tx_counter(tx_key.tx_id)?
+                                (pipeline reads work directly against slatedb)
                                 ↓
 2. Expand TxOps                 tx::expand_tx_ops(ops, &schema) -> Vec<DatomExpanded>
    - TxOp::Put -> N DatomExpanded (one per attr)

--- a/design/TX_PIPELINE.md
+++ b/design/TX_PIPELINE.md
@@ -12,8 +12,12 @@ The `transact_tx_inner` pipeline processes a set of transaction operations into 
 
 ```
 1. Clone PartitionMap           pending_pm = self.metadata.partition_map.clone()
-   Allocate tx entity           tx_eid = pending_pm.allocate_entid(TX_PARTITION)
-                                (pipeline reads go directly against slatedb;
+   Derive tx entity id          tx_eid = tx_eid_from_tx_id(tx_key.tx_id)
+   Set (not mint) TX counter    pending_pm.set_tx_counter(tx_key.tx_id)?
+                                (tx_eid is a pure function of the log-assigned
+                                 tx_id; set_tx_counter advances the TX_PARTITION
+                                 high-water mark and asserts strict monotonicity.
+                                 Pipeline reads go directly against slatedb;
                                  index writes are buffered in a WriteBatch
                                  committed atomically in step 9)
                                 ↓

--- a/examples/clojure/src/streaming_example.clj
+++ b/examples/clojure/src/streaming_example.clj
@@ -15,11 +15,10 @@
                        '{:find [?e ?name]
                          :where [[?e :name ?name]]}))
 
-(tc/basis sub)
+(tc/tx-key sub)
 ;; => {:tx-id 1,
 ;;     :system-time
-;;     #object[java.time.Instant 0x64cae1b "2026-06-02T13:52:43.058559Z"],
-;;     :tx-eid 4398046511105}
+;;     #object[java.time.Instant 0x64cae1b "2026-06-02T13:52:43.058559Z"]}
 
 
 ;; Transact a name; the subscription receives a delta.

--- a/examples/java/src/main/java/SimpleExample.java
+++ b/examples/java/src/main/java/SimpleExample.java
@@ -40,7 +40,7 @@ public final class SimpleExample {
             System.out.println("Data inserted (tx_id=" + dataResult.txId() + ").");
 
             var db = node.openDb();
-            System.out.println("Opened DB value (tx_eid=" + db.txEid() + ").");
+            System.out.println("Opened DB value (tx_id=" + db.txKey().txId() + ").");
             var rows = db.query("{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}");
 
             System.out.println("Query returned " + rows.size() + " row(s):");

--- a/examples/java/src/main/java/StreamingExample.java
+++ b/examples/java/src/main/java/StreamingExample.java
@@ -37,7 +37,7 @@ public final class StreamingExample {
 
             // Subscribe at the latest indexed basis; closing the subscription unsubscribes.
             try (Subscription sub = node.subscribe("[:find ?name :where [?e :name ?name]]")) {
-                System.out.println("Subscribed at tx_id=" + sub.basis().txId() + ".");
+                System.out.println("Subscribed at tx_id=" + sub.txKey().txId() + ".");
 
                 for (var name : new String[] {"alice", "bob", "carol"}) {
                     node.executeTx(list(new TxOp.Put(map(":name", name))));

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
 
     // 3. Open a DB value and query
     let db = node.db().await?;
-    println!("Opened DB value (tx_eid={}).", db.tx_basis().tx_eid);
+    println!("Opened DB value (tx_id={}).", db.tx_key().tx_id);
 
     let rows = db
         .query(r#"{:find [?e ?name ?age] :where [[?e :name ?name] [?e :age ?age]]}"#)

--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     ];
     let result = node.execute_tx(schema_ops).await?;
     match &result {
-        TransactionResult::TxCommited(tx_key) => {
+        TransactionResult::TxCommitted(tx_key) => {
             println!("Schema defined (tx_id={}).", tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
     ];
     let result = node.execute_tx(data_ops).await?;
     match &result {
-        TransactionResult::TxCommited(tx_key) => {
+        TransactionResult::TxCommitted(tx_key) => {
             println!("Data inserted (tx_id={}).", tx_key.tx_id);
         }
         TransactionResult::TxAborted(_, err) => {

--- a/examples/rust/src/streaming_example.rs
+++ b/examples/rust/src/streaming_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
         .execute_tx(vec![schema_attribute("name", "string")])
         .await?
     {
-        TransactionResult::TxCommited(_) => println!("Schema defined."),
+        TransactionResult::TxCommitted(_) => println!("Schema defined."),
         TransactionResult::TxAborted(_, err) => anyhow::bail!("Schema aborted: {err}"),
     }
 
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     let mut sub = node
         .subscribe("[:find ?name :where [?e :name ?name]]", &[])
         .await?;
-    println!("Subscribed at tx_id={}.", sub.basis().tx_key.tx_id);
+    println!("Subscribed at tx_id={}.", sub.tx_key().tx_id);
 
     // Transact three names; each produces a delta on the subscription.
     for name in ["alice", "bob", "carol"] {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -12,7 +12,7 @@ use crate::partition::{
 use crate::schema::{bootstrap_schema, bootstrap_schema_tx, load_schema_from_indices, Schema};
 use crate::slate::{SlateComponents, DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
-use crate::transaction::{TxBasis, TxKey};
+use crate::transaction::TxKey;
 use crate::tx;
 use crate::util::concat_bytes;
 use slatedb::{Db, WriteBatch};
@@ -29,14 +29,10 @@ const DB_PARTITION_COUNTER_FLOOR: i64 = 1000;
 pub(crate) const BOOTSTRAP_TX_EID: i64 = (TX_PARTITION as i64) << COUNTER_BITS;
 
 /// TxKey reserved for the bootstrap transaction and the initial empty log record.
+/// Its `tx_eid` is `tx_eid_from_tx_id(0) == BOOTSTRAP_TX_EID`.
 pub(crate) static BOOTSTRAP_TX_KEY: LazyLock<TxKey> = LazyLock::new(|| TxKey {
     tx_id: 0,
     system_time: st_from_unix_epoch(0),
-});
-
-pub(crate) static BOOTSTRAP_TX_BASIS: LazyLock<TxBasis> = LazyLock::new(|| TxBasis {
-    tx_key: *BOOTSTRAP_TX_KEY,
-    tx_eid: BOOTSTRAP_TX_EID,
 });
 
 /// Scan each partition's EAV prefix and return per-partition counters (max counter + 1).
@@ -104,7 +100,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             // Fresh DB — build schema from constants, then bootstrap
             let bootstrap_schema = bootstrap_schema();
             let tx_ops = bootstrap_schema_tx();
-            let basis = *BOOTSTRAP_TX_BASIS;
+            let tx_key = *BOOTSTRAP_TX_KEY;
             let mut boot_pm = PartitionMap::new();
 
             // Same normalization and tempid-resolution stages as the indexer.
@@ -116,12 +112,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
                 tempids::resolve_tempids(with_tempids, &bootstrap_schema, &slate.db, &mut boot_pm)
                     .await
                     .unwrap();
-            datoms.extend(build_tx_entity_datoms(
-                basis.tx_eid,
-                basis.tx_key,
-                true,
-                None,
-            ));
+            datoms.extend(build_tx_entity_datoms(BOOTSTRAP_TX_EID, tx_key, true, None));
 
             // Validate against pre-built schema, then derive the bootstrap schema delta.
             let validation = bootstrap_schema.validate_datoms(&datoms).unwrap();
@@ -141,7 +132,7 @@ pub async fn init_db(slate: &SlateComponents) -> Result<Metadata> {
             );
 
             let mut batch = WriteBatch::new();
-            write_index_entries(&mut batch, &datoms, &bootstrap_schema, basis.tx_eid).unwrap();
+            write_index_entries(&mut batch, &datoms, &bootstrap_schema, BOOTSTRAP_TX_EID).unwrap();
             // Write version
             let version = env!("CARGO_PKG_VERSION");
             batch.put(&version_key, version.as_bytes());

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::thread;
 
+use crate::partition::tx_eid_from_tx_id;
 use anyhow::{anyhow, Context, Result};
 use dbsp::{utils::Tup2, ZWeight};
 use slatedb::object_store::ObjectStore;
@@ -14,7 +15,7 @@ use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use triplox_client::transaction::TxBasis;
+use triplox_client::transaction::TxKey;
 
 use crate::inc_query::{plan_query, IncrementalQueryPlan};
 use crate::incremental::cdc::{scan_current_triples, spawn_cdc_loop};
@@ -59,13 +60,13 @@ pub(crate) type IncrementalQueryHandle = u64;
 #[derive(Debug)]
 pub(crate) struct IncrementalQuerySubscription {
     pub handle: IncrementalQueryHandle,
-    pub basis: TxBasis,
+    pub tx_key: TxKey,
     pub deltas: mpsc::Receiver<IncrementalQueryDelta>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct IncrementalQueryDelta {
-    pub basis: TxBasis,
+    pub tx_key: TxKey,
     pub rows: Vec<(Vec<DataType>, isize)>,
 }
 
@@ -74,7 +75,7 @@ type ServiceResult<T> = std::result::Result<T, String>;
 enum IncrementalCommand {
     Register {
         plan: IncrementalQueryPlan,
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_cursor: CdcCursor,
         initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
         response: oneshot::Sender<ServiceResult<IncrementalQuerySubscription>>,
@@ -84,7 +85,7 @@ enum IncrementalCommand {
         response: oneshot::Sender<ServiceResult<()>>,
     },
     ApplyTriples {
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_seq: u64,
         triples: Vec<Tup2<EncodedTriple, ZWeight>>,
         response: oneshot::Sender<ServiceResult<()>>,
@@ -139,19 +140,20 @@ impl IncrementalQueryService {
         indexer: Arc<RwLock<Indexer>>,
     ) -> Result<IncrementalQuerySubscription> {
         let _registration_guard = self.registration_gate.lock().await;
-        let (basis, schema) = {
+        let (tx_key, schema) = {
             let indexer = indexer.read().await;
-            (indexer.latest_tx_basis(), indexer.metadata().schema.clone())
+            (indexer.latest_tx_key(), indexer.metadata().schema.clone())
         };
         let plan = plan_query(&query, &schema)?;
-        let initial_triples = scan_current_triples(db, &plan, basis.tx_eid).await?;
+        let initial_triples =
+            scan_current_triples(db, &plan, tx_eid_from_tx_id(tx_key.tx_id)).await?;
         let wal_cursor = CdcCursor {
             // TODO: This should likely be initialized to manifest.replay_after_wal_id + 1. See #337
             wal_id: 0,
             last_seq: db.status().durable_seq,
         };
         let subscription = self
-            .register_prepared_query(plan, basis, wal_cursor, initial_triples)
+            .register_prepared_query(plan, tx_key, wal_cursor, initial_triples)
             .await?;
         self.start_cdc_once(indexer);
         Ok(subscription)
@@ -191,7 +193,7 @@ impl IncrementalQueryService {
     pub(crate) async fn register_prepared_query(
         &self,
         plan: IncrementalQueryPlan,
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_cursor: CdcCursor,
         initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
     ) -> Result<IncrementalQuerySubscription> {
@@ -199,7 +201,7 @@ impl IncrementalQueryService {
         self.commands
             .send(IncrementalCommand::Register {
                 plan,
-                basis,
+                tx_key,
                 wal_cursor,
                 initial_triples,
                 response,
@@ -224,14 +226,14 @@ impl IncrementalQueryService {
 
     pub(crate) async fn apply_triples(
         &self,
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_seq: u64,
         triples: Vec<Tup2<EncodedTriple, ZWeight>>,
     ) -> Result<()> {
         let (response, result) = oneshot::channel();
         self.commands
             .send(IncrementalCommand::ApplyTriples {
-                basis,
+                tx_key,
                 wal_seq,
                 triples,
                 response,
@@ -300,7 +302,7 @@ struct RegisteredQuery {
     _plan: IncrementalQueryPlan,
     _circuit: QueryCircuit,
     sender: mpsc::Sender<IncrementalQueryDelta>,
-    _basis: TxBasis,
+    _tx_key: TxKey,
     _wal_cursor: CdcCursor,
 }
 
@@ -328,23 +330,23 @@ impl IncrementalQueryServiceInner {
             match command {
                 IncrementalCommand::Register {
                     plan,
-                    basis,
+                    tx_key,
                     wal_cursor,
                     initial_triples,
                     response,
                 } => {
-                    let _ = response.send(self.register(plan, basis, wal_cursor, initial_triples));
+                    let _ = response.send(self.register(plan, tx_key, wal_cursor, initial_triples));
                 }
                 IncrementalCommand::Unregister { handle, response } => {
                     let _ = response.send(self.unregister(handle));
                 }
                 IncrementalCommand::ApplyTriples {
-                    basis,
+                    tx_key,
                     wal_seq,
                     triples,
                     response,
                 } => {
-                    let _ = response.send(self.apply_triples(basis, wal_seq, triples));
+                    let _ = response.send(self.apply_triples(tx_key, wal_seq, triples));
                 }
                 IncrementalCommand::Shutdown { response } => {
                     let _ = response.send(self.remove_all_queries());
@@ -357,7 +359,7 @@ impl IncrementalQueryServiceInner {
     fn register(
         &mut self,
         plan: IncrementalQueryPlan,
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_cursor: CdcCursor,
         initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
     ) -> ServiceResult<IncrementalQuerySubscription> {
@@ -377,14 +379,14 @@ impl IncrementalQueryServiceInner {
                 _plan: plan,
                 _circuit: circuit,
                 sender,
-                _basis: basis,
+                _tx_key: tx_key,
                 _wal_cursor: wal_cursor,
             },
         );
 
         Ok(IncrementalQuerySubscription {
             handle,
-            basis,
+            tx_key,
             deltas: receiver,
         })
     }
@@ -396,7 +398,7 @@ impl IncrementalQueryServiceInner {
 
     fn apply_triples(
         &mut self,
-        basis: TxBasis,
+        tx_key: TxKey,
         wal_seq: u64,
         triples: Vec<Tup2<EncodedTriple, ZWeight>>,
     ) -> ServiceResult<()> {
@@ -405,7 +407,7 @@ impl IncrementalQueryServiceInner {
         let cancel = self.cancel.clone();
 
         for (id, query) in &mut self.queries {
-            if basis.tx_key.tx_id <= query._basis.tx_key.tx_id {
+            if tx_key.tx_id <= query._tx_key.tx_id {
                 query._wal_cursor.last_seq = wal_seq;
                 continue;
             }
@@ -418,7 +420,7 @@ impl IncrementalQueryServiceInner {
                 query._wal_cursor.last_seq = wal_seq;
                 continue;
             }
-            let delta = IncrementalQueryDelta { basis, rows };
+            let delta = IncrementalQueryDelta { tx_key, rows };
             match send_delta(&self.runtime, &query.sender, delta, &cancel) {
                 DeltaDelivery::Delivered => query._wal_cursor.last_seq = wal_seq,
                 DeltaDelivery::Closed => closed.push(*id),
@@ -524,7 +526,7 @@ mod tests {
         let subscription = service
             .register(
                 single_pattern_plan(),
-                test_basis(),
+                test_tx_key(),
                 test_cursor(),
                 initial_triples(),
             )
@@ -550,7 +552,7 @@ mod tests {
         let subscription = service
             .register(
                 single_pattern_plan(),
-                test_basis(),
+                test_tx_key(),
                 test_cursor(),
                 initial_triples(),
             )
@@ -575,8 +577,8 @@ mod tests {
             runtime.handle().clone(),
             CancellationToken::new(),
         );
-        let old_basis = test_basis_with_tx_id(1);
-        let new_basis = test_basis_with_tx_id(2);
+        let old_basis = test_tx_key_with_tx_id(1);
+        let new_basis = test_tx_key_with_tx_id(2);
         let mut old_subscription = service
             .register(
                 single_pattern_plan(),
@@ -636,7 +638,7 @@ mod tests {
         let _subscription = service
             .register(
                 single_pattern_plan(),
-                test_basis(),
+                test_tx_key(),
                 test_cursor(),
                 Vec::new(),
             )
@@ -646,7 +648,7 @@ mod tests {
             let name = format!("Alice {seq}");
             service
                 .apply_triples(
-                    test_basis_with_tx_id(seq as i64 + 1),
+                    test_tx_key_with_tx_id(seq as i64 + 1),
                     seq as u64,
                     vec![name_triple(seq as i64, &name)],
                 )
@@ -657,7 +659,7 @@ mod tests {
         let handle = thread::spawn(move || {
             let name = format!("Alice {}", SUBSCRIPTION_CAPACITY + 1);
             let result = service.apply_triples(
-                test_basis_with_tx_id(SUBSCRIPTION_CAPACITY as i64 + 2),
+                test_tx_key_with_tx_id(SUBSCRIPTION_CAPACITY as i64 + 2),
                 (SUBSCRIPTION_CAPACITY + 1) as u64,
                 vec![name_triple((SUBSCRIPTION_CAPACITY + 1) as i64, &name)],
             );
@@ -732,7 +734,7 @@ mod tests {
         let _subscription = service
             .register_prepared_query(
                 single_pattern_plan(),
-                test_basis(),
+                test_tx_key(),
                 test_cursor(),
                 initial_triples(),
             )
@@ -776,12 +778,12 @@ mod tests {
             "/test_incremental_registration_gate".to_string(),
             Arc::new(InMemory::new()),
         );
-        let query_basis = test_basis_with_tx_id(1);
-        let tx_basis = test_basis_with_tx_id(2);
+        let query_tx_key = test_tx_key_with_tx_id(1);
+        let apply_tx_key = test_tx_key_with_tx_id(2);
         let mut first_subscription = service
             .register_prepared_query(
                 single_pattern_plan(),
-                query_basis,
+                query_tx_key,
                 test_cursor(),
                 vec![name_triple(42, "Alice")],
             )
@@ -793,7 +795,7 @@ mod tests {
         let apply = tokio::spawn(async move {
             let _registration_guard = applying_service.registration_gate.lock().await;
             applying_service
-                .apply_triples(tx_basis, 2, vec![name_triple(43, "Bob")])
+                .apply_triples(apply_tx_key, 2, vec![name_triple(43, "Bob")])
                 .await
         });
         tokio::task::yield_now().await;
@@ -802,7 +804,7 @@ mod tests {
         let mut second_subscription = service
             .register_prepared_query(
                 single_pattern_plan(),
-                query_basis,
+                query_tx_key,
                 test_cursor(),
                 vec![name_triple(42, "Alice")],
             )
@@ -816,14 +818,14 @@ mod tests {
         assert_eq!(
             first_subscription.deltas.recv().await.unwrap(),
             IncrementalQueryDelta {
-                basis: tx_basis,
+                tx_key: apply_tx_key,
                 rows: vec![(vec![DataType::String("Bob".to_string())], 1)],
             }
         );
         assert_eq!(
             second_subscription.deltas.recv().await.unwrap(),
             IncrementalQueryDelta {
-                basis: tx_basis,
+                tx_key: apply_tx_key,
                 rows: vec![(vec![DataType::String("Bob".to_string())], 1)],
             }
         );
@@ -865,17 +867,14 @@ mod tests {
         )
     }
 
-    fn test_basis() -> TxBasis {
-        test_basis_with_tx_id(1)
+    fn test_tx_key() -> TxKey {
+        test_tx_key_with_tx_id(1)
     }
 
-    fn test_basis_with_tx_id(tx_id: i64) -> TxBasis {
-        TxBasis {
-            tx_key: TxKey {
-                tx_id,
-                system_time: Utc::now(),
-            },
-            tx_eid: tx_id + 1,
+    fn test_tx_key_with_tx_id(tx_id: i64) -> TxKey {
+        TxKey {
+            tx_id,
+            system_time: Utc::now(),
         }
     }
 

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use dbsp::{utils::Tup2, ZWeight};
+use edn::kw;
 use log::info;
 use slatedb::object_store::ObjectStore;
 use slatedb::WalReader;
@@ -17,6 +18,7 @@ use crate::incremental::{EncodedTriple, IncrementalQueryService};
 use crate::indexer::eav_key_to_parts;
 use crate::node::SchemaProvider;
 use crate::ops::{DataType, Datom, DatomOp};
+use crate::partition::{extract_counter, extract_partition, TX_PARTITION};
 use crate::schema::Schema;
 use crate::slate::cdc::{CdcCursor, CdcStream};
 use crate::slate::DEFAULT_SCAN_OPTIONS;
@@ -107,28 +109,20 @@ where
     Ok(())
 }
 
+/// Recover the `TxKey` for a CDC-streamed transaction from its datoms.
 pub(crate) fn tx_key_from_datoms(datoms: &[Datom]) -> Result<TxKey> {
-    let mut by_entity: HashMap<i64, (Option<i64>, Option<crate::clock::Instant>)> = HashMap::new();
-    for datom in datoms {
-        let entry = by_entity.entry(datom.entity).or_default();
-        match &datom.value {
-            DataType::Long(tx_id) if datom.attribute == edn::kw!(:db/txId) => {
-                entry.0 = Some(*tx_id);
+    datoms
+        .iter()
+        .find_map(|datom| match &datom.value {
+            DataType::Instant(instant)
+                if datom.attribute == kw!(:db/txInstant)
+                    && extract_partition(datom.entity) == TX_PARTITION =>
+            {
+                Some(TxKey {
+                    tx_id: extract_counter(datom.entity),
+                    system_time: *instant,
+                })
             }
-            DataType::Instant(instant) if datom.attribute == edn::kw!(:db/txInstant) => {
-                entry.1 = Some(*instant);
-            }
-            _ => {}
-        }
-    }
-
-    by_entity
-        .into_values()
-        .find_map(|(tx_id, instant)| match (tx_id, instant) {
-            (Some(tx_id), Some(instant)) => Some(TxKey {
-                tx_id,
-                system_time: instant,
-            }),
             _ => None,
         })
         .ok_or_else(|| anyhow::anyhow!("CDC transaction datoms missing transaction key"))
@@ -205,6 +199,7 @@ mod tests {
     use crate::clock::st_from_unix_epoch;
     use crate::indexer::{Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
     use crate::metadata::{Metadata, PartitionMap};
+    use crate::partition::{make_entity_id, tx_eid_from_tx_id, USER_PARTITION};
     use crate::schema::{Attribute, Schema, ValueType};
 
     #[tokio::test]
@@ -278,15 +273,18 @@ mod tests {
     #[test]
     fn tx_key_from_datoms_extracts_transaction_key() {
         let instant = st_from_unix_epoch(123);
+        // A real tx entity's id is `tx_eid_from_tx_id(tx_id)`, so `tx_id` is
+        // recovered by masking the entity id rather than reading `db/txId`.
+        let tx_eid = tx_eid_from_tx_id(42);
         let datoms = [
             Datom {
-                entity: 99,
+                entity: tx_eid,
                 attribute: kw!(:db/txId),
                 value: DataType::Long(42),
                 op: DatomOp::Assert,
             },
             Datom {
-                entity: 99,
+                entity: tx_eid,
                 attribute: kw!(:db/txInstant),
                 value: DataType::Instant(instant),
                 op: DatomOp::Assert,

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -20,7 +20,7 @@ use crate::ops::{DataType, Datom, DatomOp};
 use crate::schema::Schema;
 use crate::slate::cdc::{CdcCursor, CdcStream};
 use crate::slate::DEFAULT_SCAN_OPTIONS;
-use crate::transaction::{TxBasis, TxKey};
+use crate::transaction::TxKey;
 use crate::{codec, util::concat_bytes};
 
 const CDC_POLL_INTERVAL: Duration = Duration::from_millis(200);
@@ -96,10 +96,10 @@ where
         if datoms.is_empty() {
             continue;
         }
-        let basis = tx_basis_from_datoms(&datoms)?;
+        let tx_key = tx_key_from_datoms(&datoms)?;
         let tuples = datoms_to_tuples(&datoms, &schema)?;
         let _registration_guard = registration_gate.lock().await;
-        service.apply_triples(basis, seq, tuples).await?;
+        service.apply_triples(tx_key, seq, tuples).await?;
         // The registration gate is released before polling the next WAL transaction.
     }
 
@@ -107,7 +107,7 @@ where
     Ok(())
 }
 
-pub(crate) fn tx_basis_from_datoms(datoms: &[Datom]) -> Result<TxBasis> {
+pub(crate) fn tx_key_from_datoms(datoms: &[Datom]) -> Result<TxKey> {
     let mut by_entity: HashMap<i64, (Option<i64>, Option<crate::clock::Instant>)> = HashMap::new();
     for datom in datoms {
         let entry = by_entity.entry(datom.entity).or_default();
@@ -123,18 +123,15 @@ pub(crate) fn tx_basis_from_datoms(datoms: &[Datom]) -> Result<TxBasis> {
     }
 
     by_entity
-        .into_iter()
-        .find_map(|(tx_eid, (tx_id, instant))| match (tx_id, instant) {
-            (Some(tx_id), Some(instant)) => Some(TxBasis {
-                tx_key: TxKey {
-                    tx_id,
-                    system_time: instant,
-                },
-                tx_eid,
+        .into_values()
+        .find_map(|(tx_id, instant)| match (tx_id, instant) {
+            (Some(tx_id), Some(instant)) => Some(TxKey {
+                tx_id,
+                system_time: instant,
             }),
             _ => None,
         })
-        .ok_or_else(|| anyhow::anyhow!("CDC transaction datoms missing transaction basis"))
+        .ok_or_else(|| anyhow::anyhow!("CDC transaction datoms missing transaction key"))
 }
 
 pub(crate) async fn scan_current_triples<D>(
@@ -216,7 +213,7 @@ mod tests {
         let indexer = Arc::new(RwLock::new(Indexer::new(
             slate.db.clone(),
             Metadata::new(test_schema(), PartitionMap::new()),
-            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            *crate::bootstrap::BOOTSTRAP_TX_KEY,
             DEFAULT_TX_COMPLETION_CAPACITY,
         )));
         let service = IncrementalQueryService::new(
@@ -279,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn tx_basis_from_datoms_extracts_transaction_basis() {
+    fn tx_key_from_datoms_extracts_transaction_key() {
         let instant = st_from_unix_epoch(123);
         let datoms = [
             Datom {
@@ -296,22 +293,19 @@ mod tests {
             },
         ];
 
-        let basis = tx_basis_from_datoms(&datoms).unwrap();
+        let tx_key = tx_key_from_datoms(&datoms).unwrap();
 
         assert_eq!(
-            basis,
-            TxBasis {
-                tx_key: TxKey {
-                    tx_id: 42,
-                    system_time: instant,
-                },
-                tx_eid: 99,
+            tx_key,
+            TxKey {
+                tx_id: 42,
+                system_time: instant,
             }
         );
     }
 
     #[test]
-    fn tx_basis_from_datoms_errors_without_transaction_basis() {
+    fn tx_key_from_datoms_errors_without_transaction_key() {
         let datoms = [Datom {
             entity: 42,
             attribute: kw!(:name),
@@ -319,11 +313,11 @@ mod tests {
             op: DatomOp::Assert,
         }];
 
-        let err = tx_basis_from_datoms(&datoms).unwrap_err();
+        let err = tx_key_from_datoms(&datoms).unwrap_err();
 
         assert!(err
             .to_string()
-            .contains("CDC transaction datoms missing transaction basis"));
+            .contains("CDC transaction datoms missing transaction key"));
     }
 
     #[test]

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -199,7 +199,7 @@ mod tests {
     use crate::clock::st_from_unix_epoch;
     use crate::indexer::{Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
     use crate::metadata::{Metadata, PartitionMap};
-    use crate::partition::{make_entity_id, tx_eid_from_tx_id, USER_PARTITION};
+    use crate::partition::tx_eid_from_tx_id;
     use crate::schema::{Attribute, Schema, ValueType};
 
     #[tokio::test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1109,7 +1109,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_deserialization_failure_notifies_without_basis() -> Result<(), Error> {
+    async fn test_deserialization_failure_notifies_failed() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
@@ -1134,8 +1134,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_transact_failure_writes_aborted_tx_and_notifies_with_basis() -> Result<(), Error>
-    {
+    async fn test_transact_failure_writes_aborted_tx_and_notifies_aborted() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
@@ -1165,7 +1164,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_transact_node_failure_notifies_without_basis() -> Result<(), Error> {
+    async fn test_transact_node_failure_notifies_failed() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = Indexer::new(
             components.db.clone(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -151,9 +151,6 @@ pub(crate) fn write_index_entries(
 /// restricting the scan to TX_PARTITION entities. With descending entity encoding,
 /// the first TX_PARTITION entity is the latest.
 ///
-/// Derives tx_id from the tx entity's id (its counter is the tx_id, the inverse
-/// of `tx_eid_from_tx_id`) and reads system_time from `db/txInstant`.
-///
 /// Errors if no TX_PARTITION entity exists (an initialized DB always has the
 /// bootstrap tx) or if the latest tx entity is missing `:db/txInstant`.
 pub async fn latest_tx_key_from_sdb<D>(sdb: &D) -> Result<TxKey>
@@ -177,6 +174,7 @@ where
             Some(first) if first != eid => break,
             _ => {}
         }
+        // extract system-time
         if attribute == crate::schema::DB_TX_INSTANT {
             if let DataType::Instant(st) = value {
                 system_time = Some(st);
@@ -184,8 +182,9 @@ where
         }
     }
     match (first_eid, system_time) {
-        (Some(eid), Some(system_time)) => Ok(TxKey {
-            tx_id: extract_counter(eid),
+        (Some(tx_eid), Some(system_time)) => Ok(TxKey {
+            // extract tx_id from tx_eid
+            tx_id: extract_counter(tx_eid),
             system_time,
         }),
         (None, _) => bail!("TX_PARTITION is empty; database not initialized"),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -18,22 +18,22 @@ use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;
 use crate::ops::{Datom, DatomOp, Entid, TxOp};
-use crate::partition::{partition_entity_prefix, TX_PARTITION};
+use crate::partition::{partition_entity_prefix, tx_eid_from_tx_id, TX_PARTITION};
 use crate::schema::{Schema, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
-use crate::transaction::{TxBasis, TxKey};
+use crate::transaction::TxKey;
 use crate::tx;
 use crate::util::concat_bytes;
 
-type TxCompletionMessage = (TxKey, Option<TxBasis>, Result<(), Arc<Error>>);
+type TxCompletionMessage = (TxKey, Option<TxKey>, Result<(), Arc<Error>>);
 
 pub const DEFAULT_TX_COMPLETION_CAPACITY: usize = 1024;
 
 pub struct Indexer {
     slatedb: Arc<Db>,
     metadata: Metadata,
-    latest_indexed_tx: TxBasis,
+    latest_indexed_tx: TxKey,
     tx_completion_sender: broadcast::Sender<TxCompletionMessage>,
 }
 
@@ -133,19 +133,19 @@ pub(crate) fn write_index_entries(
     Ok(())
 }
 
-/// Scan EAV entries for TX_PARTITION entities and return (tx_eid, TxKey) for the latest tx.
+/// Scan EAV entries for TX_PARTITION entities and return the `TxKey` of the latest tx.
 ///
 /// Uses the high bits of TX_PARTITION entity IDs to build a targeted EAV prefix,
 /// restricting the scan to TX_PARTITION entities. With descending entity encoding,
 /// the first TX_PARTITION entity is the latest.
 ///
-/// Collects tx_eid from the entity position, tx_id from `db/txId` value, and
-/// system_time from `db/txInstant` value.
+/// Collects tx_id from the `db/txId` value and system_time from `db/txInstant`.
+/// (The tx entity's id is `tx_eid_from_tx_id(tx_id)`, so it is not read separately.)
 ///
 /// Errors if no TX_PARTITION entity exists (an initialized DB always has the
 /// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
 /// `:db/txInstant`.
-pub async fn latest_tx_basis_from_sdb<D>(sdb: &D) -> Result<TxBasis>
+pub async fn latest_tx_key_from_sdb<D>(sdb: &D) -> Result<TxKey>
 where
     D: DbReadOps + Sync,
 {
@@ -179,13 +179,7 @@ where
         }
     }
     match (first_eid, tx_id, system_time) {
-        (Some(eid), Some(tid), Some(st)) => Ok(TxBasis {
-            tx_key: TxKey {
-                tx_id: tid,
-                system_time: st,
-            },
-            tx_eid: eid,
-        }),
+        (Some(_eid), Some(tx_id), Some(system_time)) => Ok(TxKey { tx_id, system_time }),
         (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
         (Some(eid), tid, st) => {
             bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
@@ -244,7 +238,7 @@ impl Indexer {
     pub fn new(
         slatedb: Arc<Db>,
         metadata: Metadata,
-        latest_indexed_tx: TxBasis,
+        latest_indexed_tx: TxKey,
         tx_completion_capacity: usize,
     ) -> Self {
         let (tx_completion_sender, _) = broadcast::channel(tx_completion_capacity);
@@ -260,7 +254,7 @@ impl Indexer {
         &self.metadata
     }
 
-    pub(crate) fn latest_tx_basis(&self) -> TxBasis {
+    pub(crate) fn latest_tx_key(&self) -> TxKey {
         self.latest_indexed_tx
     }
 
@@ -270,21 +264,17 @@ impl Indexer {
     /// Pipeline reads go directly against the DB (the indexer is the only
     /// writer, so they see the latest committed state). Pipeline writes are
     /// buffered in a `WriteBatch` and committed atomically at the end.
-    pub async fn transact_tx(
-        &mut self,
-        tx_key: TxKey,
-        tx_ops: Vec<TxOp>,
-    ) -> Result<TxBasis, Error> {
+    pub async fn transact_tx(&mut self, tx_key: TxKey, tx_ops: Vec<TxOp>) -> Result<TxKey, Error> {
         match self.transact_tx_inner(tx_key, tx_ops).await {
-            Ok(basis) => Ok(basis),
+            Ok(indexed) => Ok(indexed),
             Err(e) => match self.write_aborted_tx(tx_key, format!("{:#}", e)).await {
                 // semantic error
-                Ok(basis) => {
+                Ok(indexed) => {
                     let err = Arc::new(e);
-                    let _ = self
-                        .tx_completion_sender
-                        .send((tx_key, Some(basis), Err(err.clone())));
-                    Ok(basis)
+                    let _ =
+                        self.tx_completion_sender
+                            .send((tx_key, Some(indexed), Err(err.clone())));
+                    Ok(indexed)
                 }
                 // technical error
                 Err(abort_err) => {
@@ -308,10 +298,13 @@ impl Indexer {
         &mut self,
         tx_key: TxKey,
         tx_ops: Vec<TxOp>,
-    ) -> Result<TxBasis, Error> {
-        // 1. Clone PartitionMap + allocate tx entity
+    ) -> Result<TxKey, Error> {
+        // 1. Clone PartitionMap + derive the tx entity id from the log-assigned
+        //    tx_id (not minted). Advancing the TX_PARTITION counter enforces that
+        //    tx_eids are strictly increasing.
         let mut pending_pm = self.metadata.partition_map.clone();
-        let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
+        let tx_eid = tx_eid_from_tx_id(tx_key.tx_id);
+        pending_pm.set_tx_counter(tx_key.tx_id)?;
 
         // 2. Expand TxOps to DatomExpanded (resolves idents, keeps lookup refs + tempids)
         let expanded = tx::expand_tx_ops(&tx_ops, &self.metadata.schema)?;
@@ -372,12 +365,11 @@ impl Indexer {
         }
 
         // Update latest indexed tx and broadcast completion
-        let basis = TxBasis { tx_key, tx_eid };
-        self.latest_indexed_tx = basis;
+        self.latest_indexed_tx = tx_key;
 
         if let Err(e) = self
             .tx_completion_sender
-            .send((tx_key, Some(basis), Ok(())))
+            .send((tx_key, Some(tx_key), Ok(())))
         {
             trace!(
                 "No receivers for indexed transaction {}: {}",
@@ -386,7 +378,7 @@ impl Indexer {
             );
         }
 
-        Ok(basis)
+        Ok(tx_key)
     }
 
     async fn finalize_datoms_for_commit(&self, datoms: Vec<Datom>) -> Result<Vec<Datom>, Error> {
@@ -563,9 +555,10 @@ impl Indexer {
     }
 
     /// Write an aborted transaction entity (no user data) when transact_tx fails.
-    async fn write_aborted_tx(&mut self, tx_key: TxKey, error: String) -> Result<TxBasis, Error> {
+    async fn write_aborted_tx(&mut self, tx_key: TxKey, error: String) -> Result<TxKey, Error> {
         let mut pending_pm = self.metadata.partition_map.clone();
-        let tx_eid = pending_pm.allocate_entid(TX_PARTITION);
+        let tx_eid = tx_eid_from_tx_id(tx_key.tx_id);
+        pending_pm.set_tx_counter(tx_key.tx_id)?;
         let datoms = build_tx_entity_datoms(tx_eid, tx_key, false, Some(error));
         let mut batch = WriteBatch::new();
         write_index_entries(&mut batch, &datoms, &self.metadata.schema, tx_eid)?;
@@ -574,9 +567,8 @@ impl Indexer {
             .await?;
         // No need to advance generation for aborted transactions
         self.metadata.partition_map = pending_pm;
-        let basis = TxBasis { tx_key, tx_eid };
-        self.latest_indexed_tx = basis;
-        Ok(basis)
+        self.latest_indexed_tx = tx_key;
+        Ok(tx_key)
     }
 }
 
@@ -586,13 +578,14 @@ impl Indexer {
 /// no messages are missed between subscription and the actual wait.
 pub(crate) struct TxWaiter {
     /// Latest indexed tx captured when this waiter subscribed.
-    baseline: TxBasis,
+    baseline: TxKey,
     rx: broadcast::Receiver<TxCompletionMessage>,
     slatedb: Arc<Db>,
 }
 
 pub(crate) struct TxCompletion {
-    pub basis: Option<TxBasis>,
+    /// The indexed `TxKey`, present iff a tx entity was written for it.
+    pub tx_key: Option<TxKey>,
     pub result: Result<(), Arc<anyhow::Error>>,
 }
 
@@ -600,23 +593,23 @@ impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
 
-    /// Wait until `tx_key` has been indexed. Returns the indexed basis and status,
+    /// Wait until `tx_key` has been indexed. Returns the indexed `TxKey` and status,
     /// `Err` on abort or if the indexer shuts down.
     pub async fn await_tx(mut self, tx_key: TxKey) -> Result<TxCompletion, Error> {
         // Fast path: already indexed at subscription time; storage is the
         // authoritative record of its outcome.
-        if tx_key <= self.baseline.tx_key {
+        if tx_key <= self.baseline {
             return self.completion_from_storage(tx_key).await;
         }
 
         loop {
             match self.rx.recv().await {
-                Ok((completed_tx_key, completed_basis, result)) => {
+                Ok((completed_tx_key, indexed_tx_key, result)) => {
                     match completed_tx_key.cmp(&tx_key) {
                         std::cmp::Ordering::Less => continue,
                         std::cmp::Ordering::Equal => {
                             return Ok(TxCompletion {
-                                basis: completed_basis,
+                                tx_key: indexed_tx_key,
                                 result,
                             });
                         }
@@ -644,13 +637,13 @@ impl TxWaiter {
     /// Wait until indexing has reached `tx_key`, regardless of whether that
     /// transaction committed or aborted.
     pub async fn await_indexed(mut self, tx_key: TxKey) -> Result<(), Error> {
-        if tx_key.tx_id <= self.baseline.tx_key.tx_id {
+        if tx_key.tx_id <= self.baseline.tx_id {
             return Ok(());
         }
 
         loop {
             match self.rx.recv().await {
-                Ok((completed_tx_key, _completed_basis, _result)) => {
+                Ok((completed_tx_key, _indexed_tx_key, _result)) => {
                     if completed_tx_key.tx_id >= tx_key.tx_id {
                         return Ok(());
                     }
@@ -809,8 +802,8 @@ mod tests {
     use edn::query::ParsedQuery;
 
     /// Create an indexer with bootstrap schema and test attributes already transacted.
-    /// Uses init_db for bootstrap, then transacts test schema via the indexer.
-    /// Returns the indexer ready for test data at tx_id=1+.
+    /// Uses init_db for bootstrap (tx_id 0), then transacts the test schema at tx_id 1
+    /// via the indexer. Returns the indexer ready for test data at tx_id=2+.
     async fn bootstrapped_indexer(slate: &SlateComponents) -> Indexer {
         bootstrapped_indexer_with_capacity(slate, DEFAULT_TX_COMPLETION_CAPACITY).await
     }
@@ -825,15 +818,15 @@ mod tests {
         let mut indexer = Indexer::new(
             slate.db.clone(),
             metadata,
-            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            *crate::bootstrap::BOOTSTRAP_TX_KEY,
             capacity,
         );
-        let tx_key_0 = TxKey {
-            tx_id: 0,
+        let schema_tx_key = TxKey {
+            tx_id: 1,
             system_time: st_from_unix_epoch(1),
         };
         indexer
-            .transact_tx(tx_key_0, test_schema_tx())
+            .transact_tx(schema_tx_key, test_schema_tx())
             .await
             .unwrap();
         indexer
@@ -893,7 +886,7 @@ mod tests {
             .unwrap()
             .0;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let tx_ops = vec![TxOp::Add {
@@ -936,7 +929,7 @@ mod tests {
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
 
@@ -959,7 +952,7 @@ mod tests {
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
 
@@ -991,7 +984,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_latest_tx_basis_after_transact() -> Result<(), Error> {
+    async fn test_latest_tx_key_after_transact() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
@@ -1007,21 +1000,21 @@ mod tests {
         }];
         indexer.transact_tx(tx_key, tx_ops).await?;
 
-        let latest = latest_tx_basis_from_sdb(slate.as_ref()).await?;
-        assert_eq!(latest.tx_key.tx_id, 42);
-        assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(1000));
-        assert!(latest.tx_eid > 0, "tx_eid should be a valid entity ID");
+        let latest = latest_tx_key_from_sdb(slate.as_ref()).await?;
+        assert_eq!(latest.tx_id, 42);
+        assert_eq!(latest.system_time, st_from_unix_epoch(1000));
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_latest_tx_basis_highest_wins() -> Result<(), Error> {
+    async fn test_latest_tx_key_highest_wins() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
 
+        // Data txs start at tx_id 2 (bootstrap=0, test schema=1).
         for i in 0..3 {
-            let tx_id = i + 1;
+            let tx_id = i + 2;
             let tx_key = TxKey {
                 tx_id,
                 system_time: st_from_unix_epoch(tx_id as u64 * 100),
@@ -1034,9 +1027,9 @@ mod tests {
             indexer.transact_tx(tx_key, tx_ops).await?;
         }
 
-        let latest = latest_tx_basis_from_sdb(slate.as_ref()).await?;
-        assert_eq!(latest.tx_key.tx_id, 3, "Should return highest tx_id");
-        assert_eq!(latest.tx_key.system_time, st_from_unix_epoch(300));
+        let latest = latest_tx_key_from_sdb(slate.as_ref()).await?;
+        assert_eq!(latest.tx_id, 4, "Should return highest tx_id");
+        assert_eq!(latest.system_time, st_from_unix_epoch(400));
         Ok(())
     }
 
@@ -1047,7 +1040,7 @@ mod tests {
         let mut indexer = bootstrapped_indexer(&components).await;
 
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let tx_ops = vec![TxOp::Add {
@@ -1070,7 +1063,7 @@ mod tests {
         let indexer = Arc::new(RwLock::new(bootstrapped_indexer(&components).await));
 
         let tx_key_1 = TxKey {
-            tx_id: 1,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
 
@@ -1099,7 +1092,7 @@ mod tests {
         let indexer = Indexer::new(
             slate.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
-            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            *crate::bootstrap::BOOTSTRAP_TX_KEY,
             DEFAULT_TX_COMPLETION_CAPACITY,
         );
 
@@ -1126,7 +1119,7 @@ mod tests {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let waiter = indexer.tx_waiter();
@@ -1139,7 +1132,7 @@ mod tests {
             .await;
 
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.basis, None);
+        assert_eq!(completion.tx_key, None);
         assert!(completion
             .result
             .unwrap_err()
@@ -1155,12 +1148,12 @@ mod tests {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let waiter = indexer.tx_waiter();
 
-        let basis = indexer
+        let indexed = indexer
             .transact_tx(
                 tx_key,
                 vec![TxOp::Add {
@@ -1171,9 +1164,9 @@ mod tests {
             )
             .await?;
 
-        assert_eq!(basis.tx_key, tx_key);
+        assert_eq!(indexed, tx_key);
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.basis.map(|basis| basis.tx_key), Some(tx_key));
+        assert_eq!(completion.tx_key, Some(tx_key));
         assert!(completion
             .result
             .unwrap_err()
@@ -1189,11 +1182,11 @@ mod tests {
         let mut indexer = Indexer::new(
             components.db.clone(),
             Metadata::new(Schema::default(), crate::metadata::PartitionMap::new()),
-            *crate::bootstrap::BOOTSTRAP_TX_BASIS,
+            *crate::bootstrap::BOOTSTRAP_TX_KEY,
             DEFAULT_TX_COMPLETION_CAPACITY,
         );
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let waiter = indexer.tx_waiter();
@@ -1214,7 +1207,7 @@ mod tests {
             .to_string()
             .contains("Failed to write aborted tx entity"));
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.basis, None);
+        assert_eq!(completion.tx_key, None);
         assert!(completion
             .result
             .unwrap_err()
@@ -1229,7 +1222,7 @@ mod tests {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let basis = indexer
@@ -1246,7 +1239,7 @@ mod tests {
         let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("tx entity should exist");
-        assert_eq!(completion.basis, Some(basis));
+        assert_eq!(completion.tx_key, Some(basis));
         assert!(completion.result.is_ok());
 
         Ok(())
@@ -1257,7 +1250,7 @@ mod tests {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let basis = indexer
@@ -1274,7 +1267,7 @@ mod tests {
         let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("aborted tx entity should exist");
-        assert_eq!(completion.basis, Some(basis));
+        assert_eq!(completion.tx_key, Some(basis));
         assert!(completion
             .result
             .unwrap_err()
@@ -1326,15 +1319,15 @@ mod tests {
     async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
-        let tx_key_1 = test_tx_key(1);
+        let tx_key_1 = test_tx_key(2);
         let waiter = indexer.tx_waiter();
 
         let basis_1 = indexer.transact_tx(tx_key_1, aborting_op()).await?;
         // The second completion evicts the first from the capacity-1 channel
-        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+        indexer.transact_tx(test_tx_key(3), add_op("bob")).await?;
 
         let completion = waiter.await_tx(tx_key_1).await?;
-        assert_eq!(completion.basis, Some(basis_1));
+        assert_eq!(completion.tx_key, Some(basis_1));
         assert!(completion
             .result
             .unwrap_err()
@@ -1348,7 +1341,7 @@ mod tests {
     async fn test_await_tx_lagged_technical_abort_returns_error() -> Result<(), Error> {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer_with_capacity(&components, 1).await;
-        let tx_key_1 = test_tx_key(1);
+        let tx_key_1 = test_tx_key(2);
         let waiter = indexer.tx_waiter();
 
         // Deserialize failure: notifies without persisting a tx entity
@@ -1358,7 +1351,7 @@ mod tests {
                 record: vec![0xff],
             })
             .await;
-        indexer.transact_tx(test_tx_key(2), add_op("bob")).await?;
+        indexer.transact_tx(test_tx_key(3), add_op("bob")).await?;
 
         // No tx entity persisted: completion can't be recovered, so await_tx
         // itself errors rather than returning a completion with an error result.
@@ -1377,8 +1370,9 @@ mod tests {
         let slate = components.db.clone();
         let mut indexer = bootstrapped_indexer(&components).await;
 
+        // Data txs start at tx_id 2 (bootstrap=0, test schema=1).
         for i in 0..2 {
-            let tx_id = i + 1;
+            let tx_id = i + 2;
             let tx_key = TxKey {
                 tx_id,
                 system_time: st_from_unix_epoch(tx_id as u64 * 100),
@@ -1392,13 +1386,13 @@ mod tests {
         }
 
         let tx_key_1 = TxKey {
-            tx_id: 1,
-            system_time: st_from_unix_epoch(100),
+            tx_id: 2,
+            system_time: st_from_unix_epoch(200),
         };
         indexer.tx_waiter().await_tx(tx_key_1).await?;
         let tx_key_2 = TxKey {
-            tx_id: 2,
-            system_time: st_from_unix_epoch(200),
+            tx_id: 3,
+            system_time: st_from_unix_epoch(300),
         };
         indexer.tx_waiter().await_tx(tx_key_2).await?;
 
@@ -1459,7 +1453,7 @@ mod tests {
 
         // First tx: assert name="alice" for a new entity (auto-assigned)
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         let tx_ops = vec![TxOp::Add {
@@ -1474,7 +1468,7 @@ mod tests {
 
         // Second tx: assert name="bob" for same entity — should auto-retract "alice"
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         indexer
@@ -1535,7 +1529,7 @@ mod tests {
 
         // First tx: assert name="alice" for a new entity
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         let tx_ops = vec![TxOp::Add {
@@ -1550,7 +1544,7 @@ mod tests {
 
         // Second tx: assert same name="alice" — datom should be dropped entirely
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         indexer
@@ -1587,7 +1581,7 @@ mod tests {
             .0;
 
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         indexer
@@ -1604,7 +1598,7 @@ mod tests {
 
         // Second tx: retract + re-assert the stored value — must abort, not retract
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         let waiter = indexer.tx_waiter();
@@ -1655,7 +1649,7 @@ mod tests {
             .0;
 
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         indexer
@@ -1672,7 +1666,7 @@ mod tests {
 
         // Second tx: assert stored value + a different value — must abort, not let "bob" win
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         let waiter = indexer.tx_waiter();
@@ -1727,11 +1721,11 @@ mod tests {
         assert_eq!(attr.value_type, crate::schema::ValueType::String);
 
         let tx = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         let waiter = indexer.tx_waiter();
-        let basis = indexer
+        let indexed = indexer
             .transact_tx(
                 tx,
                 vec![TxOp::put(vec![
@@ -1743,9 +1737,9 @@ mod tests {
             )
             .await?;
 
-        assert_eq!(basis.tx_key, tx);
+        assert_eq!(indexed, tx);
         let completion = waiter.await_tx(tx).await?;
-        assert_eq!(completion.basis.map(|basis| basis.tx_key), Some(tx));
+        assert_eq!(completion.tx_key, Some(tx));
         assert!(completion
             .result
             .unwrap_err()
@@ -1792,7 +1786,7 @@ mod tests {
             .0;
 
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         indexer
@@ -1835,7 +1829,7 @@ mod tests {
         let bob_eid = *entities.get("bob").expect("bob entity should exist");
 
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         indexer
@@ -1924,7 +1918,7 @@ mod tests {
         indexer
             .transact_tx(
                 TxKey {
-                    tx_id: 1,
+                    tx_id: 2,
                     system_time: st_from_unix_epoch(100),
                 },
                 vec![TxOp::Add {
@@ -1940,7 +1934,7 @@ mod tests {
         indexer
             .transact_tx(
                 TxKey {
-                    tx_id: 2,
+                    tx_id: 3,
                     system_time: st_from_unix_epoch(200),
                 },
                 vec![
@@ -1989,7 +1983,7 @@ mod tests {
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         let tx_ops1 = vec![TxOp::Add {
@@ -2010,7 +2004,7 @@ mod tests {
 
         // Second tx: assert tags="database" for same entity — should NOT retract "rust"
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         let tx_ops2 = vec![TxOp::Add {
@@ -2042,7 +2036,7 @@ mod tests {
 
         // First tx: assert tags="rust" for a new entity (auto-assigned ID)
         let tx1 = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(100),
         };
         let tx_ops1 = vec![TxOp::Add {
@@ -2063,7 +2057,7 @@ mod tests {
 
         // Second tx: assert same tags="rust" again — should still be written (unlike card-one)
         let tx2 = TxKey {
-            tx_id: 2,
+            tx_id: 3,
             system_time: st_from_unix_epoch(200),
         };
         let tx_ops2 = vec![TxOp::Add {
@@ -2091,7 +2085,7 @@ mod tests {
         let components = in_memory_slate().await;
         let mut indexer = bootstrapped_indexer(&components).await;
         let tx_key = TxKey {
-            tx_id: 1,
+            tx_id: 2,
             system_time: st_from_unix_epoch(2),
         };
         let waiter = indexer.tx_waiter();
@@ -2109,10 +2103,10 @@ mod tests {
                 value: DataType::Long(30),
             },
         ];
-        let basis = indexer.transact_tx(tx_key, tx_ops).await?;
-        assert_eq!(basis.tx_key, tx_key);
+        let indexed = indexer.transact_tx(tx_key, tx_ops).await?;
+        assert_eq!(indexed, tx_key);
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.basis.map(|basis| basis.tx_key), Some(tx_key));
+        assert_eq!(completion.tx_key, Some(tx_key));
         assert!(completion
             .result
             .unwrap_err()
@@ -2142,7 +2136,7 @@ mod tests {
         indexer
             .transact_tx(
                 TxKey {
-                    tx_id: 1,
+                    tx_id: 2,
                     system_time: st_from_unix_epoch(2),
                 },
                 vec![TxOp::put(vec![
@@ -2239,7 +2233,7 @@ mod tests {
 
         transact(
             &mut indexer,
-            1,
+            2,
             TxOp::Add {
                 entity: "e".into(),
                 attribute: kw!(:name),
@@ -2250,7 +2244,7 @@ mod tests {
         let entity_id = find_first_user_entity(&slate).await?;
         transact(
             &mut indexer,
-            2,
+            3,
             TxOp::Add {
                 entity: EntityRef::Id(entity_id),
                 attribute: kw!(:name),
@@ -2260,7 +2254,7 @@ mod tests {
         .await?;
         transact(
             &mut indexer,
-            3,
+            4,
             TxOp::Add {
                 entity: EntityRef::Id(entity_id),
                 attribute: kw!(:name),
@@ -2309,7 +2303,7 @@ mod tests {
 
         transact(
             &mut indexer,
-            1,
+            2,
             TxOp::put(vec![
                 (kw!(:name), "alice".into()),
                 (kw!(:age), DataType::Long(2)),
@@ -2319,7 +2313,7 @@ mod tests {
         let entity_id = find_first_user_entity(&slate).await?;
         transact(
             &mut indexer,
-            2,
+            3,
             TxOp::put(vec![
                 (kw!(:db/id), DataType::Long(entity_id)),
                 (kw!(:name), "bob".into()),
@@ -2329,7 +2323,7 @@ mod tests {
         .await?;
         transact(
             &mut indexer,
-            3,
+            4,
             TxOp::put(vec![
                 (kw!(:db/id), DataType::Long(entity_id)),
                 (kw!(:name), "carol".into()),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -18,7 +18,7 @@ use crate::log::{Record, Subscriber};
 use crate::metadata::Metadata;
 use crate::ops::DataType;
 use crate::ops::{Datom, DatomOp, Entid, TxOp};
-use crate::partition::{partition_entity_prefix, tx_eid_from_tx_id, TX_PARTITION};
+use crate::partition::{extract_counter, partition_entity_prefix, tx_eid_from_tx_id, TX_PARTITION};
 use crate::schema::{Schema, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::{DEFAULT_SCAN_OPTIONS, DEFAULT_WRITE_OPTIONS};
 use crate::tempids;
@@ -151,12 +151,11 @@ pub(crate) fn write_index_entries(
 /// restricting the scan to TX_PARTITION entities. With descending entity encoding,
 /// the first TX_PARTITION entity is the latest.
 ///
-/// Collects tx_id from the `db/txId` value and system_time from `db/txInstant`.
-/// (The tx entity's id is `tx_eid_from_tx_id(tx_id)`, so it is not read separately.)
+/// Derives tx_id from the tx entity's id (its counter is the tx_id, the inverse
+/// of `tx_eid_from_tx_id`) and reads system_time from `db/txInstant`.
 ///
 /// Errors if no TX_PARTITION entity exists (an initialized DB always has the
-/// bootstrap tx) or if the latest tx entity is missing `:db/txId` or
-/// `:db/txInstant`.
+/// bootstrap tx) or if the latest tx entity is missing `:db/txInstant`.
 pub async fn latest_tx_key_from_sdb<D>(sdb: &D) -> Result<TxKey>
 where
     D: DbReadOps + Sync,
@@ -166,7 +165,6 @@ where
         .scan_prefix_with_options(&eav_tx_prefix, &DEFAULT_SCAN_OPTIONS)
         .await?;
     let mut first_eid: Option<i64> = None;
-    let mut tx_id: Option<i64> = None;
     let mut system_time: Option<crate::clock::Instant> = None;
     while let Some(kv) = iter.next().await? {
         let (entity_dt, attribute, value, _tx_eid, _op) = eav_key_to_parts(kv.key)?;
@@ -179,23 +177,19 @@ where
             Some(first) if first != eid => break,
             _ => {}
         }
-        if attribute == crate::schema::DB_TX_ID {
-            if let DataType::Long(id) = value {
-                tx_id = Some(id);
-            }
-        }
         if attribute == crate::schema::DB_TX_INSTANT {
             if let DataType::Instant(st) = value {
                 system_time = Some(st);
             }
         }
     }
-    match (first_eid, tx_id, system_time) {
-        (Some(_eid), Some(tx_id), Some(system_time)) => Ok(TxKey { tx_id, system_time }),
-        (None, _, _) => bail!("TX_PARTITION is empty; database not initialized"),
-        (Some(eid), tid, st) => {
-            bail!("Tx entity {eid} missing required attributes (tx_id={tid:?}, system_time={st:?})")
-        }
+    match (first_eid, system_time) {
+        (Some(eid), Some(system_time)) => Ok(TxKey {
+            tx_id: extract_counter(eid),
+            system_time,
+        }),
+        (None, _) => bail!("TX_PARTITION is empty; database not initialized"),
+        (Some(eid), None) => bail!("Tx entity {eid} missing required :db/txInstant"),
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -26,7 +26,19 @@ use crate::transaction::TxKey;
 use crate::tx;
 use crate::util::concat_bytes;
 
-type TxCompletionMessage = (TxKey, Option<TxKey>, Result<(), Arc<Error>>);
+#[derive(Clone, Debug)]
+enum TxOutcome {
+    Committed,           // Standard committed tx
+    Aborted(Arc<Error>), // A semantic tx error like a schema violation
+    Failed(Arc<Error>),  // A hard technical indexer failure (shouldn't happen)
+}
+
+/// A transaction's `TxOutcome` paired with the `TxKey` it applies to.
+#[derive(Clone, Debug)]
+struct TxCompletionMessage {
+    tx_key: TxKey,
+    outcome: TxOutcome,
+}
 
 pub const DEFAULT_TX_COMPLETION_CAPACITY: usize = 1024;
 
@@ -270,10 +282,10 @@ impl Indexer {
             Err(e) => match self.write_aborted_tx(tx_key, format!("{:#}", e)).await {
                 // semantic error
                 Ok(indexed) => {
-                    let err = Arc::new(e);
-                    let _ =
-                        self.tx_completion_sender
-                            .send((tx_key, Some(indexed), Err(err.clone())));
+                    let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                        tx_key,
+                        outcome: TxOutcome::Aborted(Arc::new(e)),
+                    });
                     Ok(indexed)
                 }
                 // technical error
@@ -285,9 +297,10 @@ impl Indexer {
                         e
                     ));
                     error!("{:#}", err);
-                    let _ = self
-                        .tx_completion_sender
-                        .send((tx_key, None, Err(err.clone())));
+                    let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                        tx_key,
+                        outcome: TxOutcome::Failed(err.clone()),
+                    });
                     Err(anyhow::anyhow!("{:#}", err))
                 }
             },
@@ -367,10 +380,10 @@ impl Indexer {
         // Update latest indexed tx and broadcast completion
         self.latest_indexed_tx = tx_key;
 
-        if let Err(e) = self
-            .tx_completion_sender
-            .send((tx_key, Some(tx_key), Ok(())))
-        {
+        if let Err(e) = self.tx_completion_sender.send(TxCompletionMessage {
+            tx_key,
+            outcome: TxOutcome::Committed,
+        }) {
             trace!(
                 "No receivers for indexed transaction {}: {}",
                 tx_key.tx_id,
@@ -589,6 +602,27 @@ pub(crate) struct TxCompletion {
     pub result: Result<(), Arc<anyhow::Error>>,
 }
 
+impl TxOutcome {
+    /// Resolve into a `TxCompletion` for `tx_key`. `Failed` wrote no entity, so
+    /// its completion carries `tx_key: None`.
+    fn into_completion(self, tx_key: TxKey) -> TxCompletion {
+        match self {
+            TxOutcome::Committed => TxCompletion {
+                tx_key: Some(tx_key),
+                result: Ok(()),
+            },
+            TxOutcome::Aborted(err) => TxCompletion {
+                tx_key: Some(tx_key),
+                result: Err(err),
+            },
+            TxOutcome::Failed(err) => TxCompletion {
+                tx_key: None,
+                result: Err(err),
+            },
+        }
+    }
+}
+
 impl TxWaiter {
     // await_tx answers if a transaction commited or aborted, ie the exact tx outcome.
     // await_indexed answers "Are we there yet?" without knowing anything about the result.
@@ -604,14 +638,14 @@ impl TxWaiter {
 
         loop {
             match self.rx.recv().await {
-                Ok((completed_tx_key, indexed_tx_key, result)) => {
+                Ok(TxCompletionMessage {
+                    tx_key: completed_tx_key,
+                    outcome,
+                }) => {
                     match completed_tx_key.cmp(&tx_key) {
                         std::cmp::Ordering::Less => continue,
                         std::cmp::Ordering::Equal => {
-                            return Ok(TxCompletion {
-                                tx_key: indexed_tx_key,
-                                result,
-                            });
+                            return Ok(outcome.into_completion(completed_tx_key));
                         }
                         // Seeing a later tx first means we were lagging at some point.
                         std::cmp::Ordering::Greater => {
@@ -643,7 +677,10 @@ impl TxWaiter {
 
         loop {
             match self.rx.recv().await {
-                Ok((completed_tx_key, _indexed_tx_key, _result)) => {
+                Ok(TxCompletionMessage {
+                    tx_key: completed_tx_key,
+                    ..
+                }) => {
                     if completed_tx_key.tx_id >= tx_key.tx_id {
                         return Ok(());
                     }
@@ -687,9 +724,10 @@ impl Subscriber for Indexer {
                     "Transaction {} deserialization failed: {}",
                     record.tx_key.tx_id, err
                 );
-                let _ = self
-                    .tx_completion_sender
-                    .send((record.tx_key, None, Err(Arc::new(err))));
+                let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                    tx_key: record.tx_key,
+                    outcome: TxOutcome::Failed(Arc::new(err)),
+                });
                 return;
             }
         };

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -27,17 +27,20 @@ use crate::tx;
 use crate::util::concat_bytes;
 
 #[derive(Clone, Debug)]
-enum TxOutcome {
+pub(crate) enum TxOutcome {
     Committed,           // Standard committed tx
     Aborted(Arc<Error>), // A semantic tx error like a schema violation
     Failed(Arc<Error>),  // A hard technical indexer failure (shouldn't happen)
 }
 
 /// A transaction's `TxOutcome` paired with the `TxKey` it applies to.
+///
+/// Broadcast by the indexer as each tx is indexed, and returned by
+/// `TxWaiter::await_tx` / `lookup_tx_completion` as a tx's resolved outcome.
 #[derive(Clone, Debug)]
-struct TxCompletionMessage {
-    tx_key: TxKey,
-    outcome: TxOutcome,
+pub(crate) struct TxCompletion {
+    pub tx_key: TxKey,
+    pub outcome: TxOutcome,
 }
 
 pub const DEFAULT_TX_COMPLETION_CAPACITY: usize = 1024;
@@ -46,7 +49,7 @@ pub struct Indexer {
     slatedb: Arc<Db>,
     metadata: Metadata,
     latest_indexed_tx: TxKey,
-    tx_completion_sender: broadcast::Sender<TxCompletionMessage>,
+    tx_completion_sender: broadcast::Sender<TxCompletion>,
 }
 
 /// Write index entries for datoms into a SlateDB WriteBatch.
@@ -275,7 +278,7 @@ impl Indexer {
             Err(e) => match self.write_aborted_tx(tx_key, format!("{:#}", e)).await {
                 // semantic error
                 Ok(indexed) => {
-                    let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                    let _ = self.tx_completion_sender.send(TxCompletion {
                         tx_key,
                         outcome: TxOutcome::Aborted(Arc::new(e)),
                     });
@@ -290,7 +293,7 @@ impl Indexer {
                         e
                     ));
                     error!("{:#}", err);
-                    let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                    let _ = self.tx_completion_sender.send(TxCompletion {
                         tx_key,
                         outcome: TxOutcome::Failed(err.clone()),
                     });
@@ -305,9 +308,7 @@ impl Indexer {
         tx_key: TxKey,
         tx_ops: Vec<TxOp>,
     ) -> Result<TxKey, Error> {
-        // 1. Clone PartitionMap + derive the tx entity id from the log-assigned
-        //    tx_id (not minted). Advancing the TX_PARTITION counter enforces that
-        //    tx_eids are strictly increasing.
+        // 1. Clone PartitionMap + derive the tx entity id from the log-assigned tx_id
         let mut pending_pm = self.metadata.partition_map.clone();
         let tx_eid = tx_eid_from_tx_id(tx_key.tx_id);
         pending_pm.set_tx_counter(tx_key.tx_id)?;
@@ -373,7 +374,7 @@ impl Indexer {
         // Update latest indexed tx and broadcast completion
         self.latest_indexed_tx = tx_key;
 
-        if let Err(e) = self.tx_completion_sender.send(TxCompletionMessage {
+        if let Err(e) = self.tx_completion_sender.send(TxCompletion {
             tx_key,
             outcome: TxOutcome::Committed,
         }) {
@@ -585,35 +586,8 @@ impl Indexer {
 pub(crate) struct TxWaiter {
     /// Latest indexed tx captured when this waiter subscribed.
     baseline: TxKey,
-    rx: broadcast::Receiver<TxCompletionMessage>,
+    rx: broadcast::Receiver<TxCompletion>,
     slatedb: Arc<Db>,
-}
-
-pub(crate) struct TxCompletion {
-    /// The indexed `TxKey`, present iff a tx entity was written for it.
-    pub tx_key: Option<TxKey>,
-    pub result: Result<(), Arc<anyhow::Error>>,
-}
-
-impl TxOutcome {
-    /// Resolve into a `TxCompletion` for `tx_key`. `Failed` wrote no entity, so
-    /// its completion carries `tx_key: None`.
-    fn into_completion(self, tx_key: TxKey) -> TxCompletion {
-        match self {
-            TxOutcome::Committed => TxCompletion {
-                tx_key: Some(tx_key),
-                result: Ok(()),
-            },
-            TxOutcome::Aborted(err) => TxCompletion {
-                tx_key: Some(tx_key),
-                result: Err(err),
-            },
-            TxOutcome::Failed(err) => TxCompletion {
-                tx_key: None,
-                result: Err(err),
-            },
-        }
-    }
 }
 
 impl TxWaiter {
@@ -631,15 +605,10 @@ impl TxWaiter {
 
         loop {
             match self.rx.recv().await {
-                Ok(TxCompletionMessage {
-                    tx_key: completed_tx_key,
-                    outcome,
-                }) => {
-                    match completed_tx_key.cmp(&tx_key) {
+                Ok(completion) => {
+                    match completion.tx_key.cmp(&tx_key) {
                         std::cmp::Ordering::Less => continue,
-                        std::cmp::Ordering::Equal => {
-                            return Ok(outcome.into_completion(completed_tx_key));
-                        }
+                        std::cmp::Ordering::Equal => return Ok(completion),
                         // Seeing a later tx first means we were lagging at some point.
                         std::cmp::Ordering::Greater => {
                             return self.completion_from_storage(tx_key).await;
@@ -670,11 +639,8 @@ impl TxWaiter {
 
         loop {
             match self.rx.recv().await {
-                Ok(TxCompletionMessage {
-                    tx_key: completed_tx_key,
-                    ..
-                }) => {
-                    if completed_tx_key.tx_id >= tx_key.tx_id {
+                Ok(completion) => {
+                    if completion.tx_key.tx_id >= tx_key.tx_id {
                         return Ok(());
                     }
                 }
@@ -717,7 +683,7 @@ impl Subscriber for Indexer {
                     "Transaction {} deserialization failed: {}",
                     record.tx_key.tx_id, err
                 );
-                let _ = self.tx_completion_sender.send(TxCompletionMessage {
+                let _ = self.tx_completion_sender.send(TxCompletion {
                     tx_key: record.tx_key,
                     outcome: TxOutcome::Failed(Arc::new(err)),
                 });
@@ -1163,12 +1129,9 @@ mod tests {
             .await;
 
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.tx_key, None);
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to deserialize TxOps"));
+        assert_eq!(completion.tx_key, tx_key);
+        assert!(matches!(completion.outcome, TxOutcome::Failed(_)));
+        assert_outcome_err(&completion.outcome, "Failed to deserialize TxOps");
 
         Ok(())
     }
@@ -1197,12 +1160,9 @@ mod tests {
 
         assert_eq!(indexed, tx_key);
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.tx_key, Some(tx_key));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown attribute"));
+        assert_eq!(completion.tx_key, tx_key);
+        assert!(matches!(completion.outcome, TxOutcome::Aborted(_)));
+        assert_outcome_err(&completion.outcome, "Unknown attribute");
 
         Ok(())
     }
@@ -1238,12 +1198,9 @@ mod tests {
             .to_string()
             .contains("Failed to write aborted tx entity"));
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.tx_key, None);
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to write aborted tx entity"));
+        assert_eq!(completion.tx_key, tx_key);
+        assert!(matches!(completion.outcome, TxOutcome::Failed(_)));
+        assert_outcome_err(&completion.outcome, "Failed to write aborted tx entity");
 
         Ok(())
     }
@@ -1270,8 +1227,8 @@ mod tests {
         let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("tx entity should exist");
-        assert_eq!(completion.tx_key, Some(basis));
-        assert!(completion.result.is_ok());
+        assert_eq!(completion.tx_key, basis);
+        assert!(matches!(completion.outcome, TxOutcome::Committed));
 
         Ok(())
     }
@@ -1298,12 +1255,9 @@ mod tests {
         let completion = tx::lookup_tx_completion(components.db.as_ref(), tx_key)
             .await?
             .expect("aborted tx entity should exist");
-        assert_eq!(completion.tx_key, Some(basis));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown attribute"));
+        assert_eq!(completion.tx_key, basis);
+        assert!(matches!(completion.outcome, TxOutcome::Aborted(_)));
+        assert_outcome_err(&completion.outcome, "Unknown attribute");
 
         Ok(())
     }
@@ -1346,6 +1300,20 @@ mod tests {
         }]
     }
 
+    /// Unwrap an error outcome (`Aborted` or `Failed`), asserting its message
+    /// contains `needle`.
+    #[track_caller]
+    fn assert_outcome_err(outcome: &TxOutcome, needle: &str) {
+        let err = match outcome {
+            TxOutcome::Aborted(e) | TxOutcome::Failed(e) => e,
+            TxOutcome::Committed => panic!("expected an error outcome, got Committed"),
+        };
+        assert!(
+            err.to_string().contains(needle),
+            "outcome error {err:?} should contain {needle:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_await_tx_lagged_aborted_tx_recovers_from_storage() -> Result<(), Error> {
         let components = in_memory_slate().await;
@@ -1358,12 +1326,9 @@ mod tests {
         indexer.transact_tx(test_tx_key(3), add_op("bob")).await?;
 
         let completion = waiter.await_tx(tx_key_1).await?;
-        assert_eq!(completion.tx_key, Some(basis_1));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown attribute"));
+        assert_eq!(completion.tx_key, basis_1);
+        assert!(matches!(completion.outcome, TxOutcome::Aborted(_)));
+        assert_outcome_err(&completion.outcome, "Unknown attribute");
 
         Ok(())
     }
@@ -1651,11 +1616,7 @@ mod tests {
             )
             .await?;
         let completion = waiter.await_tx(tx2).await?;
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot both assert and retract"));
+        assert_outcome_err(&completion.outcome, "cannot both assert and retract");
 
         // The stored value must survive: 1 ADD, no RETRACTs
         let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
@@ -1719,11 +1680,7 @@ mod tests {
             )
             .await?;
         let completion = waiter.await_tx(tx2).await?;
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot assert multiple values"));
+        assert_outcome_err(&completion.outcome, "cannot assert multiple values");
 
         // Storage unchanged: only the original ADD, no "bob", no RETRACTs
         let (add_count, retract_count) = count_eav_ops(&slate, entity_id, name_id).await?;
@@ -1770,12 +1727,8 @@ mod tests {
 
         assert_eq!(indexed, tx);
         let completion = waiter.await_tx(tx).await?;
-        assert_eq!(completion.tx_key, Some(tx));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("Cannot modify schema entity"));
+        assert_eq!(completion.tx_key, tx);
+        assert_outcome_err(&completion.outcome, "Cannot modify schema entity");
         let (_name_id, attr) = indexer
             .metadata()
             .schema
@@ -2137,12 +2090,8 @@ mod tests {
         let indexed = indexer.transact_tx(tx_key, tx_ops).await?;
         assert_eq!(indexed, tx_key);
         let completion = waiter.await_tx(tx_key).await?;
-        assert_eq!(completion.tx_key, Some(tx_key));
-        assert!(completion
-            .result
-            .unwrap_err()
-            .to_string()
-            .contains("No entity found for lookup ref"));
+        assert_eq!(completion.tx_key, tx_key);
+        assert_outcome_err(&completion.outcome, "No entity found for lookup ref");
         Ok(())
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -34,9 +34,6 @@ pub(crate) enum TxOutcome {
 }
 
 /// A transaction's `TxOutcome` paired with the `TxKey` it applies to.
-///
-/// Broadcast by the indexer as each tx is indexed, and returned by
-/// `TxWaiter::await_tx` / `lookup_tx_completion` as a tx's resolved outcome.
 #[derive(Clone, Debug)]
 pub(crate) struct TxCompletion {
     pub tx_key: TxKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,5 @@ pub mod config;
 pub mod node;
 pub mod server;
 
-pub use node::{
-    Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult, TxBasis, TxKey, DB,
-};
+pub use node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult, TxKey, DB};
 pub use triplox_client::{client, msgpack_codec, protocol, subscription, transaction};

--- a/src/log.rs
+++ b/src/log.rs
@@ -19,7 +19,7 @@ pub struct Record {
 }
 
 pub(crate) static BOOTSTRAP_RECORD: LazyLock<Record> = LazyLock::new(|| Record {
-    tx_key: crate::bootstrap::BOOTSTRAP_TX_BASIS.tx_key,
+    tx_key: *crate::bootstrap::BOOTSTRAP_TX_KEY,
     record: Vec::new(),
 });
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -42,6 +42,9 @@ impl PartitionMap {
 
     /// Check if an entity ID has been allocated (counter < next_counter for its partition).
     /// Used to validate explicit db/id values in transactions.
+    /// 
+    /// TODO: As tx_eid is derived from tx_id. tx_eids for a file-log might have gaps. 
+    /// This is not considered in this function.
     pub fn contains_entid(&self, eid: i64) -> bool {
         let partition = extract_partition(eid);
         let counter = extract_counter(eid);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -31,14 +31,6 @@ impl PartitionMap {
     }
 
     /// Record an externally-assigned transaction id in `TX_PARTITION`.
-    ///
-    /// Transaction entity IDs are not minted by the partition map; they are
-    /// derived from the log-assigned `tx_id` (see
-    /// [`crate::partition::tx_eid_from_tx_id`]). This advances the `TX_PARTITION`
-    /// high-water mark to `tx_id + 1` so that `contains_entid` keeps working,
-    /// and enforces that `tx_id` is strictly greater than every previously
-    /// assigned one (tx_eids must be strictly increasing). Gaps are allowed
-    /// (e.g. file-log byte offsets).
     pub fn set_tx_counter(&mut self, tx_id: i64) -> Result<()> {
         let next = self.0.entry(TX_PARTITION).or_insert(0);
         if tx_id < *next {
@@ -110,12 +102,11 @@ mod tests {
     #[test]
     fn set_tx_counter_advances_high_water_mark_and_allows_gaps() {
         let mut pm = PartitionMap::new();
-        // Consecutive tx_ids (memory/Kafka style).
         pm.set_tx_counter(0).unwrap();
         assert!(pm.contains_entid(tx_eid_from_tx_id(0)));
         pm.set_tx_counter(1).unwrap();
         assert!(pm.contains_entid(tx_eid_from_tx_id(1)));
-        // Gaps are allowed (file-log byte offsets).
+        // Gaps are allowed
         pm.set_tx_counter(5000).unwrap();
         assert!(pm.contains_entid(tx_eid_from_tx_id(5000)));
         assert_eq!(pm[&TX_PARTITION], 5001);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -42,8 +42,8 @@ impl PartitionMap {
 
     /// Check if an entity ID has been allocated (counter < next_counter for its partition).
     /// Used to validate explicit db/id values in transactions.
-    /// 
-    /// TODO: As tx_eid is derived from tx_id. tx_eids for a file-log might have gaps. 
+    ///
+    /// TODO: As tx_eid is derived from tx_id. tx_eids for a file-log might have gaps.
     /// This is not considered in this function.
     pub fn contains_entid(&self, eid: i64) -> bool {
         let partition = extract_partition(eid);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,8 @@
+use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
-use crate::partition::{extract_counter, extract_partition, make_entity_id};
+use crate::partition::{extract_counter, extract_partition, make_entity_id, TX_PARTITION};
 use crate::schema::Schema;
 
 /// Newtype wrapping partition counters. Deref/DerefMut to inner HashMap
@@ -27,6 +28,24 @@ impl PartitionMap {
     pub fn allocate_entid(&mut self, partition: u32) -> i64 {
         let counter = self.allocate_counter(partition);
         make_entity_id(partition, counter)
+    }
+
+    /// Record an externally-assigned transaction id in `TX_PARTITION`.
+    ///
+    /// Transaction entity IDs are not minted by the partition map; they are
+    /// derived from the log-assigned `tx_id` (see
+    /// [`crate::partition::tx_eid_from_tx_id`]). This advances the `TX_PARTITION`
+    /// high-water mark to `tx_id + 1` so that `contains_entid` keeps working,
+    /// and enforces that `tx_id` is strictly greater than every previously
+    /// assigned one (tx_eids must be strictly increasing). Gaps are allowed
+    /// (e.g. file-log byte offsets).
+    pub fn set_tx_counter(&mut self, tx_id: i64) -> Result<()> {
+        let next = self.0.entry(TX_PARTITION).or_insert(0);
+        if tx_id < *next {
+            bail!("non-monotonic tx_id {tx_id}: TX_PARTITION counter is already at {next}");
+        }
+        *next = tx_id + 1;
+        Ok(())
     }
 
     /// Check if an entity ID has been allocated (counter < next_counter for its partition).
@@ -80,5 +99,37 @@ impl Metadata {
 
     pub fn advance_generation(&mut self) {
         self.generation += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::partition::tx_eid_from_tx_id;
+
+    #[test]
+    fn set_tx_counter_advances_high_water_mark_and_allows_gaps() {
+        let mut pm = PartitionMap::new();
+        // Consecutive tx_ids (memory/Kafka style).
+        pm.set_tx_counter(0).unwrap();
+        assert!(pm.contains_entid(tx_eid_from_tx_id(0)));
+        pm.set_tx_counter(1).unwrap();
+        assert!(pm.contains_entid(tx_eid_from_tx_id(1)));
+        // Gaps are allowed (file-log byte offsets).
+        pm.set_tx_counter(5000).unwrap();
+        assert!(pm.contains_entid(tx_eid_from_tx_id(5000)));
+        assert_eq!(pm[&TX_PARTITION], 5001);
+    }
+
+    #[test]
+    fn set_tx_counter_rejects_non_monotonic_tx_id() {
+        let mut pm = PartitionMap::new();
+        pm.set_tx_counter(10).unwrap();
+        // Re-using the same tx_id (next is 11, so 10 < 11) must fail.
+        assert!(pm.set_tx_counter(10).is_err());
+        // Going backwards must fail.
+        assert!(pm.set_tx_counter(3).is_err());
+        // Resuming forward succeeds.
+        pm.set_tx_counter(11).unwrap();
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -405,7 +405,7 @@ impl<L: TxLog> SubmitNode for Node<L> {
             anyhow::anyhow!("Indexer did not return a TxKey for tx {}", tx_key.tx_id)
         })?;
         match completion.result {
-            Ok(()) => Ok(TransactionResult::TxCommited(indexed)),
+            Ok(()) => Ok(TransactionResult::TxCommitted(indexed)),
             Err(e) => Ok(TransactionResult::TxAborted(
                 indexed,
                 // TODO: Assure identical errors on live and reconstruction path. See #393.
@@ -460,7 +460,7 @@ mod tests {
     /// Define common test attributes (name, age, email, follows) through the standard tx path.
     async fn define_test_schema(node: &impl SubmitNode) {
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
     }
 
     fn assert_aborted_with_error_matching(result: TransactionResult, pattern: &str) {
@@ -530,7 +530,7 @@ mod tests {
         }];
 
         let result = node.execute_tx(tx_ops).await.unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -578,7 +578,7 @@ mod tests {
                 }])
                 .await
                 .unwrap();
-            assert!(matches!(result, TransactionResult::TxCommited(_)));
+            assert!(matches!(result, TransactionResult::TxCommitted(_)));
         }
 
         let db = node.db().await.unwrap();
@@ -1140,7 +1140,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             _ => panic!("Tx1 should commit"),
         };
 
@@ -1153,7 +1153,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             _ => panic!("Tx2 should commit"),
         };
 
@@ -1255,7 +1255,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let results = db
@@ -1286,7 +1286,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let results = db
@@ -1316,7 +1316,7 @@ mod tests {
         .await
         .expect("first log transaction after bootstrap-only restart should not be skipped")
         .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let result = node
             .execute_tx(vec![TxOp::Add {
@@ -1326,7 +1326,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         node.close().await.unwrap();
     }
@@ -1373,7 +1373,7 @@ mod tests {
             .await
             .unwrap();
         let basis = match result {
-            TransactionResult::TxCommited(k) => k,
+            TransactionResult::TxCommitted(k) => k,
             _ => panic!("expected commit"),
         };
 
@@ -1442,7 +1442,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         node.close().await.unwrap();
     }
@@ -1462,8 +1462,8 @@ mod tests {
             .await
             .unwrap();
         let basis1 = match result1 {
-            TransactionResult::TxCommited(tk) => tk,
-            _ => panic!("Expected TxCommited"),
+            TransactionResult::TxCommitted(tk) => tk,
+            _ => panic!("Expected TxCommitted"),
         };
 
         // Second transaction: insert bob
@@ -2013,7 +2013,7 @@ mod tests {
 
     async fn execute_and_flush(node: &Node<MemoryLog>, tx_ops: Vec<TxOp>) -> TxKey {
         let basis = match node.execute_tx(tx_ops).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         flush_wal(node).await;
@@ -2100,7 +2100,7 @@ mod tests {
             .await
             .unwrap();
         let basis = match node.execute_tx(test_schema_tx()).await.unwrap() {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         flush_wal(&node).await;
@@ -2132,7 +2132,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let mut subscription = node
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
@@ -2157,7 +2157,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let mut subscription = node
             .register_incremental_query(
@@ -2175,7 +2175,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         flush_wal(&node).await;
@@ -2209,7 +2209,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
 
@@ -2237,7 +2237,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         let mut subscription = node
@@ -2258,7 +2258,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
         flush_wal(&node).await;
@@ -2299,7 +2299,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
 
@@ -2329,7 +2329,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
         flush_wal(&node).await;
         let mut subscription = node
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
@@ -2344,7 +2344,7 @@ mod tests {
             .await
             .unwrap()
         {
-            TransactionResult::TxCommited(basis) => basis,
+            TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
         };
 
@@ -2813,14 +2813,14 @@ mod tests {
                     msg
                 );
             }
-            TransactionResult::TxCommited(_) => panic!("Expected TxAborted, got TxCommited"),
+            TransactionResult::TxCommitted(_) => panic!("Expected TxAborted, got TxCommitted"),
         }
 
         // Define schema and submit a valid tx — indexer should still be alive
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
         assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
-            "Expected TxCommited for schema tx, got: {:?}",
+            matches!(result, TransactionResult::TxCommitted(_)),
+            "Expected TxCommitted for schema tx, got: {:?}",
             result
         );
 
@@ -2837,8 +2837,8 @@ mod tests {
         .expect("execute_tx should not return Err");
 
         assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
-            "Expected TxCommited for valid tx, got: {:?}",
+            matches!(result, TransactionResult::TxCommitted(_)),
+            "Expected TxCommitted for valid tx, got: {:?}",
             result
         );
     }
@@ -2905,7 +2905,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result1, TransactionResult::TxCommited(_)));
+        assert!(matches!(result1, TransactionResult::TxCommitted(_)));
 
         // tx2: insert with unknown attribute — should fail
         let result2 = node
@@ -2927,7 +2927,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result3, TransactionResult::TxCommited(_)));
+        assert!(matches!(result3, TransactionResult::TxCommitted(_)));
 
         // Query all (entity, name) pairs and verify contiguous counter values
         let db = node.db().await.unwrap();
@@ -2967,7 +2967,7 @@ mod tests {
             .await
             .unwrap();
         let basis = match result {
-            TransactionResult::TxCommited(k) => k,
+            TransactionResult::TxCommitted(k) => k,
             _ => panic!("Expected committed"),
         };
 
@@ -3052,7 +3052,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         // Verify both :name and :age are on the same entity
         let db = node.db().await.unwrap();
@@ -3100,7 +3100,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         // Verify the follow relationship
         let db = node.db().await.unwrap();
@@ -3155,7 +3155,7 @@ mod tests {
             ])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -3192,7 +3192,7 @@ mod tests {
             }])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -3242,7 +3242,7 @@ mod tests {
             )])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         // Verify :age was added to the same entity as :name
         let db = node.db().await.unwrap();
@@ -3302,7 +3302,7 @@ mod tests {
             ])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -3345,7 +3345,7 @@ mod tests {
             ])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -3365,7 +3365,7 @@ mod tests {
             node.execute_tx(vec![unique_identity_schema_attribute(kw!(:ref-id), "ref")])
                 .await
                 .unwrap(),
-            TransactionResult::TxCommited(_)
+            TransactionResult::TxCommitted(_)
         ));
 
         node.execute_tx(vec![TxOp::put(vec![
@@ -3411,7 +3411,7 @@ mod tests {
             ])
             .await
             .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let db = node.db().await.unwrap();
         let result = db
@@ -3536,7 +3536,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
+            matches!(result, TransactionResult::TxCommitted(_)),
             "expected commit, got {:?}",
             result
         );
@@ -3623,7 +3623,7 @@ mod tests {
                     msg
                 );
             }
-            TransactionResult::TxCommited(_) => panic!("expected TxAborted, got TxCommited"),
+            TransactionResult::TxCommitted(_) => panic!("expected TxAborted, got TxCommitted"),
         }
     }
 
@@ -3680,7 +3680,7 @@ mod tests {
                     msg
                 );
             }
-            TransactionResult::TxCommited(_) => panic!("expected TxAborted, got TxCommited"),
+            TransactionResult::TxCommitted(_) => panic!("expected TxAborted, got TxCommitted"),
         }
     }
 
@@ -3766,7 +3766,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
+            matches!(result, TransactionResult::TxCommitted(_)),
             "expected in-tx transfer to succeed, got: {:?}",
             result
         );
@@ -3780,7 +3780,7 @@ mod tests {
             node.execute_tx(vec![unique_value_schema_attribute(kw!(:ssn), "string")])
                 .await
                 .unwrap(),
-            TransactionResult::TxCommited(_)
+            TransactionResult::TxCommitted(_)
         ));
 
         node.execute_tx(vec![TxOp::Add {
@@ -3860,7 +3860,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(result, TransactionResult::TxCommited(_)),
+            matches!(result, TransactionResult::TxCommitted(_)),
             "expected in-tx transfer to succeed, got: {:?}",
             result
         );

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,7 +15,7 @@ use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
 };
-use crate::indexer::{latest_tx_key_from_sdb, Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
+use crate::indexer::{latest_tx_key_from_sdb, Indexer, TxOutcome, DEFAULT_TX_COMPLETION_CAPACITY};
 #[cfg(feature = "kafka")]
 use crate::kafka_log::KafkaLog;
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
@@ -401,16 +401,15 @@ impl<L: TxLog> SubmitNode for Node<L> {
         let tx_key = self.log.append_tx(serialized).await?;
 
         let completion = waiter.await_tx(tx_key).await?;
-        let indexed = completion.tx_key.ok_or_else(|| {
-            anyhow::anyhow!("Indexer did not return a TxKey for tx {}", tx_key.tx_id)
-        })?;
-        match completion.result {
-            Ok(()) => Ok(TransactionResult::TxCommitted(indexed)),
-            Err(e) => Ok(TransactionResult::TxAborted(
-                indexed,
-                // TODO: Assure identical errors on live and reconstruction path. See #393.
+        match completion.outcome {
+            TxOutcome::Committed => Ok(TransactionResult::TxCommitted(completion.tx_key)),
+            // TODO: Assure identical errors on live and reconstruction path. See #393.
+            TxOutcome::Aborted(e) => Ok(TransactionResult::TxAborted(
+                completion.tx_key,
                 anyhow::anyhow!("{:#}", e).into(),
             )),
+            // A technical indexer failure wrote no tx entity; surface it as an error.
+            TxOutcome::Failed(e) => Err(anyhow::anyhow!("{:#}", e)),
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,12 +15,13 @@ use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
 };
-use crate::indexer::{latest_tx_basis_from_sdb, Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
+use crate::indexer::{latest_tx_key_from_sdb, Indexer, DEFAULT_TX_COMPLETION_CAPACITY};
 #[cfg(feature = "kafka")]
 use crate::kafka_log::KafkaLog;
 use crate::log::{subscribe, TxLog, TxLogReader, TxLogWriter};
 use crate::memory_log::MemoryLog;
 use crate::ops::{Entid, QueryArg, TxOp};
+use crate::partition::tx_eid_from_tx_id;
 use crate::query::{execute_query, QueryResult};
 use crate::query_validation::validate_query;
 use crate::schema::{IdentMap, Schema};
@@ -31,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 pub use triplox_client::node::{
     collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, SubmitNode,
 };
-pub use triplox_client::transaction::{TransactionResult, TxBasis, TxKey};
+pub use triplox_client::transaction::{TransactionResult, TxKey};
 
 const DB_AS_OF_INDEXING_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -43,7 +44,7 @@ where
     sdb: Arc<D>,
     ident_map: IdentMap,
     handle: Handle,
-    tx_basis: TxBasis,
+    tx_key: TxKey,
     range_stats: Arc<slatedb_estimates::RangeStats<M>>,
 }
 
@@ -57,41 +58,37 @@ where
         sdb: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
-        tx_basis: TxBasis,
+        tx_key: TxKey,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Self {
         Self {
             sdb,
             ident_map,
             handle,
-            tx_basis,
+            tx_key,
             range_stats,
         }
     }
 
-    /// Construct a DB from a Db by scanning EAV for TX_PARTITION entities to find the latest TxBasis.
+    /// Construct a DB from a Db by scanning EAV for TX_PARTITION entities to find the latest TxKey.
     pub async fn from_latest_sdb(
         sdb: Arc<D>,
         ident_map: IdentMap,
         handle: Handle,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
-        let tx_basis = latest_tx_basis_from_sdb(sdb.as_ref()).await?;
+        let tx_key = latest_tx_key_from_sdb(sdb.as_ref()).await?;
         Ok(Self {
             sdb,
             ident_map,
             handle,
-            tx_basis,
+            tx_key,
             range_stats,
         })
     }
 
     pub fn tx_key(&self) -> &TxKey {
-        &self.tx_basis.tx_key
-    }
-
-    pub fn tx_basis(&self) -> &TxBasis {
-        &self.tx_basis
+        &self.tx_key
     }
 
     pub fn entity(&self, _eid: Entid) {
@@ -123,7 +120,7 @@ where
         let ident_map = self.ident_map.clone();
         let query = query.clone();
         let args = args.to_vec();
-        let as_of = self.tx_basis.tx_eid;
+        let as_of = tx_eid_from_tx_id(self.tx_key.tx_id);
         let range_stats = self.range_stats.clone();
 
         tokio::task::spawn_blocking(move || {
@@ -162,8 +159,8 @@ impl<L: TxLog> Node<L> {
     ) -> Result<Self, Error> {
         let metadata = crate::bootstrap::init_db(&slate).await?;
 
-        let latest_indexed = latest_tx_basis_from_sdb(slate.db.as_ref()).await?;
-        if latest_indexed == *crate::bootstrap::BOOTSTRAP_TX_BASIS {
+        let latest_indexed = latest_tx_key_from_sdb(slate.db.as_ref()).await?;
+        if latest_indexed == *crate::bootstrap::BOOTSTRAP_TX_KEY {
             log.ensure_bootstrap_record().await?;
         }
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
@@ -173,7 +170,7 @@ impl<L: TxLog> Node<L> {
             DEFAULT_TX_COMPLETION_CAPACITY,
         )));
 
-        let after_tx_id = Some(latest_indexed.tx_key.tx_id);
+        let after_tx_id = Some(latest_indexed.tx_id);
 
         // TODO: This read_txs_after is called here and then again in the catch-up phase of
         // the subscriber.
@@ -215,22 +212,18 @@ impl Node<MemoryLog> {
     pub async fn memory_node() -> Self {
         let slate = in_memory_slate().await;
         let metadata = crate::bootstrap::init_db(&slate).await.unwrap();
-        let bootstrap_basis = *crate::bootstrap::BOOTSTRAP_TX_BASIS;
+        let bootstrap_tx_key = *crate::bootstrap::BOOTSTRAP_TX_KEY;
         let indexer = Arc::new(tokio::sync::RwLock::new(Indexer::new(
             slate.db.clone(),
             metadata,
-            bootstrap_basis,
+            bootstrap_tx_key,
             DEFAULT_TX_COMPLETION_CAPACITY,
         )));
         let log = Arc::new(MemoryLog::new(Box::new(clock::SystemClock)));
         log.ensure_bootstrap_record().await.unwrap();
 
-        let subscription = subscribe(
-            log.clone(),
-            Some(bootstrap_basis.tx_key.tx_id),
-            indexer.clone(),
-        )
-        .await;
+        let subscription =
+            subscribe(log.clone(), Some(bootstrap_tx_key.tx_id), indexer.clone()).await;
         let incremental = IncrementalQueryService::new(
             std::env::temp_dir().join(format!(
                 "triplox-dbsp-incremental-{}",
@@ -340,12 +333,12 @@ impl<L: TxLog> Node<L> {
         }
     }
 
-    async fn db_as_of_with_timeout(&self, basis: TxBasis, timeout: Duration) -> Result<DB, Error> {
+    async fn db_as_of_with_timeout(&self, tx_key: TxKey, timeout: Duration) -> Result<DB, Error> {
         let waiter = self.indexer.read().await.tx_waiter();
-        tokio::time::timeout(timeout, waiter.await_indexed(basis.tx_key))
+        tokio::time::timeout(timeout, waiter.await_indexed(tx_key))
             .await
             .map_err(|_| TriploxError::TxIndexingTimeout {
-                tx_id: basis.tx_key.tx_id,
+                tx_id: tx_key.tx_id,
                 timeout,
             })??;
 
@@ -363,7 +356,7 @@ impl<L: TxLog> Node<L> {
             self.slate.db.clone(),
             ident_map,
             handle,
-            basis,
+            tx_key,
             range_stats,
         ))
     }
@@ -408,13 +401,13 @@ impl<L: TxLog> SubmitNode for Node<L> {
         let tx_key = self.log.append_tx(serialized).await?;
 
         let completion = waiter.await_tx(tx_key).await?;
-        let basis = completion.basis.ok_or_else(|| {
-            anyhow::anyhow!("Indexer did not return TxBasis for tx {}", tx_key.tx_id)
+        let indexed = completion.tx_key.ok_or_else(|| {
+            anyhow::anyhow!("Indexer did not return a TxKey for tx {}", tx_key.tx_id)
         })?;
         match completion.result {
-            Ok(()) => Ok(TransactionResult::TxCommited(basis)),
+            Ok(()) => Ok(TransactionResult::TxCommited(indexed)),
             Err(e) => Ok(TransactionResult::TxAborted(
-                basis,
+                indexed,
                 // TODO: Assure identical errors on live and reconstruction path. See #393.
                 anyhow::anyhow!("{:#}", e).into(),
             )),
@@ -439,8 +432,8 @@ impl<L: TxLog> QueryNode for Node<L> {
         DB::from_latest_sdb(self.slate.db.clone(), ident_map, handle, range_stats).await
     }
 
-    async fn db_as_of(&self, basis: TxBasis) -> Result<DB, Error> {
-        self.db_as_of_with_timeout(basis, DB_AS_OF_INDEXING_TIMEOUT)
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
+        self.db_as_of_with_timeout(tx_key, DB_AS_OF_INDEXING_TIMEOUT)
             .await
     }
 }
@@ -1203,12 +1196,12 @@ mod tests {
         };
 
         let db = node.db_as_of(basis).await.unwrap();
-        assert_eq!(*db.tx_basis(), basis);
+        assert_eq!(*db.tx_key(), basis);
 
         let query_str = format!(
             "[:find ?ident ?error \
              :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident] [?tx :db/txError ?error]]",
-            basis.tx_key.tx_id
+            basis.tx_id
         );
         let result = db.query(query_str).await.unwrap();
 
@@ -1224,16 +1217,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_db_as_of_times_out_for_unindexed_tx() {
         let node = Node::memory_node().await;
-        let basis = TxBasis {
-            tx_key: TxKey {
-                tx_id: 999,
-                system_time: st_from_unix_epoch(999),
-            },
-            tx_eid: 999,
+        let tx_key = TxKey {
+            tx_id: 999,
+            system_time: st_from_unix_epoch(999),
         };
 
         let err = match node
-            .db_as_of_with_timeout(basis, Duration::from_millis(10))
+            .db_as_of_with_timeout(tx_key, Duration::from_millis(10))
             .await
         {
             Ok(_) => panic!("expected db_as_of timeout"),
@@ -1395,11 +1385,8 @@ mod tests {
         // A waiter obtained after restart should resolve immediately for the
         // already-indexed tx_key. Without the fix this hangs forever.
         let waiter = node.indexer.read().await.tx_waiter();
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            waiter.await_tx(basis.tx_key),
-        )
-        .await;
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), waiter.await_tx(basis)).await;
 
         assert!(
             result.is_ok(),
@@ -2024,7 +2011,7 @@ mod tests {
         sort_query_rows(rows);
     }
 
-    async fn execute_and_flush(node: &Node<MemoryLog>, tx_ops: Vec<TxOp>) -> TxBasis {
+    async fn execute_and_flush(node: &Node<MemoryLog>, tx_ops: Vec<TxOp>) -> TxKey {
         let basis = match node.execute_tx(tx_ops).await.unwrap() {
             TransactionResult::TxCommited(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
@@ -2037,7 +2024,7 @@ mod tests {
         node: &Node<MemoryLog>,
         subscription: &mut IncrementalQuerySubscription,
         rows: &mut Vec<Vec<DataType>>,
-        basis: TxBasis,
+        basis: TxKey,
         query: &str,
     ) {
         let db = node.db_as_of(basis).await.unwrap();
@@ -2066,14 +2053,14 @@ mod tests {
     async fn test_register_incremental_query_installs_subscription() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
-        let expected_basis = *node.db().await.unwrap().tx_basis();
+        let expected_basis = *node.db().await.unwrap().tx_key();
 
         let mut subscription = node
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
 
-        assert_eq!(subscription.basis, expected_basis);
+        assert_eq!(subscription.tx_key, expected_basis);
         assert!(matches!(
             subscription.deltas.try_recv(),
             Err(tokio::sync::mpsc::error::TryRecvError::Empty)
@@ -2119,7 +2106,7 @@ mod tests {
         flush_wal(&node).await;
 
         let delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(delta.basis, basis);
+        assert_eq!(delta.tx_key, basis);
         let mut rows = delta.rows;
         rows.sort_by_key(|row| format!("{:?}", row));
         let mut expected = vec![
@@ -2194,7 +2181,7 @@ mod tests {
         flush_wal(&node).await;
 
         let delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(delta.basis, future_basis);
+        assert_eq!(delta.tx_key, future_basis);
         assert_eq!(
             delta.rows,
             vec![(
@@ -2229,7 +2216,7 @@ mod tests {
         flush_wal(&node).await;
 
         let delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(delta.basis, basis);
+        assert_eq!(delta.tx_key, basis);
         assert_eq!(
             delta.rows,
             vec![(vec![DataType::String("Alice".to_string())], 1)]
@@ -2257,7 +2244,7 @@ mod tests {
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
-        assert_eq!(subscription.basis, first_basis);
+        assert_eq!(subscription.tx_key, first_basis);
         assert!(try_recv_incremental_delta(&mut subscription)
             .await
             .is_none());
@@ -2277,7 +2264,7 @@ mod tests {
         flush_wal(&node).await;
 
         let delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(delta.basis, second_basis);
+        assert_eq!(delta.tx_key, second_basis);
         assert_eq!(
             delta.rows,
             vec![(vec![DataType::String("Bob".to_string())], 1)]
@@ -2320,7 +2307,7 @@ mod tests {
 
         let mut delta = recv_incremental_delta(&mut subscription).await;
         delta.rows.sort_by_key(|row| format!("{:?}", row));
-        assert_eq!(delta.basis, basis);
+        assert_eq!(delta.tx_key, basis);
         assert_eq!(
             delta.rows,
             vec![
@@ -2365,7 +2352,7 @@ mod tests {
 
         let mut delta = recv_incremental_delta(&mut subscription).await;
         delta.rows.sort_by_key(|row| format!("{:?}", row));
-        assert_eq!(delta.basis, basis);
+        assert_eq!(delta.tx_key, basis);
         assert_eq!(
             delta.rows,
             vec![
@@ -2989,7 +2976,7 @@ mod tests {
         let query_str = format!(
             "[:find ?ident \
              :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident]]",
-            basis.tx_key.tx_id
+            basis.tx_id
         );
         let result = db.query(query_str).await.unwrap();
 
@@ -3021,7 +3008,7 @@ mod tests {
         let query_str = format!(
             "[:find ?ident ?error \
              :where [?tx :db/txId {}] [?tx :db/txResult ?r] [?r :db/ident ?ident] [?tx :db/txError ?error]]",
-            basis.tx_key.tx_id
+            basis.tx_id
         );
         let result = db.query(query_str).await.unwrap();
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -54,12 +54,6 @@ pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
 
 /// Map a `tx_id` (the log-assigned transaction sequence number) to its
 /// transaction entity ID in `TX_PARTITION`.
-///
-/// `tx_eid` is no longer minted by the partition map; it is a pure function of
-/// `tx_id`: `make_entity_id(TX_PARTITION, tx_id)` (equivalently the TX_PARTITION
-/// mask OR/XOR `tx_id`, since the mask and counter bits are disjoint). The
-/// inverse is [`extract_counter`]. `make_entity_id`'s counter assertion guards
-/// against `tx_id` overflowing the 42-bit counter field.
 pub fn tx_eid_from_tx_id(tx_id: i64) -> i64 {
     make_entity_id(TX_PARTITION, tx_id)
 }
@@ -140,22 +134,6 @@ mod tests {
         assert_eq!(extract_partition(eid), TX_PARTITION);
         assert_eq!(extract_counter(eid), 100);
         assert_eq!(eid, (1i64 << 42) | 100);
-    }
-
-    #[test]
-    fn test_tx_eid_from_tx_id_round_trips() {
-        for tx_id in [0, 1, 100, COUNTER_MASK] {
-            let tx_eid = tx_eid_from_tx_id(tx_id);
-            assert_eq!(extract_partition(tx_eid), TX_PARTITION);
-            assert_eq!(extract_counter(tx_eid), tx_id);
-            // The mapping is the partition mask OR/XOR the tx_id (disjoint bits).
-            assert_eq!(tx_eid, ((TX_PARTITION as i64) << COUNTER_BITS) ^ tx_id);
-        }
-    }
-
-    #[test]
-    fn test_tx_eid_from_tx_id_matches_bootstrap() {
-        assert_eq!(tx_eid_from_tx_id(0), crate::bootstrap::BOOTSTRAP_TX_EID);
     }
 
     #[test]

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -52,6 +52,18 @@ pub fn partition_entity_prefix(partition: u32) -> Vec<u8> {
     prefix
 }
 
+/// Map a `tx_id` (the log-assigned transaction sequence number) to its
+/// transaction entity ID in `TX_PARTITION`.
+///
+/// `tx_eid` is no longer minted by the partition map; it is a pure function of
+/// `tx_id`: `make_entity_id(TX_PARTITION, tx_id)` (equivalently the TX_PARTITION
+/// mask OR/XOR `tx_id`, since the mask and counter bits are disjoint). The
+/// inverse is [`extract_counter`]. `make_entity_id`'s counter assertion guards
+/// against `tx_id` overflowing the 42-bit counter field.
+pub fn tx_eid_from_tx_id(tx_id: i64) -> i64 {
+    make_entity_id(TX_PARTITION, tx_id)
+}
+
 /// Construct an entity ID from a partition number and counter value.
 ///
 /// For partition 0, the result equals the counter (small, readable IDs).
@@ -128,6 +140,22 @@ mod tests {
         assert_eq!(extract_partition(eid), TX_PARTITION);
         assert_eq!(extract_counter(eid), 100);
         assert_eq!(eid, (1i64 << 42) | 100);
+    }
+
+    #[test]
+    fn test_tx_eid_from_tx_id_round_trips() {
+        for tx_id in [0, 1, 100, COUNTER_MASK] {
+            let tx_eid = tx_eid_from_tx_id(tx_id);
+            assert_eq!(extract_partition(tx_eid), TX_PARTITION);
+            assert_eq!(extract_counter(tx_eid), tx_id);
+            // The mapping is the partition mask OR/XOR the tx_id (disjoint bits).
+            assert_eq!(tx_eid, ((TX_PARTITION as i64) << COUNTER_BITS) ^ tx_id);
+        }
+    }
+
+    #[test]
+    fn test_tx_eid_from_tx_id_matches_bootstrap() {
+        assert_eq!(tx_eid_from_tx_id(0), crate::bootstrap::BOOTSTRAP_TX_EID);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@ use triplox_client::msgpack_codec::{
 use triplox_client::protocol::{
     ColumnDescription, ErrorCode, DEFAULT_MAX_MESSAGE_SIZE, SEVERITY_ERROR, TAG_UNKNOWN,
 };
-use triplox_client::transaction::{TxBasis, TxKey};
+use triplox_client::transaction::TxKey;
 
 static NEXT_CONN_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -138,42 +138,34 @@ async fn open_db<L: TxLog + 'static>(
         )
     })?;
 
-    let basis = match (
-        open_request.tx_id,
-        open_request.system_time,
-        open_request.tx_eid,
-    ) {
-        (None, None, None) => {
+    let tx_key = match (open_request.tx_id, open_request.system_time) {
+        (None, None) => {
             let db = state
                 .node
                 .db()
                 .await
                 .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
-            *db.tx_basis()
+            *db.tx_key()
         }
-        (Some(tid), Some(system_time), Some(tx_eid)) => {
-            let basis = TxBasis {
-                tx_key: TxKey {
-                    tx_id: tid,
-                    system_time,
-                },
-                tx_eid,
+        (Some(tid), Some(system_time)) => {
+            let tx_key = TxKey {
+                tx_id: tid,
+                system_time,
             };
-            state.node.db_as_of(basis).await.map_err(open_db_error)?;
-            basis
+            state.node.db_as_of(tx_key).await.map_err(open_db_error)?;
+            tx_key
         }
         _ => {
             return Err(ApiError::bad_request(
                 ErrorCode::InvalidStartup,
-                "OpenDb requires tx_id, system_time, and tx_eid, or none of them",
+                "OpenDb requires both tx_id and system_time, or neither",
             ))
         }
     };
 
     let body = encode_db_opened_response(&DbOpenedResponse {
-        tx_id: basis.tx_key.tx_id,
-        system_time: basis.tx_key.system_time,
-        tx_eid: basis.tx_eid,
+        tx_id: tx_key.tx_id,
+        system_time: tx_key.system_time,
     })
     .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
     Ok(ok_response(body))
@@ -271,18 +263,16 @@ async fn execute_tx<L: TxLog + 'static>(
         .map_err(|e| ApiError::internal(ErrorCode::TxError, e.to_string()))?;
 
     let resp = match result {
-        TransactionResult::TxCommited(basis) => TxResultResponse {
+        TransactionResult::TxCommited(tx_key) => TxResultResponse {
             status: 0,
-            tx_id: basis.tx_key.tx_id,
-            system_time: basis.tx_key.system_time,
-            tx_eid: basis.tx_eid,
+            tx_id: tx_key.tx_id,
+            system_time: tx_key.system_time,
             error_message: None,
         },
-        TransactionResult::TxAborted(basis, err) => TxResultResponse {
+        TransactionResult::TxAborted(tx_key, err) => TxResultResponse {
             status: 1,
-            tx_id: basis.tx_key.tx_id,
-            system_time: basis.tx_key.system_time,
-            tx_eid: basis.tx_eid,
+            tx_id: tx_key.tx_id,
+            system_time: tx_key.system_time,
             error_message: Some(err.to_string()),
         },
     };
@@ -339,7 +329,7 @@ async fn subscribe<L: TxLog + 'static>(
         .map_err(|e| ApiError::internal(ErrorCode::QueryError, e.to_string()))?;
 
     let open_frame = encode_subscription_frame(&SubscriptionFrame::Open {
-        basis: subscription.basis,
+        tx_key: subscription.tx_key,
         columns,
     })
     .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
@@ -398,7 +388,7 @@ fn subscription_body(
                         delta = deltas.recv() => match delta {
                             Some(delta) => {
                                 let frame = SubscriptionFrame::Delta {
-                                    basis: delta.basis,
+                                    tx_key: delta.tx_key,
                                     rows: delta
                                         .rows
                                         .into_iter()
@@ -637,11 +627,11 @@ mod tests {
         decode_subscription_frame, encode_subscribe_request, SubscribeRequest,
     };
 
-    fn subscribe_body(query: &str, db: Option<TxBasis>) -> Bytes {
+    fn subscribe_body(query: &str, db: Option<TxKey>) -> Bytes {
         subscribe_body_with_args(query, db, vec![])
     }
 
-    fn subscribe_body_with_args(query: &str, db: Option<TxBasis>, args: Vec<QueryArg>) -> Bytes {
+    fn subscribe_body_with_args(query: &str, db: Option<TxKey>, args: Vec<QueryArg>) -> Bytes {
         Bytes::from(
             encode_subscribe_request(&SubscribeRequest {
                 db,
@@ -655,16 +645,13 @@ mod tests {
     #[tokio::test]
     async fn subscribe_rejects_non_nil_db() {
         let server = Arc::new(Server::new(Arc::new(Node::memory_node().await)));
-        let basis = TxBasis {
-            tx_key: TxKey {
-                tx_id: 0,
-                system_time: chrono::Utc::now(),
-            },
-            tx_eid: 0,
+        let tx_key = TxKey {
+            tx_id: 0,
+            system_time: chrono::Utc::now(),
         };
         let err = subscribe(
             State(server),
-            subscribe_body("[:find ?n :where [?e :name ?n]]", Some(basis)),
+            subscribe_body("[:find ?n :where [?e :name ?n]]", Some(tx_key)),
         )
         .await
         .unwrap_err();
@@ -725,7 +712,7 @@ mod tests {
         node.execute_tx(crate::schema::test_schema_tx())
             .await
             .expect("schema tx");
-        let expected_basis = *node.db().await.unwrap().tx_basis();
+        let expected_tx_key = *node.db().await.unwrap().tx_key();
         let server = Arc::new(Server::new(node));
 
         let resp = subscribe(
@@ -750,8 +737,8 @@ mod tests {
             .expect("open frame chunk")
             .expect("chunk should be ok");
         match decode_subscription_frame(&chunk).expect("decode open frame") {
-            SubscriptionFrame::Open { basis, columns } => {
-                assert_eq!(basis, expected_basis);
+            SubscriptionFrame::Open { tx_key, columns } => {
+                assert_eq!(tx_key, expected_tx_key);
                 assert_eq!(columns.len(), 1);
             }
             other => panic!("expected open frame, got {other:?}"),

--- a/src/server.rs
+++ b/src/server.rs
@@ -180,7 +180,7 @@ async fn query<L: TxLog + 'static>(
     })?;
     let db = state
         .node
-        .db_as_of(query_request.db)
+        .db_as_of(query_request.basis_tx_key)
         .await
         .map_err(open_db_error)?;
 
@@ -287,10 +287,10 @@ async fn subscribe<L: TxLog + 'static>(
     })?;
 
     // subscriptions start at the latest indexed basis only (for now).
-    if request.db.is_some() {
+    if request.basis_tx_key.is_some() {
         return Err(ApiError::bad_request(
             ErrorCode::InvalidQuery,
-            "Subscriptions must start at the latest indexed basis; `db` must be nil",
+            "Subscriptions must start at the latest indexed basis; `basis_tx_key` must be nil",
         ));
     }
 
@@ -628,7 +628,7 @@ mod tests {
     fn subscribe_body_with_args(query: &str, db: Option<TxKey>, args: Vec<QueryArg>) -> Bytes {
         Bytes::from(
             encode_subscribe_request(&SubscribeRequest {
-                db,
+                basis_tx_key: db,
                 query: query.to_string(),
                 args,
             })

--- a/src/server.rs
+++ b/src/server.rs
@@ -257,7 +257,7 @@ async fn execute_tx<L: TxLog + 'static>(
         .map_err(|e| ApiError::internal(ErrorCode::TxError, e.to_string()))?;
 
     let resp = match result {
-        TransactionResult::TxCommited(tx_key) => TxResultResponse {
+        TransactionResult::TxCommitted(tx_key) => TxResultResponse {
             status: 0,
             tx_id: tx_key.tx_id,
             system_time: tx_key.system_time,

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,9 +39,9 @@ use crate::log::TxLog;
 use crate::node::{Database, IntoQuery, Node, QueryNode, SubmitNode, TransactionResult};
 use triplox_client::msgpack_codec::{
     decode_execute_request, decode_open_db_request, decode_query_request, decode_subscribe_request,
-    encode_db_opened_response, encode_error_body, encode_query_response, encode_subscription_frame,
-    encode_tx_key_response, encode_tx_result_response, DbOpenedResponse, ErrorResponseBody,
-    QueryResponse, SubscriptionFrame, TxKeyResponse, TxResultResponse,
+    encode_error_body, encode_query_response, encode_subscription_frame, encode_tx_key,
+    encode_tx_result_response, ErrorResponseBody, QueryResponse, SubscriptionFrame,
+    TxResultResponse,
 };
 use triplox_client::protocol::{
     ColumnDescription, ErrorCode, DEFAULT_MAX_MESSAGE_SIZE, SEVERITY_ERROR, TAG_UNKNOWN,
@@ -163,11 +163,8 @@ async fn open_db<L: TxLog + 'static>(
         }
     };
 
-    let body = encode_db_opened_response(&DbOpenedResponse {
-        tx_id: tx_key.tx_id,
-        system_time: tx_key.system_time,
-    })
-    .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
+    let body = encode_tx_key(&tx_key)
+        .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
     Ok(ok_response(body))
 }
 
@@ -237,11 +234,8 @@ async fn submit_tx<L: TxLog + 'static>(
         .await
         .map_err(|e| ApiError::internal(ErrorCode::TxError, e.to_string()))?;
 
-    let body = encode_tx_key_response(&TxKeyResponse {
-        tx_id: tx_key.tx_id,
-        system_time: tx_key.system_time,
-    })
-    .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
+    let body = encode_tx_key(&tx_key)
+        .map_err(|e| ApiError::internal(ErrorCode::InternalError, e.to_string()))?;
     Ok(ok_response(body))
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -180,7 +180,7 @@ async fn query<L: TxLog + 'static>(
     })?;
     let db = state
         .node
-        .db_as_of(query_request.basis_tx_key)
+        .db_as_of(query_request.tx_key)
         .await
         .map_err(open_db_error)?;
 
@@ -287,10 +287,10 @@ async fn subscribe<L: TxLog + 'static>(
     })?;
 
     // subscriptions start at the latest indexed basis only (for now).
-    if request.basis_tx_key.is_some() {
+    if request.tx_key.is_some() {
         return Err(ApiError::bad_request(
             ErrorCode::InvalidQuery,
-            "Subscriptions must start at the latest indexed basis; `basis_tx_key` must be nil",
+            "Subscriptions must start at the latest indexed basis; `tx_key` must be nil",
         ));
     }
 
@@ -628,7 +628,7 @@ mod tests {
     fn subscribe_body_with_args(query: &str, db: Option<TxKey>, args: Vec<QueryArg>) -> Bytes {
         Bytes::from(
             encode_subscribe_request(&SubscribeRequest {
-                basis_tx_key: db,
+                tx_key: db,
                 query: query.to_string(),
                 args,
             })

--- a/src/slate/cdc.rs
+++ b/src/slate/cdc.rs
@@ -836,7 +836,7 @@ mod tests {
     async fn setup_node_with_schema() -> Node<MemoryLog> {
         let node = Node::memory_node().await;
         let result = node.execute_tx(test_schema_tx()).await.unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
         node
     }
 
@@ -898,7 +898,7 @@ mod tests {
         doc.insert(kw!(:name), DataType::String("alice".to_string()));
         doc.insert(kw!(:age), DataType::Long(30));
         let result = node.execute_tx(vec![TxOp::Put(doc)]).await.unwrap();
-        assert!(matches!(result, TransactionResult::TxCommited(_)));
+        assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
         let all_tx_datoms = collect_cdc_datoms(&node).await;
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -7,7 +7,9 @@ use edn::symbols::Keyword;
 use slatedb::DbReadOps;
 
 use crate::codec::{self, encode_datatype, encode_i64_bytes, Encode};
-use crate::indexer::{ave_key_to_parts, eav_key_to_parts, vae_key_to_parts, TxCompletion};
+use crate::indexer::{
+    ave_key_to_parts, eav_key_to_parts, vae_key_to_parts, TxCompletion, TxOutcome,
+};
 use crate::iterator::slate_key_iterator::SlateKeyIterator;
 use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
@@ -528,20 +530,17 @@ where
         }
     }
 
-    let result = match tx_result {
-        Some(DB_TX_COMMITTED) => Ok(()),
+    let outcome = match tx_result {
+        Some(DB_TX_COMMITTED) => TxOutcome::Committed,
         // TODO: Assure identical errors on live and reconstruction path. See #393.
-        Some(DB_TX_ABORTED) => Err(Arc::new(anyhow::anyhow!(
+        Some(DB_TX_ABORTED) => TxOutcome::Aborted(Arc::new(anyhow::anyhow!(
             "{}",
             tx_error.unwrap_or_else(|| format!("Transaction {} aborted", tx_key.tx_id))
         ))),
         Some(other) => bail!("Tx entity {tx_eid} has unknown :db/txResult {other}"),
         None => bail!("Tx entity {tx_eid} missing :db/txResult"),
     };
-    Ok(Some(TxCompletion {
-        tx_key: Some(tx_key),
-        result,
-    }))
+    Ok(Some(TxCompletion { tx_key, outcome }))
 }
 
 #[cfg(test)]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -13,7 +13,7 @@ use crate::metadata::PartitionMap;
 use crate::ops::{DataType, Datom, DatomOp, Entid, EntityRef, TxOp};
 use crate::schema::{Schema, Unique, ValueType, DB_TX_ABORTED, DB_TX_COMMITTED};
 use crate::slate::DEFAULT_SCAN_OPTIONS;
-use crate::transaction::{TxBasis, TxKey};
+use crate::transaction::TxKey;
 use crate::util::{concat_bytes, next_prefix};
 
 // ---------------------------------------------------------------------------
@@ -466,7 +466,7 @@ pub(crate) fn validate_allocated_entity_ids(
 /// failed without persisting an outcome (technical abort, deserialize failure).
 ///
 /// TODO: I think this function can be replaced by an entity API call once we have
-/// simplified TxKey/TxBasis and an actual entity API.
+/// simplified TxKey and an actual entity API.
 pub(crate) async fn lookup_tx_completion<D>(
     sdb: &D,
     tx_key: TxKey,
@@ -539,7 +539,7 @@ where
         None => bail!("Tx entity {tx_eid} missing :db/txResult"),
     };
     Ok(Some(TxCompletion {
-        basis: Some(TxBasis { tx_key, tx_eid }),
+        tx_key: Some(tx_key),
         result,
     }))
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -15,7 +15,7 @@ use triplox::{TransactionResult, TxKey};
 
 async fn define_base_schema(client: &ClientNode) {
     let result = client.execute_tx(test_schema_tx()).await.unwrap();
-    assert!(matches!(result, TransactionResult::TxCommited(_)));
+    assert!(matches!(result, TransactionResult::TxCommitted(_)));
 }
 
 /// Start an in-memory HTTP server on a free port.
@@ -59,7 +59,7 @@ async fn test_execute_tx_and_query() {
         }])
         .await
         .unwrap();
-    assert!(matches!(result, TransactionResult::TxCommited(_)));
+    assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
     // Open a DB and query
     let db = client.db().await.unwrap();
@@ -88,7 +88,7 @@ async fn test_execute_tx_with_string_ops() {
         ])
         .await
         .unwrap();
-    assert!(matches!(result, TransactionResult::TxCommited(_)));
+    assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
     let db = client.db().await.unwrap();
     let result = db
@@ -183,8 +183,8 @@ async fn test_multiple_stateless_dbs_for_same_basis() {
         .await
         .unwrap();
     let basis = match result {
-        TransactionResult::TxCommited(basis) => basis,
-        _ => panic!("Expected TxCommited"),
+        TransactionResult::TxCommitted(basis) => basis,
+        _ => panic!("Expected TxCommitted"),
     };
 
     // Open two DB values for the same basis.
@@ -256,10 +256,10 @@ async fn test_execute_tx_returns_tx_key() {
         .unwrap();
 
     match result {
-        TransactionResult::TxCommited(tx_key) => {
+        TransactionResult::TxCommitted(tx_key) => {
             assert!(tx_key.tx_id > 0, "tx_id should be positive after indexing");
         }
-        _ => panic!("Expected TxCommited"),
+        _ => panic!("Expected TxCommitted"),
     }
 
     token.cancel();
@@ -281,8 +281,8 @@ async fn test_db_as_of() {
         .await
         .unwrap();
     let basis1 = match result1 {
-        TransactionResult::TxCommited(basis) => basis,
-        _ => panic!("Expected TxCommited"),
+        TransactionResult::TxCommitted(basis) => basis,
+        _ => panic!("Expected TxCommitted"),
     };
 
     // Second transaction
@@ -323,8 +323,8 @@ async fn test_open_latest_db_value_stays_pinned_after_later_tx() {
         .await
         .unwrap();
     let basis1 = match result1 {
-        TransactionResult::TxCommited(basis) => basis,
-        _ => panic!("Expected TxCommited"),
+        TransactionResult::TxCommitted(basis) => basis,
+        _ => panic!("Expected TxCommitted"),
     };
 
     let db = client.db().await.unwrap();

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -11,7 +11,7 @@ use triplox::node::{Database, Node, QueryNode, SubmitNode};
 use triplox::ops::{DataType, EntityRef, TxOp};
 use triplox::schema::test_schema_tx;
 use triplox::server::{DevServer, Server};
-use triplox::{TransactionResult, TxBasis, TxKey};
+use triplox::{TransactionResult, TxKey};
 
 async fn define_base_schema(client: &ClientNode) {
     let result = client.execute_tx(test_schema_tx()).await.unwrap();
@@ -190,8 +190,8 @@ async fn test_multiple_stateless_dbs_for_same_basis() {
     // Open two DB values for the same basis.
     let db1 = client.db_as_of(basis).await.unwrap();
     let db2 = client.db_as_of(basis).await.unwrap();
-    assert_eq!(db1.tx_basis().tx_eid, basis.tx_eid);
-    assert_eq!(db2.tx_basis().tx_eid, basis.tx_eid);
+    assert_eq!(db1.tx_key(), basis);
+    assert_eq!(db2.tx_key(), basis);
 
     // Both should return the same data independently.
     let r1 = db1
@@ -256,12 +256,8 @@ async fn test_execute_tx_returns_tx_key() {
         .unwrap();
 
     match result {
-        TransactionResult::TxCommited(basis) => {
-            assert!(
-                basis.tx_key.tx_id > 0,
-                "tx_id should be positive after indexing"
-            );
-            assert!(basis.tx_eid > 0, "tx_eid should be positive after indexing");
+        TransactionResult::TxCommited(tx_key) => {
+            assert!(tx_key.tx_id > 0, "tx_id should be positive after indexing");
         }
         _ => panic!("Expected TxCommited"),
     }
@@ -301,7 +297,7 @@ async fn test_db_as_of() {
 
     // Open DB pinned to the first transaction basis — should only see alice
     let db = client.db_as_of(basis1).await.unwrap();
-    assert_eq!(db.tx_basis().tx_eid, basis1.tx_eid);
+    assert_eq!(db.tx_key(), basis1);
     let result = db
         .query("{:find [?name] :where [[?e :name ?name]]}")
         .await
@@ -332,7 +328,7 @@ async fn test_open_latest_db_value_stays_pinned_after_later_tx() {
     };
 
     let db = client.db().await.unwrap();
-    assert_eq!(db.tx_basis().tx_eid, basis1.tx_eid);
+    assert_eq!(db.tx_key(), basis1);
 
     client
         .execute_tx(vec![TxOp::Add {

--- a/tests/remote_storage_test.rs
+++ b/tests/remote_storage_test.rs
@@ -73,7 +73,7 @@ async fn test_remote_node_with_s3_storage() {
 
     // Define schema
     let result = node.execute_tx(test_schema_tx()).await.unwrap();
-    assert!(matches!(result, TransactionResult::TxCommited(_)));
+    assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
     // Insert data
     let result = node
@@ -91,7 +91,7 @@ async fn test_remote_node_with_s3_storage() {
         ])
         .await
         .unwrap();
-    assert!(matches!(result, TransactionResult::TxCommited(_)));
+    assert!(matches!(result, TransactionResult::TxCommitted(_)));
 
     // Query
     let db = node.db().await.unwrap();

--- a/tests/subscription_test.rs
+++ b/tests/subscription_test.rs
@@ -145,7 +145,7 @@ async fn subscription_deltas_match_one_shot_query() {
         .await
         .unwrap();
     let last_basis = match last {
-        TransactionResult::TxCommited(basis) => basis,
+        TransactionResult::TxCommitted(basis) => basis,
         TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
     };
 

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -16,7 +16,7 @@ use crate::node::{collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, Subm
 use crate::ops::QueryArg;
 use crate::query::QueryResult;
 use crate::subscription::Subscription;
-use crate::transaction::{TransactionResult, TxBasis, TxKey};
+use crate::transaction::{TransactionResult, TxKey};
 use edn::query::ParsedQuery;
 
 // ---------------------------------------------------------------------------
@@ -100,21 +100,13 @@ impl ClientNode {
         Subscription::connect(resp).await
     }
 
-    async fn open_db(&self, basis: Option<TxBasis>) -> Result<ClientDb> {
-        let (tx_id, system_time, tx_eid) = match basis {
-            None => (None, None, None),
-            Some(basis) => (
-                Some(basis.tx_key.tx_id),
-                Some(basis.tx_key.system_time),
-                Some(basis.tx_eid),
-            ),
+    async fn open_db(&self, tx_key: Option<TxKey>) -> Result<ClientDb> {
+        let (tx_id, system_time) = match tx_key {
+            None => (None, None),
+            Some(tx_key) => (Some(tx_key.tx_id), Some(tx_key.system_time)),
         };
 
-        let body = encode_open_db_request(&OpenDbRequest {
-            tx_id,
-            system_time,
-            tx_eid,
-        })?;
+        let body = encode_open_db_request(&OpenDbRequest { tx_id, system_time })?;
         let resp = self
             .client
             .post(format!("{}/db/open", self.base_url))
@@ -125,16 +117,13 @@ impl ClientNode {
 
         let data = check_response(resp).await?;
         let opened = decode_db_opened_response(&data)?;
-        let basis = TxBasis {
-            tx_key: TxKey {
-                tx_id: opened.tx_id,
-                system_time: opened.system_time,
-            },
-            tx_eid: opened.tx_eid,
+        let tx_key = TxKey {
+            tx_id: opened.tx_id,
+            system_time: opened.system_time,
         };
 
         Ok(ClientDb {
-            basis,
+            tx_key,
             client: self.client.clone(),
             base_url: self.base_url.clone(),
         })
@@ -174,22 +163,19 @@ impl SubmitNode for ClientNode {
 
         let data = check_response(resp).await?;
         let tx_result = decode_tx_result_response(&data)?;
-        let basis = TxBasis {
-            tx_key: TxKey {
-                tx_id: tx_result.tx_id,
-                system_time: tx_result.system_time,
-            },
-            tx_eid: tx_result.tx_eid,
+        let tx_key = TxKey {
+            tx_id: tx_result.tx_id,
+            system_time: tx_result.system_time,
         };
 
         if tx_result.status == 0 {
-            Ok(TransactionResult::TxCommited(basis))
+            Ok(TransactionResult::TxCommited(tx_key))
         } else {
             let err_msg = tx_result
                 .error_message
                 .unwrap_or_else(|| "transaction aborted".to_string());
             Ok(TransactionResult::TxAborted(
-                basis,
+                tx_key,
                 anyhow::anyhow!("{}", err_msg).into(),
             ))
         }
@@ -203,8 +189,8 @@ impl QueryNode for ClientNode {
         self.open_db(None).await
     }
 
-    async fn db_as_of(&self, basis: TxBasis) -> Result<ClientDb, Error> {
-        self.open_db(Some(basis)).await
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<ClientDb, Error> {
+        self.open_db(Some(tx_key)).await
     }
 }
 
@@ -214,15 +200,15 @@ impl QueryNode for ClientNode {
 
 /// A remote DB read basis. Mirrors the `DB` API.
 pub struct ClientDb {
-    basis: TxBasis,
+    tx_key: TxKey,
     client: Client,
     base_url: String,
 }
 
 impl ClientDb {
-    /// The transaction basis this DB value is pinned to.
-    pub fn tx_basis(&self) -> TxBasis {
-        self.basis
+    /// The transaction key this DB value is pinned to.
+    pub fn tx_key(&self) -> TxKey {
+        self.tx_key
     }
 }
 
@@ -238,7 +224,7 @@ impl Database for ClientDb {
         args: &[QueryArg],
     ) -> Result<QueryResult, Error> {
         let body = encode_query_request(&QueryRequest {
-            db: self.basis,
+            db: self.tx_key,
             query: query.to_string(),
             args: args.to_vec(),
         })?;

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -7,10 +7,9 @@ use anyhow::{bail, Error, Result};
 use reqwest::Client;
 
 use crate::msgpack_codec::{
-    decode_db_opened_response, decode_error_body, decode_query_response, decode_tx_key_response,
-    decode_tx_result_response, encode_execute_request, encode_open_db_request,
-    encode_query_request, encode_subscribe_request, ExecuteRequest, OpenDbRequest, QueryRequest,
-    SubscribeRequest,
+    decode_error_body, decode_query_response, decode_tx_key, decode_tx_result_response,
+    encode_execute_request, encode_open_db_request, encode_query_request, encode_subscribe_request,
+    ExecuteRequest, OpenDbRequest, QueryRequest, SubscribeRequest,
 };
 use crate::node::{collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, SubmitNode};
 use crate::ops::QueryArg;
@@ -116,11 +115,7 @@ impl ClientNode {
             .await?;
 
         let data = check_response(resp).await?;
-        let opened = decode_db_opened_response(&data)?;
-        let tx_key = TxKey {
-            tx_id: opened.tx_id,
-            system_time: opened.system_time,
-        };
+        let tx_key = decode_tx_key(&data)?;
 
         Ok(ClientDb {
             tx_key,
@@ -143,11 +138,8 @@ impl SubmitNode for ClientNode {
             .await?;
 
         let data = check_response(resp).await?;
-        let tx_key = decode_tx_key_response(&data)?;
-        Ok(TxKey {
-            tx_id: tx_key.tx_id,
-            system_time: tx_key.system_time,
-        })
+        let tx_key = decode_tx_key(&data)?;
+        Ok(tx_key)
     }
 
     async fn execute_tx<O: IntoTxOp>(&self, ops: Vec<O>) -> Result<TransactionResult, Error> {

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -75,7 +75,7 @@ impl ClientNode {
     ) -> Result<Subscription> {
         let parsed = query.into_query()?;
         let body = encode_subscribe_request(&SubscribeRequest {
-            basis_tx_key: None,
+            tx_key: None,
             query: parsed.to_string(),
             args: args.to_vec(),
         })?;
@@ -216,7 +216,7 @@ impl Database for ClientDb {
         args: &[QueryArg],
     ) -> Result<QueryResult, Error> {
         let body = encode_query_request(&QueryRequest {
-            basis_tx_key: self.tx_key,
+            tx_key: self.tx_key,
             query: query.to_string(),
             args: args.to_vec(),
         })?;

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -161,7 +161,7 @@ impl SubmitNode for ClientNode {
         };
 
         if tx_result.status == 0 {
-            Ok(TransactionResult::TxCommited(tx_key))
+            Ok(TransactionResult::TxCommitted(tx_key))
         } else {
             let err_msg = tx_result
                 .error_message

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -75,7 +75,7 @@ impl ClientNode {
     ) -> Result<Subscription> {
         let parsed = query.into_query()?;
         let body = encode_subscribe_request(&SubscribeRequest {
-            db: None,
+            basis_tx_key: None,
             query: parsed.to_string(),
             args: args.to_vec(),
         })?;
@@ -216,7 +216,7 @@ impl Database for ClientDb {
         args: &[QueryArg],
     ) -> Result<QueryResult, Error> {
         let body = encode_query_request(&QueryRequest {
-            db: self.tx_key,
+            basis_tx_key: self.tx_key,
             query: query.to_string(),
             args: args.to_vec(),
         })?;

--- a/triplox-client/src/lib.rs
+++ b/triplox-client/src/lib.rs
@@ -17,4 +17,4 @@ pub use node::{collect_tx_ops, Database, IntoQuery, IntoTxOp, QueryNode, SubmitN
 pub use ops::{DataType, Entid, EntityRef, QueryArg, TxOp};
 pub use query::QueryResult;
 pub use subscription::{Delta, Subscription};
-pub use transaction::{TransactionResult, TxBasis, TxKey};
+pub use transaction::{TransactionResult, TxKey};

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -639,12 +639,6 @@ pub struct OpenDbRequest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct DbOpenedResponse {
-    pub tx_id: i64,
-    pub system_time: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct QueryRequest {
     pub db: TxKey,
     pub query: String,
@@ -660,12 +654,6 @@ pub struct QueryResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecuteRequest {
     pub ops: Vec<TxOp>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct TxKeyResponse {
-    pub tx_id: i64,
-    pub system_time: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -703,22 +691,16 @@ pub fn decode_open_db_request(data: &[u8]) -> Result<OpenDbRequest> {
     Ok(OpenDbRequest { tx_id, system_time })
 }
 
-/// Encode a DbOpened response: `{"tx_id": int, "system_time": Timestamp}`.
-pub fn encode_db_opened_response(resp: &DbOpenedResponse) -> Result<Vec<u8>> {
+/// Encode a bare `TxKey` body: `{"tx_id": int, "system_time": Timestamp}`.
+/// Used for both the DbOpened and submit/execute responses.
+pub fn encode_tx_key(tx_key: &TxKey) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 2)?;
-    rmp::encode::write_str(&mut buf, "tx_id")?;
-    rmp::encode::write_sint(&mut buf, resp.tx_id)?;
-    rmp::encode::write_str(&mut buf, "system_time")?;
-    write_timestamp(&mut buf, &resp.system_time)?;
+    write_tx_key(&mut buf, tx_key)?;
     Ok(buf)
 }
 
-pub fn decode_db_opened_response(data: &[u8]) -> Result<DbOpenedResponse> {
-    let mut map = map_from_value(read_body_value(data)?)?;
-    let tx_id = take_i64(&mut map, "tx_id")?;
-    let system_time = take_timestamp(&mut map, "system_time")?;
-    Ok(DbOpenedResponse { tx_id, system_time })
+pub fn decode_tx_key(data: &[u8]) -> Result<TxKey> {
+    tx_key_from_value(read_body_value(data)?)
 }
 
 fn write_tx_key<W: Write>(w: &mut W, tx_key: &TxKey) -> Result<()> {
@@ -894,24 +876,6 @@ pub fn decode_execute_request(data: &[u8]) -> Result<ExecuteRequest> {
         ops.push(tx_op_from_value(item)?);
     }
     Ok(ExecuteRequest { ops })
-}
-
-/// Encode a TxKey response: `{"tx_id": int, "system_time": Timestamp}`.
-pub fn encode_tx_key_response(resp: &TxKeyResponse) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 2)?;
-    rmp::encode::write_str(&mut buf, "tx_id")?;
-    rmp::encode::write_sint(&mut buf, resp.tx_id)?;
-    rmp::encode::write_str(&mut buf, "system_time")?;
-    write_timestamp(&mut buf, &resp.system_time)?;
-    Ok(buf)
-}
-
-pub fn decode_tx_key_response(data: &[u8]) -> Result<TxKeyResponse> {
-    let mut map = map_from_value(read_body_value(data)?)?;
-    let tx_id = take_i64(&mut map, "tx_id")?;
-    let system_time = take_timestamp(&mut map, "system_time")?;
-    Ok(TxKeyResponse { tx_id, system_time })
 }
 
 /// Encode a TxResult response.
@@ -1569,14 +1533,13 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_db_opened_response_body() {
-        let system_time = Utc.timestamp_opt(1_700_000_001, 0).unwrap();
-        let response = DbOpenedResponse {
+    fn round_trip_tx_key_body() {
+        let tx_key = TxKey {
             tx_id: 7,
-            system_time,
+            system_time: Utc.timestamp_opt(1_700_000_001, 0).unwrap(),
         };
-        let buf = encode_db_opened_response(&response).unwrap();
-        assert_eq!(decode_db_opened_response(&buf).unwrap(), response);
+        let buf = encode_tx_key(&tx_key).unwrap();
+        assert_eq!(decode_tx_key(&buf).unwrap(), tx_key);
     }
 
     #[test]
@@ -1638,17 +1601,6 @@ mod tests {
         let request = ExecuteRequest { ops };
         let buf = encode_execute_request(&request).unwrap();
         assert_eq!(decode_execute_request(&buf).unwrap(), request);
-    }
-
-    #[test]
-    fn round_trip_tx_key_response_body() {
-        let now = Utc.timestamp_opt(1_700_000_000, 123_456).unwrap();
-        let response = TxKeyResponse {
-            tx_id: 101,
-            system_time: now,
-        };
-        let buf = encode_tx_key_response(&response).unwrap();
-        assert_eq!(decode_tx_key_response(&buf).unwrap(), response);
     }
 
     #[test]
@@ -1721,7 +1673,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_db_opened_rejects_wrong_type() {
+    fn decode_tx_key_rejects_wrong_type() {
         // {"tx_id": "not an int", "system_time": ts}
         let body = pack(Value::Map(vec![
             (Value::String("tx_id".into()), Value::String("nope".into())),
@@ -1730,16 +1682,16 @@ mod tests {
                 Value::Ext(EXT_TIMESTAMP, vec![0, 0, 0, 0]),
             ),
         ]));
-        assert!(decode_db_opened_response(&body).is_err());
+        assert!(decode_tx_key(&body).is_err());
     }
 
     #[test]
-    fn decode_db_opened_rejects_missing_system_time() {
+    fn decode_tx_key_rejects_missing_system_time() {
         let body = pack(Value::Map(vec![(
             Value::String("tx_id".into()),
             Value::Integer(1.into()),
         )]));
-        assert!(decode_db_opened_response(&body).is_err());
+        assert!(decode_tx_key(&body).is_err());
     }
 
     #[test]

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::ops::{DataType, EntityRef, QueryArg, TxOp};
 use crate::protocol::ColumnDescription;
-use crate::transaction::{TxBasis, TxKey};
+use crate::transaction::TxKey;
 
 // =============================================================================
 // Ext type codes
@@ -636,19 +636,17 @@ fn read_body_value(data: &[u8]) -> Result<Value> {
 pub struct OpenDbRequest {
     pub tx_id: Option<i64>,
     pub system_time: Option<DateTime<Utc>>,
-    pub tx_eid: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DbOpenedResponse {
     pub tx_id: i64,
     pub system_time: DateTime<Utc>,
-    pub tx_eid: i64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueryRequest {
-    pub db: TxBasis,
+    pub db: TxKey,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -675,7 +673,6 @@ pub struct TxResultResponse {
     pub status: u8,
     pub tx_id: i64,
     pub system_time: DateTime<Utc>,
-    pub tx_eid: i64,
     pub error_message: Option<String>,
 }
 
@@ -688,16 +685,14 @@ pub struct ErrorResponseBody {
     pub hint: Option<String>,
 }
 
-/// Encode an OpenDb request: `{"tx_id": int|nil, "system_time": Timestamp|nil, "tx_eid": int|nil}`.
+/// Encode an OpenDb request: `{"tx_id": int|nil, "system_time": Timestamp|nil}`.
 pub fn encode_open_db_request(req: &OpenDbRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 3)?;
+    rmp::encode::write_map_len(&mut buf, 2)?;
     rmp::encode::write_str(&mut buf, "tx_id")?;
     write_optional_i64(&mut buf, req.tx_id)?;
     rmp::encode::write_str(&mut buf, "system_time")?;
     write_optional_timestamp(&mut buf, req.system_time)?;
-    rmp::encode::write_str(&mut buf, "tx_eid")?;
-    write_optional_i64(&mut buf, req.tx_eid)?;
     Ok(buf)
 }
 
@@ -705,24 +700,17 @@ pub fn decode_open_db_request(data: &[u8]) -> Result<OpenDbRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
     let tx_id = take_optional_i64(&mut map, "tx_id")?;
     let system_time = take_optional_timestamp(&mut map, "system_time")?;
-    let tx_eid = take_optional_i64(&mut map, "tx_eid")?;
-    Ok(OpenDbRequest {
-        tx_id,
-        system_time,
-        tx_eid,
-    })
+    Ok(OpenDbRequest { tx_id, system_time })
 }
 
-/// Encode a DbOpened response: `{"tx_id": int, "system_time": Timestamp, "tx_eid": int}`.
+/// Encode a DbOpened response: `{"tx_id": int, "system_time": Timestamp}`.
 pub fn encode_db_opened_response(resp: &DbOpenedResponse) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 3)?;
+    rmp::encode::write_map_len(&mut buf, 2)?;
     rmp::encode::write_str(&mut buf, "tx_id")?;
     rmp::encode::write_sint(&mut buf, resp.tx_id)?;
     rmp::encode::write_str(&mut buf, "system_time")?;
     write_timestamp(&mut buf, &resp.system_time)?;
-    rmp::encode::write_str(&mut buf, "tx_eid")?;
-    rmp::encode::write_sint(&mut buf, resp.tx_eid)?;
     Ok(buf)
 }
 
@@ -730,42 +718,32 @@ pub fn decode_db_opened_response(data: &[u8]) -> Result<DbOpenedResponse> {
     let mut map = map_from_value(read_body_value(data)?)?;
     let tx_id = take_i64(&mut map, "tx_id")?;
     let system_time = take_timestamp(&mut map, "system_time")?;
-    let tx_eid = take_i64(&mut map, "tx_eid")?;
-    Ok(DbOpenedResponse {
-        tx_id,
-        system_time,
-        tx_eid,
-    })
+    Ok(DbOpenedResponse { tx_id, system_time })
 }
 
-fn write_tx_basis<W: Write>(w: &mut W, basis: &TxBasis) -> Result<()> {
-    rmp::encode::write_map_len(w, 3)?;
+fn write_tx_key<W: Write>(w: &mut W, tx_key: &TxKey) -> Result<()> {
+    rmp::encode::write_map_len(w, 2)?;
     rmp::encode::write_str(w, "tx_id")?;
-    rmp::encode::write_sint(w, basis.tx_key.tx_id)?;
+    rmp::encode::write_sint(w, tx_key.tx_id)?;
     rmp::encode::write_str(w, "system_time")?;
-    write_timestamp(w, &basis.tx_key.system_time)?;
-    rmp::encode::write_str(w, "tx_eid")?;
-    rmp::encode::write_sint(w, basis.tx_eid)?;
+    write_timestamp(w, &tx_key.system_time)?;
     Ok(())
 }
 
-fn tx_basis_from_value(value: Value) -> Result<TxBasis> {
+fn tx_key_from_value(value: Value) -> Result<TxKey> {
     let mut map = map_from_value(value)?;
-    Ok(TxBasis {
-        tx_key: TxKey {
-            tx_id: take_i64(&mut map, "tx_id")?,
-            system_time: take_timestamp(&mut map, "system_time")?,
-        },
-        tx_eid: take_i64(&mut map, "tx_eid")?,
+    Ok(TxKey {
+        tx_id: take_i64(&mut map, "tx_id")?,
+        system_time: take_timestamp(&mut map, "system_time")?,
     })
 }
 
-/// Encode a Query request: `{"db": TxBasis, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Query request: `{"db": TxKey, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
     rmp::encode::write_str(&mut buf, "db")?;
-    write_tx_basis(&mut buf, &req.db)?;
+    write_tx_key(&mut buf, &req.db)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -778,7 +756,7 @@ pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
 
 pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let db = tx_basis_from_value(take_field(&mut map, "db")?)?;
+    let db = tx_key_from_value(take_field(&mut map, "db")?)?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -939,15 +917,13 @@ pub fn decode_tx_key_response(data: &[u8]) -> Result<TxKeyResponse> {
 /// Encode a TxResult response.
 pub fn encode_tx_result_response(resp: &TxResultResponse) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    rmp::encode::write_map_len(&mut buf, 5)?;
+    rmp::encode::write_map_len(&mut buf, 4)?;
     rmp::encode::write_str(&mut buf, "status")?;
     rmp::encode::write_uint(&mut buf, resp.status as u64)?;
     rmp::encode::write_str(&mut buf, "tx_id")?;
     rmp::encode::write_sint(&mut buf, resp.tx_id)?;
     rmp::encode::write_str(&mut buf, "system_time")?;
     write_timestamp(&mut buf, &resp.system_time)?;
-    rmp::encode::write_str(&mut buf, "tx_eid")?;
-    rmp::encode::write_sint(&mut buf, resp.tx_eid)?;
     rmp::encode::write_str(&mut buf, "error_message")?;
     write_optional_string(&mut buf, &resp.error_message)?;
     Ok(buf)
@@ -961,13 +937,11 @@ pub fn decode_tx_result_response(data: &[u8]) -> Result<TxResultResponse> {
     }
     let tx_id = take_i64(&mut map, "tx_id")?;
     let system_time = take_timestamp(&mut map, "system_time")?;
-    let tx_eid = take_i64(&mut map, "tx_eid")?;
     let error_message = take_optional_string(&mut map, "error_message")?;
     Ok(TxResultResponse {
         status: status_i64 as u8,
         tx_id,
         system_time,
-        tx_eid,
         error_message,
     })
 }
@@ -1024,7 +998,7 @@ pub fn decode_error_body(data: &[u8]) -> Result<ErrorResponseBody> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubscribeRequest {
-    pub db: Option<TxBasis>,
+    pub db: Option<TxKey>,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -1033,35 +1007,32 @@ pub struct SubscribeRequest {
 /// msgpack maps tagged by a `kind` discriminator.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SubscriptionFrame {
-    /// First frame: registration basis and (internal) column schema.
+    /// First frame: registration tx_key and (internal) column schema.
     Open {
-        basis: TxBasis,
+        tx_key: TxKey,
         columns: Vec<ColumnDescription>,
     },
     /// One transaction's z-set changes as `(values, weight)` rows.
     Delta {
-        basis: TxBasis,
+        tx_key: TxKey,
         rows: Vec<(Vec<DataType>, i64)>,
     },
     /// Terminal error raised after the stream has started.
     Error(ErrorResponseBody),
 }
 
-fn write_optional_tx_basis<W: Write>(w: &mut W, basis: &Option<TxBasis>) -> Result<()> {
-    match basis {
-        Some(b) => write_tx_basis(w, b)?,
+fn write_optional_tx_key<W: Write>(w: &mut W, tx_key: &Option<TxKey>) -> Result<()> {
+    match tx_key {
+        Some(k) => write_tx_key(w, k)?,
         None => rmp::encode::write_nil(w)?,
     }
     Ok(())
 }
 
-fn take_optional_tx_basis(
-    map: &mut BTreeMap<String, Value>,
-    name: &str,
-) -> Result<Option<TxBasis>> {
+fn take_optional_tx_key(map: &mut BTreeMap<String, Value>, name: &str) -> Result<Option<TxKey>> {
     match map.remove(name) {
         None | Some(Value::Nil) => Ok(None),
-        Some(v) => Ok(Some(tx_basis_from_value(v)?)),
+        Some(v) => Ok(Some(tx_key_from_value(v)?)),
     }
 }
 
@@ -1093,12 +1064,12 @@ fn delta_row_from_value(v: Value) -> Result<(Vec<DataType>, i64)> {
     Ok((values, weight))
 }
 
-/// Encode a Subscribe request: `{"db": TxBasis|nil, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Subscribe request: `{"db": TxKey|nil, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
     rmp::encode::write_str(&mut buf, "db")?;
-    write_optional_tx_basis(&mut buf, &req.db)?;
+    write_optional_tx_key(&mut buf, &req.db)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -1111,7 +1082,7 @@ pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
 
 pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let db = take_optional_tx_basis(&mut map, "db")?;
+    let db = take_optional_tx_key(&mut map, "db")?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -1128,22 +1099,22 @@ pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
 pub fn encode_subscription_frame(frame: &SubscriptionFrame) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     match frame {
-        SubscriptionFrame::Open { basis, columns } => {
+        SubscriptionFrame::Open { tx_key, columns } => {
             rmp::encode::write_map_len(&mut buf, 3)?;
             write_str_field(&mut buf, "kind", "open")?;
-            rmp::encode::write_str(&mut buf, "basis")?;
-            write_tx_basis(&mut buf, basis)?;
+            rmp::encode::write_str(&mut buf, "tx_key")?;
+            write_tx_key(&mut buf, tx_key)?;
             rmp::encode::write_str(&mut buf, "columns")?;
             rmp::encode::write_array_len(&mut buf, columns.len() as u32)?;
             for col in columns {
                 write_column_description(&mut buf, col)?;
             }
         }
-        SubscriptionFrame::Delta { basis, rows } => {
+        SubscriptionFrame::Delta { tx_key, rows } => {
             rmp::encode::write_map_len(&mut buf, 3)?;
             write_str_field(&mut buf, "kind", "delta")?;
-            rmp::encode::write_str(&mut buf, "basis")?;
-            write_tx_basis(&mut buf, basis)?;
+            rmp::encode::write_str(&mut buf, "tx_key")?;
+            write_tx_key(&mut buf, tx_key)?;
             rmp::encode::write_str(&mut buf, "rows")?;
             rmp::encode::write_array_len(&mut buf, rows.len() as u32)?;
             for (values, weight) in rows {
@@ -1190,7 +1161,7 @@ pub fn subscription_frame_from_value(v: Value) -> Result<SubscriptionFrame> {
     let kind = take_string(&mut map, "kind")?;
     match kind.as_str() {
         "open" => {
-            let basis = tx_basis_from_value(take_field(&mut map, "basis")?)?;
+            let tx_key = tx_key_from_value(take_field(&mut map, "tx_key")?)?;
             let cols_arr = match take_field(&mut map, "columns")? {
                 Value::Array(arr) => arr,
                 other => bail!("field \"columns\" expected array, got {other:?}"),
@@ -1199,10 +1170,10 @@ pub fn subscription_frame_from_value(v: Value) -> Result<SubscriptionFrame> {
             for item in cols_arr {
                 columns.push(column_description_from_value(item)?);
             }
-            Ok(SubscriptionFrame::Open { basis, columns })
+            Ok(SubscriptionFrame::Open { tx_key, columns })
         }
         "delta" => {
-            let basis = tx_basis_from_value(take_field(&mut map, "basis")?)?;
+            let tx_key = tx_key_from_value(take_field(&mut map, "tx_key")?)?;
             let rows_arr = match take_field(&mut map, "rows")? {
                 Value::Array(arr) => arr,
                 other => bail!("field \"rows\" expected array, got {other:?}"),
@@ -1211,7 +1182,7 @@ pub fn subscription_frame_from_value(v: Value) -> Result<SubscriptionFrame> {
             for entry in rows_arr {
                 rows.push(delta_row_from_value(entry)?);
             }
-            Ok(SubscriptionFrame::Delta { basis, rows })
+            Ok(SubscriptionFrame::Delta { tx_key, rows })
         }
         "error" => {
             let severity_str = take_string(&mut map, "severity")?;
@@ -1245,19 +1216,16 @@ mod tests {
     use chrono::TimeZone;
     use edn::kw;
 
-    fn sample_basis() -> TxBasis {
-        TxBasis {
-            tx_key: TxKey {
-                tx_id: 7,
-                system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-            },
-            tx_eid: 8_796_093_022_208,
+    fn sample_tx_key() -> TxKey {
+        TxKey {
+            tx_id: 7,
+            system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
         }
     }
 
     #[test]
     fn subscribe_request_round_trip() {
-        for db in [None, Some(sample_basis())] {
+        for db in [None, Some(sample_tx_key())] {
             let req = SubscribeRequest {
                 db,
                 query: "[:find ?n :where [?e :name ?n]]".to_string(),
@@ -1271,7 +1239,7 @@ mod tests {
     #[test]
     fn open_frame_round_trip() {
         let frame = SubscriptionFrame::Open {
-            basis: sample_basis(),
+            tx_key: sample_tx_key(),
             columns: vec![ColumnDescription {
                 name: "n".to_string(),
                 data_type: 255,
@@ -1286,7 +1254,7 @@ mod tests {
     fn delta_frame_round_trip() {
         // Includes a |weight| > 1 row to assert raw signed weights round-trip.
         let frame = SubscriptionFrame::Delta {
-            basis: sample_basis(),
+            tx_key: sample_tx_key(),
             rows: vec![
                 (vec![DataType::String("Ivan".to_string())], 1),
                 (vec![DataType::String("Petr".to_string())], -2),
@@ -1331,12 +1299,12 @@ mod tests {
         write_data_type(&mut buf, &DataType::Long(5)).unwrap();
         rmp::encode::write_sint(&mut buf, 1).unwrap();
         write_str_field(&mut buf, "kind", "delta").unwrap();
-        rmp::encode::write_str(&mut buf, "basis").unwrap();
-        write_tx_basis(&mut buf, &sample_basis()).unwrap();
+        rmp::encode::write_str(&mut buf, "tx_key").unwrap();
+        write_tx_key(&mut buf, &sample_tx_key()).unwrap();
         assert_eq!(
             decode_subscription_frame(&buf).expect("decode"),
             SubscriptionFrame::Delta {
-                basis: sample_basis(),
+                tx_key: sample_tx_key(),
                 rows: vec![(vec![DataType::Long(5)], 1)],
             }
         );
@@ -1586,20 +1554,15 @@ mod tests {
 
     #[test]
     fn round_trip_open_db_request_bodies() {
-        for (tx_id, system_time, tx_eid) in [
-            (None, None, None),
+        for (tx_id, system_time) in [
+            (None, None),
             (
                 Some(42i64),
                 Some(Utc.timestamp_opt(1_700_000_000, 0).unwrap()),
-                Some(100i64),
             ),
-            (Some(-1), Some(Utc.timestamp_opt(0, 1).unwrap()), Some(101)),
+            (Some(-1), Some(Utc.timestamp_opt(0, 1).unwrap())),
         ] {
-            let request = OpenDbRequest {
-                tx_id,
-                system_time,
-                tx_eid,
-            };
+            let request = OpenDbRequest { tx_id, system_time };
             let buf = encode_open_db_request(&request).unwrap();
             assert_eq!(decode_open_db_request(&buf).unwrap(), request);
         }
@@ -1611,7 +1574,6 @@ mod tests {
         let response = DbOpenedResponse {
             tx_id: 7,
             system_time,
-            tx_eid: 12345,
         };
         let buf = encode_db_opened_response(&response).unwrap();
         assert_eq!(decode_db_opened_response(&buf).unwrap(), response);
@@ -1620,12 +1582,9 @@ mod tests {
     #[test]
     fn round_trip_query_request_body() {
         let q = "{:find [?n] :where [[?e :name ?n]]}";
-        let db = TxBasis {
-            tx_key: TxKey {
-                tx_id: 42,
-                system_time: Utc.timestamp_opt(1_700_000_002, 0).unwrap(),
-            },
-            tx_eid: 100,
+        let db = TxKey {
+            tx_id: 42,
+            system_time: Utc.timestamp_opt(1_700_000_002, 0).unwrap(),
         };
         let args = vec![
             QueryArg::Scalar(DataType::Long(7)),
@@ -1700,7 +1659,6 @@ mod tests {
                 status,
                 tx_id: 7,
                 system_time: now,
-                tx_eid: 123,
                 error_message: err,
             };
             let buf = encode_tx_result_response(&response).unwrap();
@@ -1764,24 +1722,23 @@ mod tests {
 
     #[test]
     fn decode_db_opened_rejects_wrong_type() {
-        // {"tx_id": "not an int", "system_time": ts, "tx_eid": 7}
+        // {"tx_id": "not an int", "system_time": ts}
         let body = pack(Value::Map(vec![
             (Value::String("tx_id".into()), Value::String("nope".into())),
             (
                 Value::String("system_time".into()),
                 Value::Ext(EXT_TIMESTAMP, vec![0, 0, 0, 0]),
             ),
-            (Value::String("tx_eid".into()), Value::Integer(7.into())),
         ]));
         assert!(decode_db_opened_response(&body).is_err());
     }
 
     #[test]
     fn decode_db_opened_rejects_missing_system_time() {
-        let body = pack(Value::Map(vec![
-            (Value::String("tx_id".into()), Value::Integer(1.into())),
-            (Value::String("tx_eid".into()), Value::Integer(2.into())),
-        ]));
+        let body = pack(Value::Map(vec![(
+            Value::String("tx_id".into()),
+            Value::Integer(1.into()),
+        )]));
         assert!(decode_db_opened_response(&body).is_err());
     }
 
@@ -1873,7 +1830,6 @@ mod tests {
         let one = encode_open_db_request(&OpenDbRequest {
             tx_id: None,
             system_time: None,
-            tx_eid: None,
         })
         .unwrap();
         let mut two = one.clone();

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -640,7 +640,7 @@ pub struct OpenDbRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueryRequest {
-    pub db: TxKey,
+    pub basis_tx_key: TxKey,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -720,12 +720,12 @@ fn tx_key_from_value(value: Value) -> Result<TxKey> {
     })
 }
 
-/// Encode a Query request: `{"db": TxKey, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Query request: `{"basis_tx_key": TxKey, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
-    rmp::encode::write_str(&mut buf, "db")?;
-    write_tx_key(&mut buf, &req.db)?;
+    rmp::encode::write_str(&mut buf, "basis_tx_key")?;
+    write_tx_key(&mut buf, &req.basis_tx_key)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -738,7 +738,7 @@ pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
 
 pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let db = tx_key_from_value(take_field(&mut map, "db")?)?;
+    let basis_tx_key = tx_key_from_value(take_field(&mut map, "basis_tx_key")?)?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -748,7 +748,11 @@ pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     for item in arr {
         args.push(query_arg_from_value(item)?);
     }
-    Ok(QueryRequest { db, query, args })
+    Ok(QueryRequest {
+        basis_tx_key,
+        query,
+        args,
+    })
 }
 
 /// Encode a query response: `{"columns": [...], "rows": [[...], ...]}`.
@@ -962,7 +966,7 @@ pub fn decode_error_body(data: &[u8]) -> Result<ErrorResponseBody> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubscribeRequest {
-    pub db: Option<TxKey>,
+    pub basis_tx_key: Option<TxKey>,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -1028,12 +1032,12 @@ fn delta_row_from_value(v: Value) -> Result<(Vec<DataType>, i64)> {
     Ok((values, weight))
 }
 
-/// Encode a Subscribe request: `{"db": TxKey|nil, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Subscribe request: `{"basis_tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
-    rmp::encode::write_str(&mut buf, "db")?;
-    write_optional_tx_key(&mut buf, &req.db)?;
+    rmp::encode::write_str(&mut buf, "basis_tx_key")?;
+    write_optional_tx_key(&mut buf, &req.basis_tx_key)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -1046,7 +1050,7 @@ pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
 
 pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let db = take_optional_tx_key(&mut map, "db")?;
+    let basis_tx_key = take_optional_tx_key(&mut map, "basis_tx_key")?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -1056,7 +1060,11 @@ pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
     for item in arr {
         args.push(query_arg_from_value(item)?);
     }
-    Ok(SubscribeRequest { db, query, args })
+    Ok(SubscribeRequest {
+        basis_tx_key,
+        query,
+        args,
+    })
 }
 
 /// Encode one subscription frame as a bare msgpack map.
@@ -1191,7 +1199,7 @@ mod tests {
     fn subscribe_request_round_trip() {
         for db in [None, Some(sample_tx_key())] {
             let req = SubscribeRequest {
-                db,
+                basis_tx_key: db,
                 query: "[:find ?n :where [?e :name ?n]]".to_string(),
                 args: vec![QueryArg::Scalar(DataType::Long(42))],
             };
@@ -1557,7 +1565,7 @@ mod tests {
             ]),
         ];
         let request = QueryRequest {
-            db,
+            basis_tx_key: db,
             query: q.into(),
             args,
         };

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -640,7 +640,7 @@ pub struct OpenDbRequest {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueryRequest {
-    pub basis_tx_key: TxKey,
+    pub tx_key: TxKey,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -720,12 +720,12 @@ fn tx_key_from_value(value: Value) -> Result<TxKey> {
     })
 }
 
-/// Encode a Query request: `{"basis_tx_key": TxKey, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Query request: `{"tx_key": TxKey, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
-    rmp::encode::write_str(&mut buf, "basis_tx_key")?;
-    write_tx_key(&mut buf, &req.basis_tx_key)?;
+    rmp::encode::write_str(&mut buf, "tx_key")?;
+    write_tx_key(&mut buf, &req.tx_key)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -738,7 +738,7 @@ pub fn encode_query_request(req: &QueryRequest) -> Result<Vec<u8>> {
 
 pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let basis_tx_key = tx_key_from_value(take_field(&mut map, "basis_tx_key")?)?;
+    let tx_key = tx_key_from_value(take_field(&mut map, "tx_key")?)?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -749,7 +749,7 @@ pub fn decode_query_request(data: &[u8]) -> Result<QueryRequest> {
         args.push(query_arg_from_value(item)?);
     }
     Ok(QueryRequest {
-        basis_tx_key,
+        tx_key,
         query,
         args,
     })
@@ -966,7 +966,7 @@ pub fn decode_error_body(data: &[u8]) -> Result<ErrorResponseBody> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubscribeRequest {
-    pub basis_tx_key: Option<TxKey>,
+    pub tx_key: Option<TxKey>,
     pub query: String,
     pub args: Vec<QueryArg>,
 }
@@ -1032,12 +1032,12 @@ fn delta_row_from_value(v: Value) -> Result<(Vec<DataType>, i64)> {
     Ok((values, weight))
 }
 
-/// Encode a Subscribe request: `{"basis_tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}`.
+/// Encode a Subscribe request: `{"tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}`.
 pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     rmp::encode::write_map_len(&mut buf, 3)?;
-    rmp::encode::write_str(&mut buf, "basis_tx_key")?;
-    write_optional_tx_key(&mut buf, &req.basis_tx_key)?;
+    rmp::encode::write_str(&mut buf, "tx_key")?;
+    write_optional_tx_key(&mut buf, &req.tx_key)?;
     rmp::encode::write_str(&mut buf, "query")?;
     rmp::encode::write_str(&mut buf, &req.query)?;
     rmp::encode::write_str(&mut buf, "args")?;
@@ -1050,7 +1050,7 @@ pub fn encode_subscribe_request(req: &SubscribeRequest) -> Result<Vec<u8>> {
 
 pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
     let mut map = map_from_value(read_body_value(data)?)?;
-    let basis_tx_key = take_optional_tx_key(&mut map, "basis_tx_key")?;
+    let tx_key = take_optional_tx_key(&mut map, "tx_key")?;
     let query = take_string(&mut map, "query")?;
     let arr = match take_field(&mut map, "args")? {
         Value::Array(arr) => arr,
@@ -1061,7 +1061,7 @@ pub fn decode_subscribe_request(data: &[u8]) -> Result<SubscribeRequest> {
         args.push(query_arg_from_value(item)?);
     }
     Ok(SubscribeRequest {
-        basis_tx_key,
+        tx_key,
         query,
         args,
     })
@@ -1199,7 +1199,7 @@ mod tests {
     fn subscribe_request_round_trip() {
         for db in [None, Some(sample_tx_key())] {
             let req = SubscribeRequest {
-                basis_tx_key: db,
+                tx_key: db,
                 query: "[:find ?n :where [?e :name ?n]]".to_string(),
                 args: vec![QueryArg::Scalar(DataType::Long(42))],
             };
@@ -1565,7 +1565,7 @@ mod tests {
             ]),
         ];
         let request = QueryRequest {
-            basis_tx_key: db,
+            tx_key: db,
             query: q.into(),
             args,
         };

--- a/triplox-client/src/node.rs
+++ b/triplox-client/src/node.rs
@@ -3,7 +3,7 @@ use edn::query::ParsedQuery;
 
 use crate::ops::{QueryArg, TxOp};
 use crate::query::QueryResult;
-use crate::transaction::{TransactionResult, TxBasis, TxKey};
+use crate::transaction::{TransactionResult, TxKey};
 
 #[allow(async_fn_in_trait)]
 pub trait SubmitNode {
@@ -84,5 +84,5 @@ pub trait Database {
 pub trait QueryNode {
     type DB: Database;
     async fn db(&self) -> Result<Self::DB, Error>;
-    async fn db_as_of(&self, basis: TxBasis) -> Result<Self::DB, Error>;
+    async fn db_as_of(&self, tx_key: TxKey) -> Result<Self::DB, Error>;
 }

--- a/triplox-client/src/subscription.rs
+++ b/triplox-client/src/subscription.rs
@@ -186,19 +186,17 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, LazyLock};
     use tokio::time::{sleep, timeout, Duration};
 
-    fn sample_tx_key() -> TxKey {
-        TxKey {
-            tx_id: 3,
-            system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-        }
-    }
+    static SAMPLE_TX_KEY: LazyLock<TxKey> = LazyLock::new(|| TxKey {
+        tx_id: 3,
+        system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+    });
 
     fn open_bytes() -> Vec<u8> {
         encode_subscription_frame(&SubscriptionFrame::Open {
-            tx_key: sample_tx_key(),
+            tx_key: *SAMPLE_TX_KEY,
             columns: vec![ColumnDescription {
                 name: "n".to_string(),
                 data_type: 255,
@@ -210,7 +208,7 @@ mod tests {
 
     fn delta_bytes(name: &str) -> Vec<u8> {
         encode_subscription_frame(&SubscriptionFrame::Delta {
-            tx_key: sample_tx_key(),
+            tx_key: *SAMPLE_TX_KEY,
             rows: vec![(vec![DataType::String(name.to_string())], 1)],
         })
         .unwrap()
@@ -274,7 +272,7 @@ mod tests {
             futures::stream::once(async move { Ok::<Bytes, io::Error>(Bytes::from(payload)) });
 
         let mut sub = Subscription::from_byte_stream(stream).await.unwrap();
-        assert_eq!(sub.tx_key(), sample_tx_key());
+        assert_eq!(sub.tx_key(), *SAMPLE_TX_KEY);
 
         let err = sub.next().await.expect("an item").unwrap_err();
         assert!(err

--- a/triplox-client/src/subscription.rs
+++ b/triplox-client/src/subscription.rs
@@ -20,7 +20,7 @@ use tokio_util::io::StreamReader;
 use crate::msgpack_codec::{subscription_frame_from_value, ErrorResponseBody, SubscriptionFrame};
 use crate::ops::DataType;
 use crate::protocol::DEFAULT_MAX_MESSAGE_SIZE;
-use crate::transaction::TxBasis;
+use crate::transaction::TxKey;
 
 type ByteStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>>;
 type FrameStream = FramedRead<StreamReader<ByteStream, Bytes>, MsgpackFrameDecoder>;
@@ -30,8 +30,8 @@ const SUBSCRIPTION_QUEUE_CAPACITY: usize = 128;
 /// A single transaction's z-set changes for a subscribed query.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Delta {
-    /// The transaction basis that produced this delta.
-    pub basis: TxBasis,
+    /// The transaction key that produced this delta.
+    pub tx_key: TxKey,
     /// `(values, weight)` rows; `weight` is the raw signed multiplicity.
     pub rows: Vec<(Vec<DataType>, i64)>,
 }
@@ -41,7 +41,7 @@ pub struct Delta {
 /// Implements `Stream<Item = Result<Delta>>`; use `StreamExt::next().await` or
 /// stream combinators. Dropping it cancels the HTTP/2 stream and unsubscribes.
 pub struct Subscription {
-    basis: TxBasis,
+    tx_key: TxKey,
     deltas: mpsc::Receiver<Result<Delta>>,
     reader: JoinHandle<()>,
 }
@@ -53,7 +53,7 @@ fn error_frame_to_error(err: ErrorResponseBody) -> Error {
 async fn read_deltas(mut frames: FrameStream, sender: mpsc::Sender<Result<Delta>>) {
     while let Some(frame) = frames.next().await {
         let (item, terminal) = match frame {
-            Ok(SubscriptionFrame::Delta { basis, rows }) => (Ok(Delta { basis, rows }), false),
+            Ok(SubscriptionFrame::Delta { tx_key, rows }) => (Ok(Delta { tx_key, rows }), false),
             Ok(SubscriptionFrame::Error(err)) => (Err(error_frame_to_error(err)), true),
             Ok(SubscriptionFrame::Open { .. }) => {
                 (Err(anyhow!("unexpected open frame mid-stream")), true)
@@ -68,9 +68,9 @@ async fn read_deltas(mut frames: FrameStream, sender: mpsc::Sender<Result<Delta>
 }
 
 impl Subscription {
-    /// The registration basis. Deltas describe transactions strictly after it.
-    pub fn basis(&self) -> TxBasis {
-        self.basis
+    /// The registration tx_key. Deltas describe transactions strictly after it.
+    pub fn tx_key(&self) -> TxKey {
+        self.tx_key
     }
 
     /// Wrap a streaming subscription response: frame its body and read the
@@ -88,8 +88,8 @@ impl Subscription {
     {
         let reader = StreamReader::new(Box::pin(stream) as ByteStream);
         let mut frames = FramedRead::new(reader, MsgpackFrameDecoder::default());
-        let basis = match frames.next().await {
-            Some(Ok(SubscriptionFrame::Open { basis, .. })) => basis,
+        let tx_key = match frames.next().await {
+            Some(Ok(SubscriptionFrame::Open { tx_key, .. })) => tx_key,
             Some(Ok(SubscriptionFrame::Error(err))) => return Err(error_frame_to_error(err)),
             Some(Ok(other)) => bail!("expected open frame, got {other:?}"),
             Some(Err(err)) => return Err(err),
@@ -98,7 +98,7 @@ impl Subscription {
         let (sender, deltas) = mpsc::channel(SUBSCRIPTION_QUEUE_CAPACITY);
         let reader = tokio::spawn(read_deltas(frames, sender));
         Ok(Subscription {
-            basis,
+            tx_key,
             deltas,
             reader,
         })
@@ -189,19 +189,16 @@ mod tests {
     use std::sync::Arc;
     use tokio::time::{sleep, timeout, Duration};
 
-    fn sample_basis() -> TxBasis {
-        TxBasis {
-            tx_key: TxKey {
-                tx_id: 3,
-                system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-            },
-            tx_eid: 42,
+    fn sample_tx_key() -> TxKey {
+        TxKey {
+            tx_id: 3,
+            system_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
         }
     }
 
     fn open_bytes() -> Vec<u8> {
         encode_subscription_frame(&SubscriptionFrame::Open {
-            basis: sample_basis(),
+            tx_key: sample_tx_key(),
             columns: vec![ColumnDescription {
                 name: "n".to_string(),
                 data_type: 255,
@@ -213,7 +210,7 @@ mod tests {
 
     fn delta_bytes(name: &str) -> Vec<u8> {
         encode_subscription_frame(&SubscriptionFrame::Delta {
-            basis: sample_basis(),
+            tx_key: sample_tx_key(),
             rows: vec![(vec![DataType::String(name.to_string())], 1)],
         })
         .unwrap()
@@ -277,7 +274,7 @@ mod tests {
             futures::stream::once(async move { Ok::<Bytes, io::Error>(Bytes::from(payload)) });
 
         let mut sub = Subscription::from_byte_stream(stream).await.unwrap();
-        assert_eq!(sub.basis(), sample_basis());
+        assert_eq!(sub.tx_key(), sample_tx_key());
 
         let err = sub.next().await.expect("an item").unwrap_err();
         assert!(err

--- a/triplox-client/src/transaction.rs
+++ b/triplox-client/src/transaction.rs
@@ -11,6 +11,6 @@ pub struct TxKey {
 
 #[derive(Debug)]
 pub enum TransactionResult {
-    TxCommited(TxKey),
+    TxCommitted(TxKey),
     TxAborted(TxKey, Box<dyn Error>),
 }

--- a/triplox-client/src/transaction.rs
+++ b/triplox-client/src/transaction.rs
@@ -9,14 +9,8 @@ pub struct TxKey {
     pub system_time: Instant,
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TxBasis {
-    pub tx_key: TxKey,
-    pub tx_eid: i64,
-}
-
 #[derive(Debug)]
 pub enum TransactionResult {
-    TxCommited(TxBasis),
-    TxAborted(TxBasis, Box<dyn Error>),
+    TxCommited(TxKey),
+    TxAborted(TxKey, Box<dyn Error>),
 }

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -16,9 +16,9 @@
   "Open a DB value. Returns a Db."
   (^Db [conn]
    (db conn nil))
-  (^Db [conn {:keys [tx-basis] :as _opts}]
-   (if tx-basis
-     (.openDbAsOf ^TriploxNode conn (TxKey. (long (:tx-id tx-basis)) (:system-time tx-basis)))
+  (^Db [conn {:keys [tx-key] :as _opts}]
+   (if tx-key
+     (.openDbAsOf ^TriploxNode conn (TxKey. (long (:tx-id tx-key)) (:system-time tx-key)))
      (.openDb ^TriploxNode conn))))
 
 (defn q
@@ -82,9 +82,9 @@
        (.isDone ^Subscription sub) nil
        :else ::timeout))))
 
-(defn basis
-  "The registration basis of a subscription, as a map."
+(defn tx-key
+  "The registration tx_key of a subscription, as a map."
   [^Subscription sub]
-  (let [b (.basis ^Subscription sub)]
+  (let [b (.txKey ^Subscription sub)]
     {:tx-id (.txId b)
      :system-time (.systemTime b)}))

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -16,9 +16,9 @@
   "Open a DB value. Returns a Db."
   (^Db [conn]
    (db conn nil))
-  (^Db [conn {:keys [tx-key] :as _opts}]
+  (^Db [conn {:keys [tx-id system-time] :as tx-key}]
    (if tx-key
-     (.openDbAsOf ^TriploxNode conn (TxKey. (long (:tx-id tx-key)) (:system-time tx-key)))
+     (.openDbAsOf ^TriploxNode conn (TxKey. (long tx-id) system-time))
      (.openDb ^TriploxNode conn))))
 
 (defn q

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -5,7 +5,7 @@
    [xyz.triplox.types :as types])
   (:import
    [java.util.concurrent TimeUnit]
-   [xyz.triplox.client Db QueryArg$Collection QueryArg$Scalar Subscription TriploxNode TxBasis TxKey TxResult]))
+   [xyz.triplox.client Db QueryArg$Collection QueryArg$Scalar Subscription TriploxNode TxKey TxResult]))
 
 (defn connect
   "Connect to a Triplox server. Returns a TriploxNode (AutoCloseable)."
@@ -18,7 +18,7 @@
    (db conn nil))
   (^Db [conn {:keys [tx-basis] :as _opts}]
    (if tx-basis
-     (.openDbAsOf ^TriploxNode conn (TxBasis. (long (:tx-id tx-basis)) (:system-time tx-basis) (long (:tx-eid tx-basis))))
+     (.openDbAsOf ^TriploxNode conn (TxKey. (long (:tx-id tx-basis)) (:system-time tx-basis)))
      (.openDb ^TriploxNode conn))))
 
 (defn q
@@ -41,7 +41,6 @@
   (let [^TxResult result (.executeTx ^TriploxNode conn (tx/tx-data->ops tx-data))]
     (cond-> {:tx-id (.txId result)
              :system-time (.systemTime result)
-             :tx-eid (.txEid result)
              :committed? (.isCommitted result)}
       (not (.isCommitted result))
       (assoc :error-message (.errorMessage result)))))
@@ -88,5 +87,4 @@
   [^Subscription sub]
   (let [b (.basis ^Subscription sub)]
     {:tx-id (.txId b)
-     :system-time (.systemTime b)
-     :tx-eid (.txEid b)}))
+     :system-time (.systemTime b)}))

--- a/triplox-jvm/src/main/java/xyz/triplox/client/BackendMessage.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/BackendMessage.java
@@ -6,11 +6,8 @@ import java.time.Instant;
  * Decoded HTTP response bodies. Used internally by {@link WireCodec}.
  */
 public sealed interface BackendMessage {
-    record DbOpened(long txId, Instant systemTime, long txEid) implements BackendMessage {
-        public TxBasis basis() { return new TxBasis(txId, systemTime, txEid); }
-    }
     record TxKey(long txId, Instant systemTime) implements BackendMessage {}
-    record TxResult(byte status, long txId, Instant systemTime, long txEid, String errorMessage)
+    record TxResult(byte status, long txId, Instant systemTime, String errorMessage)
             implements BackendMessage {}
     record ErrorResponse(byte severity, short code, String message, String detail, String hint)
             implements BackendMessage {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
@@ -10,14 +10,14 @@ import java.util.List;
  */
 public class Db {
     private final TriploxNode node;
-    private final TxKey basis;
+    private final TxKey txKey;
 
-    Db(TriploxNode node, TxKey basis) {
+    Db(TriploxNode node, TxKey txKey) {
         this.node = node;
-        this.basis = basis;
+        this.txKey = txKey;
     }
 
-    public TxKey basis() { return basis; }
+    public TxKey txKey() { return txKey; }
 
     /**
      * Execute a Datalog query against this DB read basis.

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Db.java
@@ -10,15 +10,14 @@ import java.util.List;
  */
 public class Db {
     private final TriploxNode node;
-    private final TxBasis basis;
+    private final TxKey basis;
 
-    Db(TriploxNode node, TxBasis basis) {
+    Db(TriploxNode node, TxKey basis) {
         this.node = node;
         this.basis = basis;
     }
 
-    public TxBasis basis() { return basis; }
-    public long txEid() { return basis.txEid(); }
+    public TxKey basis() { return basis; }
 
     /**
      * Execute a Datalog query against this DB read basis.

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
@@ -8,4 +8,4 @@ import java.util.List;
  * <p>{@code basis} is the transaction basis that produced the delta. Each
  * {@link Row} carries the raw signed weight.</p>
  */
-public record Delta(TxBasis basis, List<Row> rows) implements SubscriptionFrame {}
+public record Delta(TxKey basis, List<Row> rows) implements SubscriptionFrame {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * One transaction's z-set changes for a subscribed query.
  *
- * <p>{@code basis} is the transaction basis that produced the delta. Each
+ * <p>{@code txKey} is the transaction key that produced the delta. Each
  * {@link Row} carries the raw signed weight.</p>
  */
-public record Delta(TxKey basis, List<Row> rows) implements SubscriptionFrame {}
+public record Delta(TxKey txKey, List<Row> rows) implements SubscriptionFrame {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
@@ -26,7 +26,7 @@ public final class Subscription implements AutoCloseable {
     private static final int QUEUE_CAPACITY = 128;
     private static final short INTERNAL_ERROR = 4000;
 
-    private final TxKey basis;
+    private final TxKey txKey;
     private final Closeable closeable;
     private final Thread reader;
     private final BlockingQueue<QueueEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
@@ -43,8 +43,8 @@ public final class Subscription implements AutoCloseable {
         }
     }
 
-    Subscription(TxKey basis, Closeable closeable, MessageUnpacker unpacker) {
-        this.basis = basis;
+    Subscription(TxKey txKey, Closeable closeable, MessageUnpacker unpacker) {
+        this.txKey = txKey;
         this.closeable = closeable;
         this.reader = new Thread(() -> readLoop(unpacker), "triplox-subscription-reader");
         this.reader.setDaemon(true);
@@ -53,7 +53,7 @@ public final class Subscription implements AutoCloseable {
 
     /**
      * Wrap a streaming subscription response: read the leading {@code open} frame
-     * for {@link #basis()}, then start the reader thread.
+     * for {@link #txKey()}, then start the reader thread.
      */
     static Subscription open(InputStream stream) throws IOException {
         return open(stream, stream);
@@ -63,7 +63,7 @@ public final class Subscription implements AutoCloseable {
         MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(stream);
         SubscriptionFrame first = WireCodec.decodeSubscriptionFrame(unpacker);
         if (first instanceof SubscriptionFrame.Open open) {
-            return new Subscription(open.basis(), closeable, unpacker);
+            return new Subscription(open.txKey(), closeable, unpacker);
         }
         closeable.close();
         if (first instanceof SubscriptionFrame.Error error) {
@@ -72,9 +72,9 @@ public final class Subscription implements AutoCloseable {
         throw new IOException("expected open frame, got " + first);
     }
 
-    /** The registration basis. Deltas describe transactions strictly after it. */
-    public TxKey basis() {
-        return basis;
+    /** The registration tx_key. Deltas describe transactions strictly after it. */
+    public TxKey txKey() {
+        return txKey;
     }
 
     /** True once the stream has ended or the subscription has been closed. */

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
@@ -26,7 +26,7 @@ public final class Subscription implements AutoCloseable {
     private static final int QUEUE_CAPACITY = 128;
     private static final short INTERNAL_ERROR = 4000;
 
-    private final TxBasis basis;
+    private final TxKey basis;
     private final Closeable closeable;
     private final Thread reader;
     private final BlockingQueue<QueueEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
@@ -43,7 +43,7 @@ public final class Subscription implements AutoCloseable {
         }
     }
 
-    Subscription(TxBasis basis, Closeable closeable, MessageUnpacker unpacker) {
+    Subscription(TxKey basis, Closeable closeable, MessageUnpacker unpacker) {
         this.basis = basis;
         this.closeable = closeable;
         this.reader = new Thread(() -> readLoop(unpacker), "triplox-subscription-reader");
@@ -73,7 +73,7 @@ public final class Subscription implements AutoCloseable {
     }
 
     /** The registration basis. Deltas describe transactions strictly after it. */
-    public TxBasis basis() {
+    public TxKey basis() {
         return basis;
     }
 

--- a/triplox-jvm/src/main/java/xyz/triplox/client/SubscriptionFrame.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/SubscriptionFrame.java
@@ -11,8 +11,8 @@ import java.util.List;
 public sealed interface SubscriptionFrame
         permits SubscriptionFrame.Open, Delta, SubscriptionFrame.Error {
 
-    /** First frame: registration basis and (internal) column schema. */
-    record Open(TxKey basis, List<ColumnDesc> columns) implements SubscriptionFrame {}
+    /** First frame: registration tx_key and (internal) column schema. */
+    record Open(TxKey txKey, List<ColumnDesc> columns) implements SubscriptionFrame {}
 
     /** Terminal error raised after the stream has started. */
     record Error(BackendMessage.ErrorResponse error) implements SubscriptionFrame {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/SubscriptionFrame.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/SubscriptionFrame.java
@@ -12,7 +12,7 @@ public sealed interface SubscriptionFrame
         permits SubscriptionFrame.Open, Delta, SubscriptionFrame.Error {
 
     /** First frame: registration basis and (internal) column schema. */
-    record Open(TxBasis basis, List<ColumnDesc> columns) implements SubscriptionFrame {}
+    record Open(TxKey basis, List<ColumnDesc> columns) implements SubscriptionFrame {}
 
     /** Terminal error raised after the stream has started. */
     record Error(BackendMessage.ErrorResponse error) implements SubscriptionFrame {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
@@ -61,15 +61,15 @@ public class TriploxNode implements AutoCloseable {
     /**
      * Open a DB value at a specific indexed transaction basis.
      */
-    public Db openDbAsOf(TxBasis basis) throws IOException {
+    public Db openDbAsOf(TxKey basis) throws IOException {
         return openDbInternal(basis);
     }
 
-    private Db openDbInternal(TxBasis basis) throws IOException {
+    private Db openDbInternal(TxKey basis) throws IOException {
         byte[] body = WireCodec.encodeOpenDbBody(basis);
         byte[] responseBody = postBinary("/db/open", body);
-        var opened = WireCodec.decodeDbOpened(responseBody);
-        return new Db(this, opened.basis());
+        var opened = WireCodec.decodeTxKey(responseBody);
+        return new Db(this, new TxKey(opened.txId(), opened.systemTime()));
     }
 
     /**
@@ -106,7 +106,7 @@ public class TriploxNode implements AutoCloseable {
         byte[] responseBody = postBinary("/tx/execute", body);
         var txResult = WireCodec.decodeTxResult(responseBody);
         return new TxResult(txResult.status(), txResult.txId(),
-                txResult.systemTime(), txResult.txEid(), txResult.errorMessage());
+                txResult.systemTime(), txResult.errorMessage());
     }
 
     /**

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
@@ -59,14 +59,14 @@ public class TriploxNode implements AutoCloseable {
     }
 
     /**
-     * Open a DB value at a specific indexed transaction basis.
+     * Open a DB value at a specific indexed transaction key.
      */
-    public Db openDbAsOf(TxKey basis) throws IOException {
-        return openDbInternal(basis);
+    public Db openDbAsOf(TxKey txKey) throws IOException {
+        return openDbInternal(txKey);
     }
 
-    private Db openDbInternal(TxKey basis) throws IOException {
-        byte[] body = WireCodec.encodeOpenDbBody(basis);
+    private Db openDbInternal(TxKey txKey) throws IOException {
+        byte[] body = WireCodec.encodeOpenDbBody(txKey);
         byte[] responseBody = postBinary("/db/open", body);
         var opened = WireCodec.decodeTxKey(responseBody);
         return new Db(this, new TxKey(opened.txId(), opened.systemTime()));
@@ -83,7 +83,7 @@ public class TriploxNode implements AutoCloseable {
      * Execute a Datalog query with input binding arguments.
      */
     QueryResult queryInternal(Db db, String edn, List<QueryArg> args) throws IOException {
-        byte[] body = WireCodec.encodeQueryBody(db.basis(), edn, args);
+        byte[] body = WireCodec.encodeQueryBody(db.txKey(), edn, args);
         byte[] responseBody = postBinary("/db/query", body);
         return WireCodec.decodeQueryResponse(responseBody);
     }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TxBasis.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TxBasis.java
@@ -1,8 +1,0 @@
-package xyz.triplox.client;
-
-import java.time.Instant;
-
-/**
- * Indexed transaction basis for an as-of DB value.
- */
-public record TxBasis(long txId, Instant systemTime, long txEid) {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TxResult.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TxResult.java
@@ -7,5 +7,5 @@ import java.time.Instant;
  */
 public record TxResult(byte status, long txId, Instant systemTime, String errorMessage) {
     public boolean isCommitted() { return status == 0; }
-    public TxKey basis() { return new TxKey(txId, systemTime); }
+    public TxKey txKey() { return new TxKey(txId, systemTime); }
 }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TxResult.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TxResult.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 /**
  * Result of an awaited transaction.
  */
-public record TxResult(byte status, long txId, Instant systemTime, long txEid, String errorMessage) {
+public record TxResult(byte status, long txId, Instant systemTime, String errorMessage) {
     public boolean isCommitted() { return status == 0; }
-    public TxBasis basis() { return new TxBasis(txId, systemTime, txEid); }
+    public TxKey basis() { return new TxKey(txId, systemTime); }
 }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -203,7 +203,7 @@ public final class WireCodec {
             String key = unpacker.unpackString();
             switch (key) {
                 case "kind" -> kind = unpacker.unpackString();
-                case "basis" -> basis = unpackTxKey(unpacker, "basis");
+                case "tx_key" -> basis = unpackTxKey(unpacker, "tx_key");
                 case "columns" -> columns = decodeColumns(unpacker);
                 case "rows" -> rows = decodeDeltaRows(unpacker);
                 case "severity" -> severity = unpacker.unpackString();
@@ -217,11 +217,11 @@ public final class WireCodec {
         if (kind == null) throw new IOException("subscription frame missing \"kind\"");
         return switch (kind) {
             case "open" -> {
-                if (basis == null) throw new IOException("open frame missing \"basis\"");
+                if (basis == null) throw new IOException("open frame missing \"tx_key\"");
                 yield new SubscriptionFrame.Open(basis, columns == null ? List.of() : columns);
             }
             case "delta" -> {
-                if (basis == null) throw new IOException("delta frame missing \"basis\"");
+                if (basis == null) throw new IOException("delta frame missing \"tx_key\"");
                 yield new Delta(basis, rows == null ? List.of() : rows);
             }
             case "error" -> {

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -280,7 +280,8 @@ public final class WireCodec {
     // Field-map helpers
     // ---------------------------------------------------------------
 
-    private static void packTxKey(MessagePacker packer, TxKey basis) throws IOException {
+    // Package-private so test fixtures reuse the canonical tx_key encoding.
+    static void packTxKey(MessagePacker packer, TxKey basis) throws IOException {
         packer.packMapHeader(2);
         packer.packString("tx_id"); packer.packLong(basis.txId());
         packer.packString("system_time"); packer.packTimestamp(basis.systemTime());

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -25,44 +25,40 @@ public final class WireCodec {
     // ---------------------------------------------------------------
 
     /**
-     * {@code POST /db/open} body: {@code {"tx_id": int|nil, "system_time": Timestamp|nil, "tx_eid": int|nil}}.
+     * {@code POST /db/open} body: {@code {"tx_id": int|nil, "system_time": Timestamp|nil}}.
      */
-    public static byte[] encodeOpenDbBody(TxBasis basis) throws IOException {
+    public static byte[] encodeOpenDbBody(TxKey basis) throws IOException {
         return encodeOpenDbBody(
                 basis == null ? null : basis.txId(),
-                basis == null ? null : basis.systemTime(),
-                basis == null ? null : basis.txEid());
+                basis == null ? null : basis.systemTime());
     }
 
     /**
-     * {@code POST /db/open} body: {@code {"tx_id": int|nil, "system_time": Timestamp|nil, "tx_eid": int|nil}}.
+     * {@code POST /db/open} body: {@code {"tx_id": int|nil, "system_time": Timestamp|nil}}.
      */
-    public static byte[] encodeOpenDbBody(Long txId, Instant systemTime, Long txEid) throws IOException {
-        if (!((txId == null) == (systemTime == null) && (txId == null) == (txEid == null))) {
-            throw new IOException("tx_id, system_time, and tx_eid must all be set, or all be nil");
+    public static byte[] encodeOpenDbBody(Long txId, Instant systemTime) throws IOException {
+        if ((txId == null) != (systemTime == null)) {
+            throw new IOException("tx_id and system_time must both be set, or both be nil");
         }
         try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(3);
+            packer.packMapHeader(2);
             packer.packString("tx_id");
             if (txId == null) packer.packNil();
             else packer.packLong(txId);
             packer.packString("system_time");
             if (systemTime == null) packer.packNil();
             else packer.packTimestamp(systemTime);
-            packer.packString("tx_eid");
-            if (txEid == null) packer.packNil();
-            else packer.packLong(txEid);
             return packer.toByteArray();
         }
     }
 
     /**
-     * {@code POST /db/query} body: {@code {"db": TxBasis, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/query} body: {@code {"db": TxKey, "query": str, "args": [QueryArg, ...]}}.
      */
-    public static byte[] encodeQueryBody(TxBasis basis, String query, List<QueryArg> args) throws IOException {
+    public static byte[] encodeQueryBody(TxKey basis, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("db"); packTxBasis(packer, basis);
+            packer.packString("db"); packTxKey(packer, basis);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -81,14 +77,14 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/subscribe} body: {@code {"db": TxBasis|nil, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/subscribe} body: {@code {"db": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
      */
-    public static byte[] encodeSubscribeBody(TxBasis db, String query, List<QueryArg> args) throws IOException {
+    public static byte[] encodeSubscribeBody(TxKey db, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("db");
             if (db == null) packer.packNil();
-            else packTxBasis(packer, db);
+            else packTxKey(packer, db);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -98,14 +94,6 @@ public final class WireCodec {
     // ---------------------------------------------------------------
     // Response bodies (server → client)
     // ---------------------------------------------------------------
-
-    public static BackendMessage.DbOpened decodeDbOpened(byte[] body) throws IOException {
-        var fields = readFields(body);
-        long txId = expectLong(fields, "tx_id");
-        Instant systemTime = expectInstant(fields, "system_time");
-        long txEid = expectLong(fields, "tx_eid");
-        return new BackendMessage.DbOpened(txId, systemTime, txEid);
-    }
 
     public static QueryResult decodeQueryResponse(byte[] body) throws IOException {
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
@@ -177,9 +165,8 @@ public final class WireCodec {
         byte status = toU8(expectLong(fields, "status"), "status");
         long txId = expectLong(fields, "tx_id");
         Instant systemTime = expectInstant(fields, "system_time");
-        long txEid = expectLong(fields, "tx_eid");
         String err = optionalString(fields, "error_message");
-        return new BackendMessage.TxResult(status, txId, systemTime, txEid, err);
+        return new BackendMessage.TxResult(status, txId, systemTime, err);
     }
 
     public static BackendMessage.ErrorResponse decodeErrorResponse(byte[] body) throws IOException {
@@ -207,7 +194,7 @@ public final class WireCodec {
     public static SubscriptionFrame decodeSubscriptionFrame(MessageUnpacker unpacker) throws IOException {
         int n = unpacker.unpackMapHeader();
         String kind = null;
-        TxBasis basis = null;
+        TxKey basis = null;
         List<ColumnDesc> columns = null;
         List<Row> rows = null;
         String severity = null, message = null, detail = null, hint = null;
@@ -216,7 +203,7 @@ public final class WireCodec {
             String key = unpacker.unpackString();
             switch (key) {
                 case "kind" -> kind = unpacker.unpackString();
-                case "basis" -> basis = unpackTxBasis(unpacker, "basis");
+                case "basis" -> basis = unpackTxKey(unpacker, "basis");
                 case "columns" -> columns = decodeColumns(unpacker);
                 case "rows" -> rows = decodeDeltaRows(unpacker);
                 case "severity" -> severity = unpacker.unpackString();
@@ -250,26 +237,24 @@ public final class WireCodec {
         };
     }
 
-    private static TxBasis unpackTxBasis(MessageUnpacker unpacker, String field) throws IOException {
+    private static TxKey unpackTxKey(MessageUnpacker unpacker, String field) throws IOException {
         if (unpacker.tryUnpackNil()) throw new IOException(field + " cannot be nil");
-        return unpackTxBasisMap(unpacker);
+        return unpackTxKeyMap(unpacker);
     }
 
-    private static TxBasis unpackTxBasisMap(MessageUnpacker unpacker) throws IOException {
+    private static TxKey unpackTxKeyMap(MessageUnpacker unpacker) throws IOException {
         int n = unpacker.unpackMapHeader();
         long txId = 0;
-        long txEid = 0;
         Instant systemTime = null;
         for (int i = 0; i < n; i++) {
             String key = unpacker.unpackString();
             switch (key) {
                 case "tx_id" -> txId = unpacker.unpackLong();
                 case "system_time" -> systemTime = unpacker.unpackTimestamp();
-                case "tx_eid" -> txEid = unpacker.unpackLong();
                 default -> unpacker.skipValue();
             }
         }
-        return new TxBasis(txId, systemTime, txEid);
+        return new TxKey(txId, systemTime);
     }
 
     private static String unpackNullableString(MessageUnpacker unpacker) throws IOException {
@@ -295,11 +280,10 @@ public final class WireCodec {
     // Field-map helpers
     // ---------------------------------------------------------------
 
-    private static void packTxBasis(MessagePacker packer, TxBasis basis) throws IOException {
-        packer.packMapHeader(3);
+    private static void packTxKey(MessagePacker packer, TxKey basis) throws IOException {
+        packer.packMapHeader(2);
         packer.packString("tx_id"); packer.packLong(basis.txId());
         packer.packString("system_time"); packer.packTimestamp(basis.systemTime());
-        packer.packString("tx_eid"); packer.packLong(basis.txEid());
     }
 
     private static Map<String, Object> readFields(byte[] body) throws IOException {

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -27,10 +27,10 @@ public final class WireCodec {
     /**
      * {@code POST /db/open} body: {@code {"tx_id": int|nil, "system_time": Timestamp|nil}}.
      */
-    public static byte[] encodeOpenDbBody(TxKey basis) throws IOException {
+    public static byte[] encodeOpenDbBody(TxKey txKey) throws IOException {
         return encodeOpenDbBody(
-                basis == null ? null : basis.txId(),
-                basis == null ? null : basis.systemTime());
+                txKey == null ? null : txKey.txId(),
+                txKey == null ? null : txKey.systemTime());
     }
 
     /**
@@ -55,10 +55,10 @@ public final class WireCodec {
     /**
      * {@code POST /db/query} body: {@code {"tx_key": TxKey, "query": str, "args": [QueryArg, ...]}}.
      */
-    public static byte[] encodeQueryBody(TxKey basis, String query, List<QueryArg> args) throws IOException {
+    public static byte[] encodeQueryBody(TxKey txKey, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("tx_key"); packTxKey(packer, basis);
+            packer.packString("tx_key"); packTxKey(packer, txKey);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -79,12 +79,12 @@ public final class WireCodec {
     /**
      * {@code POST /db/subscribe} body: {@code {"tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
      */
-    public static byte[] encodeSubscribeBody(TxKey db, String query, List<QueryArg> args) throws IOException {
+    public static byte[] encodeSubscribeBody(TxKey txKey, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("tx_key");
-            if (db == null) packer.packNil();
-            else packTxKey(packer, db);
+            if (txKey == null) packer.packNil();
+            else packTxKey(packer, txKey);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -194,7 +194,7 @@ public final class WireCodec {
     public static SubscriptionFrame decodeSubscriptionFrame(MessageUnpacker unpacker) throws IOException {
         int n = unpacker.unpackMapHeader();
         String kind = null;
-        TxKey basis = null;
+        TxKey txKey = null;
         List<ColumnDesc> columns = null;
         List<Row> rows = null;
         String severity = null, message = null, detail = null, hint = null;
@@ -203,7 +203,7 @@ public final class WireCodec {
             String key = unpacker.unpackString();
             switch (key) {
                 case "kind" -> kind = unpacker.unpackString();
-                case "tx_key" -> basis = unpackTxKey(unpacker, "tx_key");
+                case "tx_key" -> txKey = unpackTxKey(unpacker, "tx_key");
                 case "columns" -> columns = decodeColumns(unpacker);
                 case "rows" -> rows = decodeDeltaRows(unpacker);
                 case "severity" -> severity = unpacker.unpackString();
@@ -217,12 +217,12 @@ public final class WireCodec {
         if (kind == null) throw new IOException("subscription frame missing \"kind\"");
         return switch (kind) {
             case "open" -> {
-                if (basis == null) throw new IOException("open frame missing \"tx_key\"");
-                yield new SubscriptionFrame.Open(basis, columns == null ? List.of() : columns);
+                if (txKey == null) throw new IOException("open frame missing \"tx_key\"");
+                yield new SubscriptionFrame.Open(txKey, columns == null ? List.of() : columns);
             }
             case "delta" -> {
-                if (basis == null) throw new IOException("delta frame missing \"tx_key\"");
-                yield new Delta(basis, rows == null ? List.of() : rows);
+                if (txKey == null) throw new IOException("delta frame missing \"tx_key\"");
+                yield new Delta(txKey, rows == null ? List.of() : rows);
             }
             case "error" -> {
                 byte sev = switch (severity == null ? "" : severity) {
@@ -281,10 +281,10 @@ public final class WireCodec {
     // ---------------------------------------------------------------
 
     // Package-private so test fixtures reuse the canonical tx_key encoding.
-    static void packTxKey(MessagePacker packer, TxKey basis) throws IOException {
+    static void packTxKey(MessagePacker packer, TxKey txKey) throws IOException {
         packer.packMapHeader(2);
-        packer.packString("tx_id"); packer.packLong(basis.txId());
-        packer.packString("system_time"); packer.packTimestamp(basis.systemTime());
+        packer.packString("tx_id"); packer.packLong(txKey.txId());
+        packer.packString("system_time"); packer.packTimestamp(txKey.systemTime());
     }
 
     private static Map<String, Object> readFields(byte[] body) throws IOException {

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -53,12 +53,12 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/query} body: {@code {"basis_tx_key": TxKey, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/query} body: {@code {"tx_key": TxKey, "query": str, "args": [QueryArg, ...]}}.
      */
     public static byte[] encodeQueryBody(TxKey basis, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("basis_tx_key"); packTxKey(packer, basis);
+            packer.packString("tx_key"); packTxKey(packer, basis);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -77,12 +77,12 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/subscribe} body: {@code {"basis_tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/subscribe} body: {@code {"tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
      */
     public static byte[] encodeSubscribeBody(TxKey db, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("basis_tx_key");
+            packer.packString("tx_key");
             if (db == null) packer.packNil();
             else packTxKey(packer, db);
             packer.packString("query"); packer.packString(query);

--- a/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/WireCodec.java
@@ -53,12 +53,12 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/query} body: {@code {"db": TxKey, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/query} body: {@code {"basis_tx_key": TxKey, "query": str, "args": [QueryArg, ...]}}.
      */
     public static byte[] encodeQueryBody(TxKey basis, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("db"); packTxKey(packer, basis);
+            packer.packString("basis_tx_key"); packTxKey(packer, basis);
             packer.packString("query"); packer.packString(query);
             packer.packString("args"); QueryArg.packAll(packer, args);
             return packer.toByteArray();
@@ -77,12 +77,12 @@ public final class WireCodec {
     }
 
     /**
-     * {@code POST /db/subscribe} body: {@code {"db": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
+     * {@code POST /db/subscribe} body: {@code {"basis_tx_key": TxKey|nil, "query": str, "args": [QueryArg, ...]}}.
      */
     public static byte[] encodeSubscribeBody(TxKey db, String query, List<QueryArg> args) throws IOException {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
-            packer.packString("db");
+            packer.packString("basis_tx_key");
             if (db == null) packer.packNil();
             else packTxKey(packer, db);
             packer.packString("query"); packer.packString(query);

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -65,11 +65,11 @@
 (def user-entity-ids (range first-user-entity-id (+ first-user-entity-id 100)))
 
 
-(deftest subscribe-returns-basis-and-times-out
+(deftest subscribe-returns-tx-key-and-times-out
   (with-open [conn (connect)]
     (api/transact conn name-schema)
     (with-open [sub (api/subscribe conn names-query)]
-      (is (some? (:tx-id (api/basis sub))))
+      (is (some? (:tx-id (api/tx-key sub))))
       ;; No transaction after the subscription -> bounded take! times out.
       (is (= ::api/timeout (api/take! sub 200))))))
 

--- a/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
@@ -164,18 +164,16 @@ class SubscriptionTest {
         packer.packNil();
     }
 
-    private static TxBasis sampleBasis() {
-        return new TxBasis(7L, Instant.ofEpochSecond(1_700_000_000L), 42L);
+    private static TxKey sampleBasis() {
+        return new TxKey(7L, Instant.ofEpochSecond(1_700_000_000L));
     }
 
     private static void packBasis(MessagePacker packer) throws IOException {
-        packer.packMapHeader(3);
+        packer.packMapHeader(2);
         packer.packString("tx_id");
         packer.packLong(7L);
         packer.packString("system_time");
         packer.packTimestamp(Instant.ofEpochSecond(1_700_000_000L));
-        packer.packString("tx_eid");
-        packer.packLong(42L);
     }
 
     private static Request request(String path) {

--- a/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
@@ -56,7 +56,7 @@ class SubscriptionTest {
 
         var unpacker = MessagePack.newDefaultUnpacker(new ByteArrayInputStream(body));
         var first = assertInstanceOf(SubscriptionFrame.Open.class, WireCodec.decodeSubscriptionFrame(unpacker));
-        try (Subscription sub = new Subscription(first.basis(), () -> {}, unpacker)) {
+        try (Subscription sub = new Subscription(first.txKey(), () -> {}, unpacker)) {
             var ex = assertThrows(IllegalStateException.class, () -> sub.poll(5, TimeUnit.SECONDS));
             assertTrue(ex.getMessage().contains("unexpected open frame mid-stream"));
         }

--- a/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
@@ -128,7 +128,7 @@ class SubscriptionTest {
         packer.packMapHeader(3);
         packer.packString("kind");
         packer.packString("open");
-        packer.packString("basis");
+        packer.packString("tx_key");
         packBasis(packer);
         packer.packString("columns");
         packer.packArrayHeader(0);
@@ -138,7 +138,7 @@ class SubscriptionTest {
         packer.packMapHeader(3);
         packer.packString("kind");
         packer.packString("delta");
-        packer.packString("basis");
+        packer.packString("tx_key");
         packBasis(packer);
         packer.packString("rows");
         packer.packArrayHeader(1);

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -246,7 +246,7 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("open");
-            packer.packString("tx_key"); packBasis(packer, 7L, now);
+            packer.packString("tx_key"); WireCodec.packTxKey(packer, new TxKey(7L, now));
             packer.packString("columns");
             packer.packArrayHeader(1);
             packColumn(packer, "?name", (byte) 255);
@@ -265,7 +265,7 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("tx_key"); packBasis(packer, 7L, now);
+            packer.packString("tx_key"); WireCodec.packTxKey(packer, new TxKey(7L, now));
             packer.packString("rows");
             packer.packArrayHeader(2);
             packDeltaRow(packer, "Ivan", 1);
@@ -337,7 +337,7 @@ class WireCodecTest {
             packer.packArrayHeader(1);
             packDeltaRow(packer, "Ann", 1);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("tx_key"); packBasis(packer, 3L, now);
+            packer.packString("tx_key"); WireCodec.packTxKey(packer, new TxKey(3L, now));
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));
@@ -361,11 +361,6 @@ class WireCodecTest {
         }
     }
 
-    private static void packBasis(MessagePacker packer, long txId, Instant systemTime) throws IOException {
-        packer.packMapHeader(2);
-        packer.packString("tx_id"); packer.packLong(txId);
-        packer.packString("system_time"); packer.packTimestamp(systemTime);
-    }
 
     private static void packDeltaRow(MessagePacker packer, String value, long weight) throws IOException {
         packer.packArrayHeader(2);

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -246,7 +246,7 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("open");
-            packer.packString("basis"); packBasis(packer, 7L, now);
+            packer.packString("tx_key"); packBasis(packer, 7L, now);
             packer.packString("columns");
             packer.packArrayHeader(1);
             packColumn(packer, "?name", (byte) 255);
@@ -265,7 +265,7 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("basis"); packBasis(packer, 7L, now);
+            packer.packString("tx_key"); packBasis(packer, 7L, now);
             packer.packString("rows");
             packer.packArrayHeader(2);
             packDeltaRow(packer, "Ivan", 1);
@@ -287,13 +287,13 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("basis"); packer.packNil();
+            packer.packString("tx_key"); packer.packNil();
             packer.packString("rows");
             packer.packArrayHeader(0);
             body = packer.toByteArray();
         }
         var err = assertThrows(IOException.class, () -> decodeFrame(body));
-        assertTrue(err.getMessage().contains("basis cannot be nil"));
+        assertTrue(err.getMessage().contains("tx_key cannot be nil"));
     }
 
     @Test
@@ -337,7 +337,7 @@ class WireCodecTest {
             packer.packArrayHeader(1);
             packDeltaRow(packer, "Ann", 1);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("basis"); packBasis(packer, 3L, now);
+            packer.packString("tx_key"); packBasis(packer, 3L, now);
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -253,7 +253,7 @@ class WireCodecTest {
             body = packer.toByteArray();
         }
         var open = assertInstanceOf(SubscriptionFrame.Open.class, decodeFrame(body));
-        assertEquals(new TxKey(7L, now), open.basis());
+        assertEquals(new TxKey(7L, now), open.txKey());
         assertEquals(1, open.columns().size());
         assertEquals("?name", open.columns().get(0).name());
     }
@@ -273,7 +273,7 @@ class WireCodecTest {
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));
-        assertEquals(new TxKey(7L, now), delta.basis());
+        assertEquals(new TxKey(7L, now), delta.txKey());
         assertEquals(2, delta.rows().size());
         assertEquals(List.of("Ivan"), delta.rows().get(0).values());
         assertEquals(1L, delta.rows().get(0).weight());
@@ -341,7 +341,7 @@ class WireCodecTest {
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));
-        assertEquals(new TxKey(3L, now), delta.basis());
+        assertEquals(new TxKey(3L, now), delta.txKey());
         assertEquals(List.of("Ann"), delta.rows().get(0).values());
     }
 

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -56,7 +56,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeQueryBody(new TxKey(42L, now), "{:find [?e]}", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("db", unpacker.unpackString());
+            assertEquals("basis_tx_key", unpacker.unpackString());
             assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(42L, unpacker.unpackLong());
@@ -215,7 +215,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeSubscribeBody(null, "[:find ?n :where [?e :name ?n]]", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("db", unpacker.unpackString());
+            assertEquals("basis_tx_key", unpacker.unpackString());
             unpacker.unpackNil();
             assertEquals("query", unpacker.unpackString());
             assertEquals("[:find ?n :where [?e :name ?n]]", unpacker.unpackString());
@@ -230,7 +230,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeSubscribeBody(new TxKey(7L, now), "[:find ?n]", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("db", unpacker.unpackString());
+            assertEquals("basis_tx_key", unpacker.unpackString());
             assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(7L, unpacker.unpackLong());

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -22,12 +22,10 @@ class WireCodecTest {
     void testEncodeOpenDbBodyNull() throws IOException {
         byte[] body = WireCodec.encodeOpenDbBody(null);
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
-            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             unpacker.unpackNil();
             assertEquals("system_time", unpacker.unpackString());
-            unpacker.unpackNil();
-            assertEquals("tx_eid", unpacker.unpackString());
             unpacker.unpackNil();
             assertFalse(unpacker.hasNext());
         }
@@ -36,39 +34,34 @@ class WireCodecTest {
     @Test
     void testEncodeOpenDbBodyWithTxId() throws IOException {
         Instant now = Instant.ofEpochSecond(1_700_000_000L, 123_456_789);
-        byte[] body = WireCodec.encodeOpenDbBody(new TxBasis(42L, now, 100L));
+        byte[] body = WireCodec.encodeOpenDbBody(new TxKey(42L, now));
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
-            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(42L, unpacker.unpackLong());
             assertEquals("system_time", unpacker.unpackString());
             assertEquals(now, unpacker.unpackTimestamp());
-            assertEquals("tx_eid", unpacker.unpackString());
-            assertEquals(100L, unpacker.unpackLong());
         }
     }
 
     @Test
     void testEncodeOpenDbBodyRejectsPartialTxKey() {
-        assertThrows(IOException.class, () -> WireCodec.encodeOpenDbBody(42L, null, null));
-        assertThrows(IOException.class, () -> WireCodec.encodeOpenDbBody(null, Instant.EPOCH, null));
-        assertThrows(IOException.class, () -> WireCodec.encodeOpenDbBody(42L, Instant.EPOCH, null));
+        assertThrows(IOException.class, () -> WireCodec.encodeOpenDbBody(42L, null));
+        assertThrows(IOException.class, () -> WireCodec.encodeOpenDbBody(null, Instant.EPOCH));
     }
 
     @Test
     void testEncodeQueryBody() throws IOException {
         Instant now = Instant.ofEpochSecond(1_700_000_000L);
-        byte[] body = WireCodec.encodeQueryBody(new TxBasis(42L, now, 100L), "{:find [?e]}", List.of());
+        byte[] body = WireCodec.encodeQueryBody(new TxKey(42L, now), "{:find [?e]}", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
             assertEquals("db", unpacker.unpackString());
-            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(42L, unpacker.unpackLong());
             assertEquals("system_time", unpacker.unpackString());
             assertEquals(now, unpacker.unpackTimestamp());
-            assertEquals("tx_eid", unpacker.unpackString());
-            assertEquals(100L, unpacker.unpackLong());
             assertEquals("query", unpacker.unpackString());
             assertEquals("{:find [?e]}", unpacker.unpackString());
             assertEquals("args", unpacker.unpackString());
@@ -97,24 +90,6 @@ class WireCodecTest {
     // ---------------------------------------------------------------
 
     @Test
-    void testDecodeDbOpened() throws IOException {
-        Instant now = Instant.ofEpochSecond(1_700_000_000L);
-        byte[] body;
-        try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(3);
-            packer.packString("tx_id"); packer.packLong(5);
-            packer.packString("system_time"); packer.packTimestamp(now);
-            packer.packString("tx_eid"); packer.packLong(42);
-            body = packer.toByteArray();
-        }
-        var opened = WireCodec.decodeDbOpened(body);
-        assertEquals(5L, opened.txId());
-        assertEquals(now, opened.systemTime());
-        assertEquals(42L, opened.txEid());
-        assertEquals(new TxBasis(5L, now, 42L), opened.basis());
-    }
-
-    @Test
     void testDecodeTxKey() throws IOException {
         Instant now = Instant.ofEpochSecond(1_700_000_000L, 123_456_789);
         byte[] body;
@@ -134,18 +109,16 @@ class WireCodecTest {
         Instant now = Instant.ofEpochSecond(1_700_000_000L);
         byte[] body;
         try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(5);
+            packer.packMapHeader(4);
             packer.packString("status"); packer.packLong(0);
             packer.packString("tx_id"); packer.packLong(42);
             packer.packString("system_time"); packer.packTimestamp(now);
-            packer.packString("tx_eid"); packer.packLong(100);
             packer.packString("error_message"); packer.packNil();
             body = packer.toByteArray();
         }
         var result = WireCodec.decodeTxResult(body);
         assertEquals((byte) 0, result.status());
         assertEquals(42L, result.txId());
-        assertEquals(100L, result.txEid());
         assertEquals(now, result.systemTime());
         assertNull(result.errorMessage());
     }
@@ -155,17 +128,15 @@ class WireCodecTest {
         Instant now = Instant.ofEpochSecond(1_700_000_000L);
         byte[] body;
         try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packer.packMapHeader(5);
+            packer.packMapHeader(4);
             packer.packString("status"); packer.packLong(1);
             packer.packString("tx_id"); packer.packLong(42);
             packer.packString("system_time"); packer.packTimestamp(now);
-            packer.packString("tx_eid"); packer.packLong(101);
             packer.packString("error_message"); packer.packString("constraint violation");
             body = packer.toByteArray();
         }
         var result = WireCodec.decodeTxResult(body);
         assertEquals((byte) 1, result.status());
-        assertEquals(101L, result.txEid());
         assertEquals("constraint violation", result.errorMessage());
     }
 
@@ -256,17 +227,15 @@ class WireCodecTest {
     @Test
     void testEncodeSubscribeBodyWithDb() throws IOException {
         Instant now = Instant.ofEpochSecond(1_700_000_000L);
-        byte[] body = WireCodec.encodeSubscribeBody(new TxBasis(7L, now, 42L), "[:find ?n]", List.of());
+        byte[] body = WireCodec.encodeSubscribeBody(new TxKey(7L, now), "[:find ?n]", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
             assertEquals("db", unpacker.unpackString());
-            assertEquals(3, unpacker.unpackMapHeader());
+            assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(7L, unpacker.unpackLong());
             assertEquals("system_time", unpacker.unpackString());
             assertEquals(now, unpacker.unpackTimestamp());
-            assertEquals("tx_eid", unpacker.unpackString());
-            assertEquals(42L, unpacker.unpackLong());
         }
     }
 
@@ -277,14 +246,14 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("open");
-            packer.packString("basis"); packBasis(packer, 7L, now, 42L);
+            packer.packString("basis"); packBasis(packer, 7L, now);
             packer.packString("columns");
             packer.packArrayHeader(1);
             packColumn(packer, "?name", (byte) 255);
             body = packer.toByteArray();
         }
         var open = assertInstanceOf(SubscriptionFrame.Open.class, decodeFrame(body));
-        assertEquals(new TxBasis(7L, now, 42L), open.basis());
+        assertEquals(new TxKey(7L, now), open.basis());
         assertEquals(1, open.columns().size());
         assertEquals("?name", open.columns().get(0).name());
     }
@@ -296,7 +265,7 @@ class WireCodecTest {
         try (var packer = MessagePack.newDefaultBufferPacker()) {
             packer.packMapHeader(3);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("basis"); packBasis(packer, 7L, now, 42L);
+            packer.packString("basis"); packBasis(packer, 7L, now);
             packer.packString("rows");
             packer.packArrayHeader(2);
             packDeltaRow(packer, "Ivan", 1);
@@ -304,7 +273,7 @@ class WireCodecTest {
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));
-        assertEquals(new TxBasis(7L, now, 42L), delta.basis());
+        assertEquals(new TxKey(7L, now), delta.basis());
         assertEquals(2, delta.rows().size());
         assertEquals(List.of("Ivan"), delta.rows().get(0).values());
         assertEquals(1L, delta.rows().get(0).weight());
@@ -368,11 +337,11 @@ class WireCodecTest {
             packer.packArrayHeader(1);
             packDeltaRow(packer, "Ann", 1);
             packer.packString("kind"); packer.packString("delta");
-            packer.packString("basis"); packBasis(packer, 3L, now, 42L);
+            packer.packString("basis"); packBasis(packer, 3L, now);
             body = packer.toByteArray();
         }
         var delta = assertInstanceOf(Delta.class, decodeFrame(body));
-        assertEquals(new TxBasis(3L, now, 42L), delta.basis());
+        assertEquals(new TxKey(3L, now), delta.basis());
         assertEquals(List.of("Ann"), delta.rows().get(0).values());
     }
 
@@ -392,11 +361,10 @@ class WireCodecTest {
         }
     }
 
-    private static void packBasis(MessagePacker packer, long txId, Instant systemTime, long txEid) throws IOException {
-        packer.packMapHeader(3);
+    private static void packBasis(MessagePacker packer, long txId, Instant systemTime) throws IOException {
+        packer.packMapHeader(2);
         packer.packString("tx_id"); packer.packLong(txId);
         packer.packString("system_time"); packer.packTimestamp(systemTime);
-        packer.packString("tx_eid"); packer.packLong(txEid);
     }
 
     private static void packDeltaRow(MessagePacker packer, String value, long weight) throws IOException {

--- a/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/WireCodecTest.java
@@ -56,7 +56,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeQueryBody(new TxKey(42L, now), "{:find [?e]}", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("basis_tx_key", unpacker.unpackString());
+            assertEquals("tx_key", unpacker.unpackString());
             assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(42L, unpacker.unpackLong());
@@ -215,7 +215,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeSubscribeBody(null, "[:find ?n :where [?e :name ?n]]", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("basis_tx_key", unpacker.unpackString());
+            assertEquals("tx_key", unpacker.unpackString());
             unpacker.unpackNil();
             assertEquals("query", unpacker.unpackString());
             assertEquals("[:find ?n :where [?e :name ?n]]", unpacker.unpackString());
@@ -230,7 +230,7 @@ class WireCodecTest {
         byte[] body = WireCodec.encodeSubscribeBody(new TxKey(7L, now), "[:find ?n]", List.of());
         try (var unpacker = MessagePack.newDefaultUnpacker(body)) {
             assertEquals(3, unpacker.unpackMapHeader());
-            assertEquals("basis_tx_key", unpacker.unpackString());
+            assertEquals("tx_key", unpacker.unpackString());
             assertEquals(2, unpacker.unpackMapHeader());
             assertEquals("tx_id", unpacker.unpackString());
             assertEquals(7L, unpacker.unpackLong());

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
@@ -34,7 +34,7 @@ class SubscriptionTest {
         try (var node = TriploxNode.connect(host(), port())) {
             defineNameSchema(node);
             try (Subscription sub = node.subscribe(NAMES_QUERY)) {
-                assertNotNull(sub.basis());
+                assertNotNull(sub.txKey());
 
                 node.executeTx(List.of(new TxOp.Put(map(":name", "Ivan"))));
 

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/TriploxNodeTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/TriploxNodeTest.java
@@ -54,7 +54,7 @@ class TriploxNodeTest {
             var tx2 = node.executeTx(List.of(new TxOp.Put(map(":historical-name", "bob"))));
             assertTrue(tx2.isCommitted());
 
-            var db = node.openDbAsOf(tx1.basis());
+            var db = node.openDbAsOf(tx1.txKey());
             var rows = db.query("{:find [?name] :where [[?e :historical-name ?name]]}");
             assertEquals(List.of(List.of("alice")), rows);
         }


### PR DESCRIPTION
## Summary

Unifies the two transaction identifiers into one. `tx_eid` is no longer minted by the partition map — it is a pure function of the log-assigned `tx_id`:

```
tx_eid = make_entity_id(TX_PARTITION, tx_id) = (1 << 42) | tx_id   (== mask ^ tx_id)
tx_id  = extract_counter(tx_eid)
```

A `TxKey` now immediately identifies a database value and recovers its temporal read coordinate (`as_of`) by masking, with **no storage lookup**. `TxBasis` is removed everywhere; the wire protocol and client API carry only `TxKey`, and the server derives `tx_eid` internally — simpler for users.

See https://triplox.xyz/transactions/life-of-a-transaction/ for the prior two-identifier model this replaces.

## Key changes

- **`src/partition.rs`** — `tx_eid_from_tx_id(tx_id)` helper (inverse is the existing `extract_counter`).
- **`src/metadata.rs`** — `PartitionMap::set_tx_counter(tx_id)` *sets* (rather than mints) the `TX_PARTITION` high-water mark from the incoming `tx_id` and asserts strict monotonicity so `tx_eid` is strictly increasing. Gaps are allowed (e.g. file-log byte offsets).
- **`src/indexer.rs`** — commit and abort paths derive `tx_eid` + `set_tx_counter` instead of `allocate_entid(TX_PARTITION)`; `transact_tx` returns `TxKey`; `latest_tx_basis_from_sdb` → `latest_tx_key_from_sdb`.
- **`triplox-client`** — `TxBasis` deleted; `TransactionResult` carries `TxKey`; `tx_eid` dropped from `OpenDb`/`DbOpened`/`TxResult`; `QueryRequest.db` and subscription `Open`/`Delta` frames carry `TxKey`.
- **node / server / incremental / cdc** — `TxKey` throughout; `as_of` derived via the mask.
- **docs** — `PARTITIONS.md`, `TX_PIPELINE.md`, `INCREMENTAL_QUERIES.md`.

Bootstrap is already consistent: `tx_eid_from_tx_id(0) == BOOTSTRAP_TX_EID` and `BOOTSTRAP_TX_KEY.tx_id == 0`.

## Compatibility

⚠️ **Format break (intentional, no migration).** Existing **file-log** databases are incompatible — their old minted `tx_eid` (a sequential counter) ≠ `mask | tx_id` (a byte offset), which would break historical `db_as_of`. **Memory/Kafka databases are unaffected** since their old per-partition counter already equalled `tx_id`. The wire protocol is also a breaking change (`tx_eid` removed).

## Verification

- `cargo build --all-features`, `cargo clippy --all-targets` — clean (no warnings).
- **519** lib unit tests + **72** `triplox-client` + **23** client-server + **5** subscription + **3** fixture-compat — **0 failures**. Includes new `tx_eid_from_tx_id` round-trip / `set_tx_counter` monotonicity tests and `db_as_of` time-travel tests.

## Notes

- Indexer unit tests that reused `tx_id: 0`/`1` now start data txs at `2` (bootstrap owns `0`, the test schema owns `1`) to satisfy strict monotonicity; node/integration tests were unaffected since the log assigns monotonic ids.
- Latent ceiling (now that the `TX_PARTITION` counter tracks bytes, not a tx count): `partition_entity_prefix` covers counters < ~2^40 (~1 TiB single log) and `make_entity_id` asserts < 2^42 (~4 TiB). Distant, but real — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)