### PR TITLE
Accept arrays in TxOp::put

### DIFF
--- a/examples/rust/src/simple_example.rs
+++ b/examples/rust/src/simple_example.rs
@@ -17,7 +17,7 @@ use triplox::ops::{DataType, TxOp};
 /// Build a schema attribute definition as a Put document.
 /// This mirrors the internal `plain_schema_attribute` helper.
 fn schema_attribute(name: &str, value_type: &str) -> TxOp {
-    TxOp::put(vec![
+    TxOp::put([
         (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
         (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type))),
         (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one))),
@@ -48,11 +48,11 @@ async fn main() -> Result<()> {
 
     // 2. Insert some data
     let data_ops = vec![
-        TxOp::put(vec![
+        TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ]),
-        TxOp::put(vec![
+        TxOp::put([
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
         ]),

--- a/examples/rust/src/streaming_example.rs
+++ b/examples/rust/src/streaming_example.rs
@@ -17,7 +17,7 @@ use triplox::ops::{DataType, TxOp};
 
 /// Build a schema attribute definition as a Put document.
 fn schema_attribute(name: &str, value_type: &str) -> TxOp {
-    TxOp::put(vec![
+    TxOp::put([
         (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
         (kw!(:db/valueType), DataType::Keyword(Keyword::namespaced("db.type", value_type))),
         (kw!(:db/cardinality), DataType::Keyword(kw!(:db.cardinality/one))),
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
 
     // Transact three names; each produces a delta on the subscription.
     for name in ["alice", "bob", "carol"] {
-        node.execute_tx(vec![TxOp::put(vec![(kw!(:name), name.into())])])
+        node.execute_tx(vec![TxOp::put([(kw!(:name), name.into())])])
             .await?;
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -950,7 +950,7 @@ mod tests {
             system_time: st_from_unix_epoch(2),
         };
 
-        let tx_ops = vec![TxOp::put(vec![
+        let tx_ops = vec![TxOp::put([
             (kw!(:name), "alan".into()),
             (kw!(:age), 30_i64.into()),
         ])];
@@ -1712,7 +1712,7 @@ mod tests {
         let indexed = indexer
             .transact_tx(
                 tx,
-                vec![TxOp::put(vec![
+                vec![TxOp::put([
                     (kw!(:db/id), DataType::Long(name_id)),
                     (kw!(:db/ident), DataType::Keyword(kw!(:name))),
                     (kw!(:db/valueType), DataType::Long(DB_TYPE_LONG)),
@@ -2070,7 +2070,7 @@ mod tests {
         };
         let waiter = indexer.tx_waiter();
         let tx_ops = vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:name), "Alice".into()),
                 (kw!(:email), "alice@example.com".into()),
             ]),
@@ -2115,7 +2115,7 @@ mod tests {
                     tx_id: 2,
                     system_time: st_from_unix_epoch(2),
                 },
-                vec![TxOp::put(vec![
+                vec![TxOp::put([
                     (kw!(:name), "Alice".into()),
                     (kw!(:email), "alice@example.com".into()),
                 ])],
@@ -2280,17 +2280,14 @@ mod tests {
         transact(
             &mut indexer,
             2,
-            TxOp::put(vec![
-                (kw!(:name), "alice".into()),
-                (kw!(:age), DataType::Long(2)),
-            ]),
+            TxOp::put([(kw!(:name), "alice".into()), (kw!(:age), DataType::Long(2))]),
         )
         .await?;
         let entity_id = find_first_user_entity(&slate).await?;
         transact(
             &mut indexer,
             3,
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::Long(entity_id)),
                 (kw!(:name), "bob".into()),
                 (kw!(:age), DataType::Long(1)),
@@ -2300,7 +2297,7 @@ mod tests {
         transact(
             &mut indexer,
             4,
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::Long(entity_id)),
                 (kw!(:name), "carol".into()),
                 (kw!(:age), DataType::Long(5)),

--- a/src/node.rs
+++ b/src/node.rs
@@ -695,7 +695,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
@@ -762,12 +762,12 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("ivan".to_string())),
                 (kw!(:name), "Ivan".into()),
                 (kw!(:email), "ivan@example.com".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("petr".to_string())),
                 (kw!(:name), "Petr".into()),
                 (kw!(:email), "petr@example.com".into()),
@@ -853,15 +853,15 @@ mod tests {
 
         // Insert three named entities so LIMIT can actually truncate.
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("a".to_string())),
                 (kw!(:name), "Alice".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("b".to_string())),
                 (kw!(:name), "Bob".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("c".to_string())),
                 (kw!(:name), "Carol".into()),
             ]),
@@ -924,17 +924,17 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("ivan".to_string())),
                 (kw!(:name), "Ivan".into()),
                 (kw!(:email), "ivan@example.com".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("petr".to_string())),
                 (kw!(:name), "Petr".into()),
                 (kw!(:email), "petr@example.com".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("bob".to_string())),
                 (kw!(:name), "Bob".into()),
                 (kw!(:email), "bob@example.com".into()),
@@ -986,12 +986,12 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("alice".to_string())),
                 (kw!(:name), "alice".into()),
                 (kw!(:follows), DataType::String("bob".to_string())),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("bob".to_string())),
                 (kw!(:name), "bob".into()),
             ]),
@@ -1057,19 +1057,19 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "charlie".into()),
             (kw!(:age), 35_i64.into()),
         ])])
@@ -1095,19 +1095,19 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "bob".into()),
             (kw!(:age), 25_i64.into()),
         ])])
         .await
         .unwrap();
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "charlie".into()),
             (kw!(:age), 35_i64.into()),
         ])])
@@ -1523,7 +1523,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Insert entity with auto-assigned ID
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
@@ -1626,7 +1626,7 @@ mod tests {
     async fn insert_three_people(node: &impl SubmitNode) {
         let people: Vec<(&str, i64)> = vec![("Ivan", 30), ("Bob", 40), ("Dominic", 50)];
         for (name, age) in people {
-            node.execute_tx(vec![TxOp::put(vec![
+            node.execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:age), age.into()),
             ])])
@@ -1836,7 +1836,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Define "sex" attribute with keyword value type
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
             (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword))),
             (
@@ -1854,7 +1854,7 @@ mod tests {
             ("Doris", "female"),
         ];
         for (name, sex) in people {
-            node.execute_tx(vec![TxOp::put(vec![
+            node.execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
@@ -1883,7 +1883,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:db/ident), DataType::Keyword(kw!(:sex))),
             (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/keyword))),
             (
@@ -1901,7 +1901,7 @@ mod tests {
             ("Jane", "female"),
         ];
         for (name, sex) in people {
-            node.execute_tx(vec![TxOp::put(vec![
+            node.execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
@@ -1930,7 +1930,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Define "last-name" attribute
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:db/ident), DataType::Keyword(kw!(:last-name))),
             (kw!(:db/valueType), DataType::Keyword(kw!(:db.type/string))),
             (
@@ -3179,7 +3179,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Create an entity with a known email
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:email), "alice@example.com".into()),
         ])])
@@ -3217,14 +3217,14 @@ mod tests {
         define_test_schema(&node).await;
 
         // Create two entities
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:email), "alice@example.com".into()),
         ])])
         .await
         .unwrap();
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Bob".into()),
             (kw!(:email), "bob@example.com".into()),
         ])])
@@ -3265,11 +3265,11 @@ mod tests {
         define_test_schema(&node).await;
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:name), "Alice".into()),
                 (kw!(:email), "alice@example.com".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:name), "Bob".into()),
                 (kw!(:email), "bob@example.com".into()),
             ]),
@@ -3322,7 +3322,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Bob".into()),
             (kw!(:email), "bob@example.com".into()),
         ])])
@@ -3363,7 +3363,7 @@ mod tests {
         define_test_schema(&node).await;
 
         // Create an entity with a known email
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:email), "alice@example.com".into()),
         ])])
@@ -3426,7 +3426,7 @@ mod tests {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:email), "alice@example.com".into()),
         ])])
@@ -3514,7 +3514,7 @@ mod tests {
             TransactionResult::TxCommitted(_)
         ));
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:email), "alice@example.com".into()),
         ])])
@@ -3530,7 +3530,7 @@ mod tests {
             other => panic!("Expected Long entity ID, got {:?}", other),
         };
 
-        node.execute_tx(vec![TxOp::put(vec![
+        node.execute_tx(vec![TxOp::put([
             (kw!(:name), "Bob".into()),
             (kw!(:ref-id), DataType::Long(alice)),
         ])])
@@ -3604,7 +3604,7 @@ mod tests {
         define_test_schema(&node).await;
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:db/id), DataType::Long(11111)),
                 (kw!(:name), "Ivan".into()),
             ])])
@@ -3625,7 +3625,7 @@ mod tests {
         assert_aborted_with_error_matching(result, r"^unallocated entity id \d+$");
 
         let result = node
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:name), "Bob".into()),
                 (kw!(:follows), DataType::Long(11111)),
             ])])
@@ -3655,8 +3655,8 @@ mod tests {
         .unwrap();
 
         node.execute_tx(vec![
-            TxOp::put(vec![(kw!(:user/email), "alice".into())]),
-            TxOp::put(vec![(kw!(:user/email), "bob".into())]),
+            TxOp::put([(kw!(:user/email), "alice".into())]),
+            TxOp::put([(kw!(:user/email), "bob".into())]),
         ])
         .await
         .unwrap();
@@ -3722,15 +3722,15 @@ mod tests {
         .unwrap();
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("alice".into())),
                 (kw!(:user/email), "alice".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("bob".into())),
                 (kw!(:user/email), "bob".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("carol".into())),
                 (kw!(:user/email), "carol".into()),
                 (kw!(:user/spouse), DataType::String("bob".into())),
@@ -3789,11 +3789,11 @@ mod tests {
         .unwrap();
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("alice".into())),
                 (kw!(:user/email), "a@x".into()),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("bob".into())),
                 (kw!(:user/ssn), "123".into()),
             ]),
@@ -3853,15 +3853,15 @@ mod tests {
         .unwrap();
 
         node.execute_tx(vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("alice".into())),
                 (kw!(:user/email), DataType::String("alice".into())),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("bob".into())),
                 (kw!(:user/handle), DataType::String("bob".into())),
             ]),
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::String("carol".into())),
                 (kw!(:user/primary-friend), DataType::String("bob".into())),
             ]),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1188,7 +1188,7 @@ mod tests {
         let schema = bootstrapped_schema_with_person_name();
         let (name_id, _) = schema.get_attribute(&kw!(:name)).unwrap();
 
-        let ops = [TxOp::put(vec![
+        let ops = [TxOp::put([
             (kw!(:db/id), DataType::Long(name_id)),
             (kw!(:db/ident), DataType::Keyword(kw!(:name))),
             (kw!(:db/valueType), DataType::Long(DB_TYPE_LONG)),
@@ -1349,7 +1349,7 @@ mod tests {
     fn test_prepare_schema_update_missing_cardinality_errors() {
         let schema = bootstrapped_schema();
         // Provide db/ident + db/valueType but no db/cardinality
-        let ops = [TxOp::put(vec![
+        let ops = [TxOp::put([
             (kw!(:db/ident), DataType::Keyword(kw!(:name))),
             (kw!(:db/valueType), DataType::Long(DB_TYPE_STRING)),
             // No db/cardinality

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_expand_put_with_id() {
-        let ops = vec![TxOp::put(vec![
+        let ops = vec![TxOp::put([
             (kw!(:db/id), DataType::Long(100)),
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
@@ -608,8 +608,8 @@ mod tests {
     #[test]
     fn test_expand_put_without_id() {
         let ops = vec![
-            TxOp::put(vec![(kw!(:name), "alice".into())]),
-            TxOp::put(vec![(kw!(:name), "bob".into())]),
+            TxOp::put([(kw!(:name), "alice".into())]),
+            TxOp::put([(kw!(:name), "bob".into())]),
         ];
         let datoms = expand_tx_ops(&ops, &empty_schema()).unwrap();
         assert_eq!(datoms.len(), 2);
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_expand_put_attrs_share_entity() {
-        let ops = vec![TxOp::put(vec![
+        let ops = vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])];

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -408,7 +408,7 @@ async fn test_dev_server_connections_are_isolated() {
 
 async fn define_schema_attr(client: &ClientNode, name: &str, vtype: &str) {
     client
-        .execute_tx(vec![TxOp::put(vec![
+        .execute_tx(vec![TxOp::put([
             (kw!(:db/ident), DataType::Keyword(Keyword::plain(name))),
             (
                 kw!(:db/valueType),
@@ -451,7 +451,7 @@ async fn test_query_keyword_value_comparison_via_wire() {
         ("Jane", "female"),
     ] {
         client
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
             ])])
@@ -496,7 +496,7 @@ async fn test_aggregates_and_or() {
         ("Adam", "Smith", "male", 23),
     ] {
         client
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:last-name), last.into()),
                 (kw!(:sex), DataType::Keyword(Keyword::plain(sex))),
@@ -557,7 +557,7 @@ async fn test_aggregate_set_semantics() {
 
     for (name, city) in [("Alice", "NYC"), ("Bob", "NYC"), ("Carol", "LA")] {
         client
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:city), city.into()),
             ])])
@@ -704,7 +704,7 @@ async fn test_order_and_limit() {
         ("Eve", 50),
     ] {
         client
-            .execute_tx(vec![TxOp::put(vec![
+            .execute_tx(vec![TxOp::put([
                 (kw!(:name), name.into()),
                 (kw!(:age), (age as i64).into()),
             ])])
@@ -780,7 +780,7 @@ async fn test_aggregate_min_incompatible_types() {
 
     // Insert entity with both name (string) and age (long)
     client
-        .execute_tx(vec![TxOp::put(vec![
+        .execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])
@@ -805,7 +805,7 @@ async fn test_join_ref_with_plain_long() {
 
     // Insert Bob
     client
-        .execute_tx(vec![TxOp::put(vec![(kw!(:name), "Bob".into())])])
+        .execute_tx(vec![TxOp::put([(kw!(:name), "Bob".into())])])
         .await
         .unwrap();
 
@@ -823,7 +823,7 @@ async fn test_join_ref_with_plain_long() {
 
     // Insert Alice with :follows pointing to Bob's entity id
     client
-        .execute_tx(vec![TxOp::put(vec![
+        .execute_tx(vec![TxOp::put([
             (kw!(:name), "Alice".into()),
             (kw!(:follows), DataType::Long(bob_id)),
         ])])
@@ -850,7 +850,7 @@ async fn test_upsert_with_resolved_entity_id() {
 
     // Insert entity with auto-assigned ID
     client
-        .execute_tx(vec![TxOp::put(vec![
+        .execute_tx(vec![TxOp::put([
             (kw!(:name), "alice".into()),
             (kw!(:age), 30_i64.into()),
         ])])

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -1481,7 +1481,7 @@ mod tests {
     #[test]
     fn round_trip_tx_op_variants() {
         let cases = vec![
-            TxOp::put(vec![
+            TxOp::put([
                 (kw!(:db/id), DataType::Long(1)),
                 (kw!(:person/name), DataType::String("alice".into())),
             ]),
@@ -1599,7 +1599,7 @@ mod tests {
     #[test]
     fn round_trip_execute_request_body() {
         let ops = vec![
-            TxOp::put(vec![(kw!(:name), DataType::String("alice".into()))]),
+            TxOp::put([(kw!(:name), DataType::String("alice".into()))]),
             TxOp::Add {
                 entity: EntityRef::Id(42),
                 attribute: kw!(:age),

--- a/triplox-client/src/ops.rs
+++ b/triplox-client/src/ops.rs
@@ -189,7 +189,7 @@ pub enum TxOp {
 
 impl TxOp {
     /// Build a Put without explicit entity ID (auto-allocated).
-    pub fn put(attrs: Vec<(Keyword, DataType)>) -> Self {
+    pub fn put(attrs: impl IntoIterator<Item = (Keyword, DataType)>) -> Self {
         TxOp::Put(attrs.into_iter().collect())
     }
 }
@@ -547,13 +547,25 @@ mod tests {
 
     #[test]
     fn test_op_put_bincode() {
-        let op = TxOp::put(vec![
+        let op = TxOp::put([
             (kw!(:string), "string_value".into()),
             (kw!(:int), 1i64.into()),
         ]);
         let serialized = bincode::serialize(&op).unwrap();
         let deserialized: TxOp = bincode::deserialize(&serialized).unwrap();
         assert_eq!(op, deserialized);
+    }
+
+    #[test]
+    fn test_op_put_accepts_array() {
+        let op = TxOp::put([
+            (kw!(:string), "string_value".into()),
+            (kw!(:int), 1i64.into()),
+        ]);
+        let mut expected = BTreeMap::new();
+        expected.insert(kw!(:string), "string_value".into());
+        expected.insert(kw!(:int), 1i64.into());
+        assert_eq!(op, TxOp::Put(expected));
     }
 
     #[test]

--- a/triplox-client/src/ops.rs
+++ b/triplox-client/src/ops.rs
@@ -557,18 +557,6 @@ mod tests {
     }
 
     #[test]
-    fn test_op_put_accepts_array() {
-        let op = TxOp::put([
-            (kw!(:string), "string_value".into()),
-            (kw!(:int), 1i64.into()),
-        ]);
-        let mut expected = BTreeMap::new();
-        expected.insert(kw!(:string), "string_value".into());
-        expected.insert(kw!(:int), 1i64.into());
-        assert_eq!(op, TxOp::Put(expected));
-    }
-
-    #[test]
     fn test_op_add_bincode() {
         let op = TxOp::Add {
             entity: EntityRef::Id(1),


### PR DESCRIPTION
## Summary
- widen `TxOp::put` to accept any iterator of `(Keyword, DataType)` pairs
- update Rust tests and examples to use `TxOp::put([...])` instead of `TxOp::put(vec![...])`
- keep the existing `TxOp::Put(BTreeMap<_, _>)` representation unchanged

Refs #385.

## Verification
- `cargo test -p triplox-client`
- `cargo test --workspace`
- `cargo test --manifest-path examples/rust/Cargo.toml --no-run`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features`

Autogenerated with Codex (GPT-5).
