### PR TITLE
Preserve `or` idenity in branches; fix #374.

### DIFF
--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -87,6 +87,15 @@ where
     pub(crate) fn insert(&mut self, value: T) -> &mut TrieNode<T> {
         self.children.entry(value).or_default()
     }
+
+    pub(crate) fn insert_all(&mut self, values: &[T])
+    where
+        T: Clone,
+    {
+        for value in values {
+            self.insert(value.clone());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +151,19 @@ mod tests {
         assert!(trie.contains_prefix(["a"].iter()));
         assert!(trie.contains_prefix(["a", "x"].iter()));
         assert!(!trie.contains_prefix(["x"].iter()));
+    }
+
+    #[test]
+    fn node_insert_all_adds_non_copy_child_values() {
+        let mut trie = Trie::new();
+
+        let a = trie.root.insert(String::from("a"));
+        a.insert_all(&[String::from("x"), String::from("y")]);
+
+        assert!(trie.contains_prefix([String::from("a")].iter()));
+        assert!(trie.contains_prefix([String::from("a"), String::from("x")].iter()));
+        assert!(trie.contains_prefix([String::from("a"), String::from("y")].iter()));
+        assert!(!trie.contains_prefix([String::from("x")].iter()));
     }
 
     #[test]

--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -88,12 +88,9 @@ where
         self.children.entry(value).or_default()
     }
 
-    pub(crate) fn insert_all(&mut self, values: &[T])
-    where
-        T: Clone,
-    {
+    pub(crate) fn insert_all(&mut self, values: impl IntoIterator<Item = T>) {
         for value in values {
-            self.insert(value.clone());
+            self.insert(value);
         }
     }
 }
@@ -158,7 +155,7 @@ mod tests {
         let mut trie = Trie::new();
 
         let a = trie.root.insert(String::from("a"));
-        a.insert_all(&[String::from("x"), String::from("y")]);
+        a.insert_all(vec![String::from("x"), String::from("y")]);
 
         assert!(trie.contains_prefix([String::from("a")].iter()));
         assert!(trie.contains_prefix([String::from("a"), String::from("x")].iter()));

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -13,7 +13,7 @@ use crate::algo::trie::Trie;
 /// - participates_in_level: true when any child participates
 pub struct GenericOrPrefixExtender {
     children: Vec<Box<dyn PrefixExtender>>,
-    // TODO: We could pass to a @ must self trait for PrefixExtender, then the RefCell is not needed.
+    // TODO: We could switch PrefixExtender to a &mut self receiver, then the RefCell is not needed.
     // This would require a larger refactor (worth it?)
     child_tries: Vec<RefCell<Trie<Extension>>>,
     levels: Vec<usize>,

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -118,7 +118,7 @@ mod tests {
         Bytes::from(n.to_be_bytes().to_vec())
     }
 
-    fn b(s: &str) -> Bytes {
+    fn bytes(s: &str) -> Bytes {
         Bytes::from(s.to_string())
     }
 
@@ -142,24 +142,24 @@ mod tests {
     #[test]
     fn test_or_extender_intersect_does_not_leak_across_branch_prefixes() {
         let branch_a = crate::iterator::GenericAndPrefixExtender::new(vec![
-            Box::new(FromPrefixExtender::new(vec![0], vec![b("a")])),
+            Box::new(FromPrefixExtender::new(vec![0], vec![bytes("a")])),
             Box::new(lt_age_predicate(30)),
         ]);
         let branch_b = crate::iterator::GenericAndPrefixExtender::new(vec![
-            Box::new(FromPrefixExtender::new(vec![0], vec![b("b")])),
+            Box::new(FromPrefixExtender::new(vec![0], vec![bytes("b")])),
             Box::new(lt_age_predicate(40)),
         ]);
         let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)], 2);
 
         assert_eq!(
-            or_ext.intersect(&vec![], &[b("a"), b("b")]),
-            vec![b("a"), b("b")]
+            or_ext.intersect(&vec![], &[bytes("a"), bytes("b")]),
+            vec![bytes("a"), bytes("b")]
         );
         assert_eq!(
-            or_ext.intersect(&vec![b("a")], &[long(35)]),
+            or_ext.intersect(&vec![bytes("a")], &[long(35)]),
             Vec::<Bytes>::new()
         );
-        assert_eq!(or_ext.intersect(&vec![b("b")], &[long(35)]), vec![long(35)]);
+        assert_eq!(or_ext.intersect(&vec![bytes("b")], &[long(35)]), vec![long(35)]);
     }
 
     #[test]
@@ -170,10 +170,10 @@ mod tests {
             crate::iterator::GenericAndPrefixExtender::new(vec![Box::new(lt_age_predicate(40))]);
         let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)], 2);
 
-        assert_eq!(or_ext.intersect(&vec![], &[b("entity")]), vec![b("entity")]);
-        assert_eq!(or_ext.count(&vec![b("entity")]), usize::MAX);
+        assert_eq!(or_ext.intersect(&vec![], &[bytes("entity")]), vec![bytes("entity")]);
+        assert_eq!(or_ext.count(&vec![bytes("entity")]), usize::MAX);
         assert_eq!(
-            or_ext.intersect(&vec![b("entity")], &[long(35)]),
+            or_ext.intersect(&vec![bytes("entity")], &[long(35)]),
             vec![long(35)]
         );
     }

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -1,14 +1,18 @@
+use std::cell::RefCell;
+
 use crate::algo::generic_join::{Extension, Prefix, PrefixExtender};
+use crate::algo::trie::Trie;
 
 /// An OR-combinator extender that unifies multiple child extenders with union semantics.
 ///
-/// All children must participate in the same levels (same free variables).
-/// - count: sum of all children's counts (upper bound)
-/// - propose: union of all children's proposals (sorted, deduplicated)
-/// - intersect: union of all children's intersections (sorted, deduplicated)
-/// - participates_in_level: delegates to the first child
+/// Child tries track which branches produced each OR-relevant prefix.
+/// - count: sum of matching children's counts (upper bound)
+/// - propose: union of matching children's proposals (sorted, deduplicated)
+/// - intersect: union of matching children's intersections (sorted, deduplicated)
+/// - participates_in_level: true when any child participates
 pub struct GenericOrPrefixExtender {
     children: Vec<Box<dyn PrefixExtender>>,
+    child_tries: Vec<RefCell<Trie<Extension>>>,
 }
 
 impl GenericOrPrefixExtender {
@@ -17,49 +21,107 @@ impl GenericOrPrefixExtender {
             !children.is_empty(),
             "OR extender requires at least one child"
         );
-        Self { children }
+        let child_tries = (0..children.len())
+            .map(|_| RefCell::new(Trie::new()))
+            .collect();
+        Self {
+            children,
+            child_tries,
+        }
+    }
+
+    fn relevant_prefix(&self, prefix: &Prefix) -> Prefix {
+        prefix
+            .iter()
+            .enumerate()
+            .filter(|(level, _)| self.child_participates_in_level(*level))
+            .map(|(_, value)| value.clone())
+            .collect()
+    }
+
+    fn child_participates_in_level(&self, level: usize) -> bool {
+        self.children
+            .iter()
+            .any(|child| child.participates_in_level(level))
+    }
+
+    fn child_matches_prefix(&self, child_idx: usize, relevant_prefix: &Prefix) -> bool {
+        self.child_tries[child_idx]
+            .borrow()
+            .contains_prefix(relevant_prefix.iter())
+    }
+
+    fn insert_child_extensions(
+        &self,
+        child_idx: usize,
+        relevant_prefix: &Prefix,
+        extensions: &[Extension],
+    ) {
+        let mut child_trie = self.child_tries[child_idx].borrow_mut();
+        let Some(node) = child_trie.node_mut(relevant_prefix.iter()) else {
+            return;
+        };
+        for extension in extensions {
+            node.insert(extension.clone());
+        }
     }
 }
 
 impl PrefixExtender for GenericOrPrefixExtender {
     fn count(&self, prefix: &Prefix) -> usize {
+        let relevant_prefix = self.relevant_prefix(prefix);
         self.children
             .iter()
-            .fold(0, |total, child| total.saturating_add(child.count(prefix)))
+            .enumerate()
+            .filter(|(idx, _)| self.child_matches_prefix(*idx, &relevant_prefix))
+            .fold(0, |total, (_, child)| {
+                total.saturating_add(child.count(prefix))
+            })
     }
 
     fn propose(&self, prefix: &Prefix) -> Vec<Extension> {
-        let mut all: Vec<Extension> = self
-            .children
-            .iter()
-            .flat_map(|c| c.propose(prefix))
-            .collect();
+        let relevant_prefix = self.relevant_prefix(prefix);
+        let mut all = Vec::new();
+        for (idx, child) in self.children.iter().enumerate() {
+            if !self.child_matches_prefix(idx, &relevant_prefix) {
+                continue;
+            }
+            let proposals = child.propose(prefix);
+            self.insert_child_extensions(idx, &relevant_prefix, &proposals);
+            all.extend(proposals);
+        }
         all.sort();
         all.dedup();
         all
     }
 
     fn intersect(&self, prefix: &Prefix, extensions: &[Extension]) -> Vec<Extension> {
-        let mut all: Vec<Extension> = self
-            .children
-            .iter()
-            .flat_map(|c| c.intersect(prefix, extensions))
-            .collect();
+        let relevant_prefix = self.relevant_prefix(prefix);
+        let mut all = Vec::new();
+        for (idx, child) in self.children.iter().enumerate() {
+            if !self.child_matches_prefix(idx, &relevant_prefix) {
+                continue;
+            }
+            let child_extensions = child.intersect(prefix, extensions);
+            self.insert_child_extensions(idx, &relevant_prefix, &child_extensions);
+            all.extend(child_extensions);
+        }
         all.sort();
         all.dedup();
         all
     }
 
     fn participates_in_level(&self, level: usize) -> bool {
-        self.children[0].participates_in_level(level)
+        self.child_participates_in_level(level)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algo::generic_join::{GenericJoin, SingleLevelExtender};
-    use crate::expr::Expr;
+    use crate::algo::generic_join::{FromPrefixExtender, GenericJoin, SingleLevelExtender};
+    use crate::codec::Encode;
+    use crate::expr::{BinaryExpr, BinaryOp, Expr};
     use crate::iterator::GenericPredicatePrefixExtender;
     use crate::ops::DataType;
     use bytes::Bytes;
@@ -67,6 +129,66 @@ mod tests {
 
     fn bi(n: i32) -> Bytes {
         Bytes::from(n.to_be_bytes().to_vec())
+    }
+
+    fn b(s: &str) -> Bytes {
+        Bytes::from(s.to_string())
+    }
+
+    fn long(n: i64) -> Bytes {
+        Bytes::from(DataType::Long(n).encode())
+    }
+
+    fn lt_age_predicate(limit: i64) -> GenericPredicatePrefixExtender {
+        GenericPredicatePrefixExtender::new(
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(Expr::Variable("?age".to_var())),
+                op: BinaryOp::Lt,
+                right: Box::new(Expr::Literal(DataType::Long(limit))),
+            }),
+            vec![],
+            "?age".to_var(),
+            1,
+        )
+    }
+
+    #[test]
+    fn test_or_extender_intersect_does_not_leak_across_branch_prefixes() {
+        let branch_a = crate::iterator::GenericAndPrefixExtender::new(vec![
+            Box::new(FromPrefixExtender::new(vec![0], vec![b("a")])),
+            Box::new(lt_age_predicate(30)),
+        ]);
+        let branch_b = crate::iterator::GenericAndPrefixExtender::new(vec![
+            Box::new(FromPrefixExtender::new(vec![0], vec![b("b")])),
+            Box::new(lt_age_predicate(40)),
+        ]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)]);
+
+        assert_eq!(
+            or_ext.intersect(&vec![], &[b("a"), b("b")]),
+            vec![b("a"), b("b")]
+        );
+        assert_eq!(
+            or_ext.intersect(&vec![b("a")], &[long(35)]),
+            Vec::<Bytes>::new()
+        );
+        assert_eq!(or_ext.intersect(&vec![b("b")], &[long(35)]), vec![long(35)]);
+    }
+
+    #[test]
+    fn test_or_extender_predicate_only_branches_can_filter_bound_values() {
+        let branch_a =
+            crate::iterator::GenericAndPrefixExtender::new(vec![Box::new(lt_age_predicate(30))]);
+        let branch_b =
+            crate::iterator::GenericAndPrefixExtender::new(vec![Box::new(lt_age_predicate(40))]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)]);
+
+        assert_eq!(or_ext.intersect(&vec![], &[b("entity")]), vec![b("entity")]);
+        assert_eq!(or_ext.count(&vec![b("entity")]), usize::MAX);
+        assert_eq!(
+            or_ext.intersect(&vec![b("entity")], &[long(35)]),
+            vec![long(35)]
+        );
     }
 
     #[test]

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -5,6 +5,7 @@ use crate::algo::trie::Trie;
 
 /// An OR-combinator extender that unifies multiple child extenders with union semantics.
 ///
+/// Validation assures that all children participate in the same levels.
 /// Child tries track which branches produced each OR-relevant prefix.
 /// - count: sum of matching children's counts (upper bound)
 /// - propose: union of matching children's proposals (sorted, deduplicated)
@@ -12,6 +13,7 @@ use crate::algo::trie::Trie;
 /// - participates_in_level: true when any child participates
 pub struct GenericOrPrefixExtender {
     children: Vec<Box<dyn PrefixExtender>>,
+    // TODO: We could pass to a @ must self trait for PrefixExtender, then the RefCell is not needed.
     child_tries: Vec<RefCell<Trie<Extension>>>,
 }
 

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -13,38 +13,35 @@ use crate::algo::trie::Trie;
 /// - participates_in_level: true when any child participates
 pub struct GenericOrPrefixExtender {
     children: Vec<Box<dyn PrefixExtender>>,
+    levels: Vec<usize>,
     // TODO: We could pass to a @ must self trait for PrefixExtender, then the RefCell is not needed.
     child_tries: Vec<RefCell<Trie<Extension>>>,
 }
 
 impl GenericOrPrefixExtender {
-    pub fn new(children: Vec<Box<dyn PrefixExtender>>) -> Self {
+    pub fn new(children: Vec<Box<dyn PrefixExtender>>, num_levels: usize) -> Self {
         assert!(
             !children.is_empty(),
             "OR extender requires at least one child"
         );
+        let levels = (0..num_levels)
+            .filter(|level| children[0].participates_in_level(*level))
+            .collect();
         let child_tries = (0..children.len())
             .map(|_| RefCell::new(Trie::new()))
             .collect();
         Self {
             children,
+            levels,
             child_tries,
         }
     }
 
     fn relevant_prefix(&self, prefix: &Prefix) -> Prefix {
-        prefix
+        self.levels
             .iter()
-            .enumerate()
-            .filter(|(level, _)| self.child_participates_in_level(*level))
-            .map(|(_, value)| value.clone())
+            .filter_map(|level| prefix.get(*level).cloned())
             .collect()
-    }
-
-    fn child_participates_in_level(&self, level: usize) -> bool {
-        self.children
-            .iter()
-            .any(|child| child.participates_in_level(level))
     }
 
     fn child_matches_prefix(&self, child_idx: usize, relevant_prefix: &Prefix) -> bool {
@@ -114,7 +111,7 @@ impl PrefixExtender for GenericOrPrefixExtender {
     }
 
     fn participates_in_level(&self, level: usize) -> bool {
-        self.child_participates_in_level(level)
+        self.levels.contains(&level)
     }
 }
 
@@ -164,7 +161,7 @@ mod tests {
             Box::new(FromPrefixExtender::new(vec![0], vec![b("b")])),
             Box::new(lt_age_predicate(40)),
         ]);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)], 2);
 
         assert_eq!(
             or_ext.intersect(&vec![], &[b("a"), b("b")]),
@@ -183,7 +180,7 @@ mod tests {
             crate::iterator::GenericAndPrefixExtender::new(vec![Box::new(lt_age_predicate(30))]);
         let branch_b =
             crate::iterator::GenericAndPrefixExtender::new(vec![Box::new(lt_age_predicate(40))]);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(branch_a), Box::new(branch_b)], 2);
 
         assert_eq!(or_ext.intersect(&vec![], &[b("entity")]), vec![b("entity")]);
         assert_eq!(or_ext.count(&vec![b("entity")]), usize::MAX);
@@ -197,7 +194,7 @@ mod tests {
     fn test_or_extender_count_sums_children() {
         let ext1 = SingleLevelExtender::new(vec![bi(1), bi(2), bi(3)], 0);
         let ext2 = SingleLevelExtender::new(vec![bi(4), bi(5)], 0);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)], 1);
         assert_eq!(or_ext.count(&vec![]), 5);
     }
 
@@ -215,7 +212,7 @@ mod tests {
             "?x".to_var(),
             0,
         );
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(pred1), Box::new(pred2)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(pred1), Box::new(pred2)], 1);
 
         assert_eq!(or_ext.count(&vec![]), usize::MAX);
     }
@@ -224,7 +221,7 @@ mod tests {
     fn test_or_extender_propose_returns_sorted_union() {
         let ext1 = SingleLevelExtender::new(vec![bi(1), bi(3), bi(5)], 0);
         let ext2 = SingleLevelExtender::new(vec![bi(2), bi(3), bi(4)], 0);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)], 1);
         let proposed = or_ext.propose(&vec![]);
         assert_eq!(proposed, vec![bi(1), bi(2), bi(3), bi(4), bi(5)]);
     }
@@ -233,7 +230,7 @@ mod tests {
     fn test_or_extender_intersect_returns_union_of_matching() {
         let ext1 = SingleLevelExtender::new(vec![bi(1), bi(3)], 0);
         let ext2 = SingleLevelExtender::new(vec![bi(2), bi(4)], 0);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)], 1);
         let candidates = vec![bi(1), bi(2), bi(5)];
         let result = or_ext.intersect(&vec![], &candidates);
         assert_eq!(result, vec![bi(1), bi(2)]);
@@ -243,7 +240,7 @@ mod tests {
     fn test_or_extender_participates_in_level() {
         let ext1 = SingleLevelExtender::new(vec![bi(1)], 0);
         let ext2 = SingleLevelExtender::new(vec![bi(2)], 0);
-        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)]);
+        let or_ext = GenericOrPrefixExtender::new(vec![Box::new(ext1), Box::new(ext2)], 2);
         assert!(or_ext.participates_in_level(0));
         assert!(!or_ext.participates_in_level(1));
     }
@@ -254,7 +251,8 @@ mod tests {
         // Constrained by even numbers => {2,4}
         let or_ext1 = SingleLevelExtender::new(vec![bi(1), bi(2), bi(3)], 0);
         let or_ext2 = SingleLevelExtender::new(vec![bi(3), bi(4), bi(5)], 0);
-        let or_extender = GenericOrPrefixExtender::new(vec![Box::new(or_ext1), Box::new(or_ext2)]);
+        let or_extender =
+            GenericOrPrefixExtender::new(vec![Box::new(or_ext1), Box::new(or_ext2)], 1);
         let even_extender = SingleLevelExtender::new(vec![bi(2), bi(4), bi(6)], 0);
 
         let extenders: Vec<&dyn PrefixExtender> = vec![&or_extender, &even_extender];
@@ -267,6 +265,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "OR extender requires at least one child")]
     fn test_or_extender_empty_children_panics() {
-        GenericOrPrefixExtender::new(vec![]);
+        GenericOrPrefixExtender::new(vec![], 0);
     }
 }

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -73,8 +73,8 @@ impl PrefixExtender for GenericOrPrefixExtender {
                 continue;
             };
             let proposals = child.propose(prefix);
-            node.insert_all(&proposals);
-            all.extend(proposals);
+            all.extend(proposals.iter().cloned());
+            node.insert_all(proposals);
         }
         all.sort();
         all.dedup();
@@ -90,8 +90,8 @@ impl PrefixExtender for GenericOrPrefixExtender {
                 continue;
             };
             let child_extensions = child.intersect(prefix, extensions);
-            node.insert_all(&child_extensions);
-            all.extend(child_extensions);
+            all.extend(child_extensions.iter().cloned());
+            node.insert_all(child_extensions);
         }
         all.sort();
         all.dedup();

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -50,21 +50,6 @@ impl GenericOrPrefixExtender {
             .borrow()
             .contains_prefix(relevant_prefix.iter())
     }
-
-    fn insert_child_extensions(
-        &self,
-        child_idx: usize,
-        relevant_prefix: &Prefix,
-        extensions: &[Extension],
-    ) {
-        let mut child_trie = self.child_tries[child_idx].borrow_mut();
-        let Some(node) = child_trie.node_mut(relevant_prefix.iter()) else {
-            return;
-        };
-        for extension in extensions {
-            node.insert(extension.clone());
-        }
-    }
 }
 
 impl PrefixExtender for GenericOrPrefixExtender {
@@ -83,11 +68,12 @@ impl PrefixExtender for GenericOrPrefixExtender {
         let relevant_prefix = self.relevant_prefix(prefix);
         let mut all = Vec::new();
         for (idx, child) in self.children.iter().enumerate() {
-            if !self.child_matches_prefix(idx, &relevant_prefix) {
+            let mut child_trie = self.child_tries[idx].borrow_mut();
+            let Some(node) = child_trie.node_mut(relevant_prefix.iter()) else {
                 continue;
-            }
+            };
             let proposals = child.propose(prefix);
-            self.insert_child_extensions(idx, &relevant_prefix, &proposals);
+            node.insert_all(&proposals);
             all.extend(proposals);
         }
         all.sort();
@@ -99,11 +85,12 @@ impl PrefixExtender for GenericOrPrefixExtender {
         let relevant_prefix = self.relevant_prefix(prefix);
         let mut all = Vec::new();
         for (idx, child) in self.children.iter().enumerate() {
-            if !self.child_matches_prefix(idx, &relevant_prefix) {
+            let mut child_trie = self.child_tries[idx].borrow_mut();
+            let Some(node) = child_trie.node_mut(relevant_prefix.iter()) else {
                 continue;
-            }
+            };
             let child_extensions = child.intersect(prefix, extensions);
-            self.insert_child_extensions(idx, &relevant_prefix, &child_extensions);
+            node.insert_all(&child_extensions);
             all.extend(child_extensions);
         }
         all.sort();

--- a/src/iterator/generic_or_prefix_extender.rs
+++ b/src/iterator/generic_or_prefix_extender.rs
@@ -13,9 +13,10 @@ use crate::algo::trie::Trie;
 /// - participates_in_level: true when any child participates
 pub struct GenericOrPrefixExtender {
     children: Vec<Box<dyn PrefixExtender>>,
-    levels: Vec<usize>,
     // TODO: We could pass to a @ must self trait for PrefixExtender, then the RefCell is not needed.
+    // This would require a larger refactor (worth it?)
     child_tries: Vec<RefCell<Trie<Extension>>>,
+    levels: Vec<usize>,
 }
 
 impl GenericOrPrefixExtender {
@@ -24,16 +25,16 @@ impl GenericOrPrefixExtender {
             !children.is_empty(),
             "OR extender requires at least one child"
         );
-        let levels = (0..num_levels)
-            .filter(|level| children[0].participates_in_level(*level))
-            .collect();
         let child_tries = (0..children.len())
             .map(|_| RefCell::new(Trie::new()))
             .collect();
+        let levels = (0..num_levels)
+            .filter(|level| children[0].participates_in_level(*level))
+            .collect();
         Self {
             children,
-            levels,
             child_tries,
+            levels,
         }
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1091,6 +1091,7 @@ where
             Ok(Box::new(extender))
         }
         WhereClause::OrJoin(oj) => {
+            let num_levels = join_order.len();
             let children: Vec<Box<dyn PrefixExtender>> = oj
                 .clauses
                 .iter()
@@ -1107,7 +1108,7 @@ where
                     )
                 })
                 .collect::<Result<_, _>>()?;
-            Ok(Box::new(GenericOrPrefixExtender::new(children)))
+            Ok(Box::new(GenericOrPrefixExtender::new(children, num_levels)))
         }
         WhereClause::NotJoin(nj) => {
             let children: Vec<Box<dyn PrefixExtender>> = nj

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -204,6 +204,41 @@
                       (or (and [?e :sex :female]
                                [?e :name "Ivan"]))]}))))
 
+(deftest test-or-branch-predicates-preserve-branch-identity
+  (tc/transact *conn* [{:name "A" :age 35}
+                       {:name "B" :age 35}])
+
+  (is (= #{["B" 35]}
+         (q '{:find [?name ?age]
+              :where [[?e :age ?age]
+                      (or
+                       (and [?e :name "A"]
+                            [(< ?age 30)])
+                       (and [?e :name "B"]
+                            [(< ?age 40)]))
+                      [?e :name ?name]]}))))
+
+(deftest test-or-predicate-only-branches-can-filter-bound-values
+  (tc/transact *conn* [{:name "A" :age 35}])
+
+  (is (= #{[35]}
+         (q '{:find [?age]
+              :where [[?e :age ?age]
+                      (or
+                       [(< ?age 30)]
+                       [(< ?age 40)])]}))))
+
+(deftest test-or-and-branch-predicate-after-terminal-triple-does-not-over-index
+  (tc/transact *conn* [{:name "A" :age 35}
+                       {:name "B" :age 50}])
+
+  (is (= #{["A" 35]}
+         (q '{:find [?name ?age]
+              :where [[?e :age ?age]
+                      (or (and [?e :name "A"]
+                               [(< ?age 40)]))
+                      [?e :name ?name]]}))))
+
 (deftest test-ors-must-use-same-vars
   (is (thrown? TriploxException
                (q '{:find [?e]

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -230,7 +230,7 @@
 
 (deftest test-or-and-branch-predicate-after-terminal-triple-does-not-over-index
   (tc/transact *conn* [{:name "A" :age 35}
-                       {:name "B" :age 50}])
+                       {:name "B" :age 35}])
 
   (is (= #{["A" 35]}
          (q '{:find [?name ?age]

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -218,6 +218,25 @@
                             [(< ?age 40)]))
                       [?e :name ?name]]}))))
 
+#_
+(deftest test-or-and-branch-predicates-stay-bound-to-same-prefix
+  (tc/transact *conn* [{:db/ident :limit
+                        :db/valueType :db.type/long
+                        :db/cardinality :db.cardinality/one}])
+  (tc/transact *conn* [{:name "valid" :age 5 :salary 10 :limit 5}
+                       {:name "leaked" :age 20 :salary 10 :limit 5}])
+
+  (is (= #{["valid"]}
+         (q '{:find [?name]
+              :where [[?e :name ?name]
+                      [?e :age ?age]
+                      [?e :salary ?score]
+                      [?e :limit ?limit]
+                      (or (and [(< ?age ?score)]
+                               [(< ?limit 10)])
+                          (and [(> ?age ?score)]
+                               [(< ?limit 0)]))]}))))
+
 (deftest test-or-predicate-only-branches-can-filter-bound-values
   (tc/transact *conn* [{:name "A" :age 35}])
 

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -228,17 +228,6 @@
                        [(< ?age 30)]
                        [(< ?age 40)])]}))))
 
-(deftest test-or-and-branch-predicate-after-terminal-triple-does-not-over-index
-  (tc/transact *conn* [{:name "A" :age 35}
-                       {:name "B" :age 35}])
-
-  (is (= #{["A" 35]}
-         (q '{:find [?name ?age]
-              :where [[?e :age ?age]
-                      (or (and [?e :name "A"]
-                               [(< ?age 40)]))
-                      [?e :name ?name]]}))))
-
 (deftest test-ors-must-use-same-vars
   (is (thrown? TriploxException
                (q '{:find [?e]


### PR DESCRIPTION
This fixes #374. It is a bit of adhoc approach to fix the `PrefixExtender` approach by rechecking the incoming prefixes again (only the part that is relevant for the or branches). I think in the long run this might not be very efficient and likely needs some more analysis of how bad it is. See also the writeup at 414.

The `GenericOrPrefixExtender` now gets a trie for every branch underneath. Incoming prefixes get checked again when a new variable gets introduced and only branches that have proposed or validated this prefix before propose further extensions.