### PR TITLE
Add trie-backed prefix lookup

### DIFF
--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -120,6 +120,7 @@ impl PrefixExtender for TupleExtender {
 }
 
 /// An extender with participating levels and a partial prefix
+/// TODO: If we pass to set-semantics, this implemetation can be delegated to the trie implementation.
 pub struct FromPrefixExtender {
     participating_levels: Vec<usize>,
     level_set: HashSet<usize>,

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -1,8 +1,6 @@
 use bytes::Bytes;
 use std::collections::HashSet;
 
-use crate::algo::trie::{Trie, TrieNode};
-
 pub type Prefix = Vec<Bytes>;
 pub type Extension = Bytes;
 pub type ResultTuple = Vec<Bytes>;
@@ -209,7 +207,7 @@ impl PrefixExtender for FromPrefixExtender {
 pub struct FromPrefixesExtender {
     participating_levels: Vec<usize>,
     level_set: HashSet<usize>,
-    partial_prefixes: Trie<Bytes>,
+    partial_prefixes: Vec<Prefix>,
 }
 
 impl FromPrefixesExtender {
@@ -220,50 +218,69 @@ impl FromPrefixesExtender {
             participating_levels
         );
         let level_set = participating_levels.iter().cloned().collect();
-        let mut prefix_trie = Trie::new();
-        for partial_prefix in partial_prefixes {
-            prefix_trie.insert(partial_prefix);
-        }
         Self {
             participating_levels,
             level_set,
-            partial_prefixes: prefix_trie,
+            partial_prefixes,
         }
     }
 
-    fn trie_node_for<'a>(&'a self, prefix: &'a Prefix) -> Option<&'a TrieNode<Bytes>> {
-        let trie_prefix = self
-            .participating_levels
+    fn matching_prefixes(&self, prefix: &Prefix) -> Vec<&Prefix> {
+        self.partial_prefixes
             .iter()
-            .copied()
-            .take_while(|&level| level < prefix.len())
-            .map(|level| &prefix[level]);
-        self.partial_prefixes.node_for(trie_prefix)
+            .filter(|partial_prefix| {
+                for (i, &level) in self.participating_levels.iter().enumerate() {
+                    if level >= prefix.len() {
+                        break;
+                    }
+                    if partial_prefix[i] != prefix[level] {
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect()
+    }
+
+    fn next_level_index(&self, prefix: &Prefix) -> usize {
+        let mut i = 0;
+        for &level in &self.participating_levels {
+            if level >= prefix.len() {
+                break;
+            }
+            i += 1;
+        }
+        i
     }
 }
 
 impl PrefixExtender for FromPrefixesExtender {
     fn count(&self, prefix: &Prefix) -> usize {
-        self.trie_node_for(prefix)
-            .map_or(0, TrieNode::descendant_count)
+        self.matching_prefixes(prefix).len()
     }
 
     fn propose(&self, prefix: &Prefix) -> Vec<Extension> {
-        let Some(node) = self.trie_node_for(prefix) else {
-            return vec![];
-        };
-        let mut extensions: Vec<_> = node.children().keys().cloned().collect();
+        let idx = self.next_level_index(prefix);
+        let mut extensions: Vec<_> = self
+            .matching_prefixes(prefix)
+            .into_iter()
+            .filter_map(|p| p.get(idx).cloned())
+            .collect();
         extensions.sort();
+        extensions.dedup();
         extensions
     }
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
-        let Some(node) = self.trie_node_for(prefix) else {
-            return vec![];
-        };
+        let idx = self.next_level_index(prefix);
+        let valid_extensions: HashSet<_> = self
+            .matching_prefixes(prefix)
+            .into_iter()
+            .filter_map(|p| p.get(idx))
+            .collect();
         extensions
             .iter()
-            .filter(|ext| node.children().contains_key(*ext))
+            .filter(|ext| valid_extensions.contains(ext))
             .cloned()
             .collect()
     }
@@ -719,43 +736,6 @@ mod tests {
             extender.intersect(&vec![b("z")], &[b("a"), b("b"), b("x"), b("y")]),
             Vec::<Bytes>::new()
         );
-    }
-
-    #[test]
-    fn test_from_prefixes_extender_counts_shared_prefix_rows() {
-        let extender = FromPrefixesExtender::new(
-            vec![0, 1],
-            vec![
-                vec![b("a"), b("x")],
-                vec![b("a"), b("y")],
-                vec![b("b"), b("z")],
-            ],
-        );
-
-        assert_eq!(extender.count(&vec![]), 3);
-        assert_eq!(extender.count(&vec![b("a")]), 2);
-        assert_eq!(extender.propose(&vec![b("a")]), vec![b("x"), b("y")]);
-        assert_eq!(
-            extender.intersect(&vec![b("a")], &[b("y"), b("z"), b("x")]),
-            vec![b("y"), b("x")]
-        );
-    }
-
-    #[test]
-    fn test_from_prefixes_extender_deduplicates_duplicate_prefixes() {
-        let extender = FromPrefixesExtender::new(
-            vec![0, 1],
-            vec![
-                vec![b("a"), b("b")],
-                vec![b("a"), b("b")],
-                vec![b("a"), b("c")],
-            ],
-        );
-
-        assert_eq!(extender.count(&vec![]), 2);
-        assert_eq!(extender.count(&vec![b("a")]), 2);
-        assert_eq!(extender.propose(&vec![]), vec![b("a")]);
-        assert_eq!(extender.propose(&vec![b("a")]), vec![b("b"), b("c")]);
     }
 
     #[test]

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -120,7 +120,7 @@ impl PrefixExtender for TupleExtender {
 }
 
 /// An extender with participating levels and a partial prefix
-/// TODO: If we pass to set-semantics, this implemetation can be delegated to the trie implementation.
+/// TODO: If we pass to set-semantics, this implementation can be delegated to the trie implementation.
 pub struct FromPrefixExtender {
     participating_levels: Vec<usize>,
     level_set: HashSet<usize>,

--- a/src/algo/generic_join.rs
+++ b/src/algo/generic_join.rs
@@ -1,6 +1,8 @@
 use bytes::Bytes;
 use std::collections::HashSet;
 
+use crate::algo::trie::{Trie, TrieNode};
+
 pub type Prefix = Vec<Bytes>;
 pub type Extension = Bytes;
 pub type ResultTuple = Vec<Bytes>;
@@ -207,7 +209,7 @@ impl PrefixExtender for FromPrefixExtender {
 pub struct FromPrefixesExtender {
     participating_levels: Vec<usize>,
     level_set: HashSet<usize>,
-    partial_prefixes: Vec<Prefix>,
+    partial_prefixes: Trie<Bytes>,
 }
 
 impl FromPrefixesExtender {
@@ -218,69 +220,50 @@ impl FromPrefixesExtender {
             participating_levels
         );
         let level_set = participating_levels.iter().cloned().collect();
+        let mut prefix_trie = Trie::new();
+        for partial_prefix in partial_prefixes {
+            prefix_trie.insert(partial_prefix);
+        }
         Self {
             participating_levels,
             level_set,
-            partial_prefixes,
+            partial_prefixes: prefix_trie,
         }
     }
 
-    fn matching_prefixes(&self, prefix: &Prefix) -> Vec<&Prefix> {
-        self.partial_prefixes
+    fn trie_node_for<'a>(&'a self, prefix: &'a Prefix) -> Option<&'a TrieNode<Bytes>> {
+        let trie_prefix = self
+            .participating_levels
             .iter()
-            .filter(|partial_prefix| {
-                for (i, &level) in self.participating_levels.iter().enumerate() {
-                    if level >= prefix.len() {
-                        break;
-                    }
-                    if partial_prefix[i] != prefix[level] {
-                        return false;
-                    }
-                }
-                true
-            })
-            .collect()
-    }
-
-    fn next_level_index(&self, prefix: &Prefix) -> usize {
-        let mut i = 0;
-        for &level in &self.participating_levels {
-            if level >= prefix.len() {
-                break;
-            }
-            i += 1;
-        }
-        i
+            .copied()
+            .take_while(|&level| level < prefix.len())
+            .map(|level| &prefix[level]);
+        self.partial_prefixes.node_for(trie_prefix)
     }
 }
 
 impl PrefixExtender for FromPrefixesExtender {
     fn count(&self, prefix: &Prefix) -> usize {
-        self.matching_prefixes(prefix).len()
+        self.trie_node_for(prefix)
+            .map_or(0, TrieNode::descendant_count)
     }
 
     fn propose(&self, prefix: &Prefix) -> Vec<Extension> {
-        let idx = self.next_level_index(prefix);
-        let mut extensions: Vec<_> = self
-            .matching_prefixes(prefix)
-            .into_iter()
-            .filter_map(|p| p.get(idx).cloned())
-            .collect();
+        let Some(node) = self.trie_node_for(prefix) else {
+            return vec![];
+        };
+        let mut extensions: Vec<_> = node.children().keys().cloned().collect();
         extensions.sort();
-        extensions.dedup();
         extensions
     }
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
-        let idx = self.next_level_index(prefix);
-        let valid_extensions: HashSet<_> = self
-            .matching_prefixes(prefix)
-            .into_iter()
-            .filter_map(|p| p.get(idx))
-            .collect();
+        let Some(node) = self.trie_node_for(prefix) else {
+            return vec![];
+        };
         extensions
             .iter()
-            .filter(|ext| valid_extensions.contains(ext))
+            .filter(|ext| node.children().contains_key(*ext))
             .cloned()
             .collect()
     }
@@ -736,6 +719,43 @@ mod tests {
             extender.intersect(&vec![b("z")], &[b("a"), b("b"), b("x"), b("y")]),
             Vec::<Bytes>::new()
         );
+    }
+
+    #[test]
+    fn test_from_prefixes_extender_counts_shared_prefix_rows() {
+        let extender = FromPrefixesExtender::new(
+            vec![0, 1],
+            vec![
+                vec![b("a"), b("x")],
+                vec![b("a"), b("y")],
+                vec![b("b"), b("z")],
+            ],
+        );
+
+        assert_eq!(extender.count(&vec![]), 3);
+        assert_eq!(extender.count(&vec![b("a")]), 2);
+        assert_eq!(extender.propose(&vec![b("a")]), vec![b("x"), b("y")]);
+        assert_eq!(
+            extender.intersect(&vec![b("a")], &[b("y"), b("z"), b("x")]),
+            vec![b("y"), b("x")]
+        );
+    }
+
+    #[test]
+    fn test_from_prefixes_extender_deduplicates_duplicate_prefixes() {
+        let extender = FromPrefixesExtender::new(
+            vec![0, 1],
+            vec![
+                vec![b("a"), b("b")],
+                vec![b("a"), b("b")],
+                vec![b("a"), b("c")],
+            ],
+        );
+
+        assert_eq!(extender.count(&vec![]), 2);
+        assert_eq!(extender.count(&vec![b("a")]), 2);
+        assert_eq!(extender.propose(&vec![]), vec![b("a")]);
+        assert_eq!(extender.propose(&vec![b("a")]), vec![b("b"), b("c")]);
     }
 
     #[test]

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -1,3 +1,4 @@
 pub mod generic_join;
 pub mod join;
 pub mod leapfrog;
+pub(crate) mod trie;

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -38,18 +38,37 @@ where
         Q: Eq + Hash + ?Sized + 'a,
         I: IntoIterator<Item = &'a Q>,
     {
+        self.node_for(values).is_some()
+    }
+
+    pub(crate) fn node_for<'a, Q, I>(&self, values: I) -> Option<&TrieNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized + 'a,
+        I: IntoIterator<Item = &'a Q>,
+    {
         let mut node = &self.root;
         for value in values {
-            let Some(child) = node.children.get(value) else {
-                return false;
-            };
-            node = child;
+            node = node.children.get(value)?;
         }
-        true
+        Some(node)
+    }
+
+    pub(crate) fn node_for_mut<'a, Q, I>(&mut self, values: I) -> Option<&mut TrieNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized + 'a,
+        I: IntoIterator<Item = &'a Q>,
+    {
+        let mut node = &mut self.root;
+        for value in values {
+            node = node.children.get_mut(value)?;
+        }
+        Some(node)
     }
 }
 
-struct TrieNode<T> {
+pub(crate) struct TrieNode<T> {
     children: HashMap<T, TrieNode<T>>,
 }
 
@@ -123,5 +142,28 @@ mod tests {
         assert!(trie.contains_prefix(["a"].iter()));
         assert!(trie.contains_prefix(["a", "x"].iter()));
         assert!(!trie.contains_prefix(["x"].iter()));
+    }
+
+    #[test]
+    fn node_for_finds_existing_prefix() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x"]);
+
+        assert!(trie.node_for(["a"].iter()).is_some());
+        assert!(trie.node_for(["a", "x"].iter()).is_some());
+        assert!(trie.node_for(["a", "z"].iter()).is_none());
+    }
+
+    #[test]
+    fn node_for_mut_allows_insertion_from_existing_prefix() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x"]);
+
+        let a = trie.node_for_mut(["a"].iter()).unwrap();
+        a.insert("y");
+
+        assert!(trie.contains_prefix(["a", "x"].iter()));
+        assert!(trie.contains_prefix(["a", "y"].iter()));
+        assert!(!trie.contains_prefix(["y"].iter()));
     }
 }

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -28,7 +28,7 @@ where
     {
         let mut node = &mut self.root;
         for value in values {
-            node = node.children.entry(value).or_default();
+            node = node.insert(value);
         }
     }
 
@@ -58,6 +58,15 @@ impl<T> Default for TrieNode<T> {
         Self {
             children: HashMap::new(),
         }
+    }
+}
+
+impl<T> TrieNode<T>
+where
+    T: Eq + Hash,
+{
+    pub(crate) fn insert(&mut self, value: T) -> &mut TrieNode<T> {
+        self.children.entry(value).or_default()
     }
 }
 
@@ -102,5 +111,17 @@ mod tests {
 
         assert!(trie.contains_prefix(["a"].iter()));
         assert!(trie.contains_prefix(["a", "x"].iter()));
+    }
+
+    #[test]
+    fn node_insert_adds_one_child_value() {
+        let mut trie = Trie::new();
+
+        let a = trie.root.insert("a");
+        a.insert("x");
+
+        assert!(trie.contains_prefix(["a"].iter()));
+        assert!(trie.contains_prefix(["a", "x"].iter()));
+        assert!(!trie.contains_prefix(["x"].iter()));
     }
 }

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -1,0 +1,175 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+pub(crate) struct Trie<T> {
+    root: TrieNode<T>,
+}
+
+impl<T> Default for Trie<T> {
+    fn default() -> Self {
+        Self {
+            root: TrieNode::default(),
+        }
+    }
+}
+
+impl<T> Trie<T>
+where
+    T: Eq + Hash,
+{
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert<I>(&mut self, values: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let values: Vec<T> = values.into_iter().collect();
+        if self
+            .node_for(values.iter())
+            .is_some_and(|node| node.is_terminal)
+        {
+            return;
+        }
+
+        let mut node = &mut self.root;
+        node.terminal_descendants += 1;
+        for value in values {
+            node = node.insert_child(value);
+            node.terminal_descendants += 1;
+        }
+        node.is_terminal = true;
+    }
+
+    pub(crate) fn node_for<'a, Q, I>(&self, values: I) -> Option<&TrieNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized + 'a,
+        I: IntoIterator<Item = &'a Q>,
+    {
+        let mut node = &self.root;
+        for value in values {
+            node = node.children.get(value)?;
+        }
+        Some(node)
+    }
+
+    pub(crate) fn node_for_mut<'a, Q, I>(&mut self, values: I) -> Option<&mut TrieNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized + 'a,
+        I: IntoIterator<Item = &'a Q>,
+    {
+        let mut node = &mut self.root;
+        for value in values {
+            node = node.children.get_mut(value)?;
+        }
+        Some(node)
+    }
+}
+
+pub(crate) struct TrieNode<T> {
+    children: HashMap<T, TrieNode<T>>,
+    is_terminal: bool,
+    terminal_descendants: usize,
+}
+
+impl<T> Default for TrieNode<T> {
+    fn default() -> Self {
+        Self {
+            children: HashMap::new(),
+            is_terminal: false,
+            terminal_descendants: 0,
+        }
+    }
+}
+
+impl<T> TrieNode<T>
+where
+    T: Eq + Hash,
+{
+    pub(crate) fn children(&self) -> &HashMap<T, TrieNode<T>> {
+        &self.children
+    }
+
+    pub(crate) fn descendant_count(&self) -> usize {
+        self.terminal_descendants
+    }
+
+    pub(crate) fn insert_child(&mut self, value: T) -> &mut TrieNode<T> {
+        self.children.entry(value).or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Trie;
+
+    #[test]
+    fn root_lookup_accepts_empty_prefix() {
+        let trie = Trie::<&str>::new();
+
+        let root = trie.node_for(std::iter::empty::<&str>());
+
+        assert!(root.is_some());
+        assert!(root.unwrap().children().is_empty());
+        assert_eq!(root.unwrap().descendant_count(), 0);
+    }
+
+    #[test]
+    fn finds_inserted_full_and_partial_prefixes() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x"]);
+        trie.insert(["a", "y"]);
+        trie.insert(["b", "z"]);
+
+        let root = trie.node_for(std::iter::empty::<&str>()).unwrap();
+        let a = trie.node_for(["a"].iter()).unwrap();
+        let ax = trie.node_for(["a", "x"].iter()).unwrap();
+
+        assert_eq!(root.children().len(), 2);
+        assert_eq!(a.children().len(), 2);
+        assert!(ax.children().is_empty());
+        assert_eq!(root.descendant_count(), 3);
+        assert_eq!(a.descendant_count(), 2);
+        assert_eq!(ax.descendant_count(), 1);
+    }
+
+    #[test]
+    fn missing_prefixes_return_none() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x"]);
+
+        assert!(trie.node_for(["b"].iter()).is_none());
+        assert!(trie.node_for(["a", "z"].iter()).is_none());
+    }
+
+    #[test]
+    fn duplicate_inserts_do_not_duplicate_children() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x"]);
+        trie.insert(["a", "x"]);
+        trie.insert(["a", "y"]);
+
+        let root = trie.node_for(std::iter::empty::<&str>()).unwrap();
+        let a = trie.node_for(["a"].iter()).unwrap();
+
+        assert_eq!(root.children().len(), 1);
+        assert_eq!(a.children().len(), 2);
+        assert_eq!(root.descendant_count(), 2);
+        assert_eq!(a.descendant_count(), 2);
+    }
+
+    #[test]
+    fn mutable_node_lookup_can_insert_child() {
+        let mut trie = Trie::new();
+        trie.insert(["branch"]);
+
+        let branch = trie.node_for_mut(["branch"].iter()).unwrap();
+        branch.insert_child("value");
+
+        assert!(trie.node_for(["branch", "value"].iter()).is_some());
+    }
+}

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -38,10 +38,10 @@ where
         Q: Eq + Hash + ?Sized + 'a,
         I: IntoIterator<Item = &'a Q>,
     {
-        self.node_for(values).is_some()
+        self.node(values).is_some()
     }
 
-    pub(crate) fn node_for<'a, Q, I>(&self, values: I) -> Option<&TrieNode<T>>
+    pub(crate) fn node<'a, Q, I>(&self, values: I) -> Option<&TrieNode<T>>
     where
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized + 'a,
@@ -54,7 +54,7 @@ where
         Some(node)
     }
 
-    pub(crate) fn node_for_mut<'a, Q, I>(&mut self, values: I) -> Option<&mut TrieNode<T>>
+    pub(crate) fn node_mut<'a, Q, I>(&mut self, values: I) -> Option<&mut TrieNode<T>>
     where
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized + 'a,
@@ -145,21 +145,21 @@ mod tests {
     }
 
     #[test]
-    fn node_for_finds_existing_prefix() {
+    fn node_finds_existing_prefix() {
         let mut trie = Trie::new();
         trie.insert(["a", "x"]);
 
-        assert!(trie.node_for(["a"].iter()).is_some());
-        assert!(trie.node_for(["a", "x"].iter()).is_some());
-        assert!(trie.node_for(["a", "z"].iter()).is_none());
+        assert!(trie.node(["a"].iter()).is_some());
+        assert!(trie.node(["a", "x"].iter()).is_some());
+        assert!(trie.node(["a", "z"].iter()).is_none());
     }
 
     #[test]
-    fn node_for_mut_allows_insertion_from_existing_prefix() {
+    fn node_mut_allows_insertion_from_existing_prefix() {
         let mut trie = Trie::new();
         trie.insert(["a", "x"]);
 
-        let a = trie.node_for_mut(["a"].iter()).unwrap();
+        let a = trie.node_mut(["a"].iter()).unwrap();
         a.insert("y");
 
         assert!(trie.contains_prefix(["a", "x"].iter()));

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -26,24 +26,13 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        let values: Vec<T> = values.into_iter().collect();
-        if self
-            .node_for(values.iter())
-            .is_some_and(|node| node.is_terminal)
-        {
-            return;
-        }
-
         let mut node = &mut self.root;
-        node.terminal_descendants += 1;
         for value in values {
-            node = node.insert_child(value);
-            node.terminal_descendants += 1;
+            node = node.children.entry(value).or_default();
         }
-        node.is_terminal = true;
     }
 
-    pub(crate) fn node_for<'a, Q, I>(&self, values: I) -> Option<&TrieNode<T>>
+    pub(crate) fn contains_prefix<'a, Q, I>(&self, values: I) -> bool
     where
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized + 'a,
@@ -51,55 +40,24 @@ where
     {
         let mut node = &self.root;
         for value in values {
-            node = node.children.get(value)?;
+            let Some(child) = node.children.get(value) else {
+                return false;
+            };
+            node = child;
         }
-        Some(node)
-    }
-
-    pub(crate) fn node_for_mut<'a, Q, I>(&mut self, values: I) -> Option<&mut TrieNode<T>>
-    where
-        T: Borrow<Q>,
-        Q: Eq + Hash + ?Sized + 'a,
-        I: IntoIterator<Item = &'a Q>,
-    {
-        let mut node = &mut self.root;
-        for value in values {
-            node = node.children.get_mut(value)?;
-        }
-        Some(node)
+        true
     }
 }
 
-pub(crate) struct TrieNode<T> {
+struct TrieNode<T> {
     children: HashMap<T, TrieNode<T>>,
-    is_terminal: bool,
-    terminal_descendants: usize,
 }
 
 impl<T> Default for TrieNode<T> {
     fn default() -> Self {
         Self {
             children: HashMap::new(),
-            is_terminal: false,
-            terminal_descendants: 0,
         }
-    }
-}
-
-impl<T> TrieNode<T>
-where
-    T: Eq + Hash,
-{
-    pub(crate) fn children(&self) -> &HashMap<T, TrieNode<T>> {
-        &self.children
-    }
-
-    pub(crate) fn descendant_count(&self) -> usize {
-        self.terminal_descendants
-    }
-
-    pub(crate) fn insert_child(&mut self, value: T) -> &mut TrieNode<T> {
-        self.children.entry(value).or_default()
     }
 }
 
@@ -108,68 +66,41 @@ mod tests {
     use super::Trie;
 
     #[test]
-    fn root_lookup_accepts_empty_prefix() {
+    fn empty_prefix_is_always_present() {
         let trie = Trie::<&str>::new();
 
-        let root = trie.node_for(std::iter::empty::<&str>());
-
-        assert!(root.is_some());
-        assert!(root.unwrap().children().is_empty());
-        assert_eq!(root.unwrap().descendant_count(), 0);
+        assert!(trie.contains_prefix(std::iter::empty::<&str>()));
     }
 
     #[test]
-    fn finds_inserted_full_and_partial_prefixes() {
+    fn contains_inserted_full_and_partial_prefixes() {
         let mut trie = Trie::new();
         trie.insert(["a", "x"]);
         trie.insert(["a", "y"]);
         trie.insert(["b", "z"]);
 
-        let root = trie.node_for(std::iter::empty::<&str>()).unwrap();
-        let a = trie.node_for(["a"].iter()).unwrap();
-        let ax = trie.node_for(["a", "x"].iter()).unwrap();
-
-        assert_eq!(root.children().len(), 2);
-        assert_eq!(a.children().len(), 2);
-        assert!(ax.children().is_empty());
-        assert_eq!(root.descendant_count(), 3);
-        assert_eq!(a.descendant_count(), 2);
-        assert_eq!(ax.descendant_count(), 1);
+        assert!(trie.contains_prefix(["a"].iter()));
+        assert!(trie.contains_prefix(["a", "x"].iter()));
+        assert!(trie.contains_prefix(["a", "y"].iter()));
+        assert!(trie.contains_prefix(["b", "z"].iter()));
     }
 
     #[test]
-    fn missing_prefixes_return_none() {
+    fn missing_prefixes_return_false() {
         let mut trie = Trie::new();
         trie.insert(["a", "x"]);
 
-        assert!(trie.node_for(["b"].iter()).is_none());
-        assert!(trie.node_for(["a", "z"].iter()).is_none());
+        assert!(!trie.contains_prefix(["b"].iter()));
+        assert!(!trie.contains_prefix(["a", "z"].iter()));
     }
 
     #[test]
-    fn duplicate_inserts_do_not_duplicate_children() {
+    fn duplicate_inserts_keep_prefix_present() {
         let mut trie = Trie::new();
         trie.insert(["a", "x"]);
         trie.insert(["a", "x"]);
-        trie.insert(["a", "y"]);
 
-        let root = trie.node_for(std::iter::empty::<&str>()).unwrap();
-        let a = trie.node_for(["a"].iter()).unwrap();
-
-        assert_eq!(root.children().len(), 1);
-        assert_eq!(a.children().len(), 2);
-        assert_eq!(root.descendant_count(), 2);
-        assert_eq!(a.descendant_count(), 2);
-    }
-
-    #[test]
-    fn mutable_node_lookup_can_insert_child() {
-        let mut trie = Trie::new();
-        trie.insert(["branch"]);
-
-        let branch = trie.node_for_mut(["branch"].iter()).unwrap();
-        branch.insert_child("value");
-
-        assert!(trie.node_for(["branch", "value"].iter()).is_some());
+        assert!(trie.contains_prefix(["a"].iter()));
+        assert!(trie.contains_prefix(["a", "x"].iter()));
     }
 }


### PR DESCRIPTION
## Summary
- add an internal generic trie for sequence prefix membership checks
- keep `FromPrefixesExtender` on its existing list-backed implementation for now
- cover inserted, missing, duplicate, full, and partial prefix membership behavior

## Verification
- `cargo test -p triplox algo::trie`
- `cargo test -p triplox generic_join::tests::test_from_prefixes -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace`

Autogenerated with Codex GPT-5.