### PR TITLE
ci: publish kafka-enabled Docker image variant

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,3 +108,33 @@ jobs:
             GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Kafka-enabled variant (rdkafka feature needs cmake). Tagged with a -kafka
+      # suffix so it lives alongside the default image; used by the AWS deployment.
+      - name: Extract metadata (kafka)
+        id: meta-kafka
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: suffix=-kafka
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=snapshot,enable=${{ steps.version.outputs.snapshot == 'true' }}
+            type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.stable == 'true' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push (kafka)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-kafka.outputs.tags }}
+          labels: ${{ steps.meta-kafka.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_PACKAGES=cmake
+            CARGO_FEATURES=kafka
+          cache-from: type=gha,scope=kafka
+          cache-to: type=gha,mode=max,scope=kafka


### PR DESCRIPTION
Build and push a `-kafka` suffixed image alongside the default one, with
`BUILD_PACKAGES=cmake` and `CARGO_FEATURES=kafka` so the rdkafka-backed
`kafka` storage mode is available as a ready-to-pull GHCR image
(e.g. `ghcr.io/fiv0/triplox:snapshot-kafka`). Uses a separate buildx
cache scope so it does not thrash the default image cache.

Cherry-picked from the first commit of #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)