### PR TITLE
Support `and` branches in incremental OR queries

### DIFF
--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -140,7 +140,7 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
         WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
         _ => bail!(
-            "Incremental queries currently support only triple patterns and or clauses in :where"
+            "Incremental queries currently support only triple patterns, or clauses, and and clauses in :where"
         ),
     }
 }
@@ -723,11 +723,11 @@ mod tests {
     fn rejects_unsupported_where_forms() {
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#,
-            "only triple patterns and or clauses",
+            "only triple patterns, or clauses, and and clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] (not [?e :age 30])]"#,
-            "only triple patterns and or clauses",
+            "only triple patterns, or clauses, and and clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -110,8 +110,11 @@ fn reject_unsupported_or_join(or: &OrJoin) -> Result<()> {
 fn reject_unsupported_or_branch(branch: &OrWhereClause) -> Result<()> {
     match branch {
         OrWhereClause::Clause(clause) => reject_unsupported_where_clause(clause),
-        OrWhereClause::And(_) => {
-            bail!("Incremental queries currently do not support `and` patterns!")
+        OrWhereClause::And(children) => {
+            for child in children {
+                reject_unsupported_where_clause(child)?;
+            }
+            Ok(())
         }
     }
 }
@@ -273,9 +276,7 @@ fn plan_or_join(or: &OrJoin, schema: &Schema) -> Result<RelPlan> {
 fn plan_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<RelPlan> {
     match branch {
         OrWhereClause::Clause(clause) => plan_where_clause(clause, schema),
-        OrWhereClause::And(_) => {
-            unreachable!("Incremental queries currently do not support `and` patterns!")
-        }
+        OrWhereClause::And(children) => plan_where_clauses(children, schema),
     }
 }
 
@@ -624,6 +625,53 @@ mod tests {
     }
 
     #[test]
+    fn plans_and_branch_inside_or_as_join() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#,
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Union(or) = &plan.where_plan.kind else {
+            panic!("expected union plan, got {:?}", &plan.where_plan.kind);
+        };
+        assert_eq!(or.branches.len(), 2);
+        let RelPlanKind::Join(and_branch) = &or.branches[0].kind else {
+            panic!("expected join branch, got {:?}", &or.branches[0].kind);
+        };
+        assert_eq!(and_branch.inputs.len(), 2);
+        assert_eq!(and_branch.steps.len(), 1);
+        assert_eq!(and_branch.steps[0].key_vars, vec!["?e".to_var()]);
+        assert!(matches!(or.branches[1].kind, RelPlanKind::Pattern(_)));
+        assert_eq!(plan.leaf_patterns().len(), 3);
+    }
+
+    #[test]
+    fn plans_and_branch_inside_or_with_branch_specific_variable_order() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                r#"[:find ?x ?y :where (or (and [?y :name ?x] [?y :follows ?x]) [?x :follows ?y])]"#,
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Union(or) = &plan.where_plan.kind else {
+            panic!("expected union plan, got {:?}", &plan.where_plan.kind);
+        };
+        assert_eq!(
+            plan.where_plan.output_vars,
+            vec!["?y".to_var(), "?x".to_var()]
+        );
+        assert_eq!(or.branches[0].output_vars, &["?y".to_var(), "?x".to_var()]);
+        assert_eq!(or.branches[1].output_vars, &["?x".to_var(), "?y".to_var()]);
+    }
+
+    #[test]
     fn accepts_entid_attribute() {
         let schema = test_schema();
         let plan = plan_query(&parse_query("[:find ?e :where [?e 10 ?name]]"), &schema).unwrap();
@@ -680,10 +728,6 @@ mod tests {
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] (not [?e :age 30])]"#,
             "only triple patterns and or clauses",
-        );
-        assert_plan_err(
-            r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#,
-            "do not support `and` patterns",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -140,7 +140,7 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
         WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
         _ => bail!(
-            "Incremental queries currently support only triple patterns, or clauses, and and clauses in :where"
+            "Incremental queries currently support only triple patterns, `or` clauses, and `and` clauses in :where"
         ),
     }
 }
@@ -723,11 +723,11 @@ mod tests {
     fn rejects_unsupported_where_forms() {
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#,
-            "only triple patterns, or clauses, and and clauses",
+            "only triple patterns, `or` clauses, and `and` clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where [?e :name "Alice"] (not [?e :age 30])]"#,
-            "only triple patterns, or clauses, and and clauses",
+            "only triple patterns, `or` clauses, and `and` clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/node.rs
+++ b/src/node.rs
@@ -2848,6 +2848,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_incremental_equivalence_and_branch_inside_or() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        flush_wal(&node).await;
+        let query =
+            r#"[:find ?e :where (or (and [?e :name "Alice"] [?e :age 30]) [?e :name "Bob"])]"#;
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:name),
+                value: DataType::String("Alice".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(100),
+                attribute: kw!(:age),
+                value: DataType::Long(30),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::Add {
+                entity: EntityRef::Id(101),
+                attribute: kw!(:name),
+                value: DataType::String("Bob".to_string()),
+            }],
+        )
+        .await;
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+    }
+
+    #[tokio::test]
     async fn test_register_incremental_query_rejects_unsupported_query() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -264,7 +264,6 @@
         (api/transact conn [[:db/retract alice-id :name "Alice"]])
         (is (= [[["Alice"] -1]] (take-delta! sub 300)))))))
 
-
 (deftest test-or-joined-with-outer-pattern-retraction
   (with-open [conn (connect)]
     (api/transact conn people-schema)

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -256,6 +256,34 @@
         (is (= [[["Berlin"] -1]]
                (take-delta! sub)))))))
 
+(deftest test-or-and-branch-addition
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (api/transact conn [{:name "Alice"}])
+    (let [alice-id (single-value conn '{:find [?e]
+                                        :where [[?e :name "Alice"]]})]
+      (with-open [sub (api/subscribe conn '{:find [?e]
+                                            :where [(or (and [?e :name "Alice"]
+                                                             [?e :city "Berlin"])
+                                                        [?e :name "Bob"])]})]
+        (api/transact conn [[:db/add alice-id :city "Berlin"]])
+        (is (= [[[alice-id] 1]]
+               (take-delta! sub)))))))
+
+(deftest test-or-and-branch-retraction
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (api/transact conn [{:name "Alice" :city "Berlin"}])
+    (let [alice-id (single-value conn '{:find [?e]
+                                        :where [[?e :name "Alice"]]})]
+      (with-open [sub (api/subscribe conn '{:find [?e]
+                                            :where [(or (and [?e :name "Alice"]
+                                                             [?e :city "Berlin"])
+                                                        [?e :name "Bob"])]})]
+        (api/transact conn [[:db/retract alice-id :city "Berlin"]])
+        (is (= [[[alice-id] -1]]
+               (take-delta! sub)))))))
+
 (deftest test-prefix-stable-extension-addition
   (with-open [conn (connect)]
     (api/transact conn triangle-relation-schema)

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -13,7 +13,8 @@
 (def people-schema
   [{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
    {:db/ident :last-name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
-   {:db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+   {:db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+   {:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}])
 
 (def residence-schema
   [{:db/ident :person/name
@@ -34,10 +35,11 @@
 
 (def names-query '{:find [?name] :where [[?e :name ?name]]})
 
-(def delta-timeout-ms 1000)
+(def default-delta-timeout-ms 1000)
 
-(defn take-delta! [sub]
-  (api/take! sub delta-timeout-ms))
+(defn take-delta!
+  ([sub] (take-delta! sub default-delta-timeout-ms))
+  ([sub timeout] (api/take! sub timeout)))
 
 (defn delta-set! [sub]
   (let [res (take-delta! sub)]
@@ -240,6 +242,29 @@
         (is (= [[[bob-id] -1]]
                (take-delta! sub)))))))
 
+(deftest test-or-multiple-matching-branches
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+
+    (with-open [sub (api/subscribe conn '{:find [?name]
+                                          :where [[?e :name ?name]
+                                                  (or [?e :name "Alice"]
+                                                      [?e :age 40])]})]
+      (api/transact conn [{:name "Alice" :age 40}
+                          {:name "Bob" :age 30}])
+      (is (= [[["Alice"] 1]] (take-delta! sub 300)))
+      (is (= ::api/timeout (take-delta! sub 300)))
+
+      (let [alice-id (single-value conn '{:find [?e]
+                                          :where [[?e :name "Alice"]]})]
+
+        (api/transact conn [[:db/retract alice-id :age 40]])
+        (is (= ::api/timeout (take-delta! sub 300)))
+
+        (api/transact conn [[:db/retract alice-id :name "Alice"]])
+        (is (= [[["Alice"] -1]] (take-delta! sub 300)))))))
+
+
 (deftest test-or-joined-with-outer-pattern-retraction
   (with-open [conn (connect)]
     (api/transact conn people-schema)
@@ -256,7 +281,7 @@
         (is (= [[["Berlin"] -1]]
                (take-delta! sub)))))))
 
-(deftest test-or-and-branch-addition
+(deftest test-or+and-branch-addition+retraction
   (with-open [conn (connect)]
     (api/transact conn people-schema)
     (api/transact conn [{:name "Alice"}])
@@ -266,23 +291,12 @@
                                             :where [(or (and [?e :name "Alice"]
                                                              [?e :city "Berlin"])
                                                         [?e :name "Bob"])]})]
-        (api/transact conn [[:db/add alice-id :city "Berlin"]])
-        (is (= [[[alice-id] 1]]
-               (take-delta! sub)))))))
 
-(deftest test-or-and-branch-retraction
-  (with-open [conn (connect)]
-    (api/transact conn people-schema)
-    (api/transact conn [{:name "Alice" :city "Berlin"}])
-    (let [alice-id (single-value conn '{:find [?e]
-                                        :where [[?e :name "Alice"]]})]
-      (with-open [sub (api/subscribe conn '{:find [?e]
-                                            :where [(or (and [?e :name "Alice"]
-                                                             [?e :city "Berlin"])
-                                                        [?e :name "Bob"])]})]
+        (api/transact conn [[:db/add alice-id :city "Berlin"]])
+        (is (= [[[alice-id] 1]] (take-delta! sub)))
+
         (api/transact conn [[:db/retract alice-id :city "Berlin"]])
-        (is (= [[[alice-id] -1]]
-               (take-delta! sub)))))))
+        (is (= [[[alice-id] -1]] (take-delta! sub)))))))
 
 (deftest test-prefix-stable-extension-addition
   (with-open [conn (connect)]


### PR DESCRIPTION
## Summary
- lower `(and ...)` branches inside implicit `or` clauses through the existing incremental relation join planner
- keep DBSP circuit execution unchanged by reusing recursive join/union relation streams
- add planner and node-level incremental equivalence coverage for `and` inside `or`

## Verification
- `cargo fmt --check`
- `cargo test -p triplox plans_and_branch_inside_or`
- `cargo test -p triplox node::tests::test_incremental_equivalence_and_branch_inside_or -- --exact`
- `cargo test -p triplox incremental`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated by Codex (GPT-5).
