### PR TITLE
OVHcloud stress-test deployment for Triplox (OpenTofu)

### DIFF
--- a/deploy/terraform-ovh/.gitignore
+++ b/deploy/terraform-ovh/.gitignore
@@ -1,0 +1,17 @@
+# Local provider/plugin cache
+.terraform/
+
+# State (local backend) — contains the S3 secret key in plaintext; never commit
+*.tfstate
+*.tfstate.*
+
+# Real variable values (keep terraform.tfvars.example)
+*.tfvars
+
+# Crash logs and CLI config
+crash.log
+crash.*.log
+.terraformrc
+terraform.rc
+
+# .terraform.lock.hcl IS committed (provider pinning) — do not ignore it.

--- a/deploy/terraform-ovh/.terraform.lock.hcl
+++ b/deploy/terraform-ovh/.terraform.lock.hcl
@@ -1,0 +1,69 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}
+
+provider "registry.opentofu.org/ovh/ovh" {
+  version     = "2.14.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:FfZ3ULLKzp9gNfvpGBzl01bJEYyKDVsjLko8yeRj7Kw=",
+    "zh:18a402cb9e73d1f011a9202ac0dcab44c90122d1c37b54875e62dc42bcee5687",
+    "zh:30e5fdccab94b1aea8f7ecf07f891626dedae1187691941350704c1475cddaf8",
+    "zh:651b7e84101b54abc9c353a094b3d4ff5149def97eee97c6286af06724b60a7c",
+    "zh:83c14d04d6fba83f30d36d641f3b3ae5cc4b075ba23d6737341d62e0368f85dd",
+    "zh:9a8c81b37374da11cf49ba9996c65761944c69634896a713464c583a8be5a1ff",
+    "zh:a25652ed21d7d1e424a55527f361a0c456121e6df9f44173a814ddb0c4293f40",
+    "zh:af06a8379cda8b3b583982c478fa8a7356f5b45497667fed709d6d348ba7787f",
+    "zh:b4e575eaa14335a1e712ba32a26322092accddd4a340b40aecddfb4c9ada5f30",
+    "zh:b9537f5126732a81e6e9f5ec9013901dbdad49e6919687dc5ebca8a6d0ff15c7",
+    "zh:d29f644eacee70eb61e590d5e19a509ad72f80d0e90bbcf9bfa38ab16d85cc5b",
+    "zh:d348cfdc8c983c6d8a999ae20a4a40fbcbebc3c5c6e8c3d578bdcabf70cb2b5a",
+    "zh:da4cc40c57313417bba0ac6bf57562b89e1255f63e030833c9e249252e14987b",
+    "zh:dbbef1eb4fb751995f8f4062e5299502ffca59b3fbd54fb49799046279f23317",
+  ]
+}
+
+provider "registry.opentofu.org/terraform-provider-openstack/openstack" {
+  version     = "3.4.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:MVSoVvhjbu7s1pfYfsiYED8A++XfAoyOlSX1x9PW68E=",
+    "zh:11b3c88e24197a29b13cf5ab41771944bd16707b561645323e8cbb4f1da00b7b",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:2dc60dbbbb822fbb1e7b17e3b89e3e6a7a8fe54a716d4477d2fa40f836c4de0f",
+    "zh:68f851e333f0ab2367e9b2680739d47e4151ca9f803934ef265f6fa70a28e6e0",
+    "zh:6995b0bcae5a291d7b0a4d3a5df109eb97f8d1d34be6eb27768fe29b5e0d8def",
+    "zh:7b68bf81891a0445c543629d4d160226a6f2d5e8e5ee4baf21e0221412437d17",
+    "zh:8f117b8b17280598a92c6202b183a77168fe573397cfb597b9c2028da281846d",
+    "zh:b0a23b990eb9260e9616fd8471f11b37485f92df0e5eef46cd286f87396b0e0a",
+    "zh:baa5052ab3207f3a996c1fd715935d79a4e1c57d3d24e3c549b6c20ea9307e38",
+    "zh:c012cbda058aa7b76b718074fd73829ecd4009ad98e3dafe496e5f26099625c0",
+    "zh:c1c95e5dbe546a935a62c63814aef04718b58dd4258e5da40d681b43322924e9",
+    "zh:c720bdbdf432041f99572bac40d24659239b989cbf1540f92ebb441900ac8bae",
+    "zh:c92ac802a3dd1abbf9c9ccf0aba1f261fe9f8c2e7fafc196c7119b73c25a0772",
+    "zh:fd4faf25ee72acef4ab12c93ea9c7a5ccb41315e8851609e08b37d3c91ea6584",
+    "zh:ff347392412fc7950635e2c1c5bb878d88b661c1c5ba052edd290d971a14028f",
+  ]
+}

--- a/deploy/terraform-ovh/README.md
+++ b/deploy/terraform-ovh/README.md
@@ -1,0 +1,138 @@
+# Triplox OVHcloud stress-test deployment
+
+A small, stress-testable OVHcloud Public Cloud deployment that mirrors
+`docker/docker-compose-kafka.yml` on real infrastructure. It is the OVH sibling of
+the AWS rig in [`deploy/terraform/`](../terraform); same three roles, each on its
+own instance (so a stress test attributes bottlenecks cleanly):
+
+- **AutoMQ** — single-node Kafka-on-S3 broker (`r3-16`).
+- **Triplox** — the database server under test (`b3-16`, dedicated NVMe cache volume).
+- **Load-gen** — optional AuctionMark benchmark (`b3-8`), **off by default**.
+
+Storage is three OVH S3-compatible buckets (Triplox SlateDB + AutoMQ data/ops).
+The nodes share a vRack-backed private network for inter-node traffic. Admin access
+is via SSH. State is local (`terraform.tfstate`, gitignored).
+
+Works with OpenTofu (`tofu`) or Terraform (`terraform`) — plain HCL.
+
+## How this differs from the AWS rig
+
+OVH Public Cloud is OpenStack underneath, so this stack uses **two providers**:
+
+- **`ovh/ovh`** for the account-plane — the three S3 buckets, the S3 user + keys +
+  policy, and the private network/subnet.
+- **`terraform-provider-openstack/openstack`** for the compute-plane — the three
+  instances, the SSH keypair, security groups, and the cache block volume.
+  (`ovh_cloud_project_instance` exists but is Beta: no security groups, public-only
+  networking — `openstack_compute_instance_v2` is the capable path.)
+
+Other deliberate departures from AWS, all noted inline in the code:
+
+- **No SSM.** Access is plain **SSH** with a keypair you provide (`ssh_public_key`).
+- **The host firewall (`ufw`), not security groups, is the real inbound gate.** OVH
+  does not reliably enforce security groups on the public network, and Docker's port
+  mapping bypasses them regardless. So AutoMQ and Triplox run with `--network host`
+  and each node's `ufw` locks SSH and the Triplox port to `admin_cidr`. Security
+  groups are still defined (they are enforced on the private network).
+- **No secret manager.** AWS stashed the S3 keys in SSM SecureString; OVH has no
+  equivalent here, so the keys are rendered into the nodes' `user_data` (and the
+  local `tfstate`). Fine for a throwaway bench rig; tighten if you reuse this.
+- **Region casing trips people up:** OpenStack uses `GRA11`, the storage resource
+  uses `GRA`, and the S3 SDK/endpoint use `gra`. `storage_region` is the uppercase
+  one; the lowercase form is derived.
+
+## Prerequisites
+
+1. **An OVH Public Cloud project** and its project id (`project_id`).
+2. **OVH API credentials** for the `ovh` provider, exported in your environment:
+   ```bash
+   export OVH_ENDPOINT=ovh-eu
+   export OVH_APPLICATION_KEY=...
+   export OVH_APPLICATION_SECRET=...
+   export OVH_CONSUMER_KEY=...
+   ```
+   Create them at https://api.ovh.com/createToken/ (or use OAuth2 `OVH_CLIENT_ID` /
+   `OVH_CLIENT_SECRET`).
+3. **OpenStack credentials** for the `openstack` provider. Download an OpenStack user's
+   `openrc.sh` (or `clouds.yaml`) from the OVH console and source it, or export an
+   application credential:
+   ```bash
+   source openrc.sh                       # sets OS_* env vars
+   # or:
+   export OS_AUTH_URL=https://auth.cloud.ovh.net/v3
+   export OS_APPLICATION_CREDENTIAL_ID=...
+   export OS_APPLICATION_CREDENTIAL_SECRET=...
+   ```
+4. **A kafka-enabled Triplox image on GHCR.** The published image does *not* include
+   the `kafka` feature; the `Build and push (kafka)` step in
+   `.github/workflows/docker-publish.yml` publishes `ghcr.io/fiv0/triplox:<ver>-kafka`
+   (and `:snapshot-kafka`). Run that workflow and confirm the tag is public:
+   ```bash
+   docker pull ghcr.io/fiv0/triplox:snapshot-kafka
+   ```
+5. **OpenTofu** ≥ 1.6 (`tofu`).
+
+## Run
+
+```bash
+cd deploy/terraform-ovh
+cp terraform.tfvars.example terraform.tfvars   # set project_id, ssh_public_key, admin_cidr
+
+tofu init
+tofu plan
+tofu apply
+```
+
+`admin_cidr` **must** be tightened to your own IP — port 5490 is an unauthenticated
+protocol. Apply takes a few minutes; the instances finish provisioning via user_data
+(Docker pulls + AutoMQ topic creation) shortly after they boot.
+
+## Verify
+
+```bash
+tofu output                       # endpoint, bucket names, ssh commands
+
+# Shell onto a node:
+ssh debian@$(tofu output -raw triplox_public_ip)
+sudo cat /var/log/triplox-userdata.log   # provisioning log
+sudo docker logs automq                   # broker up; topic created   (on automq)
+sudo docker logs triplox                  # kafka mode resolved, listening (on triplox)
+```
+
+Then connect a Triplox client to the `triplox_endpoint` output and run a transaction;
+objects should appear in the `triplox` bucket and records in `automq-data`.
+
+## Stress with the load generator
+
+Once the AuctionMark image exists:
+
+```bash
+tofu apply -var enable_load_gen=true -var loadgen_image=<image>
+# SSH onto the loadgen host, then:
+LOADGEN_IMAGE=<image> /usr/local/bin/run-loadgen.sh
+```
+
+Scale via `loadgen_scale_factor`, `loadgen_threads`, `loadgen_duration`. Scale the
+Triplox node (the unit under test) via `-var triplox_flavor=b3-32`, or move the cache
+onto instance-local NVMe with `-var triplox_flavor=i1-45 -var triplox_disk_mode=local`.
+
+## Teardown
+
+```bash
+tofu destroy
+```
+
+Empty the buckets first if `destroy` refuses (OVH will not delete a non-empty bucket):
+the rig writes objects into all three.
+
+## Gotchas worth knowing
+
+- **Private network attaches by name.** The instances reference the OVH private
+  network by its `name`. If the OpenStack-visible name ends up differing in your
+  region, switch the instance `network {}` blocks to the network's `openstackid`
+  (exported under `regions_attributes`).
+- **`fixed_ip_v4` is set outside the DHCP pool** (`.10`–`.12`, pool starts at `.100`).
+  The addresses must stay inside `private_subnet_cidr`.
+- **AutoMQ talks to OVH S3 virtual-hosted-style** (the documented default). If the
+  broker can't reach buckets, add `&pathStyle=true` to the `s3.*.buckets` URLs in
+  `templates/automq_user_data.sh.tftpl`.

--- a/deploy/terraform-ovh/automq.tf
+++ b/deploy/terraform-ovh/automq.tf
@@ -1,0 +1,41 @@
+resource "openstack_compute_instance_v2" "automq" {
+  name            = "${local.name}-automq"
+  flavor_name     = var.automq_flavor
+  image_id        = data.openstack_images_image_v2.os.id
+  key_pair        = openstack_compute_keypair_v2.admin.name
+  security_groups = [openstack_networking_secgroup_v2.automq.name]
+
+  # Public IP for image pulls; ufw locks inbound down to SSH from admin.
+  network {
+    name           = "Ext-Net"
+    access_network = true
+  }
+
+  # Private network with a fixed IP, so advertised.listeners is known up front.
+  network {
+    name        = ovh_cloud_project_network_private.priv.name
+    fixed_ip_v4 = var.automq_private_ip
+  }
+
+  user_data = templatefile("${path.module}/templates/automq_user_data.sh.tftpl", {
+    automq_image       = var.automq_image
+    automq_heap_opts   = var.automq_heap_opts
+    cluster_id         = var.automq_cluster_id
+    automq_data_bucket = local.automq_data_bucket
+    automq_ops_bucket  = local.automq_ops_bucket
+    kafka_topic        = var.kafka_topic
+    s3_access_key      = ovh_cloud_project_user_s3_credential.s3.access_key_id
+    s3_secret_key      = ovh_cloud_project_user_s3_credential.s3.secret_access_key
+    s3_endpoint        = local.s3_endpoint
+    s3_region          = local.s3_region
+    private_ip         = var.automq_private_ip
+    private_cidr       = var.private_subnet_cidr
+    admin_cidr         = var.admin_cidr
+  })
+
+  # The buckets, S3 keys and private subnet must exist before the broker boots.
+  depends_on = [
+    ovh_cloud_project_network_private_subnet.priv,
+    ovh_cloud_project_user_s3_policy.s3,
+  ]
+}

--- a/deploy/terraform-ovh/credentials.tf
+++ b/deploy/terraform-ovh/credentials.tf
@@ -1,0 +1,61 @@
+# Triplox's object store requires explicit S3 access keys, so we create a Public
+# Cloud user and mint S3 credentials for it. AutoMQ reuses the same keys for
+# parity with the dev compose setup.
+#
+# Two planes, both required: the objectstore_operator role is the OVH control
+# plane; the s3_policy below is the S3 data plane. Keys without a policy can do
+# nothing.
+resource "ovh_cloud_project_user" "s3" {
+  service_name = var.project_id
+  description  = "${local.name}-s3"
+  role_names   = ["objectstore_operator"]
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3" {
+  service_name = var.project_id
+  user_id      = ovh_cloud_project_user.s3.id
+}
+
+# Bucket-scoped read/write. OVH's policy dialect is an AWS subset: only
+# Statement/Sid/Effect/Action/Resource (no Principal, no Condition).
+resource "ovh_cloud_project_user_s3_policy" "s3" {
+  service_name = var.project_id
+  user_id      = ovh_cloud_project_user.s3.id
+
+  policy = jsonencode({
+    Statement = [
+      {
+        Sid    = "ListBuckets"
+        Effect = "Allow"
+        Action = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = [
+          "arn:aws:s3:::${local.triplox_bucket}",
+          "arn:aws:s3:::${local.automq_data_bucket}",
+          "arn:aws:s3:::${local.automq_ops_bucket}",
+        ]
+      },
+      {
+        Sid    = "Objects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListMultipartUploadParts",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.triplox_bucket}/*",
+          "arn:aws:s3:::${local.automq_data_bucket}/*",
+          "arn:aws:s3:::${local.automq_ops_bucket}/*",
+        ]
+      },
+    ]
+  })
+
+  depends_on = [
+    ovh_cloud_project_storage.triplox,
+    ovh_cloud_project_storage.automq_data,
+    ovh_cloud_project_storage.automq_ops,
+  ]
+}

--- a/deploy/terraform-ovh/loadgen.tf
+++ b/deploy/terraform-ovh/loadgen.tf
@@ -1,0 +1,34 @@
+# Optional load generator (AuctionMark). Default OFF; the image is added later,
+# so this only provisions the instance + a ready-to-run helper.
+resource "openstack_compute_instance_v2" "loadgen" {
+  count = var.enable_load_gen ? 1 : 0
+
+  name            = "${local.name}-loadgen"
+  flavor_name     = var.loadgen_flavor
+  image_id        = data.openstack_images_image_v2.os.id
+  key_pair        = openstack_compute_keypair_v2.admin.name
+  security_groups = [openstack_networking_secgroup_v2.loadgen.name]
+
+  network {
+    name           = "Ext-Net"
+    access_network = true
+  }
+
+  network {
+    name        = ovh_cloud_project_network_private.priv.name
+    fixed_ip_v4 = var.loadgen_private_ip
+  }
+
+  user_data = templatefile("${path.module}/templates/loadgen_user_data.sh.tftpl", {
+    loadgen_image      = var.loadgen_image
+    triplox_private_ip = var.triplox_private_ip
+    triplox_port       = var.triplox_port
+    scale_factor       = var.loadgen_scale_factor
+    threads            = var.loadgen_threads
+    duration           = var.loadgen_duration
+    private_cidr       = var.private_subnet_cidr
+    admin_cidr         = var.admin_cidr
+  })
+
+  depends_on = [ovh_cloud_project_network_private_subnet.priv]
+}

--- a/deploy/terraform-ovh/locals.tf
+++ b/deploy/terraform-ovh/locals.tf
@@ -1,0 +1,19 @@
+# Latest matching OVH public image (e.g. "Debian 12") in the compute region.
+data "openstack_images_image_v2" "os" {
+  name        = var.image_name
+  visibility  = "public"
+  most_recent = true
+}
+
+locals {
+  name = var.name_prefix
+
+  # S3 SDK region is lowercase ("gra"); ovh_cloud_project_storage wants uppercase
+  # ("GRA"); OpenStack wants the full region ("GRA11"). Three different casings.
+  s3_region   = lower(var.storage_region)
+  s3_endpoint = "https://s3.${local.s3_region}.io.cloud.ovh.net"
+
+  triplox_bucket     = "${var.name_prefix}-triplox-${random_id.suffix.hex}"
+  automq_data_bucket = "${var.name_prefix}-automq-data-${random_id.suffix.hex}"
+  automq_ops_bucket  = "${var.name_prefix}-automq-ops-${random_id.suffix.hex}"
+}

--- a/deploy/terraform-ovh/network.tf
+++ b/deploy/terraform-ovh/network.tf
@@ -1,0 +1,123 @@
+# --- Private network (vRack-backed) the three nodes share for inter-node traffic ---
+resource "ovh_cloud_project_network_private" "priv" {
+  service_name = var.project_id
+  name         = "${local.name}-net"
+  regions      = [var.os_region]
+  vlan_id      = 0
+}
+
+resource "ovh_cloud_project_network_private_subnet" "priv" {
+  service_name = var.project_id
+  network_id   = ovh_cloud_project_network_private.priv.id
+  region       = var.os_region
+  network      = var.private_subnet_cidr
+  start        = var.private_dhcp_start
+  end          = var.private_dhcp_end
+  dhcp         = true
+  no_gateway   = false
+}
+
+# --- SSH key (the only login path; no SSM on OVH) ---
+resource "openstack_compute_keypair_v2" "admin" {
+  name       = "${local.name}-admin"
+  public_key = var.ssh_public_key
+}
+
+# --- Security groups (one per role, mirroring the AWS rig) ---
+# These are enforced on the private network. On the public network OVH does not
+# reliably enforce security groups, so each host also runs a ufw firewall (see
+# the user_data templates) — that is the real lock on SSH and the Triplox port.
+resource "openstack_networking_secgroup_v2" "automq" {
+  name        = "${local.name}-automq"
+  description = "AutoMQ broker"
+}
+
+resource "openstack_networking_secgroup_v2" "triplox" {
+  name        = "${local.name}-triplox"
+  description = "Triplox server"
+}
+
+resource "openstack_networking_secgroup_v2" "loadgen" {
+  name        = "${local.name}-loadgen"
+  description = "Load generator"
+}
+
+# AutoMQ: Kafka from Triplox; controller self-reference for the single-node quorum.
+resource "openstack_networking_secgroup_rule_v2" "automq_kafka_from_triplox" {
+  security_group_id = openstack_networking_secgroup_v2.automq.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9092
+  port_range_max    = 9092
+  remote_group_id   = openstack_networking_secgroup_v2.triplox.id
+  description       = "Kafka bootstrap/produce/fetch from Triplox"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "automq_controller_self" {
+  security_group_id = openstack_networking_secgroup_v2.automq.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9093
+  port_range_max    = 9093
+  remote_group_id   = openstack_networking_secgroup_v2.automq.id
+  description       = "KRaft controller quorum (single node)"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "automq_ssh" {
+  security_group_id = openstack_networking_secgroup_v2.automq.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.admin_cidr
+  description       = "SSH from admin"
+}
+
+# Triplox: server port from admin and from the load generator; SSH from admin.
+resource "openstack_networking_secgroup_rule_v2" "triplox_from_admin" {
+  security_group_id = openstack_networking_secgroup_v2.triplox.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = var.triplox_port
+  port_range_max    = var.triplox_port
+  remote_ip_prefix  = var.admin_cidr
+  description       = "Triplox wire protocol from admin"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "triplox_from_loadgen" {
+  security_group_id = openstack_networking_secgroup_v2.triplox.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = var.triplox_port
+  port_range_max    = var.triplox_port
+  remote_group_id   = openstack_networking_secgroup_v2.loadgen.id
+  description       = "Triplox wire protocol from load generator"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "triplox_ssh" {
+  security_group_id = openstack_networking_secgroup_v2.triplox.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.admin_cidr
+  description       = "SSH from admin"
+}
+
+# Load generator: SSH from admin; everything else is outbound (default egress).
+resource "openstack_networking_secgroup_rule_v2" "loadgen_ssh" {
+  security_group_id = openstack_networking_secgroup_v2.loadgen.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.admin_cidr
+  description       = "SSH from admin"
+}

--- a/deploy/terraform-ovh/outputs.tf
+++ b/deploy/terraform-ovh/outputs.tf
@@ -1,0 +1,63 @@
+output "triplox_endpoint" {
+  description = "Triplox wire-protocol endpoint (reachable from admin_cidr)."
+  value       = "${openstack_compute_instance_v2.triplox.access_ip_v4}:${var.triplox_port}"
+}
+
+output "triplox_public_ip" {
+  description = "Public IP of the Triplox server (changes if the instance is rebuilt)."
+  value       = openstack_compute_instance_v2.triplox.access_ip_v4
+}
+
+output "triplox_private_ip" {
+  description = "Private IP of the Triplox server."
+  value       = var.triplox_private_ip
+}
+
+output "automq_public_ip" {
+  description = "Public IP of the AutoMQ broker (egress + admin SSH only)."
+  value       = openstack_compute_instance_v2.automq.access_ip_v4
+}
+
+output "automq_private_ip" {
+  description = "AutoMQ broker private IP (Kafka bootstrap target for Triplox)."
+  value       = var.automq_private_ip
+}
+
+output "loadgen_public_ip" {
+  description = "Public IP of the optional load generator (null when disabled)."
+  value       = try(openstack_compute_instance_v2.loadgen[0].access_ip_v4, null)
+}
+
+output "s3_endpoint" {
+  description = "S3 endpoint the nodes use for object storage."
+  value       = local.s3_endpoint
+}
+
+output "s3_buckets" {
+  description = "Provisioned S3 buckets."
+  value = {
+    triplox     = local.triplox_bucket
+    automq_data = local.automq_data_bucket
+    automq_ops  = local.automq_ops_bucket
+  }
+}
+
+output "s3_access_key_id" {
+  description = "S3 access key id (also baked into the nodes' user_data)."
+  value       = ovh_cloud_project_user_s3_credential.s3.access_key_id
+}
+
+output "s3_secret_access_key" {
+  description = "S3 secret key. Read with: tofu output -raw s3_secret_access_key"
+  value       = ovh_cloud_project_user_s3_credential.s3.secret_access_key
+  sensitive   = true
+}
+
+output "ssh" {
+  description = "SSH onto a node (the only login path; no SSM on OVH)."
+  value = {
+    automq  = "ssh ${var.ssh_user}@${openstack_compute_instance_v2.automq.access_ip_v4}"
+    triplox = "ssh ${var.ssh_user}@${openstack_compute_instance_v2.triplox.access_ip_v4}"
+    loadgen = try("ssh ${var.ssh_user}@${openstack_compute_instance_v2.loadgen[0].access_ip_v4}", null)
+  }
+}

--- a/deploy/terraform-ovh/storage.tf
+++ b/deploy/terraform-ovh/storage.tf
@@ -1,0 +1,26 @@
+resource "random_id" "suffix" {
+  byte_length = 3
+}
+
+# Three S3-compatible buckets (Triplox SlateDB + AutoMQ data/ops). Nested
+# versioning/encryption use attribute syntax (= {}) in ovh provider v2.
+resource "ovh_cloud_project_storage" "triplox" {
+  service_name = var.project_id
+  region_name  = var.storage_region
+  name         = local.triplox_bucket
+  encryption   = { sse_algorithm = "AES256" }
+}
+
+resource "ovh_cloud_project_storage" "automq_data" {
+  service_name = var.project_id
+  region_name  = var.storage_region
+  name         = local.automq_data_bucket
+  encryption   = { sse_algorithm = "AES256" }
+}
+
+resource "ovh_cloud_project_storage" "automq_ops" {
+  service_name = var.project_id
+  region_name  = var.storage_region
+  name         = local.automq_ops_bucket
+  encryption   = { sse_algorithm = "AES256" }
+}

--- a/deploy/terraform-ovh/templates/automq_user_data.sh.tftpl
+++ b/deploy/terraform-ovh/templates/automq_user_data.sh.tftpl
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+exec > >(tee /var/log/triplox-userdata.log) 2>&1
+
+# --- Base packages: Docker + ufw ---
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y docker.io ufw
+systemctl enable --now docker
+
+# --- Host firewall (the authoritative inbound control on OVH) ---
+# Security groups are not reliably enforced on the public network, and Docker's
+# own port mapping bypasses them anyway; AutoMQ runs with --network host so ufw
+# governs its ports. Inter-node traffic flows over the private subnet.
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from ${private_cidr}
+ufw allow from ${admin_cidr} to any port 22 proto tcp
+ufw --force enable
+
+# Static private IP — used for advertised.listeners / controller quorum.
+PRIVATE_IP='${private_ip}'
+
+docker pull '${automq_image}'
+
+# Real-S3 deltas vs the dev compose: https endpoint, virtual-hosted addressing,
+# real bucket names, advertised/controller on the host private IP. Runtime values
+# are passed via -e and expanded by the container shell (single-quoted body).
+docker run -d --name automq --restart unless-stopped --network host \
+  -e KAFKA_S3_ACCESS_KEY='${s3_access_key}' \
+  -e KAFKA_S3_SECRET_KEY='${s3_secret_key}' \
+  -e KAFKA_HEAP_OPTS='${automq_heap_opts}' \
+  -e KAFKA_OPTS='-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -XX:ErrorFile=/tmp/hs_err_pid%p.log -Dio.netty.allocator.maxOrder=11' \
+  -e CLUSTER_ID='${cluster_id}' \
+  -e LOG_DIR=/tmp/kafka-logs \
+  -e PRIVATE_IP="$PRIVATE_IP" \
+  -e S3_ENDPOINT='${s3_endpoint}' \
+  -e DATA_BUCKET='${automq_data_bucket}' \
+  -e OPS_BUCKET='${automq_ops_bucket}' \
+  -e S3_REGION='${s3_region}' \
+  '${automq_image}' \
+  bash -c '
+    cp /opt/kafka/config/log4j.properties /tmp/kafka-log4j.properties
+    printf "%s\n" "log4j.logger.kafka.network.Processor=ERROR" >> /tmp/kafka-log4j.properties
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/tmp/kafka-log4j.properties"
+    /opt/kafka/bin/kafka-server-start.sh \
+      /opt/kafka/config/kraft/server.properties \
+      --override cluster.id="$CLUSTER_ID" \
+      --override node.id=0 \
+      --override process.roles=broker,controller \
+      --override controller.quorum.voters="0@$PRIVATE_IP:9093" \
+      --override controller.quorum.bootstrap.servers="$PRIVATE_IP:9093" \
+      --override listeners=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+      --override advertised.listeners="PLAINTEXT://$PRIVATE_IP:9092" \
+      --override listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
+      --override s3.data.buckets="0@s3://$DATA_BUCKET?region=$S3_REGION&endpoint=$S3_ENDPOINT" \
+      --override s3.ops.buckets="1@s3://$OPS_BUCKET?region=$S3_REGION&endpoint=$S3_ENDPOINT" \
+      --override s3.wal.path="0@s3://$DATA_BUCKET?region=$S3_REGION&endpoint=$S3_ENDPOINT" \
+      --override log.message.timestamp.type=LogAppendTime \
+      --override offsets.topic.num.partitions=1 \
+      --override autobalancer.reporter.metrics.reporting.interval.ms=5000
+  '
+
+# Wait for the broker to accept API requests, then pre-create the tx-log topic
+# with the exact settings Triplox's ensure_tx_log_topic() validates.
+echo "Waiting for AutoMQ to accept API requests..."
+for i in $(seq 1 60); do
+  if docker exec automq /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1; then
+    echo "Broker healthy."
+    break
+  fi
+  sleep 5
+done
+
+docker exec automq /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 \
+  --create --if-not-exists \
+  --topic '${kafka_topic}' \
+  --partitions 1 \
+  --replication-factor 1 \
+  --config retention.ms=-1 \
+  --config retention.bytes=-1 \
+  --config message.timestamp.type=LogAppendTime
+
+echo "AutoMQ provisioning complete."

--- a/deploy/terraform-ovh/templates/loadgen_user_data.sh.tftpl
+++ b/deploy/terraform-ovh/templates/loadgen_user_data.sh.tftpl
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+exec > >(tee /var/log/triplox-userdata.log) 2>&1
+
+# --- Base packages: Docker + ufw ---
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y docker.io ufw
+systemctl enable --now docker
+
+# --- Host firewall: outbound only (reaches Triplox); SSH from admin. ---
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from ${private_cidr}
+ufw allow from ${admin_cidr} to any port 22 proto tcp
+ufw --force enable
+
+# The AuctionMark image is on an unmerged branch, so we don't run it here — just
+# drop a ready-to-run helper wired to this rig's Triplox host and knobs.
+cat > /usr/local/bin/run-loadgen.sh <<'LOADGEN_SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE="$${LOADGEN_IMAGE:-${loadgen_image}}"
+if [ -z "$IMAGE" ]; then
+  echo "No load-gen image set. Re-run with the AuctionMark image, e.g.:"
+  echo "  LOADGEN_IMAGE=ghcr.io/fiv0/triplox-auctionmark:latest $0"
+  exit 1
+fi
+docker pull "$IMAGE"
+docker run --rm \
+  -e TRIPLOX_HOST="${triplox_private_ip}" \
+  -e TRIPLOX_PORT="${triplox_port}" \
+  -e SCALE_FACTOR="${scale_factor}" \
+  -e THREADS="${threads}" \
+  -e DURATION="${duration}" \
+  "$IMAGE"
+LOADGEN_SCRIPT
+chmod +x /usr/local/bin/run-loadgen.sh
+
+echo "Load-gen host ready. Set LOADGEN_IMAGE and run: /usr/local/bin/run-loadgen.sh"

--- a/deploy/terraform-ovh/templates/triplox_user_data.sh.tftpl
+++ b/deploy/terraform-ovh/templates/triplox_user_data.sh.tftpl
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+exec > >(tee /var/log/triplox-userdata.log) 2>&1
+
+# --- Base packages: Docker + ufw (+ xfsprogs for the cache volume) ---
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y docker.io ufw xfsprogs
+systemctl enable --now docker
+
+CACHE_PATH="${cache_path}"
+
+# --- Host firewall (the authoritative inbound control on OVH) ---
+# The Triplox wire protocol is unauthenticated, so the port must be locked to
+# admin_cidr. Security groups are unreliable on OVH's public network and Docker
+# port mapping bypasses them, so Triplox runs with --network host and ufw is the
+# real gate. Inter-node traffic (the load generator) flows over the private subnet.
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from ${private_cidr}
+ufw allow from ${admin_cidr} to any port 22 proto tcp
+ufw allow from ${admin_cidr} to any port ${triplox_port} proto tcp
+ufw --force enable
+
+# --- Mount fast storage at $CACHE_PATH ---
+%{ if disk_mode == "volume" ~}
+# Dedicated Block Storage volume: the first non-root disk with no filesystem.
+ROOT_SRC="$(findmnt -no SOURCE /)"
+ROOT_DISK="/dev/$(lsblk -no PKNAME "$ROOT_SRC" | head -1)"
+DISK=""
+for d in $(lsblk -dno NAME -e 7); do
+  dev="/dev/$d"
+  [ "$dev" = "$ROOT_DISK" ] && continue
+  if [ -z "$(lsblk -no MOUNTPOINT "$dev" | tr -d '[:space:]')" ]; then
+    DISK="$dev"
+    break
+  fi
+done
+for i in $(seq 1 30); do [ -n "$DISK" ] && [ -b "$DISK" ] && break; sleep 2; done
+if [ -n "$DISK" ]; then
+  if ! blkid "$DISK" >/dev/null 2>&1; then mkfs.xfs -f "$DISK"; fi
+  mkdir -p "$CACHE_PATH"
+  mount "$DISK" "$CACHE_PATH"
+  echo "UUID=$(blkid -o value -s UUID "$DISK") $CACHE_PATH xfs defaults,nofail 0 2" >> /etc/fstab
+else
+  echo "WARN: no dedicated cache volume found; using root disk for cache"
+  mkdir -p "$CACHE_PATH"
+fi
+%{ else ~}
+# Local-disk mode: cache lives on the flavor's local disk (use an i1-* flavor).
+mkdir -p "$CACHE_PATH"
+%{ endif ~}
+mkdir -p "$CACHE_PATH/cache" "$CACHE_PATH/dbsp"
+# Container runs as uid 20000 (the image's triplox user).
+chown -R 20000:20000 "$CACHE_PATH"
+
+# --- Render the Triplox config (only the fields config.rs accepts) ---
+mkdir -p /etc/triplox
+cat > /etc/triplox/triplox.toml <<EOF
+[storage]
+type = "remote"
+endpoint = "${s3_endpoint}"
+bucket = "${triplox_bucket}"
+access_key = "${s3_access_key}"
+secret_key = "${s3_secret_key}"
+region = "${s3_region}"
+cache_path = "${cache_path}"
+
+[log]
+type = "kafka"
+bootstrap_servers = "${automq_private_ip}:9092"
+topic = "${kafka_topic}"
+
+[server]
+host = "0.0.0.0"
+port = ${triplox_port}
+EOF
+chown 20000:20000 /etc/triplox/triplox.toml
+chmod 600 /etc/triplox/triplox.toml
+
+# --- Pull + run Triplox (public GHCR image, no login). --network host so ufw
+#     governs the port. Restart loops until AutoMQ + the topic are ready. ---
+docker pull '${triplox_image}'
+docker run -d --name triplox --restart unless-stopped \
+  --network host \
+  -v /etc/triplox/triplox.toml:/etc/triplox/triplox.toml:ro \
+  -v "$CACHE_PATH":"$CACHE_PATH" \
+  '${triplox_image}' /etc/triplox/triplox.toml
+
+echo "Triplox provisioning complete."

--- a/deploy/terraform-ovh/terraform.tfvars.example
+++ b/deploy/terraform-ovh/terraform.tfvars.example
@@ -1,0 +1,39 @@
+# Copy to terraform.tfvars and edit. terraform.tfvars is gitignored.
+
+# OVH Public Cloud project id (the service_name). Required.
+project_id = "0123456789abcdef0123456789abcdef"
+
+# Region for compute + private network. storage_region is the same location,
+# uppercase and trimmed (GRA11 -> GRA, SBG5 -> SBG, DE1 -> DE).
+# os_region      = "GRA11"
+# storage_region = "GRA"
+
+# SSH public key — the only login path (OVH has no SSM equivalent). Required.
+ssh_public_key = "ssh-ed25519 AAAA... you@host"
+# ssh_user = "debian"   # "ubuntu" if you switch image_name to an Ubuntu image
+
+# IMPORTANT: lock SSH and the Triplox port down to your own IP. The wire protocol
+# is unauthenticated, and on OVH the host firewall (ufw) — not security groups —
+# is what enforces this, so the default 0.0.0.0/0 exposes the database.
+admin_cidr = "203.0.113.10/32"
+
+# Kafka-enabled image to deploy. Must include the kafka feature (built by the
+# "Build and push (kafka)" step in .github/workflows/docker-publish.yml).
+triplox_image = "ghcr.io/fiv0/triplox:snapshot-kafka"
+
+# --- Flavor sizing (OpenStack flavor names) ---
+# automq_flavor  = "r3-16"   # memory-leaning broker
+# triplox_flavor = "b3-16"   # the unit under test
+# loadgen_flavor = "b3-8"
+
+# --- Triplox cache disk ---
+# triplox_disk_mode         = "volume"           # or "local" with an i1-* flavor
+# triplox_cache_volume_gb   = 200
+# triplox_cache_volume_type = "high-speed-gen2"  # NVMe-backed block storage
+
+# --- Load generator (default off; image added later) ---
+# enable_load_gen      = true
+# loadgen_image        = "ghcr.io/fiv0/triplox-auctionmark:latest"
+# loadgen_scale_factor = 0.1
+# loadgen_threads      = 8
+# loadgen_duration     = 120

--- a/deploy/terraform-ovh/triplox.tf
+++ b/deploy/terraform-ovh/triplox.tf
@@ -1,0 +1,52 @@
+# Dedicated cache volume only when not using the flavor's local disk.
+resource "openstack_blockstorage_volume_v3" "cache" {
+  count       = var.triplox_disk_mode == "volume" ? 1 : 0
+  name        = "${local.name}-cache"
+  size        = var.triplox_cache_volume_gb
+  volume_type = var.triplox_cache_volume_type
+}
+
+resource "openstack_compute_volume_attach_v2" "cache" {
+  count       = var.triplox_disk_mode == "volume" ? 1 : 0
+  instance_id = openstack_compute_instance_v2.triplox.id
+  volume_id   = openstack_blockstorage_volume_v3.cache[0].id
+}
+
+resource "openstack_compute_instance_v2" "triplox" {
+  name            = "${local.name}-triplox"
+  flavor_name     = var.triplox_flavor
+  image_id        = data.openstack_images_image_v2.os.id
+  key_pair        = openstack_compute_keypair_v2.admin.name
+  security_groups = [openstack_networking_secgroup_v2.triplox.name]
+
+  network {
+    name           = "Ext-Net"
+    access_network = true
+  }
+
+  network {
+    name        = ovh_cloud_project_network_private.priv.name
+    fixed_ip_v4 = var.triplox_private_ip
+  }
+
+  user_data = templatefile("${path.module}/templates/triplox_user_data.sh.tftpl", {
+    cache_path        = var.triplox_cache_path
+    disk_mode         = var.triplox_disk_mode
+    triplox_bucket    = local.triplox_bucket
+    automq_private_ip = var.automq_private_ip
+    kafka_topic       = var.kafka_topic
+    triplox_port      = var.triplox_port
+    triplox_image     = var.triplox_image
+    s3_access_key     = ovh_cloud_project_user_s3_credential.s3.access_key_id
+    s3_secret_key     = ovh_cloud_project_user_s3_credential.s3.secret_access_key
+    s3_endpoint       = local.s3_endpoint
+    s3_region         = local.s3_region
+    private_cidr      = var.private_subnet_cidr
+    admin_cidr        = var.admin_cidr
+  })
+
+  depends_on = [
+    ovh_cloud_project_network_private_subnet.priv,
+    ovh_cloud_project_user_s3_policy.s3,
+  ]
+}

--- a/deploy/terraform-ovh/variables.tf
+++ b/deploy/terraform-ovh/variables.tf
@@ -1,0 +1,216 @@
+# --- Identity / providers ---
+variable "project_id" {
+  description = "OVH Public Cloud project id (service_name). Also settable via OVH_CLOUD_PROJECT_SERVICE."
+  type        = string
+}
+
+variable "ovh_endpoint" {
+  description = "OVH API endpoint (ovh-eu, ovh-us, ovh-ca, ...). This is the API region, not the datacenter."
+  type        = string
+  default     = "ovh-eu"
+}
+
+variable "os_auth_url" {
+  description = "OpenStack Keystone (Identity v3) URL. The same URL serves every OVH region."
+  type        = string
+  default     = "https://auth.cloud.ovh.net/v3"
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names."
+  type        = string
+  default     = "triplox-bench"
+}
+
+# --- Regions (note the three casings) ---
+variable "os_region" {
+  description = "OpenStack region for compute + private network, e.g. GRA11, SBG5, DE1."
+  type        = string
+  default     = "GRA11"
+}
+
+variable "storage_region" {
+  description = "OVH object-storage region (uppercase, e.g. GRA, SBG, DE). Lowercased for the S3 endpoint/SDK region. Use the same location as os_region."
+  type        = string
+  default     = "GRA"
+}
+
+# --- Access ---
+variable "ssh_public_key" {
+  description = "SSH public key registered on every node (the only login path; OVH has no SSM equivalent)."
+  type        = string
+}
+
+variable "ssh_user" {
+  description = "Default cloud-image login user (debian for Debian, ubuntu for Ubuntu)."
+  type        = string
+  default     = "debian"
+}
+
+variable "admin_cidr" {
+  description = "CIDR allowed to reach SSH (22) and the Triplox port. The wire protocol is unauthenticated, so tighten this to your own IP/32. Enforced by the host firewall (ufw), since OVH security groups are not reliably enforced on the public network."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "image_name" {
+  description = "OVH public image to boot. apt-based; user_data assumes Debian/Ubuntu."
+  type        = string
+  default     = "Debian 12"
+}
+
+# --- Images (containers) ---
+variable "triplox_image" {
+  description = "Kafka-enabled Triplox image to deploy. Must be built with the kafka feature (see .github/workflows/docker-publish.yml)."
+  type        = string
+  default     = "ghcr.io/fiv0/triplox:snapshot-kafka"
+}
+
+variable "automq_image" {
+  description = "AutoMQ (Kafka-on-S3) broker image."
+  type        = string
+  default     = "automqinc/automq:1.7.0-strimzi"
+}
+
+variable "loadgen_image" {
+  description = "Load-generator (AuctionMark) image. Leave empty until the image is published; the load-gen host writes a ready-to-run helper instead."
+  type        = string
+  default     = ""
+}
+
+# --- Flavors (OpenStack flavor names; b3 = general purpose, r3 = RAM, c3 = CPU) ---
+variable "automq_flavor" {
+  description = "Flavor for the AutoMQ broker (memory-leaning)."
+  type        = string
+  default     = "r3-16"
+}
+
+variable "triplox_flavor" {
+  description = "Flavor for the Triplox server (the unit under test). Swap to an i1-* flavor for instance-local NVMe (then set triplox_disk_mode=\"local\")."
+  type        = string
+  default     = "b3-16"
+}
+
+variable "loadgen_flavor" {
+  description = "Flavor for the optional load-generator."
+  type        = string
+  default     = "b3-8"
+}
+
+# --- Triplox cache disk ---
+variable "triplox_disk_mode" {
+  description = "Where the Triplox cache lives: \"volume\" (a dedicated Block Storage volume) or \"local\" (the flavor's local disk; pick an i1-* flavor for NVMe)."
+  type        = string
+  default     = "volume"
+
+  validation {
+    condition     = contains(["volume", "local"], var.triplox_disk_mode)
+    error_message = "triplox_disk_mode must be \"volume\" or \"local\"."
+  }
+}
+
+variable "triplox_cache_volume_gb" {
+  description = "Size (GiB) of the dedicated cache volume when triplox_disk_mode = \"volume\"."
+  type        = number
+  default     = 200
+}
+
+variable "triplox_cache_volume_type" {
+  description = "Block Storage class for the cache volume: classic, high-speed, or high-speed-gen2 (NVMe-backed)."
+  type        = string
+  default     = "high-speed-gen2"
+}
+
+# --- AutoMQ tuning ---
+variable "automq_cluster_id" {
+  description = "Kafka KRaft cluster id (any valid base64 UUID)."
+  type        = string
+  default     = "rZdE0DjZSrqy96PXrMUZVw"
+}
+
+variable "automq_heap_opts" {
+  description = "KAFKA_HEAP_OPTS for the AutoMQ broker JVM."
+  type        = string
+  default     = "-Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G"
+}
+
+# --- Triplox / Kafka topic ---
+variable "kafka_topic" {
+  description = "Transaction-log topic name. Triplox validates it is single-partition with infinite retention and LogAppendTime."
+  type        = string
+  default     = "triplox-tx-log"
+}
+
+variable "triplox_port" {
+  description = "Triplox server port."
+  type        = number
+  default     = 5490
+}
+
+variable "triplox_cache_path" {
+  description = "On-disk root for the SlateDB object-store cache and dbsp scratch on the Triplox node."
+  type        = string
+  default     = "/var/lib/triplox/disk"
+}
+
+# --- Private network ---
+variable "private_subnet_cidr" {
+  description = "CIDR for the vRack-backed private network the three nodes share."
+  type        = string
+  default     = "192.168.42.0/24"
+}
+
+variable "private_dhcp_start" {
+  description = "First DHCP-pool address. Keep above the static node IPs below."
+  type        = string
+  default     = "192.168.42.100"
+}
+
+variable "private_dhcp_end" {
+  description = "Last DHCP-pool address."
+  type        = string
+  default     = "192.168.42.200"
+}
+
+variable "automq_private_ip" {
+  description = "Static private IP for the AutoMQ broker (advertised.listeners + controller). Must be inside private_subnet_cidr and outside the DHCP pool."
+  type        = string
+  default     = "192.168.42.10"
+}
+
+variable "triplox_private_ip" {
+  description = "Static private IP for the Triplox server."
+  type        = string
+  default     = "192.168.42.11"
+}
+
+variable "loadgen_private_ip" {
+  description = "Static private IP for the optional load-generator."
+  type        = string
+  default     = "192.168.42.12"
+}
+
+# --- Load-gen (default OFF) ---
+variable "enable_load_gen" {
+  description = "Provision the optional load-generator instance."
+  type        = bool
+  default     = false
+}
+
+variable "loadgen_scale_factor" {
+  description = "AuctionMark scale factor for the load-generator."
+  type        = number
+  default     = 0.1
+}
+
+variable "loadgen_threads" {
+  description = "Worker threads for the load-generator."
+  type        = number
+  default     = 8
+}
+
+variable "loadgen_duration" {
+  description = "Benchmark duration (seconds) for the load-generator."
+  type        = number
+  default     = 120
+}

--- a/deploy/terraform-ovh/versions.tf
+++ b/deploy/terraform-ovh/versions.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    # Account-plane: object storage, S3 users/keys, private network.
+    ovh = {
+      source  = "ovh/ovh"
+      version = "~> 2.0"
+    }
+    # Compute-plane: OVH Public Cloud is OpenStack underneath. The instances,
+    # keypair, security groups and block volumes live here.
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Endpoint selects the OVH *API* (ovh-eu / ovh-us / ovh-ca), NOT the datacenter.
+# Credentials come from OVH_APPLICATION_KEY / OVH_APPLICATION_SECRET /
+# OVH_CONSUMER_KEY (or OVH_CLIENT_ID / OVH_CLIENT_SECRET for OAuth2) in the env.
+provider "ovh" {
+  endpoint = var.ovh_endpoint
+}
+
+# OVH Keystone is one URL for every region; the region picks the datacenter.
+# Credentials come from OS_* env vars, clouds.yaml, or
+# OS_APPLICATION_CREDENTIAL_ID / OS_APPLICATION_CREDENTIAL_SECRET in the env.
+provider "openstack" {
+  auth_url = var.os_auth_url
+  region   = var.os_region
+}


### PR DESCRIPTION
## Summary

The OVHcloud sibling of the AWS rig in #405 (`deploy/terraform/`). Adds `deploy/terraform-ovh/`: the same small, stress-testable deployment mirroring `docker/docker-compose-kafka.yml`, with three single-purpose nodes so a stress test attributes bottlenecks cleanly:

- **AutoMQ** (Kafka-on-S3) broker, single node, real-S3 endpoint (`r3-16`).
- **Triplox** server — the unit under test, dedicated NVMe cache volume (`b3-16`).
- **Load generator** (AuctionMark) — `enable_load_gen`, **off by default**; provisions the instance + a ready-to-run helper (image added later, see #209).

Plus three S3-compatible buckets, an object-storage user with bucket-scoped S3 keys + policy, a vRack-backed private network/subnet, an SSH keypair, and per-role security groups.

## Two providers, because OVH Public Cloud is OpenStack underneath

- **`ovh/ovh` (~> 2.0)** — account-plane: the three buckets (`ovh_cloud_project_storage`), the S3 user/credential/policy, the private network.
- **`terraform-provider-openstack`** — compute-plane: the three instances, keypair, security groups, cache block volume. `ovh_cloud_project_instance` is Beta (no security groups, public-only networking), so `openstack_compute_instance_v2` drives the VMs.

The two need **two credential sets, both issued by OVH**: `OVH_*` API keys (api.ovh.com) for the `ovh` provider, and OpenStack `OS_*` / application credentials (auth.cloud.ovh.net Keystone) for the `openstack` provider.

## Deliberate departures from the AWS rig (all documented inline + in the README)

- **Access is SSH** (you supply `ssh_public_key`) — OVH has no SSM equivalent.
- **The host firewall (`ufw`), not security groups, is the authoritative inbound gate.** OVH does not reliably enforce security groups on the public network, and Docker port-mapping bypasses them anyway — so AutoMQ/Triplox run `--network host` and `ufw` locks SSH + the unauthenticated Triplox port to `admin_cidr`. Security groups are still defined (enforced on the private net).
- **S3 keys are rendered into `user_data`** (and local `tfstate`) — OVH has no SSM SecureString here. Fine for a throwaway rig; flagged in the README.
- **Region casing** is handled explicitly: `GRA11` (OpenStack) / `GRA` (storage resource) / `gra` (S3 endpoint + SDK region).
- **Static private IPs** (`.10/.11/.12`) so AutoMQ's `advertised.listeners` is known up front — no IMDS dance.

`user_data` renders the Triplox TOML, mounts the cache volume (or uses local NVMe with an `i1-*` flavor + `triplox_disk_mode=local`), pre-creates the tx-log topic with the exact settings `ensure_tx_log_topic` validates, and runs containers with `--restart unless-stopped` to ride out cross-host startup order.

## Before applying

1. Run the `Docker Publish` workflow so the `…-kafka` GHCR tag exists and is public.
2. Export `OVH_*` API credentials and source an OpenStack `openrc.sh` (or set `OS_APPLICATION_CREDENTIAL_*`).
3. `cp terraform.tfvars.example terraform.tfvars` and set `project_id`, `ssh_public_key`, and `admin_cidr` to your IP/32 (5490 is unauthenticated).
4. `tofu init && tofu plan && tofu apply`.

## Test plan

- [x] `tofu fmt` — clean
- [x] `tofu init` — providers resolve (ovh 2.14.0, openstack 3.4.0, random 3.9.0); lock file committed
- [x] `tofu validate` — configuration is valid (checks the v2 `ovh_cloud_project_storage` attribute syntax, `access_key_id`/`secret_access_key` refs, etc.)
- [x] Rendered all three `user_data` templates via `tofu console` — TF tokens substitute, container-side `$VAR`s preserved, the `%{ if }` disk-mode directive resolves for both `volume` and `local`, loadgen `$${...}` escaping yields literal `${LOADGEN_IMAGE:-...}`
- [ ] `tofu apply` against a real OVH project (needs `OVH_*` + `OS_*` credentials; not run)
- [ ] Confirm the private network attaches by name in the target region (else use the network's `openstackid`)
- [ ] Confirm AutoMQ reaches OVH S3 virtual-hosted (else add `&pathStyle=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)