### PR TITLE
Standard engine rewrite [1/N]: BindingBag

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,7 @@
 #![allow(unused)]
 
+pub(crate) mod binding_set;
+
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-pub(crate) mod binding_set;
+pub(crate) mod binding_bag;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -496,6 +496,22 @@ mod tests {
     }
 
     #[test]
+    fn natural_join_build_sides_produce_the_same_bag() {
+        let left = binding_bag(&["?x", "?left"], &[&["a", "l1"], &["a", "l2"]]);
+        let larger_left = binding_bag(
+            &["?x", "?left"],
+            &[&["a", "l1"], &["a", "l2"], &["b", "l3"]],
+        );
+        let right = binding_bag(&["?x", "?right"], &[&["a", "1"], &["a", "2"]]);
+        let larger_right = binding_bag(&["?x", "?right"], &[&["a", "1"], &["a", "2"], &["c", "3"]]);
+
+        assert_eq!(
+            left.natural_join(&larger_right).unwrap(),
+            larger_left.natural_join(&right).unwrap()
+        );
+    }
+
+    #[test]
     fn natural_join_without_shared_variables_is_a_cartesian_product() {
         let left = binding_bag(&["?x"], &[&["a"], &["b"]]);
         let right = binding_bag(&["?y"], &[&["1"], &["2"]]);
@@ -553,6 +569,10 @@ mod tests {
         assert_eq!(values.natural_join(&unit).unwrap(), values);
         assert_eq!(
             empty.natural_join(&values).unwrap(),
+            BindingBag::empty(vec!["?x".to_var()]).unwrap()
+        );
+        assert_eq!(
+            values.natural_join(&empty).unwrap(),
             BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
         assert_eq!(values.semijoin(&unit).unwrap(), values);

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -182,33 +182,66 @@ impl BindingBag {
         indexes.iter().map(|index| row[*index].clone()).collect()
     }
 
+    fn joined_row(
+        left_row: &BindingRow,
+        right_row: &BindingRow,
+        right_only_indexes: &[usize],
+    ) -> BindingRow {
+        let mut row = left_row.clone();
+        row.extend(
+            right_only_indexes
+                .iter()
+                .map(|index| right_row[*index].clone()),
+        );
+        row
+    }
+
     pub(crate) fn natural_join(&self, other: &Self) -> Result<Self> {
         let shared_variables = self.shared_variables(other);
-        let left_shared_indexes = self.projection_indexes(&shared_variables)?;
-        let right_index = other.index_by(&shared_variables)?;
-        let right_only: Vec<(Variable, usize)> = other
+        let right_only_indexes: Vec<usize> = other
             .variables
             .iter()
             .enumerate()
             .filter(|(_, variable)| !self.column_indexes.contains_key(*variable))
-            .map(|(index, variable)| (variable.clone(), index))
+            .map(|(index, _)| index)
             .collect();
 
         let mut variables = self.variables.clone();
-        variables.extend(right_only.iter().map(|(variable, _)| variable.clone()));
+        variables.extend(
+            right_only_indexes
+                .iter()
+                .map(|index| other.variables[*index].clone()),
+        );
 
         let mut rows = Vec::new();
-        for left_row in &self.rows {
-            let key = Self::row_key(left_row, &left_shared_indexes);
-            if let Some(right_row_indexes) = right_index.get(&key) {
-                for right_row_index in right_row_indexes {
-                    let mut row = left_row.clone();
-                    row.extend(
-                        right_only
-                            .iter()
-                            .map(|(_, index)| other.rows[*right_row_index][*index].clone()),
-                    );
-                    rows.push(row);
+        if self.rows.len() < other.rows.len() {
+            let left_index = self.index_by(&shared_variables)?;
+            let right_shared_indexes = other.projection_indexes(&shared_variables)?;
+            for right_row in &other.rows {
+                let key = Self::row_key(right_row, &right_shared_indexes);
+                if let Some(left_row_indexes) = left_index.get(&key) {
+                    for left_row_index in left_row_indexes {
+                        rows.push(Self::joined_row(
+                            &self.rows[*left_row_index],
+                            right_row,
+                            &right_only_indexes,
+                        ));
+                    }
+                }
+            }
+        } else {
+            let left_shared_indexes = self.projection_indexes(&shared_variables)?;
+            let right_index = other.index_by(&shared_variables)?;
+            for left_row in &self.rows {
+                let key = Self::row_key(left_row, &left_shared_indexes);
+                if let Some(right_row_indexes) = right_index.get(&key) {
+                    for right_row_index in right_row_indexes {
+                        rows.push(Self::joined_row(
+                            left_row,
+                            &other.rows[*right_row_index],
+                            &right_only_indexes,
+                        ));
+                    }
                 }
             }
         }
@@ -397,8 +430,8 @@ mod tests {
     }
 
     #[test]
-    fn natural_join_preserves_bag_multiplicity_and_layout_order() {
-        let left = binding_bag(&["?x"], &[&["a"], &["a"], &["b"]]);
+    fn natural_join_indexes_smaller_receiver_and_preserves_layout_and_multiplicity() {
+        let left = binding_bag(&["?x", "?left"], &[&["a", "l1"], &["a", "l2"]]);
         let right = binding_bag(
             &["?x", "?y"],
             &[&["a", "1"], &["a", "1"], &["a", "2"], &["c", "3"]],
@@ -409,15 +442,32 @@ mod tests {
         assert_eq!(
             joined,
             binding_bag(
-                &["?x", "?y"],
+                &["?x", "?left", "?y"],
                 &[
-                    &["a", "1"],
-                    &["a", "1"],
-                    &["a", "2"],
-                    &["a", "1"],
-                    &["a", "1"],
-                    &["a", "2"],
+                    &["a", "l1", "1"],
+                    &["a", "l2", "1"],
+                    &["a", "l1", "1"],
+                    &["a", "l2", "1"],
+                    &["a", "l1", "2"],
+                    &["a", "l2", "2"],
                 ],
+            )
+        );
+    }
+
+    #[test]
+    fn natural_join_indexes_smaller_other_and_preserves_receiver_layout() {
+        let left = binding_bag(
+            &["?x", "?left"],
+            &[&["a", "l1"], &["a", "l2"], &["b", "l3"]],
+        );
+        let right = binding_bag(&["?right", "?x"], &[&["r1", "a"]]);
+
+        assert_eq!(
+            left.natural_join(&right).unwrap(),
+            binding_bag(
+                &["?x", "?left", "?right"],
+                &[&["a", "l1", "r1"], &["a", "l2", "r1"]],
             )
         );
     }

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -155,14 +155,10 @@ impl BindingBag {
         let rows = self
             .rows
             .iter()
-            .filter(|row| seen.insert((*row).clone()))
+            .filter(|row| seen.insert(*row))
             .cloned()
             .collect();
-        Self {
-            variables: self.variables.clone(),
-            rows,
-            column_indexes: self.column_indexes.clone(),
-        }
+        self.with_rows(rows)
     }
 
     pub(crate) fn index_by(

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -38,6 +38,14 @@ impl BindingBag {
         })
     }
 
+    fn with_rows(&self, rows: Vec<BindingRow>) -> Self {
+        Self {
+            variables: self.variables.clone(),
+            rows,
+            column_indexes: self.column_indexes.clone(),
+        }
+    }
+
     pub(crate) fn unit() -> Self {
         Self {
             variables: Vec::new(),
@@ -81,7 +89,7 @@ impl BindingBag {
                     .ok_or_else(|| anyhow::anyhow!("Unknown BindingBag row index: {row_index}"))
             })
             .collect::<Result<Vec<_>>>()?;
-        Self::new(self.variables.clone(), rows)
+        Ok(self.with_rows(rows))
     }
 
     pub(crate) fn extend_rows(
@@ -266,7 +274,7 @@ impl BindingBag {
             .filter(|row| right_index.contains_key(&Self::row_key(row, &left_shared_indexes)))
             .cloned()
             .collect();
-        Self::new(self.variables.clone(), rows)
+        Ok(self.with_rows(rows))
     }
 
     pub(crate) fn antijoin(&self, other: &Self) -> Result<Self> {
@@ -279,7 +287,7 @@ impl BindingBag {
             .filter(|row| !right_index.contains_key(&Self::row_key(row, &left_shared_indexes)))
             .cloned()
             .collect();
-        Self::new(self.variables.clone(), rows)
+        Ok(self.with_rows(rows))
     }
 
     pub(crate) fn union(&self, other: &Self) -> Result<Self> {
@@ -289,7 +297,7 @@ impl BindingBag {
         );
         let mut rows = self.rows.clone();
         rows.extend(other.rows.iter().cloned());
-        Self::new(self.variables.clone(), rows)
+        Ok(self.with_rows(rows))
     }
 
     pub(crate) fn distinct_union(&self, other: &Self) -> Result<Self> {

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -8,8 +8,8 @@ pub(crate) type BindingRow = Vec<Bytes>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BindingBag {
-    variables: Vec<Variable>,
-    rows: Vec<BindingRow>,
+    pub(crate) variables: Vec<Variable>,
+    pub(crate) rows: Vec<BindingRow>,
     column_indexes: HashMap<Variable, usize>,
 }
 
@@ -48,14 +48,6 @@ impl BindingBag {
 
     pub(crate) fn empty(variables: Vec<Variable>) -> Result<Self> {
         Self::new(variables, Vec::new())
-    }
-
-    pub(crate) fn variables(&self) -> &[Variable] {
-        &self.variables
-    }
-
-    pub(crate) fn rows(&self) -> &[BindingRow] {
-        &self.rows
     }
 
     pub(crate) fn column_index(&self, variable: &Variable) -> Result<usize> {
@@ -308,10 +300,10 @@ mod tests {
         let unit = BindingBag::unit();
         let empty = BindingBag::empty(vec!["?x".to_var()]).unwrap();
 
-        assert!(unit.variables().is_empty());
-        assert_eq!(unit.rows(), &[Vec::<Bytes>::new()]);
-        assert_eq!(empty.variables(), &["?x".to_var()]);
-        assert!(empty.rows().is_empty());
+        assert!(unit.variables.is_empty());
+        assert_eq!(unit.rows, &[Vec::<Bytes>::new()]);
+        assert_eq!(empty.variables, ["?x".to_var()]);
+        assert!(empty.rows.is_empty());
     }
 
     #[test]
@@ -500,7 +492,7 @@ mod tests {
             BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
         assert_eq!(values.antijoin(&empty).unwrap(), values);
-        assert_eq!(unit.union(&unit).unwrap().rows().len(), 2);
+        assert_eq!(unit.union(&unit).unwrap().rows.len(), 2);
         assert_eq!(unit.distinct_union(&unit).unwrap(), unit);
     }
 }

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -7,25 +7,25 @@ use edn::query::Variable;
 pub(crate) type BindingRow = Vec<Bytes>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct BindingSet {
+pub(crate) struct BindingBag {
     variables: Vec<Variable>,
     rows: Vec<BindingRow>,
     column_indexes: HashMap<Variable, usize>,
 }
 
-impl BindingSet {
+impl BindingBag {
     pub(crate) fn new(variables: Vec<Variable>, rows: Vec<BindingRow>) -> Result<Self> {
         let mut column_indexes = HashMap::with_capacity(variables.len());
         for (index, variable) in variables.iter().enumerate() {
             ensure!(
                 column_indexes.insert(variable.clone(), index).is_none(),
-                "BindingSet variables must be unique: {variable}"
+                "BindingBag variables must be unique: {variable}"
             );
         }
         for (index, row) in rows.iter().enumerate() {
             ensure!(
                 row.len() == variables.len(),
-                "BindingSet row {index} has arity {}, expected {}",
+                "BindingBag row {index} has arity {}, expected {}",
                 row.len(),
                 variables.len()
             );
@@ -62,7 +62,7 @@ impl BindingSet {
         self.column_indexes
             .get(variable)
             .copied()
-            .ok_or_else(|| anyhow::anyhow!("Unknown BindingSet variable: {variable}"))
+            .ok_or_else(|| anyhow::anyhow!("Unknown BindingBag variable: {variable}"))
     }
 
     fn projection_indexes(&self, variables: &[Variable]) -> Result<Vec<usize>> {
@@ -86,7 +86,7 @@ impl BindingSet {
                 self.rows
                     .get(*row_index)
                     .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("Unknown BindingSet row index: {row_index}"))
+                    .ok_or_else(|| anyhow::anyhow!("Unknown BindingBag row index: {row_index}"))
             })
             .collect::<Result<Vec<_>>>()?;
         Self::new(self.variables.clone(), rows)
@@ -99,7 +99,7 @@ impl BindingSet {
     ) -> Result<Self> {
         ensure!(
             extensions.len() == self.rows.len(),
-            "BindingSet extensions have {} input rows, expected {}",
+            "BindingBag extensions have {} input rows, expected {}",
             extensions.len(),
             self.rows.len()
         );
@@ -108,7 +108,7 @@ impl BindingSet {
         for variable in &added_variables {
             ensure!(
                 seen.insert(variable.clone()),
-                "Extended BindingSet variables must be unique: {variable}"
+                "Extended BindingBag variables must be unique: {variable}"
             );
         }
 
@@ -117,7 +117,7 @@ impl BindingSet {
             for mut extension in input_extensions {
                 ensure!(
                     extension.len() == added_variables.len(),
-                    "BindingSet extension has arity {}, expected {}",
+                    "BindingBag extension has arity {}, expected {}",
                     extension.len(),
                     added_variables.len()
                 );
@@ -253,7 +253,7 @@ impl BindingSet {
     pub(crate) fn union(&self, other: &Self) -> Result<Self> {
         ensure!(
             self.variables == other.variables,
-            "Union requires identical BindingSet layouts"
+            "Union requires identical BindingBag layouts"
         );
         let mut rows = self.rows.clone();
         rows.extend(other.rows.iter().cloned());
@@ -270,14 +270,14 @@ mod tests {
     use bytes::Bytes;
     use edn::query::ToVariable;
 
-    use super::BindingSet;
+    use super::BindingBag;
 
     fn bytes(value: &str) -> Bytes {
         Bytes::copy_from_slice(value.as_bytes())
     }
 
-    fn binding_set(variables: &[&str], rows: &[&[&str]]) -> BindingSet {
-        BindingSet::new(
+    fn binding_bag(variables: &[&str], rows: &[&[&str]]) -> BindingBag {
+        BindingBag::new(
             variables.iter().map(|variable| variable.to_var()).collect(),
             rows.iter()
                 .map(|row| row.iter().map(|value| bytes(value)).collect())
@@ -290,13 +290,13 @@ mod tests {
     fn construction_rejects_duplicate_variables_and_wrong_row_arity() {
         let x = "?x".to_var();
 
-        assert!(BindingSet::new(vec![x.clone(), x], vec![]).is_err());
-        assert!(BindingSet::new(vec!["?x".to_var()], vec![vec![]]).is_err());
+        assert!(BindingBag::new(vec![x.clone(), x], vec![]).is_err());
+        assert!(BindingBag::new(vec!["?x".to_var()], vec![vec![]]).is_err());
     }
 
     #[test]
     fn column_lookup_reports_unknown_variables() {
-        let bindings = binding_set(&["?x", "?y"], &[&["a", "b"]]);
+        let bindings = binding_bag(&["?x", "?y"], &[&["a", "b"]]);
 
         assert_eq!(bindings.column_index(&"?x".to_var()).unwrap(), 0);
         assert_eq!(bindings.column_index(&"?y".to_var()).unwrap(), 1);
@@ -305,8 +305,8 @@ mod tests {
 
     #[test]
     fn unit_and_empty_have_relational_identity_layouts() {
-        let unit = BindingSet::unit();
-        let empty = BindingSet::empty(vec!["?x".to_var()]).unwrap();
+        let unit = BindingBag::unit();
+        let empty = BindingBag::empty(vec!["?x".to_var()]).unwrap();
 
         assert!(unit.variables().is_empty());
         assert_eq!(unit.rows(), &[Vec::<Bytes>::new()]);
@@ -316,17 +316,17 @@ mod tests {
 
     #[test]
     fn row_selection_preserves_requested_order_and_multiplicity() {
-        let bindings = binding_set(&["?x"], &[&["a"], &["b"], &["c"]]);
+        let bindings = binding_bag(&["?x"], &[&["a"], &["b"], &["c"]]);
 
         let selected = bindings.select_rows(&[2, 0, 2]).unwrap();
 
-        assert_eq!(selected, binding_set(&["?x"], &[&["c"], &["a"], &["c"]]));
+        assert_eq!(selected, binding_bag(&["?x"], &[&["c"], &["a"], &["c"]]));
         assert!(bindings.select_rows(&[3]).is_err());
     }
 
     #[test]
     fn row_extension_supports_one_to_many_results() {
-        let bindings = binding_set(&["?x"], &[&["a"], &["b"]]);
+        let bindings = binding_bag(&["?x"], &[&["a"], &["b"]]);
 
         let extended = bindings
             .extend_rows(
@@ -337,7 +337,7 @@ mod tests {
 
         assert_eq!(
             extended,
-            binding_set(&["?x", "?y"], &[&["a", "1"], &["a", "2"]])
+            binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]])
         );
         assert!(bindings
             .extend_rows(vec!["?y".to_var()], vec![vec![]])
@@ -355,20 +355,20 @@ mod tests {
 
     #[test]
     fn projection_and_reorder_address_columns_by_variable() {
-        let bindings = binding_set(
+        let bindings = binding_bag(
             &["?x", "?y", "?z"],
             &[&["x1", "y1", "z1"], &["x2", "y2", "z2"]],
         );
 
         assert_eq!(
             bindings.project(&["?z".to_var(), "?x".to_var()]).unwrap(),
-            binding_set(&["?z", "?x"], &[&["z1", "x1"], &["z2", "x2"]])
+            binding_bag(&["?z", "?x"], &[&["z1", "x1"], &["z2", "x2"]])
         );
         assert_eq!(
             bindings
                 .reorder(&["?z".to_var(), "?x".to_var(), "?y".to_var()])
                 .unwrap(),
-            binding_set(
+            binding_bag(
                 &["?z", "?x", "?y"],
                 &[&["z1", "x1", "y1"], &["z2", "x2", "y2"]],
             )
@@ -380,20 +380,20 @@ mod tests {
 
     #[test]
     fn distinct_removes_complete_row_duplicates_stably() {
-        let bindings = binding_set(
+        let bindings = binding_bag(
             &["?x", "?y"],
             &[&["a", "1"], &["b", "2"], &["a", "1"], &["a", "3"]],
         );
 
         assert_eq!(
             bindings.distinct(),
-            binding_set(&["?x", "?y"], &[&["a", "1"], &["b", "2"], &["a", "3"]],)
+            binding_bag(&["?x", "?y"], &[&["a", "1"], &["b", "2"], &["a", "3"]],)
         );
     }
 
     #[test]
     fn row_index_preserves_all_source_row_indexes() {
-        let bindings = binding_set(&["?x", "?y"], &[&["a", "1"], &["b", "1"], &["c", "2"]]);
+        let bindings = binding_bag(&["?x", "?y"], &[&["a", "1"], &["b", "1"], &["c", "2"]]);
 
         let by_y = bindings.index_by(&["?y".to_var()]).unwrap();
         assert_eq!(by_y.get(&vec![bytes("1")]), Some(&vec![0, 1]));
@@ -406,8 +406,8 @@ mod tests {
 
     #[test]
     fn natural_join_preserves_bag_multiplicity_and_layout_order() {
-        let left = binding_set(&["?x"], &[&["a"], &["a"], &["b"]]);
-        let right = binding_set(
+        let left = binding_bag(&["?x"], &[&["a"], &["a"], &["b"]]);
+        let right = binding_bag(
             &["?x", "?y"],
             &[&["a", "1"], &["a", "1"], &["a", "2"], &["c", "3"]],
         );
@@ -416,7 +416,7 @@ mod tests {
 
         assert_eq!(
             joined,
-            binding_set(
+            binding_bag(
                 &["?x", "?y"],
                 &[
                     &["a", "1"],
@@ -432,12 +432,12 @@ mod tests {
 
     #[test]
     fn natural_join_without_shared_variables_is_a_cartesian_product() {
-        let left = binding_set(&["?x"], &[&["a"], &["b"]]);
-        let right = binding_set(&["?y"], &[&["1"], &["2"]]);
+        let left = binding_bag(&["?x"], &[&["a"], &["b"]]);
+        let right = binding_bag(&["?y"], &[&["1"], &["2"]]);
 
         assert_eq!(
             left.natural_join(&right).unwrap(),
-            binding_set(
+            binding_bag(
                 &["?x", "?y"],
                 &[&["a", "1"], &["a", "2"], &["b", "1"], &["b", "2"]],
             )
@@ -446,58 +446,58 @@ mod tests {
 
     #[test]
     fn semijoin_and_antijoin_filter_without_multiplying_left_rows() {
-        let left = binding_set(
+        let left = binding_bag(
             &["?x", "?value"],
             &[&["a", "1"], &["a", "1"], &["b", "2"], &["c", "3"]],
         );
-        let right = binding_set(&["?x"], &[&["a"], &["a"], &["c"]]);
+        let right = binding_bag(&["?x"], &[&["a"], &["a"], &["c"]]);
 
         assert_eq!(
             left.semijoin(&right).unwrap(),
-            binding_set(&["?x", "?value"], &[&["a", "1"], &["a", "1"], &["c", "3"]],)
+            binding_bag(&["?x", "?value"], &[&["a", "1"], &["a", "1"], &["c", "3"]],)
         );
         assert_eq!(
             left.antijoin(&right).unwrap(),
-            binding_set(&["?x", "?value"], &[&["b", "2"]])
+            binding_bag(&["?x", "?value"], &[&["b", "2"]])
         );
     }
 
     #[test]
     fn union_has_bag_semantics_and_requires_identical_layouts() {
-        let left = binding_set(&["?x"], &[&["a"], &["a"]]);
-        let right = binding_set(&["?x"], &[&["a"], &["b"]]);
+        let left = binding_bag(&["?x"], &[&["a"], &["a"]]);
+        let right = binding_bag(&["?x"], &[&["a"], &["b"]]);
 
         assert_eq!(
             left.union(&right).unwrap(),
-            binding_set(&["?x"], &[&["a"], &["a"], &["a"], &["b"]])
+            binding_bag(&["?x"], &[&["a"], &["a"], &["a"], &["b"]])
         );
         assert_eq!(
             left.distinct_union(&right).unwrap(),
-            binding_set(&["?x"], &[&["a"], &["b"]])
+            binding_bag(&["?x"], &[&["a"], &["b"]])
         );
-        assert!(left.union(&binding_set(&["?y"], &[&["a"]])).is_err());
+        assert!(left.union(&binding_bag(&["?y"], &[&["a"]])).is_err());
     }
 
     #[test]
     fn zero_column_relations_follow_relational_identity_rules() {
-        let unit = BindingSet::unit();
-        let empty = BindingSet::empty(vec![]).unwrap();
-        let values = binding_set(&["?x"], &[&["a"], &["b"]]);
+        let unit = BindingBag::unit();
+        let empty = BindingBag::empty(vec![]).unwrap();
+        let values = binding_bag(&["?x"], &[&["a"], &["b"]]);
 
         assert_eq!(unit.natural_join(&values).unwrap(), values);
         assert_eq!(values.natural_join(&unit).unwrap(), values);
         assert_eq!(
             empty.natural_join(&values).unwrap(),
-            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+            BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
         assert_eq!(values.semijoin(&unit).unwrap(), values);
         assert_eq!(
             values.semijoin(&empty).unwrap(),
-            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+            BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
         assert_eq!(
             values.antijoin(&unit).unwrap(),
-            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+            BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
         assert_eq!(values.antijoin(&empty).unwrap(), values);
         assert_eq!(unit.union(&unit).unwrap().rows().len(), 2);

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -217,16 +217,23 @@ impl BindingBag {
         if self.rows.len() < other.rows.len() {
             let left_index = self.index_by(&shared_variables)?;
             let right_shared_indexes = other.projection_indexes(&shared_variables)?;
-            for right_row in &other.rows {
+            let mut right_row_indexes_by_left = vec![Vec::new(); self.rows.len()];
+            for (right_row_index, right_row) in other.rows.iter().enumerate() {
                 let key = Self::row_key(right_row, &right_shared_indexes);
                 if let Some(left_row_indexes) = left_index.get(&key) {
                     for left_row_index in left_row_indexes {
-                        rows.push(Self::joined_row(
-                            &self.rows[*left_row_index],
-                            right_row,
-                            &right_only_indexes,
-                        ));
+                        right_row_indexes_by_left[*left_row_index].push(right_row_index);
                     }
+                }
+            }
+            for (left_row_index, right_row_indexes) in right_row_indexes_by_left.iter().enumerate()
+            {
+                for right_row_index in right_row_indexes {
+                    rows.push(Self::joined_row(
+                        &self.rows[left_row_index],
+                        &other.rows[*right_row_index],
+                        &right_only_indexes,
+                    ));
                 }
             }
         } else {
@@ -445,13 +452,25 @@ mod tests {
                 &["?x", "?left", "?y"],
                 &[
                     &["a", "l1", "1"],
-                    &["a", "l2", "1"],
                     &["a", "l1", "1"],
-                    &["a", "l2", "1"],
                     &["a", "l1", "2"],
+                    &["a", "l2", "1"],
+                    &["a", "l2", "1"],
                     &["a", "l2", "2"],
                 ],
             )
+        );
+    }
+
+    #[test]
+    fn natural_join_row_order_is_independent_of_build_side() {
+        let left = binding_bag(&["?x", "?left"], &[&["a", "l1"], &["a", "l2"]]);
+        let right = binding_bag(&["?x", "?right"], &[&["a", "1"], &["a", "2"]]);
+        let larger_right = binding_bag(&["?x", "?right"], &[&["a", "1"], &["a", "2"], &["b", "3"]]);
+
+        assert_eq!(
+            left.natural_join(&right).unwrap(),
+            left.natural_join(&larger_right).unwrap()
         );
     }
 

--- a/src/query/binding_set.rs
+++ b/src/query/binding_set.rs
@@ -1,0 +1,506 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{ensure, Result};
+use bytes::Bytes;
+use edn::query::Variable;
+
+pub(crate) type BindingRow = Vec<Bytes>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BindingSet {
+    variables: Vec<Variable>,
+    rows: Vec<BindingRow>,
+    column_indexes: HashMap<Variable, usize>,
+}
+
+impl BindingSet {
+    pub(crate) fn new(variables: Vec<Variable>, rows: Vec<BindingRow>) -> Result<Self> {
+        let mut column_indexes = HashMap::with_capacity(variables.len());
+        for (index, variable) in variables.iter().enumerate() {
+            ensure!(
+                column_indexes.insert(variable.clone(), index).is_none(),
+                "BindingSet variables must be unique: {variable}"
+            );
+        }
+        for (index, row) in rows.iter().enumerate() {
+            ensure!(
+                row.len() == variables.len(),
+                "BindingSet row {index} has arity {}, expected {}",
+                row.len(),
+                variables.len()
+            );
+        }
+
+        Ok(Self {
+            variables,
+            rows,
+            column_indexes,
+        })
+    }
+
+    pub(crate) fn unit() -> Self {
+        Self {
+            variables: Vec::new(),
+            rows: vec![Vec::new()],
+            column_indexes: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn empty(variables: Vec<Variable>) -> Result<Self> {
+        Self::new(variables, Vec::new())
+    }
+
+    pub(crate) fn variables(&self) -> &[Variable] {
+        &self.variables
+    }
+
+    pub(crate) fn rows(&self) -> &[BindingRow] {
+        &self.rows
+    }
+
+    pub(crate) fn column_index(&self, variable: &Variable) -> Result<usize> {
+        self.column_indexes
+            .get(variable)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("Unknown BindingSet variable: {variable}"))
+    }
+
+    fn projection_indexes(&self, variables: &[Variable]) -> Result<Vec<usize>> {
+        let mut seen = HashSet::with_capacity(variables.len());
+        variables
+            .iter()
+            .map(|variable| {
+                ensure!(
+                    seen.insert(variable),
+                    "Projection variables must be unique: {variable}"
+                );
+                self.column_index(variable)
+            })
+            .collect()
+    }
+
+    pub(crate) fn select_rows(&self, row_indexes: &[usize]) -> Result<Self> {
+        let rows = row_indexes
+            .iter()
+            .map(|row_index| {
+                self.rows
+                    .get(*row_index)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("Unknown BindingSet row index: {row_index}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Self::new(self.variables.clone(), rows)
+    }
+
+    pub(crate) fn extend_rows(
+        &self,
+        added_variables: Vec<Variable>,
+        extensions: Vec<Vec<BindingRow>>,
+    ) -> Result<Self> {
+        ensure!(
+            extensions.len() == self.rows.len(),
+            "BindingSet extensions have {} input rows, expected {}",
+            extensions.len(),
+            self.rows.len()
+        );
+
+        let mut seen: HashSet<Variable> = self.variables.iter().cloned().collect();
+        for variable in &added_variables {
+            ensure!(
+                seen.insert(variable.clone()),
+                "Extended BindingSet variables must be unique: {variable}"
+            );
+        }
+
+        let mut rows = Vec::new();
+        for (input, input_extensions) in self.rows.iter().zip(extensions) {
+            for mut extension in input_extensions {
+                ensure!(
+                    extension.len() == added_variables.len(),
+                    "BindingSet extension has arity {}, expected {}",
+                    extension.len(),
+                    added_variables.len()
+                );
+                let mut row = input.clone();
+                row.append(&mut extension);
+                rows.push(row);
+            }
+        }
+
+        let mut variables = self.variables.clone();
+        variables.extend(added_variables);
+        Self::new(variables, rows)
+    }
+
+    pub(crate) fn project(&self, variables: &[Variable]) -> Result<Self> {
+        let indexes = self.projection_indexes(variables)?;
+        let rows = self
+            .rows
+            .iter()
+            .map(|row| indexes.iter().map(|index| row[*index].clone()).collect())
+            .collect();
+        Self::new(variables.to_vec(), rows)
+    }
+
+    pub(crate) fn reorder(&self, variables: &[Variable]) -> Result<Self> {
+        ensure!(
+            variables.len() == self.variables.len(),
+            "Reordered layout must contain exactly the current variables"
+        );
+        self.project(variables)
+    }
+
+    pub(crate) fn distinct(&self) -> Self {
+        let mut seen = HashSet::with_capacity(self.rows.len());
+        let rows = self
+            .rows
+            .iter()
+            .filter(|row| seen.insert((*row).clone()))
+            .cloned()
+            .collect();
+        Self {
+            variables: self.variables.clone(),
+            rows,
+            column_indexes: self.column_indexes.clone(),
+        }
+    }
+
+    pub(crate) fn index_by(
+        &self,
+        variables: &[Variable],
+    ) -> Result<HashMap<BindingRow, Vec<usize>>> {
+        let indexes = self.projection_indexes(variables)?;
+        let mut result = HashMap::new();
+        for (row_index, row) in self.rows.iter().enumerate() {
+            let key = indexes.iter().map(|index| row[*index].clone()).collect();
+            result.entry(key).or_insert_with(Vec::new).push(row_index);
+        }
+        Ok(result)
+    }
+
+    fn shared_variables(&self, other: &Self) -> Vec<Variable> {
+        self.variables
+            .iter()
+            .filter(|variable| other.column_indexes.contains_key(*variable))
+            .cloned()
+            .collect()
+    }
+
+    fn row_key(row: &BindingRow, indexes: &[usize]) -> BindingRow {
+        indexes.iter().map(|index| row[*index].clone()).collect()
+    }
+
+    pub(crate) fn natural_join(&self, other: &Self) -> Result<Self> {
+        let shared_variables = self.shared_variables(other);
+        let left_shared_indexes = self.projection_indexes(&shared_variables)?;
+        let right_index = other.index_by(&shared_variables)?;
+        let right_only: Vec<(Variable, usize)> = other
+            .variables
+            .iter()
+            .enumerate()
+            .filter(|(_, variable)| !self.column_indexes.contains_key(*variable))
+            .map(|(index, variable)| (variable.clone(), index))
+            .collect();
+
+        let mut variables = self.variables.clone();
+        variables.extend(right_only.iter().map(|(variable, _)| variable.clone()));
+
+        let mut rows = Vec::new();
+        for left_row in &self.rows {
+            let key = Self::row_key(left_row, &left_shared_indexes);
+            if let Some(right_row_indexes) = right_index.get(&key) {
+                for right_row_index in right_row_indexes {
+                    let mut row = left_row.clone();
+                    row.extend(
+                        right_only
+                            .iter()
+                            .map(|(_, index)| other.rows[*right_row_index][*index].clone()),
+                    );
+                    rows.push(row);
+                }
+            }
+        }
+
+        Self::new(variables, rows)
+    }
+
+    pub(crate) fn semijoin(&self, other: &Self) -> Result<Self> {
+        let shared_variables = self.shared_variables(other);
+        let left_shared_indexes = self.projection_indexes(&shared_variables)?;
+        let right_index = other.index_by(&shared_variables)?;
+        let rows = self
+            .rows
+            .iter()
+            .filter(|row| right_index.contains_key(&Self::row_key(row, &left_shared_indexes)))
+            .cloned()
+            .collect();
+        Self::new(self.variables.clone(), rows)
+    }
+
+    pub(crate) fn antijoin(&self, other: &Self) -> Result<Self> {
+        let shared_variables = self.shared_variables(other);
+        let left_shared_indexes = self.projection_indexes(&shared_variables)?;
+        let right_index = other.index_by(&shared_variables)?;
+        let rows = self
+            .rows
+            .iter()
+            .filter(|row| !right_index.contains_key(&Self::row_key(row, &left_shared_indexes)))
+            .cloned()
+            .collect();
+        Self::new(self.variables.clone(), rows)
+    }
+
+    pub(crate) fn union(&self, other: &Self) -> Result<Self> {
+        ensure!(
+            self.variables == other.variables,
+            "Union requires identical BindingSet layouts"
+        );
+        let mut rows = self.rows.clone();
+        rows.extend(other.rows.iter().cloned());
+        Self::new(self.variables.clone(), rows)
+    }
+
+    pub(crate) fn distinct_union(&self, other: &Self) -> Result<Self> {
+        Ok(self.union(other)?.distinct())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use edn::query::ToVariable;
+
+    use super::BindingSet;
+
+    fn bytes(value: &str) -> Bytes {
+        Bytes::copy_from_slice(value.as_bytes())
+    }
+
+    fn binding_set(variables: &[&str], rows: &[&[&str]]) -> BindingSet {
+        BindingSet::new(
+            variables.iter().map(|variable| variable.to_var()).collect(),
+            rows.iter()
+                .map(|row| row.iter().map(|value| bytes(value)).collect())
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn construction_rejects_duplicate_variables_and_wrong_row_arity() {
+        let x = "?x".to_var();
+
+        assert!(BindingSet::new(vec![x.clone(), x], vec![]).is_err());
+        assert!(BindingSet::new(vec!["?x".to_var()], vec![vec![]]).is_err());
+    }
+
+    #[test]
+    fn column_lookup_reports_unknown_variables() {
+        let bindings = binding_set(&["?x", "?y"], &[&["a", "b"]]);
+
+        assert_eq!(bindings.column_index(&"?x".to_var()).unwrap(), 0);
+        assert_eq!(bindings.column_index(&"?y".to_var()).unwrap(), 1);
+        assert!(bindings.column_index(&"?z".to_var()).is_err());
+    }
+
+    #[test]
+    fn unit_and_empty_have_relational_identity_layouts() {
+        let unit = BindingSet::unit();
+        let empty = BindingSet::empty(vec!["?x".to_var()]).unwrap();
+
+        assert!(unit.variables().is_empty());
+        assert_eq!(unit.rows(), &[Vec::<Bytes>::new()]);
+        assert_eq!(empty.variables(), &["?x".to_var()]);
+        assert!(empty.rows().is_empty());
+    }
+
+    #[test]
+    fn row_selection_preserves_requested_order_and_multiplicity() {
+        let bindings = binding_set(&["?x"], &[&["a"], &["b"], &["c"]]);
+
+        let selected = bindings.select_rows(&[2, 0, 2]).unwrap();
+
+        assert_eq!(selected, binding_set(&["?x"], &[&["c"], &["a"], &["c"]]));
+        assert!(bindings.select_rows(&[3]).is_err());
+    }
+
+    #[test]
+    fn row_extension_supports_one_to_many_results() {
+        let bindings = binding_set(&["?x"], &[&["a"], &["b"]]);
+
+        let extended = bindings
+            .extend_rows(
+                vec!["?y".to_var()],
+                vec![vec![vec![bytes("1")], vec![bytes("2")]], vec![]],
+            )
+            .unwrap();
+
+        assert_eq!(
+            extended,
+            binding_set(&["?x", "?y"], &[&["a", "1"], &["a", "2"]])
+        );
+        assert!(bindings
+            .extend_rows(vec!["?y".to_var()], vec![vec![]])
+            .is_err());
+        assert!(bindings
+            .extend_rows(
+                vec!["?y".to_var()],
+                vec![vec![vec![]], vec![vec![bytes("1")]]],
+            )
+            .is_err());
+        assert!(bindings
+            .extend_rows(vec!["?x".to_var()], vec![vec![], vec![]])
+            .is_err());
+    }
+
+    #[test]
+    fn projection_and_reorder_address_columns_by_variable() {
+        let bindings = binding_set(
+            &["?x", "?y", "?z"],
+            &[&["x1", "y1", "z1"], &["x2", "y2", "z2"]],
+        );
+
+        assert_eq!(
+            bindings.project(&["?z".to_var(), "?x".to_var()]).unwrap(),
+            binding_set(&["?z", "?x"], &[&["z1", "x1"], &["z2", "x2"]])
+        );
+        assert_eq!(
+            bindings
+                .reorder(&["?z".to_var(), "?x".to_var(), "?y".to_var()])
+                .unwrap(),
+            binding_set(
+                &["?z", "?x", "?y"],
+                &[&["z1", "x1", "y1"], &["z2", "x2", "y2"]],
+            )
+        );
+        assert!(bindings.project(&["?missing".to_var()]).is_err());
+        assert!(bindings.project(&["?x".to_var(), "?x".to_var()]).is_err());
+        assert!(bindings.reorder(&["?x".to_var(), "?y".to_var()]).is_err());
+    }
+
+    #[test]
+    fn distinct_removes_complete_row_duplicates_stably() {
+        let bindings = binding_set(
+            &["?x", "?y"],
+            &[&["a", "1"], &["b", "2"], &["a", "1"], &["a", "3"]],
+        );
+
+        assert_eq!(
+            bindings.distinct(),
+            binding_set(&["?x", "?y"], &[&["a", "1"], &["b", "2"], &["a", "3"]],)
+        );
+    }
+
+    #[test]
+    fn row_index_preserves_all_source_row_indexes() {
+        let bindings = binding_set(&["?x", "?y"], &[&["a", "1"], &["b", "1"], &["c", "2"]]);
+
+        let by_y = bindings.index_by(&["?y".to_var()]).unwrap();
+        assert_eq!(by_y.get(&vec![bytes("1")]), Some(&vec![0, 1]));
+        assert_eq!(by_y.get(&vec![bytes("2")]), Some(&vec![2]));
+
+        let by_nothing = bindings.index_by(&[]).unwrap();
+        assert_eq!(by_nothing.get(&vec![]), Some(&vec![0, 1, 2]));
+        assert!(bindings.index_by(&["?missing".to_var()]).is_err());
+    }
+
+    #[test]
+    fn natural_join_preserves_bag_multiplicity_and_layout_order() {
+        let left = binding_set(&["?x"], &[&["a"], &["a"], &["b"]]);
+        let right = binding_set(
+            &["?x", "?y"],
+            &[&["a", "1"], &["a", "1"], &["a", "2"], &["c", "3"]],
+        );
+
+        let joined = left.natural_join(&right).unwrap();
+
+        assert_eq!(
+            joined,
+            binding_set(
+                &["?x", "?y"],
+                &[
+                    &["a", "1"],
+                    &["a", "1"],
+                    &["a", "2"],
+                    &["a", "1"],
+                    &["a", "1"],
+                    &["a", "2"],
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn natural_join_without_shared_variables_is_a_cartesian_product() {
+        let left = binding_set(&["?x"], &[&["a"], &["b"]]);
+        let right = binding_set(&["?y"], &[&["1"], &["2"]]);
+
+        assert_eq!(
+            left.natural_join(&right).unwrap(),
+            binding_set(
+                &["?x", "?y"],
+                &[&["a", "1"], &["a", "2"], &["b", "1"], &["b", "2"]],
+            )
+        );
+    }
+
+    #[test]
+    fn semijoin_and_antijoin_filter_without_multiplying_left_rows() {
+        let left = binding_set(
+            &["?x", "?value"],
+            &[&["a", "1"], &["a", "1"], &["b", "2"], &["c", "3"]],
+        );
+        let right = binding_set(&["?x"], &[&["a"], &["a"], &["c"]]);
+
+        assert_eq!(
+            left.semijoin(&right).unwrap(),
+            binding_set(&["?x", "?value"], &[&["a", "1"], &["a", "1"], &["c", "3"]],)
+        );
+        assert_eq!(
+            left.antijoin(&right).unwrap(),
+            binding_set(&["?x", "?value"], &[&["b", "2"]])
+        );
+    }
+
+    #[test]
+    fn union_has_bag_semantics_and_requires_identical_layouts() {
+        let left = binding_set(&["?x"], &[&["a"], &["a"]]);
+        let right = binding_set(&["?x"], &[&["a"], &["b"]]);
+
+        assert_eq!(
+            left.union(&right).unwrap(),
+            binding_set(&["?x"], &[&["a"], &["a"], &["a"], &["b"]])
+        );
+        assert_eq!(
+            left.distinct_union(&right).unwrap(),
+            binding_set(&["?x"], &[&["a"], &["b"]])
+        );
+        assert!(left.union(&binding_set(&["?y"], &[&["a"]])).is_err());
+    }
+
+    #[test]
+    fn zero_column_relations_follow_relational_identity_rules() {
+        let unit = BindingSet::unit();
+        let empty = BindingSet::empty(vec![]).unwrap();
+        let values = binding_set(&["?x"], &[&["a"], &["b"]]);
+
+        assert_eq!(unit.natural_join(&values).unwrap(), values);
+        assert_eq!(values.natural_join(&unit).unwrap(), values);
+        assert_eq!(
+            empty.natural_join(&values).unwrap(),
+            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+        );
+        assert_eq!(values.semijoin(&unit).unwrap(), values);
+        assert_eq!(
+            values.semijoin(&empty).unwrap(),
+            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+        );
+        assert_eq!(
+            values.antijoin(&unit).unwrap(),
+            BindingSet::empty(vec!["?x".to_var()]).unwrap()
+        );
+        assert_eq!(values.antijoin(&empty).unwrap(), values);
+        assert_eq!(unit.union(&unit).unwrap().rows().len(), 2);
+        assert_eq!(unit.distinct_union(&unit).unwrap(), unit);
+    }
+}

--- a/src/query/binding_set.rs
+++ b/src/query/binding_set.rs
@@ -170,10 +170,10 @@ impl BindingSet {
         variables: &[Variable],
     ) -> Result<HashMap<BindingRow, Vec<usize>>> {
         let indexes = self.projection_indexes(variables)?;
-        let mut result = HashMap::new();
+        let mut result: HashMap<BindingRow, Vec<usize>> = HashMap::new();
         for (row_index, row) in self.rows.iter().enumerate() {
             let key = indexes.iter().map(|index| row[*index].clone()).collect();
-            result.entry(key).or_insert_with(Vec::new).push(row_index);
+            result.entry(key).or_default().push(row_index);
         }
         Ok(result)
     }


### PR DESCRIPTION
I am pulling the `BindingSet` out of #422 and pull it in by itself. This is likely something that eventually gets replaced by a columnar trie (see https://github.com/FiV0/triplox/issues/373). For now we just use a row based set to represent intermediate results. They will get translated to `RelationPattern` at runtime when joined against other structures. `RelationPattern` will be backed by a trie.