### PR TITLE
Return subscription priming result set

### DIFF
--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -102,6 +102,7 @@ IncrementalQueryService::register_query
 triplox-incremental-query thread
     builds one QueryCircuit for the plan
     primes it with the initial triples
+    queues the non-empty priming result at the registration basis
     stores the plan, circuit, basis, WAL cursor, and subscription sender
     returns an IncrementalQuerySubscription
 ```
@@ -148,10 +149,11 @@ In the future the server should drain these subscribers eagerly server side and 
 the appropriate deltas to the corresponding clients. The clients then need to deal
 with the backpressure themselves, depending on the client implementation.
 
-`IncrementalQueryDelta` is a subscriber-facing result batch emitted
-after a circuit step. The command protocol exists to serialize
-mutations to the query registry and DBSP circuits onto the single
-service thread.
+`IncrementalQueryDelta` is a subscriber-facing result batch emitted after a
+circuit step. The first delta is the non-empty priming result at the registration
+basis; later deltas describe transactions after that basis. The command protocol
+exists to serialize mutations to the query registry and DBSP circuits onto the
+single service thread.
 
 Registration is serialized against the application of CDC changes by a registration gate owned
 by `IncrementalQueryService`. `register_query` holds the gate across its whole
@@ -178,8 +180,9 @@ Registration creates a cutover point:
 5. Insert the registered query into the incremental service.
 6. Start the CDC loop if it is not already running.
 
-The subscription does not emit initial snapshot rows. It emits only transactions
-after the returned basis.
+If the initial query result is non-empty, registration queues it as the first
+delta with the registration `TxKey`. Empty priming results are omitted. Later
+deltas describe transactions after the returned basis.
 
 Registration is serialized against CDC application. This prevents a race where
 the global CDC loop consumes a transaction after the new query's snapshot basis

--- a/design/PROTOCOL.md
+++ b/design/PROTOCOL.md
@@ -307,9 +307,10 @@ failures and are rejected with HTTP 500 / `QueryError` (code 2001).
 
 On success the response is **HTTP 200** with `Content-Type:
 application/vnd.triplox+msgpack` and a body that is a **frame stream** (§4.12),
-not a single value. The subscription starts at the latest indexed basis; it does
-not replay existing rows, only deltas for transactions after the returned basis.
-Closing the HTTP/2 stream unsubscribes and releases server-side resources.
+not a single value. The subscription starts at the latest indexed basis. A
+non-empty result at that basis is emitted as the first delta, followed by deltas
+for later transactions. Closing the HTTP/2 stream unsubscribes and releases
+server-side resources.
 
 ### 4.12 Subscription Frame Stream
 
@@ -331,10 +332,11 @@ Each frame is a map with a `kind` discriminator. Decoders **MUST reject unknown
  "columns": [<ColumnDescription>, ...]}
 ```
 
-`tx_key` is the registration basis; deltas describe transactions strictly after
-it. `columns` matches [QueryResponse](#46-queryresponse).
+`tx_key` is the registration basis. A priming delta can use the same key; later
+deltas describe transactions strictly after it. `columns` matches
+[QueryResponse](#46-queryresponse).
 
-#### `delta` frame — zero or more, one per affecting transaction
+#### `delta` frame — optional priming result, then one per affecting transaction
 
 ```
 {"kind": "delta",
@@ -342,12 +344,13 @@ it. `columns` matches [QueryResponse](#46-queryresponse).
  "rows":    [[[<DataType>, ...], <int weight>], ...]}
 ```
 
-Each entry of `rows` is a 2-element array `[values, weight]`: `values` has one
+The first delta is the non-empty priming result, if any, and uses the registration
+`tx_key`. Later deltas use the transaction key that produced the change. Each
+entry of `rows` is a 2-element array `[values, weight]`: `values` has one
 `DataType` per column (positional, per the `open` frame), `weight` is a **raw
 signed multiplicity** (`> 0` added, `< 0` retracted; not limited to `±1`). A
 `delta` frame is emitted only for a transaction that produces a non-empty change
-(`rows` is never empty). `tx_key` is the transaction basis that produced the
-delta.
+or for a non-empty priming result (`rows` is never empty).
 
 #### `error` frame — terminal
 

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -107,7 +107,7 @@ pub(crate) struct IncrementalQueryService {
 
 // The two result levels in this service have two different meanings.
 // The first level is about the communication of this service.
-// The second level is about actual errors when sending a command. 
+// The second level is about actual errors when sending a command.
 impl IncrementalQueryService {
     pub(crate) fn new(
         storage_root: PathBuf,
@@ -659,7 +659,7 @@ mod tests {
                 single_pattern_plan(),
                 old_basis,
                 test_cursor(),
-                Vec::new(),
+                vec![name_triple(42, "Alice")],
             )
             .unwrap();
         let mut new_subscription = service
@@ -667,9 +667,13 @@ mod tests {
                 single_pattern_plan(),
                 new_basis,
                 test_cursor(),
-                Vec::new(),
+                vec![name_triple(42, "Alice"), name_triple(43, "Bob")],
             )
             .unwrap();
+
+        // Drain priming deltas before testing application relative to each basis.
+        old_subscription.deltas.try_recv().unwrap();
+        new_subscription.deltas.try_recv().unwrap();
 
         service
             .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")])

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -107,7 +107,7 @@ pub(crate) struct IncrementalQueryService {
 
 // The two result levels in this service have two different meanings.
 // The first level is about the communication of this service.
-// The second level is about actual errors when sending a command.
+// The second level reports errors while processing a command.
 impl IncrementalQueryService {
     pub(crate) fn new(
         storage_root: PathBuf,

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -368,10 +368,18 @@ impl IncrementalQueryServiceInner {
         let handle = self.allocate_query_id();
         let mut circuit = QueryCircuit::build(plan.clone(), &self.query_storage_path(handle))
             .map_err(|err| format!("{:#}", err))?;
-        circuit
+        let priming_rows = circuit
             .prime(initial_triples)
             .map_err(|err| format!("{:#}", err))?;
         let (sender, receiver) = mpsc::channel(SUBSCRIPTION_CAPACITY);
+        if !priming_rows.is_empty() {
+            sender
+                .try_send(IncrementalQueryDelta {
+                    tx_key,
+                    rows: priming_rows,
+                })
+                .map_err(|err| format!("Failed to enqueue priming result set: {}", err))?;
+        }
 
         self.queries.insert(
             handle,
@@ -569,6 +577,70 @@ mod tests {
     }
 
     #[test]
+    fn register_enqueues_non_empty_priming_result_before_future_deltas() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = test_runtime();
+        let mut service = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            runtime.handle().clone(),
+            CancellationToken::new(),
+        );
+        let registration_basis = test_tx_key_with_tx_id(1);
+        let future_basis = test_tx_key_with_tx_id(2);
+        let mut subscription = service
+            .register(
+                single_pattern_plan(),
+                registration_basis,
+                test_cursor(),
+                vec![name_triple(42, "Alice")],
+            )
+            .unwrap();
+
+        service
+            .apply_triples(future_basis, 2, vec![name_triple(43, "Bob")])
+            .unwrap();
+
+        assert_eq!(
+            subscription.deltas.try_recv().unwrap(),
+            IncrementalQueryDelta {
+                tx_key: registration_basis,
+                rows: vec![(vec![DataType::String("Alice".to_string())], 1)],
+            }
+        );
+        assert_eq!(
+            subscription.deltas.try_recv().unwrap(),
+            IncrementalQueryDelta {
+                tx_key: future_basis,
+                rows: vec![(vec![DataType::String("Bob".to_string())], 1)],
+            }
+        );
+    }
+
+    #[test]
+    fn register_skips_empty_priming_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = test_runtime();
+        let mut service = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            runtime.handle().clone(),
+            CancellationToken::new(),
+        );
+        let mut subscription = service
+            .register(
+                single_pattern_plan(),
+                test_tx_key(),
+                test_cursor(),
+                Vec::new(),
+            )
+            .unwrap();
+
+        assert!(matches!(
+            subscription.deltas.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
     fn apply_triples_skips_transactions_at_or_before_query_basis() {
         let dir = tempfile::tempdir().unwrap();
         let runtime = test_runtime();
@@ -595,6 +667,15 @@ mod tests {
                 vec![name_triple(42, "Alice"), name_triple(43, "Bob")],
             )
             .unwrap();
+
+        assert_eq!(
+            old_subscription.deltas.try_recv().unwrap().tx_key,
+            old_basis
+        );
+        assert_eq!(
+            new_subscription.deltas.try_recv().unwrap().tx_key,
+            new_basis
+        );
 
         service
             .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")])
@@ -789,6 +870,10 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            first_subscription.deltas.try_recv().unwrap().tx_key,
+            query_tx_key
+        );
 
         let registration_guard = service.registration_gate.lock().await;
         let applying_service = service.clone();
@@ -810,6 +895,10 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            second_subscription.deltas.try_recv().unwrap().tx_key,
+            query_tx_key
+        );
         assert!(second_subscription.deltas.try_recv().is_err());
 
         drop(registration_guard);

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -371,8 +371,9 @@ impl IncrementalQueryServiceInner {
         let handle = self.allocate_query_id();
         let mut circuit = QueryCircuit::build(plan.clone(), &self.query_storage_path(handle))
             .map_err(|err| format!("{:#}", err))?;
+        // Priming is the circuit's first batch, so its delta is the whole query result.
         let priming_rows = circuit
-            .prime(initial_triples)
+            .apply(initial_triples)
             .map_err(|err| format!("{:#}", err))?;
         let (sender, receiver) = mpsc::channel(SUBSCRIPTION_CAPACITY);
         if !priming_rows.is_empty() {

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -105,6 +105,9 @@ pub(crate) struct IncrementalQueryService {
     registration_gate: Arc<Mutex<()>>,
 }
 
+// The two result levels in this service have two different meanings.
+// The first level is about the communication of this service.
+// The second level is about actual errors when sending a command. 
 impl IncrementalQueryService {
     pub(crate) fn new(
         storage_root: PathBuf,

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -656,7 +656,7 @@ mod tests {
                 single_pattern_plan(),
                 old_basis,
                 test_cursor(),
-                vec![name_triple(42, "Alice")],
+                Vec::new(),
             )
             .unwrap();
         let mut new_subscription = service
@@ -664,18 +664,9 @@ mod tests {
                 single_pattern_plan(),
                 new_basis,
                 test_cursor(),
-                vec![name_triple(42, "Alice"), name_triple(43, "Bob")],
+                Vec::new(),
             )
             .unwrap();
-
-        assert_eq!(
-            old_subscription.deltas.try_recv().unwrap().tx_key,
-            old_basis
-        );
-        assert_eq!(
-            new_subscription.deltas.try_recv().unwrap().tx_key,
-            new_basis
-        );
 
         service
             .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")])
@@ -866,14 +857,10 @@ mod tests {
                 single_pattern_plan(),
                 query_tx_key,
                 test_cursor(),
-                vec![name_triple(42, "Alice")],
+                Vec::new(),
             )
             .await
             .unwrap();
-        assert_eq!(
-            first_subscription.deltas.try_recv().unwrap().tx_key,
-            query_tx_key
-        );
 
         let registration_guard = service.registration_gate.lock().await;
         let applying_service = service.clone();
@@ -891,14 +878,10 @@ mod tests {
                 single_pattern_plan(),
                 query_tx_key,
                 test_cursor(),
-                vec![name_triple(42, "Alice")],
+                Vec::new(),
             )
             .await
             .unwrap();
-        assert_eq!(
-            second_subscription.deltas.try_recv().unwrap().tx_key,
-            query_tx_key
-        );
         assert!(second_subscription.deltas.try_recv().is_err());
 
         drop(registration_guard);

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -277,17 +277,8 @@ impl QueryCircuit {
         })
     }
 
-    // Loads the initial snapshot and returns the decoded query result.
-    pub(super) fn prime(
-        &mut self,
-        mut initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
-    ) -> Result<Vec<(Vec<DataType>, isize)>> {
-        self._input.append(&mut initial_triples);
-        self._circuit.transaction().map_err(anyhow::Error::from)?;
-        decode_output_rows(&self._output.consolidate())
-    }
-
     // Applies one weighted triple batch and returns the decoded query result delta.
+    // The first batch is the initial snapshot, so its delta is the whole query result.
     pub(super) fn apply(
         &mut self,
         mut triples: Vec<Tup2<EncodedTriple, ZWeight>>,
@@ -478,7 +469,7 @@ mod tests {
 
         let mut circuit = QueryCircuit::build(plan, &storage_path).unwrap();
         let priming_rows = circuit
-            .prime(vec![
+            .apply(vec![
                 Tup2(triple(42, 10, DataType::String("Alice".to_string())), 1),
                 Tup2(triple(42, 11, DataType::Long(30)), 1),
             ])

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -277,15 +277,14 @@ impl QueryCircuit {
         })
     }
 
-    // Loads the initial snapshot into the circuit and discards the bootstrap output.
+    // Loads the initial snapshot and returns the decoded query result.
     pub(super) fn prime(
         &mut self,
         mut initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
-    ) -> Result<()> {
+    ) -> Result<Vec<(Vec<DataType>, isize)>> {
         self._input.append(&mut initial_triples);
         self._circuit.transaction().map_err(anyhow::Error::from)?;
-        let _ = self._output.consolidate();
-        Ok(())
+        decode_output_rows(&self._output.consolidate())
     }
 
     // Applies one weighted triple batch and returns the decoded query result delta.
@@ -478,12 +477,20 @@ mod tests {
         );
 
         let mut circuit = QueryCircuit::build(plan, &storage_path).unwrap();
-        circuit
+        let priming_rows = circuit
             .prime(vec![
                 Tup2(triple(42, 10, DataType::String("Alice".to_string())), 1),
                 Tup2(triple(42, 11, DataType::Long(30)), 1),
             ])
             .unwrap();
+
+        assert_eq!(
+            priming_rows,
+            vec![(
+                vec![DataType::String("Alice".to_string()), DataType::Long(30)],
+                1,
+            )]
+        );
 
         assert!(storage_path.exists());
         assert!(!storage_path.join("stale").exists());

--- a/src/node.rs
+++ b/src/node.rs
@@ -1989,6 +1989,14 @@ mod tests {
             .expect("subscription should be open")
     }
 
+    async fn take_priming_delta(
+        subscription: &mut IncrementalQuerySubscription,
+    ) -> crate::incremental::IncrementalQueryDelta {
+        let delta = recv_incremental_delta(subscription).await;
+        assert!(!delta.rows.is_empty());
+        delta
+    }
+
     async fn try_recv_incremental_delta(
         subscription: &mut IncrementalQuerySubscription,
     ) -> Option<crate::incremental::IncrementalQueryDelta> {
@@ -2116,9 +2124,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let priming_delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(priming_delta.tx_key, subscription.tx_key);
-        assert!(!priming_delta.rows.is_empty());
+        take_priming_delta(&mut subscription).await;
 
         let basis = match node.execute_tx(test_schema_tx()).await.unwrap() {
             TransactionResult::TxCommitted(basis) => basis,
@@ -2272,13 +2278,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(subscription.tx_key, first_basis);
-        assert_eq!(
-            recv_incremental_delta(&mut subscription).await,
-            crate::incremental::IncrementalQueryDelta {
-                tx_key: first_basis,
-                rows: vec![(vec![DataType::String("Alice".to_string())], 1)],
-            }
-        );
+        take_priming_delta(&mut subscription).await;
         assert!(try_recv_incremental_delta(&mut subscription)
             .await
             .is_none());
@@ -2369,12 +2369,7 @@ mod tests {
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
-        let priming_delta = recv_incremental_delta(&mut subscription).await;
-        assert_eq!(priming_delta.tx_key, subscription.tx_key);
-        assert_eq!(
-            priming_delta.rows,
-            vec![(vec![DataType::String("Alice".to_string())], 1)]
-        );
+        take_priming_delta(&mut subscription).await;
         let basis = match node
             .execute_tx(vec![TxOp::Add {
                 entity: EntityRef::Id(100),

--- a/src/node.rs
+++ b/src/node.rs
@@ -2116,6 +2116,10 @@ mod tests {
             )
             .await
             .unwrap();
+        let priming_delta = recv_incremental_delta(&mut subscription).await;
+        assert_eq!(priming_delta.tx_key, subscription.tx_key);
+        assert!(!priming_delta.rows.is_empty());
+
         let basis = match node.execute_tx(test_schema_tx()).await.unwrap() {
             TransactionResult::TxCommitted(basis) => basis,
             TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
@@ -2138,28 +2142,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_incremental_query_after_existing_data_emits_no_initial_delta() {
+    async fn test_register_incremental_query_after_existing_data_emits_priming_delta() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
-        let result = node
+        let basis = match node
             .execute_tx(vec![TxOp::Add {
                 entity: EntityRef::Id(100),
                 attribute: kw!(:name),
                 value: DataType::String("Alice".to_string()),
             }])
             .await
-            .unwrap();
-        assert!(matches!(result, TransactionResult::TxCommitted(_)));
+            .unwrap()
+        {
+            TransactionResult::TxCommitted(basis) => basis,
+            TransactionResult::TxAborted(_, err) => panic!("transaction aborted: {err}"),
+        };
 
         let mut subscription = node
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
 
-        assert!(matches!(
-            subscription.deltas.try_recv(),
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
-        ));
+        assert_eq!(
+            subscription.deltas.try_recv().unwrap(),
+            crate::incremental::IncrementalQueryDelta {
+                tx_key: basis,
+                rows: vec![(vec![DataType::String("Alice".to_string())], 1)],
+            }
+        );
     }
 
     #[tokio::test]
@@ -2262,6 +2272,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(subscription.tx_key, first_basis);
+        assert_eq!(
+            recv_incremental_delta(&mut subscription).await,
+            crate::incremental::IncrementalQueryDelta {
+                tx_key: first_basis,
+                rows: vec![(vec![DataType::String("Alice".to_string())], 1)],
+            }
+        );
         assert!(try_recv_incremental_delta(&mut subscription)
             .await
             .is_none());
@@ -2352,6 +2369,12 @@ mod tests {
             .register_incremental_query(parse_query("[:find ?name :where [?e :name ?name]]"), &[])
             .await
             .unwrap();
+        let priming_delta = recv_incremental_delta(&mut subscription).await;
+        assert_eq!(priming_delta.tx_key, subscription.tx_key);
+        assert_eq!(
+            priming_delta.rows,
+            vec![(vec![DataType::String("Alice".to_string())], 1)]
+        );
         let basis = match node
             .execute_tx(vec![TxOp::Add {
                 entity: EntityRef::Id(100),

--- a/tests/subscription_test.rs
+++ b/tests/subscription_test.rs
@@ -78,6 +78,28 @@ async fn subscribe_receives_transaction_delta() {
     token.cancel();
 }
 
+/// Existing query results are delivered once at the subscription basis before
+/// deltas for later transactions.
+#[tokio::test(flavor = "multi_thread")]
+async fn subscription_returns_existing_rows_as_priming_delta() {
+    let (addr, token) = start_test_server().await;
+    let client = ClientNode::connect(&addr).await.unwrap();
+    client.execute_tx(test_schema_tx()).await.unwrap();
+    client.execute_tx(add_name("alice", "Alice")).await.unwrap();
+
+    let mut sub = client.subscribe(NAMES_QUERY, &[]).await.unwrap();
+    let registration_basis = sub.tx_key();
+    let delta = next_delta(&mut sub).await;
+
+    assert_eq!(delta.tx_key, registration_basis);
+    assert_eq!(
+        delta.rows,
+        vec![(vec![DataType::String("Alice".to_string())], 1)]
+    );
+
+    token.cancel();
+}
+
 /// A slow consumer (transactions made before the client reads) loses no deltas:
 /// every transaction's change is delivered once the client drains.
 #[tokio::test(flavor = "multi_thread")]
@@ -195,6 +217,8 @@ async fn dropping_a_subscription_keeps_the_server_serving() {
 
     // A fresh subscription still works.
     let mut sub = client.subscribe(NAMES_QUERY, &[]).await.unwrap();
+    let priming_delta = next_delta(&mut sub).await;
+    assert_eq!(priming_delta.tx_key, sub.tx_key());
     client.execute_tx(add_name("b", "Bob")).await.unwrap();
     let delta = next_delta(&mut sub).await;
     assert_eq!(

--- a/triplox-client/src/client.rs
+++ b/triplox-client/src/client.rs
@@ -67,7 +67,8 @@ impl ClientNode {
     /// Register an incremental query and stream its result deltas.
     ///
     /// Subscribes at the latest indexed basis. The returned [`Subscription`] is a
-    /// `Stream` of [`Delta`](crate::Delta)s; dropping it unsubscribes.
+    /// `Stream` of [`Delta`](crate::Delta)s. A non-empty initial result is emitted
+    /// first at the registration basis; dropping the subscription unsubscribes.
     pub async fn subscribe(
         &self,
         query: impl IntoQuery,

--- a/triplox-client/src/msgpack_codec.rs
+++ b/triplox-client/src/msgpack_codec.rs
@@ -980,7 +980,7 @@ pub enum SubscriptionFrame {
         tx_key: TxKey,
         columns: Vec<ColumnDescription>,
     },
-    /// One transaction's z-set changes as `(values, weight)` rows.
+    /// Priming or transaction changes as `(values, weight)` rows.
     Delta {
         tx_key: TxKey,
         rows: Vec<(Vec<DataType>, i64)>,

--- a/triplox-client/src/subscription.rs
+++ b/triplox-client/src/subscription.rs
@@ -27,10 +27,10 @@ type FrameStream = FramedRead<StreamReader<ByteStream, Bytes>, MsgpackFrameDecod
 
 const SUBSCRIPTION_QUEUE_CAPACITY: usize = 128;
 
-/// A single transaction's z-set changes for a subscribed query.
+/// A subscribed query's weighted result changes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Delta {
-    /// The transaction key that produced this delta.
+    /// The registration basis for a priming delta, or the transaction that produced a later delta.
     pub tx_key: TxKey,
     /// `(values, weight)` rows; `weight` is the raw signed multiplicity.
     pub rows: Vec<(Vec<DataType>, i64)>,
@@ -68,7 +68,7 @@ async fn read_deltas(mut frames: FrameStream, sender: mpsc::Sender<Result<Delta>
 }
 
 impl Subscription {
-    /// The registration tx_key. Deltas describe transactions strictly after it.
+    /// The registration tx_key. A priming delta can equal it; later deltas are strictly after it.
     pub fn tx_key(&self) -> TxKey {
         self.tx_key
     }

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -58,8 +58,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn subscribe
-  "Register an incremental query and stream its result deltas. Returns a
-  Subscription (Closeable); use with `with-open`. Closing unsubscribes."
+  "Register an incremental query and stream its result deltas. A non-empty
+  initial result is the first delta. Returns a Subscription (Closeable); use
+  with `with-open`. Closing unsubscribes."
   ^Subscription [conn query & args]
   (if (seq args)
     (let [query-args (mapv (fn [a]

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Delta.java
@@ -3,9 +3,9 @@ package xyz.triplox.client;
 import java.util.List;
 
 /**
- * One transaction's z-set changes for a subscribed query.
+ * A subscribed query's weighted result changes.
  *
- * <p>{@code txKey} is the transaction key that produced the delta. Each
- * {@link Row} carries the raw signed weight.</p>
+ * <p>{@code txKey} is the registration basis for a priming delta, or the
+ * transaction key that produced a later delta. Each {@link Row} carries the raw signed weight.</p>
  */
 public record Delta(TxKey txKey, List<Row> rows) implements SubscriptionFrame {}

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
@@ -72,7 +72,7 @@ public final class Subscription implements AutoCloseable {
         throw new IOException("expected open frame, got " + first);
     }
 
-    /** The registration tx_key. Deltas describe transactions strictly after it. */
+    /** The registration tx_key. A priming delta can equal it; later deltas are strictly after it. */
     public TxKey txKey() {
         return txKey;
     }

--- a/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/TriploxNode.java
@@ -112,8 +112,9 @@ public class TriploxNode implements AutoCloseable {
     /**
      * Register an incremental query and stream its result deltas.
      *
-     * <p>Subscribes at the latest indexed basis. The returned {@link Subscription}
-     * is an {@link AutoCloseable}; closing it cancels the stream and unsubscribes.</p>
+     * <p>Subscribes at the latest indexed basis. A non-empty initial result is
+     * emitted first at that basis. The returned {@link Subscription} is an
+     * {@link AutoCloseable}; closing it cancels the stream and unsubscribes.</p>
      */
     public Subscription subscribe(String edn) throws IOException {
         return subscribe(edn, List.of());

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -47,6 +47,11 @@
       (set res)
       res)))
 
+(defn take-priming! [sub]
+  (let [delta (take-delta! sub)]
+    (is (seq delta))
+    delta))
+
 (defn q [conn query]
   (api/q (api/db conn) query))
 
@@ -90,6 +95,7 @@
                                        :where [[?e :name "Ivan"]]})]
       (with-open [sub (api/subscribe conn {:find ['?name]
                                             :where [[ivan-id :name '?name]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/add ivan-id :name "Ivanov"]])
         (is (= #{[["Ivan"] -1]
                  [["Ivanov"] 1]}
@@ -192,6 +198,7 @@
                                        :where [[?e :name "Ivan"]]})]
       (with-open [sub (api/subscribe conn '{:find [?name]
                                              :where [[?e :name ?name]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/add ivan-id :name "Ivanova"]])
         (is (= #{[["Ivan"] -1]
                  [["Ivanova"] 1]}
@@ -206,6 +213,7 @@
                                        :where [[?e :name "Ivan"]]})]
       (with-open [sub (api/subscribe conn '{:find [?name]
                                              :where [[?e :name ?name]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract ivan-id :name "Ivan"]])
         (is (= [[["Ivan"] -1]]
                (take-delta! sub)))))))
@@ -222,6 +230,7 @@
                                       :where [[?e :name "Bob"]]})]
       (with-open [sub (api/subscribe conn '{:find [?city]
                                             :where [[?e :city ?city]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract bob-id :city "NYC"]])
         (is (= [[["NYC"] -1]] (take-delta! sub)))
         (api/transact conn [[:db/retract alice-id :city "NYC"]])
@@ -238,6 +247,7 @@
       (with-open [sub (api/subscribe conn '{:find [?e]
                                             :where [(or [?e :name "Alice"]
                                                         [?e :name "Bob"])]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract bob-id :name "Bob"]])
         (is (= [[[bob-id] -1]]
                (take-delta! sub)))))))
@@ -276,6 +286,7 @@
                                             :where [(or [?e :name "Alice"]
                                                         [?e :name "Bob"])
                                                     [?e :city ?city]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract bob-id :name "Bob"]])
         (is (= [[["Berlin"] -1]]
                (take-delta! sub)))))))
@@ -308,6 +319,7 @@
       (with-open [sub (api/subscribe conn '{:find [?a ?b ?c]
                                             :where [[?a :r/to ?b]
                                                     [?b :s/to ?c]]})]
+        (take-priming! sub)
         (t/is (true? (:committed? (api/transact conn [[:db/add b-id :s/to d-id]]))))
         (is (= #{[[a-id b-id d-id] 1]}
                (delta-set! sub)))))))
@@ -323,6 +335,7 @@
       (with-open [sub (api/subscribe conn '{:find [?a ?b ?c]
                                             :where [[?a :r/to ?b]
                                                     [?b :s/to ?c]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract b-id :s/to d-id]])
         (is (= #{[[a-id b-id d-id] -1]}
                (delta-set! sub)))))))
@@ -339,6 +352,7 @@
                                             :where [[?a :r/to ?b]
                                                     [?b :s/to ?c]
                                                     [?c :t/to ?a]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/retract b-id :s/to c-id]])
         (is (= [[[a-id b-id c-id] -1]] (take-delta! sub)))))))
 
@@ -381,6 +395,7 @@
       (with-open [sub (api/subscribe conn '{:find [?name ?residence]
                                              :where [[?p :person/name ?name]
                                                      [?p :person/residence ?residence]]})]
+        (take-priming! sub)
         (api/transact conn [[:db/add ada-id :person/residence "Buckingham Palace"]])
         (is (= #{[["Ada Lovelace" "12 St. James's Square"] -1]
                  [["Ada Lovelace" "Buckingham Palace"] 1]}

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
@@ -48,23 +48,6 @@ class SubscriptionTest {
     }
 
     @Test
-    void testSubscribeReturnsExistingRowsAsPrimingDelta() throws Exception {
-        try (var node = TriploxNode.connect(host(), port())) {
-            defineNameSchema(node);
-            node.executeTx(List.of(new TxOp.Put(map(":name", "Alice"))));
-
-            try (Subscription sub = node.subscribe(NAMES_QUERY)) {
-                Delta delta = sub.poll(10, TimeUnit.SECONDS);
-                assertNotNull(delta, "expected a priming delta within 10s");
-                assertEquals(sub.txKey(), delta.txKey());
-                assertEquals(1, delta.rows().size());
-                assertEquals(List.of("Alice"), delta.rows().get(0).values());
-                assertEquals(1L, delta.rows().get(0).weight());
-            }
-        }
-    }
-
-    @Test
     void testPollTimesOutWithoutChange() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
             defineNameSchema(node);

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
@@ -48,6 +48,23 @@ class SubscriptionTest {
     }
 
     @Test
+    void testSubscribeReturnsExistingRowsAsPrimingDelta() throws Exception {
+        try (var node = TriploxNode.connect(host(), port())) {
+            defineNameSchema(node);
+            node.executeTx(List.of(new TxOp.Put(map(":name", "Alice"))));
+
+            try (Subscription sub = node.subscribe(NAMES_QUERY)) {
+                Delta delta = sub.poll(10, TimeUnit.SECONDS);
+                assertNotNull(delta, "expected a priming delta within 10s");
+                assertEquals(sub.txKey(), delta.txKey());
+                assertEquals(1, delta.rows().size());
+                assertEquals(List.of("Alice"), delta.rows().get(0).values());
+                assertEquals(1L, delta.rows().get(0).weight());
+            }
+        }
+    }
+
+    @Test
     void testPollTimesOutWithoutChange() throws Exception {
         try (var node = TriploxNode.connect(host(), port())) {
             defineNameSchema(node);


### PR DESCRIPTION
We want to return the priming result when initializing circuits. Otherwise it becomes difficult to build views. See #417.