### PR TITLE
ci: publish a single kafka-enabled Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,45 +96,22 @@ jobs:
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.stable == 'true' }}
             type=sha,prefix=sha-
 
+      # The published image is always built with the kafka feature enabled
+      # (rdkafka, which needs cmake). Kafka support is purely additive, so this
+      # single image is a superset that serves every storage mode, kafka
+      # included -- there is no separate -kafka variant.
       - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            GIT_SHA=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Kafka-enabled variant (rdkafka feature needs cmake). Tagged with a -kafka
-      # suffix so it lives alongside the default image; used by the AWS deployment.
-      - name: Extract metadata (kafka)
-        id: meta-kafka
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: suffix=-kafka
-          tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=snapshot,enable=${{ steps.version.outputs.snapshot == 'true' }}
-            type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.stable == 'true' }}
-            type=sha,prefix=sha-
-
-      - name: Build and push (kafka)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta-kafka.outputs.tags }}
-          labels: ${{ steps.meta-kafka.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_SHA=${{ github.sha }}
             BUILD_PACKAGES=cmake
             CARGO_FEATURES=kafka
-          cache-from: type=gha,scope=kafka
-          cache-to: type=gha,mode=max,scope=kafka
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What

The Docker Publish workflow built and pushed **two** images per run — a default image and a `-kafka`-suffixed variant compiled with the kafka feature. This collapses them into **one** build.

## Why it's safe

The `kafka` feature is purely additive: every gate is `#[cfg(feature = "kafka")]` (no `#[cfg(not(feature = "kafka"))]` fallbacks anywhere), and `kafka = ["dep:rdkafka"]` only pulls in the optional `rdkafka` dep without touching default features. So the kafka image is a **strict functional superset** of the default one — shipping only it loses nothing.

## Changes

- Removed the `Extract metadata (kafka)` + `Build and push (kafka)` steps and the `-kafka` tag suffix.
- The single `Build and push` now always passes `BUILD_PACKAGES=cmake` + `CARGO_FEATURES=kafka`, publishing under the normal tags (`<version>`, `snapshot`, `<minor>`, `sha-…`).
- Carried over `platforms: linux/amd64` (parity with the image shipped today) and collapsed the two GHA cache scopes to the single default `type=gha`.

Net: one Docker build per publish instead of two.

## Left intentionally alone

`docker/Dockerfile` stays parameterized — its `BUILD_PACKAGES`/`CARGO_FEATURES` args are still used by `docker/docker-compose-kafka.yml` and the default `docker-compose.yml` for local dev.

## ⚠️ Breaking for external consumers

The `…-kafka` tags are **no longer published**. Anything pulling `ghcr.io/fiv0/triplox:snapshot-kafka` / `:<version>-kafka` (the comment noted the AWS deployment) must switch to the unsuffixed tag, which is now a kafka-capable superset.

## Testing

- Workflow YAML validated with `yaml.safe_load` (passes). `actionlint` was not available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)