### PR TITLE
Standard engine rewrite [2/N]: `ExecPattern`, `TriplePattern` and `RelationPattern`.

### DIFF
--- a/src/algo/trie.rs
+++ b/src/algo/trie.rs
@@ -80,6 +80,12 @@ impl<T> Default for TrieNode<T> {
     }
 }
 
+impl<T> TrieNode<T> {
+    pub(crate) fn children(&self) -> impl Iterator<Item = (&T, &TrieNode<T>)> {
+        self.children.iter()
+    }
+}
+
 impl<T> TrieNode<T>
 where
     T: Eq + Hash,
@@ -91,6 +97,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::Trie;
 
     #[test]
@@ -165,5 +173,25 @@ mod tests {
         assert!(trie.contains_prefix(["a", "x"].iter()));
         assert!(trie.contains_prefix(["a", "y"].iter()));
         assert!(!trie.contains_prefix(["y"].iter()));
+    }
+
+    #[test]
+    fn node_children_expose_unique_values_and_subtrees() {
+        let mut trie = Trie::new();
+        trie.insert(["a", "x", "1"]);
+        trie.insert(["a", "x", "2"]);
+        trie.insert(["a", "x", "2"]);
+        trie.insert(["a", "y", "3"]);
+
+        let a = trie.node(["a"].iter()).unwrap();
+        let children: HashSet<_> = a.children().map(|(value, _)| *value).collect();
+        assert_eq!(children, HashSet::from(["x", "y"]));
+
+        let x = a
+            .children()
+            .find_map(|(value, child)| (*value == "x").then_some(child))
+            .unwrap();
+        let descendants: HashSet<_> = x.children().map(|(value, _)| *value).collect();
+        assert_eq!(descendants, HashSet::from(["1", "2"]));
     }
 }

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn attribute_prefix_ave_iterates_ve_pairs_and_seeks_exact_pairs() {
+    async fn attribute_prefix_ave_seeks_ve_pair_and_continues_iteration() {
         let components = in_memory_slate().await;
         let prefix = attribute_prefix(codec::AVE, 42);
         let entity_1 = encoded(DataType::Long(1));

--- a/src/iterator/temporal_filter_iterator.rs
+++ b/src/iterator/temporal_filter_iterator.rs
@@ -194,7 +194,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
+    use crate::codec::Encode;
+    use crate::ops::DataType;
     use crate::slate::in_memory_slate;
 
     const PFX: &[u8] = b"\x04"; // AV prefix
@@ -209,6 +213,164 @@ mod tests {
 
     fn make_test_extractor(prefix_len: usize) -> Extractor {
         Box::new(move |key: Bytes| key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX))
+    }
+
+    fn attribute_prefix(index: u8, attribute: i64) -> Vec<u8> {
+        let mut prefix = vec![index];
+        prefix.extend_from_slice(&codec::encode_i64_bytes(attribute));
+        prefix
+    }
+
+    fn pair_key(prefix: &[u8], first: &[u8], second: &[u8], tx_eid: i64, op: u8) -> Vec<u8> {
+        let mut key = prefix.to_vec();
+        key.extend_from_slice(first);
+        key.extend_from_slice(second);
+        key.extend_from_slice(&codec::encode_i64_bytes(tx_eid));
+        key.push(op);
+        key
+    }
+
+    fn pair(first: &Bytes, second: &Bytes) -> Bytes {
+        let mut pair = first.to_vec();
+        pair.extend_from_slice(second);
+        Bytes::from(pair)
+    }
+
+    fn encoded(value: DataType) -> Bytes {
+        Bytes::from(value.encode())
+    }
+
+    fn collect_current_group<M>(
+        iter: &mut TemporalFilterIterator<M>,
+        first: &Bytes,
+    ) -> Result<Vec<Bytes>, Error>
+    where
+        M: DbMetadataOps + Send + Sync,
+    {
+        let mut pairs = Vec::new();
+        while let Some(current) = iter.get_value()? {
+            if !current.starts_with(first) {
+                break;
+            }
+            pairs.push(current);
+            iter.next()?;
+        }
+        Ok(pairs)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn attribute_prefix_aev_iterates_and_seeks_ev_pairs() {
+        let components = in_memory_slate().await;
+        let prefix = attribute_prefix(codec::AEV, 42);
+        let entity_1 = encoded(DataType::Long(1));
+        let entity_2 = encoded(DataType::Long(2));
+        let entity_3 = encoded(DataType::Long(3));
+        let alice = encoded(DataType::String("alice".into()));
+        let ally = encoded(DataType::String("ally".into()));
+        let bob = encoded(DataType::String("bob".into()));
+        let carol = encoded(DataType::String("carol".into()));
+
+        components
+            .db
+            .put(&pair_key(&prefix, &entity_1, &alice, 10, codec::ADD), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &entity_1, &ally, 10, codec::ADD), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &entity_2, &bob, 10, codec::ADD), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &entity_2, &bob, 20, codec::RETRACT), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &entity_3, &carol, 10, codec::ADD), b"")
+            .await;
+
+        let prefix_len = prefix.len();
+        let db = components.db;
+        let range_stats = components.range_stats;
+        let handle = tokio::runtime::Handle::current();
+        tokio::task::spawn_blocking(move || {
+            let entity_1_pairs = vec![pair(&entity_1, &alice), pair(&entity_1, &ally)];
+            let entity_3_pairs = vec![pair(&entity_3, &carol)];
+            let expected = BTreeMap::from([
+                (entity_1, entity_1_pairs),
+                (entity_2, Vec::new()),
+                (entity_3, entity_3_pairs),
+            ]);
+            let mut iter = TemporalFilterIterator::new(
+                &prefix,
+                db.as_ref(),
+                handle,
+                make_test_extractor(prefix_len),
+                20,
+                range_stats,
+            )?;
+
+            for (entity, expected_pairs) in expected {
+                iter.seek(entity.clone())?;
+                assert_eq!(collect_current_group(&mut iter, &entity)?, expected_pairs);
+            }
+            Ok::<_, Error>(())
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn attribute_prefix_ave_iterates_ve_pairs_and_seeks_exact_pairs() {
+        let components = in_memory_slate().await;
+        let prefix = attribute_prefix(codec::AVE, 42);
+        let entity_1 = encoded(DataType::Long(1));
+        let entity_2 = encoded(DataType::Long(2));
+        let alice = encoded(DataType::String("alice".into()));
+        let bob = encoded(DataType::String("bob".into()));
+
+        components
+            .db
+            .put(&pair_key(&prefix, &alice, &entity_1, 10, codec::ADD), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &alice, &entity_2, 10, codec::ADD), b"")
+            .await;
+        components
+            .db
+            .put(&pair_key(&prefix, &bob, &entity_2, 10, codec::ADD), b"")
+            .await;
+
+        let exact = pair(&alice, &entity_2);
+        let prefix_len = prefix.len();
+        let db = components.db;
+        let range_stats = components.range_stats;
+        let handle = tokio::runtime::Handle::current();
+        tokio::task::spawn_blocking(move || {
+            let mut iter = TemporalFilterIterator::new(
+                &prefix,
+                db.as_ref(),
+                handle,
+                make_test_extractor(prefix_len),
+                10,
+                range_stats,
+            )?;
+
+            iter.seek(exact.clone())?;
+            assert_eq!(iter.get_value()?, Some(exact));
+            iter.next()?;
+            assert_eq!(iter.get_value()?, Some(pair(&alice, &entity_1)));
+            iter.next()?;
+            assert_eq!(iter.get_value()?, Some(pair(&bob, &entity_2)));
+            Ok::<_, Error>(())
+        })
+        .await
+        .unwrap()
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,9 @@
 #![allow(unused)]
 
 pub(crate) mod binding_bag;
+pub(crate) mod exec_pattern;
+pub(crate) mod patterns;
+pub(crate) mod stage;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -10,7 +10,7 @@ pub(crate) type BindingRow = Vec<Bytes>;
 pub(crate) struct BindingBag {
     pub(crate) variables: Vec<Variable>,
     pub(crate) rows: Vec<BindingRow>,
-    column_indexes: HashMap<Variable, usize>,
+    pub(crate) column_indexes: HashMap<Variable, usize>,
 }
 
 impl BindingBag {

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -133,13 +133,17 @@ impl BindingBag {
     }
 
     pub(crate) fn project(&self, variables: &[Variable]) -> Result<Self> {
-        let indexes = self.projection_indexes(variables)?;
-        let rows = self
-            .rows
-            .iter()
-            .map(|row| indexes.iter().map(|index| row[*index].clone()).collect())
-            .collect();
-        Self::new(variables.to_vec(), rows)
+        if (variables == self.variables) {
+            return Ok(self.clone());
+        } else {
+            let indexes = self.projection_indexes(variables)?;
+            let rows = self
+                .rows
+                .iter()
+                .map(|row| indexes.iter().map(|index| row[*index].clone()).collect())
+                .collect();
+            Self::new(variables.to_vec(), rows)
+        }
     }
 
     pub(crate) fn reorder(&self, variables: &[Variable]) -> Result<Self> {

--- a/src/query/binding_bag.rs
+++ b/src/query/binding_bag.rs
@@ -133,8 +133,8 @@ impl BindingBag {
     }
 
     pub(crate) fn project(&self, variables: &[Variable]) -> Result<Self> {
-        if (variables == self.variables) {
-            return Ok(self.clone());
+        if variables == self.variables {
+            Ok(self.clone())
         } else {
             let indexes = self.projection_indexes(variables)?;
             let rows = self

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -3,16 +3,16 @@ use edn::query::Variable;
 
 use super::binding_bag::BindingBag;
 
-pub(crate) type ParticipantIndex = usize;
+pub(crate) type PatternIndex = usize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Proposal {
-    proposer: Option<ParticipantIndex>,
+    proposer: Option<PatternIndex>,
     count: usize,
 }
 
 impl Proposal {
-    pub(crate) fn proposer(&self) -> Option<ParticipantIndex> {
+    pub(crate) fn proposer(&self) -> Option<PatternIndex> {
         self.proposer
     }
 
@@ -20,7 +20,7 @@ impl Proposal {
         self.count
     }
 
-    pub(crate) fn consider(&mut self, proposer: ParticipantIndex, count: usize) {
+    pub(crate) fn consider(&mut self, proposer: PatternIndex, count: usize) {
         if count > 0 && count < self.count {
             self.proposer = Some(proposer);
             self.count = count;
@@ -38,6 +38,9 @@ impl Default for Proposal {
 }
 
 pub(crate) trait ExecPattern: Send + Sync {
+    // The stable index assigned to this pattern in the executable plan.
+    fn index(&self) -> PatternIndex;
+
     // The variables this pattern participates in.
     fn variables(&self) -> &[Variable];
 
@@ -46,7 +49,6 @@ pub(crate) trait ExecPattern: Send + Sync {
         &self,
         input: &BindingBag,
         added: &[Variable],
-        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()>;
 

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -52,7 +52,7 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
-    // Extends the `input`` when `added` is non-empty; otherwise filters `input` potentially changing the layout via target_variables.
+    // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
     /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.
     fn join(
         &self,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -52,8 +52,8 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
-    // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
-    /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.
+    // Extends `input` when `added` is non-empty; otherwise filters it without changing its layout.
+    /// Incomplete patterns may retain safe candidates, but fully bound patterns must validate definitively.
     fn join(
         &self,
         input: &BindingBag,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -40,8 +40,10 @@ impl Default for Proposal {
 pub(crate) trait ExecPattern: Send + Sync {
     fn id(&self) -> PatternId;
 
+    // The variables this pattern participates in.
     fn variables(&self) -> &[Variable];
 
+    // Updates per-row proposals only when this pattern has a strictly cheaper positive count.
     fn count(
         &self,
         input: &BindingBag,
@@ -49,7 +51,8 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
-    /// An empty `added` existentially validates the current binding prefix; unbound pattern variables remain for later stages.
+    // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
+    /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.
     fn join(
         &self,
         input: &BindingBag,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -52,7 +52,7 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
-    // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
+    // Extends the `input`` when `added` is non-empty; otherwise filters `input` potentially changing the layout via target_variables.
     /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.
     fn join(
         &self,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use edn::query::Variable;
+
+use super::binding_bag::BindingBag;
+
+pub(crate) type PatternId = usize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Proposal {
+    proposer: Option<PatternId>,
+    count: usize,
+}
+
+impl Proposal {
+    pub(crate) fn proposer(&self) -> Option<PatternId> {
+        self.proposer
+    }
+
+    pub(crate) fn count(&self) -> usize {
+        self.count
+    }
+
+    pub(crate) fn consider(&mut self, proposer: PatternId, count: usize) {
+        if count > 0 && count < self.count {
+            self.proposer = Some(proposer);
+            self.count = count;
+        }
+    }
+}
+
+impl Default for Proposal {
+    fn default() -> Self {
+        Self {
+            proposer: None,
+            count: usize::MAX,
+        }
+    }
+}
+
+pub(crate) trait ExecPattern: Send + Sync {
+    fn id(&self) -> PatternId;
+
+    fn variables(&self) -> &[Variable];
+
+    fn count(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        proposals: &mut [Proposal],
+    ) -> Result<()>;
+
+    fn join(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        target_variables: &[Variable],
+    ) -> Result<BindingBag>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Proposal;
+
+    #[test]
+    fn proposal_keeps_the_first_strictly_cheapest_positive_count() {
+        let mut proposal = Proposal::default();
+
+        proposal.consider(4, 0);
+        assert_eq!(proposal.proposer(), None);
+
+        proposal.consider(4, 3);
+        proposal.consider(5, 3);
+        assert_eq!(proposal.proposer(), Some(4));
+        assert_eq!(proposal.count(), 3);
+
+        proposal.consider(5, 2);
+        assert_eq!(proposal.proposer(), Some(5));
+        assert_eq!(proposal.count(), 2);
+    }
+}

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -49,6 +49,7 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
+    /// An empty `added` existentially validates the current binding prefix; unbound pattern variables remain for later stages.
     fn join(
         &self,
         input: &BindingBag,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -52,8 +52,8 @@ pub(crate) trait ExecPattern: Send + Sync {
         proposals: &mut [Proposal],
     ) -> Result<()>;
 
-    // Extends `input` when `added` is non-empty; otherwise filters it without changing its layout.
-    /// Incomplete patterns may retain safe candidates, but fully bound patterns must validate definitively.
+    // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
+    /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.
     fn join(
         &self,
         input: &BindingBag,

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -21,7 +21,7 @@ impl Proposal {
     }
 
     pub(crate) fn consider(&mut self, proposer: PatternIndex, count: usize) {
-        if count > 0 && count < self.count {
+        if self.proposer.is_none() || count < self.count {
             self.proposer = Some(proposer);
             self.count = count;
         }
@@ -44,7 +44,7 @@ pub(crate) trait ExecPattern: Send + Sync {
     // The variables this pattern participates in.
     fn variables(&self) -> &[Variable];
 
-    // Updates per-row proposals only when this pattern has a strictly cheaper positive count.
+    // Updates proposals without a proposer or with a strictly higher count.
     fn count(
         &self,
         input: &BindingBag,
@@ -67,19 +67,21 @@ mod tests {
     use super::Proposal;
 
     #[test]
-    fn proposal_keeps_the_first_strictly_cheapest_positive_count() {
+    fn proposal_keeps_the_first_strictly_cheapest_count() {
         let mut proposal = Proposal::default();
 
-        proposal.consider(4, 0);
-        assert_eq!(proposal.proposer(), None);
-
-        proposal.consider(4, 3);
-        proposal.consider(5, 3);
+        proposal.consider(4, usize::MAX);
+        proposal.consider(5, usize::MAX);
         assert_eq!(proposal.proposer(), Some(4));
+        assert_eq!(proposal.count(), usize::MAX);
+
+        proposal.consider(5, 3);
+        proposal.consider(6, 3);
+        assert_eq!(proposal.proposer(), Some(5));
         assert_eq!(proposal.count(), 3);
 
-        proposal.consider(5, 2);
-        assert_eq!(proposal.proposer(), Some(5));
-        assert_eq!(proposal.count(), 2);
+        proposal.consider(6, 0);
+        assert_eq!(proposal.proposer(), Some(6));
+        assert_eq!(proposal.count(), 0);
     }
 }

--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -3,16 +3,16 @@ use edn::query::Variable;
 
 use super::binding_bag::BindingBag;
 
-pub(crate) type PatternId = usize;
+pub(crate) type ParticipantIndex = usize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Proposal {
-    proposer: Option<PatternId>,
+    proposer: Option<ParticipantIndex>,
     count: usize,
 }
 
 impl Proposal {
-    pub(crate) fn proposer(&self) -> Option<PatternId> {
+    pub(crate) fn proposer(&self) -> Option<ParticipantIndex> {
         self.proposer
     }
 
@@ -20,7 +20,7 @@ impl Proposal {
         self.count
     }
 
-    pub(crate) fn consider(&mut self, proposer: PatternId, count: usize) {
+    pub(crate) fn consider(&mut self, proposer: ParticipantIndex, count: usize) {
         if count > 0 && count < self.count {
             self.proposer = Some(proposer);
             self.count = count;
@@ -38,8 +38,6 @@ impl Default for Proposal {
 }
 
 pub(crate) trait ExecPattern: Send + Sync {
-    fn id(&self) -> PatternId;
-
     // The variables this pattern participates in.
     fn variables(&self) -> &[Variable];
 
@@ -48,6 +46,7 @@ pub(crate) trait ExecPattern: Send + Sync {
         &self,
         input: &BindingBag,
         added: &[Variable],
+        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()>;
 

--- a/src/query/patterns/mod.rs
+++ b/src/query/patterns/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod relation;

--- a/src/query/patterns/mod.rs
+++ b/src/query/patterns/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod relation;
+pub(crate) mod triple;

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -6,6 +6,12 @@ use crate::algo::trie::{Trie, TrieNode};
 use crate::query::binding_bag::{BindingBag, BindingRow};
 use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 
+/// A pattern that matches a relation (set of rows) with a fixed set of variables.
+///
+/// Bound variables are read from the input in this relation's variable order, regardless of
+/// their input column order or unrelated interleaved columns. For proposals, the bound variables
+/// followed by the introduced variables must form a relation prefix. Validation requires the bound
+/// variables themselves to form a relation prefix.
 pub(crate) struct RelationPattern {
     id: PatternId,
     variables: Vec<Variable>,

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -9,12 +9,14 @@ use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 /// A pattern that matches a relation (set of rows) with a fixed set of variables.
 ///
 /// Bound variables are read from the input in this relation's variable order, regardless of
-/// their input column order or unrelated interleaved columns. For proposals, the bound variables
+/// column order in the input or unrelated interleaved columns. For proposals, the bound variables
 /// followed by the introduced variables must form a relation prefix. Validation requires the bound
 /// variables themselves to form a relation prefix.
 pub(crate) struct RelationPattern {
     id: PatternId,
     variables: Vec<Variable>,
+    // The only reason we have this field is to distinguish between an empty relation `{}` and a relation with no rows `{()}`.
+    // An empty trie can not distinguish between the two.
     has_rows: bool,
     trie: Trie<Bytes>,
 }
@@ -35,38 +37,21 @@ impl RelationPattern {
         }
     }
 
-    fn bound_prefix_len(&self, input: &BindingBag) -> Option<usize> {
-        let mut prefix_len = 0;
-        let mut missing_prefix = false;
+    fn prefix_indexes(&self, input: &BindingBag, added: &[Variable]) -> Option<Vec<usize>> {
+        let mut indexes = Vec::new();
+        let mut saw_unbound = false;
+
         for variable in &self.variables {
-            if input.variables.contains(variable) {
-                if missing_prefix {
-                    return None;
-                }
-                prefix_len += 1;
-            } else {
-                missing_prefix = true;
+            match input.column_indexes.get(variable).copied() {
+                Some(_) if saw_unbound => return None,
+                Some(index) => indexes.push(index),
+                None => saw_unbound = true,
             }
         }
-        Some(prefix_len)
-    }
 
-    fn prefix_indexes_or_none(
-        &self,
-        input: &BindingBag,
-        added: &[Variable],
-    ) -> Result<Option<Vec<usize>>> {
-        let Some(prefix_len) = self.bound_prefix_len(input) else {
-            return Ok(None);
-        };
-        if !self.variables[prefix_len..].starts_with(added) {
-            return Ok(None);
-        }
-        self.variables[..prefix_len]
-            .iter()
-            .map(|variable| input.column_index(variable))
-            .collect::<Result<Vec<_>>>()
-            .map(Some)
+        self.variables[indexes.len()..]
+            .starts_with(added)
+            .then_some(indexes)
     }
 
     fn trie_node_for(
@@ -144,7 +129,7 @@ impl ExecPattern for RelationPattern {
         if added.is_empty() {
             return Ok(());
         }
-        let Some(prefix_indexes) = self.prefix_indexes_or_none(input, added)? else {
+        let Some(prefix_indexes) = self.prefix_indexes(input, added) else {
             return Ok(());
         };
 
@@ -169,7 +154,7 @@ impl ExecPattern for RelationPattern {
                 target_variables == input.variables,
                 "Relation validation must preserve the input layout"
             );
-            let prefix_indexes = self.prefix_indexes_or_none(input, added)?.ok_or_else(|| {
+            let prefix_indexes = self.prefix_indexes(input, added).ok_or_else(|| {
                 anyhow::anyhow!("Relation validation requires bound variables to form a prefix")
             })?;
             let matches = if self.has_rows {
@@ -189,7 +174,7 @@ impl ExecPattern for RelationPattern {
             return input.select_rows(&matches);
         }
 
-        let prefix_indexes = self.prefix_indexes_or_none(input, added)?.ok_or_else(|| {
+        let prefix_indexes = self.prefix_indexes(input, added).ok_or_else(|| {
             anyhow::anyhow!("Relation cannot propose the requested variables: {added:?}")
         })?;
         let extensions = input

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -4,7 +4,7 @@ use edn::query::Variable;
 
 use crate::algo::trie::{Trie, TrieNode};
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
 
 /// A pattern that matches a relation (set of rows) with a fixed set of variables.
 ///
@@ -13,7 +13,6 @@ use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 /// followed by the introduced variables must form a relation prefix. Validation requires the bound
 /// variables themselves to form a relation prefix.
 pub(crate) struct RelationPattern {
-    id: PatternId,
     variables: Vec<Variable>,
     // The reason we have this field is to distinguish between an the unit relation`{()}` and an empty relation `{}`.
     // More generally, an empty bound prefix reaches the trie root whether the relation has
@@ -23,7 +22,7 @@ pub(crate) struct RelationPattern {
 }
 
 impl RelationPattern {
-    pub(crate) fn new(id: PatternId, relation: BindingBag) -> Self {
+    pub(crate) fn new(relation: BindingBag) -> Self {
         let has_rows = !relation.rows.is_empty();
         let variables = relation.variables;
         let mut trie = Trie::new();
@@ -31,7 +30,6 @@ impl RelationPattern {
             trie.insert(row);
         }
         Self {
-            id,
             variables,
             has_rows,
             trie,
@@ -107,10 +105,6 @@ impl RelationPattern {
 }
 
 impl ExecPattern for RelationPattern {
-    fn id(&self) -> PatternId {
-        self.id
-    }
-
     fn variables(&self) -> &[Variable] {
         &self.variables
     }
@@ -119,6 +113,7 @@ impl ExecPattern for RelationPattern {
         &self,
         input: &BindingBag,
         added: &[Variable],
+        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()> {
         ensure!(
@@ -139,7 +134,7 @@ impl ExecPattern for RelationPattern {
                 .trie_node_for(input_row, &prefix_indexes)
                 .map(|node| Self::count_extensions(node, added.len()))
                 .unwrap_or(0);
-            proposal.consider(self.id, count);
+            proposal.consider(participant_index, count);
         }
         Ok(())
     }
@@ -223,18 +218,15 @@ mod tests {
 
     #[test]
     fn count_updates_each_row_with_its_distinct_positive_candidate_count() {
-        let pattern = RelationPattern::new(
-            7,
-            binding_bag(
-                &["?x", "?y"],
-                &[&["a", "1"], &["a", "1"], &["a", "2"], &["b", "3"]],
-            ),
-        );
+        let pattern = RelationPattern::new(binding_bag(
+            &["?x", "?y"],
+            &[&["a", "1"], &["a", "1"], &["a", "2"], &["b", "3"]],
+        ));
         let input = binding_bag(&["?x"], &[&["a"], &["b"], &["c"]]);
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
         pattern
-            .count(&input, &["?y".to_var()], &mut proposals)
+            .count(&input, &["?y".to_var()], 7, &mut proposals)
             .unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(7));
@@ -246,27 +238,26 @@ mod tests {
 
     #[test]
     fn count_is_a_noop_for_non_prefix_proposals_and_checks_proposal_length() {
-        let pattern = RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"]]));
+        let pattern = RelationPattern::new(binding_bag(&["?x", "?y"], &[&["a", "1"]]));
         let input = binding_bag(&["?y"], &[&["1"]]);
         let mut proposals = vec![Proposal::default()];
 
         pattern
-            .count(&input, &["?x".to_var()], &mut proposals)
+            .count(&input, &["?x".to_var()], 7, &mut proposals)
             .unwrap();
         assert_eq!(proposals, vec![Proposal::default()]);
 
-        assert!(pattern.count(&input, &["?x".to_var()], &mut []).is_err());
+        assert!(pattern.count(&input, &["?x".to_var()], 7, &mut []).is_err());
     }
 
     #[test]
     fn multi_variable_non_prefix_proposals_are_ignored_and_rejected() {
-        let pattern =
-            RelationPattern::new(7, binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
+        let pattern = RelationPattern::new(binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
         let input = BindingBag::unit();
         let added = ["?y".to_var(), "?z".to_var()];
         let mut proposals = vec![Proposal::default()];
 
-        pattern.count(&input, &added, &mut proposals).unwrap();
+        pattern.count(&input, &added, 7, &mut proposals).unwrap();
 
         assert_eq!(proposals, vec![Proposal::default()]);
         assert!(pattern.join(&input, &added, &added).is_err());
@@ -274,24 +265,21 @@ mod tests {
 
     #[test]
     fn counts_and_proposes_distinct_multi_variable_prefixes_from_the_root() {
-        let pattern = RelationPattern::new(
-            7,
-            binding_bag(
-                &["?x", "?y", "?z"],
-                &[
-                    &["a", "1", "red"],
-                    &["a", "1", "blue"],
-                    &["a", "1", "red"],
-                    &["a", "2", "green"],
-                    &["b", "3", "black"],
-                ],
-            ),
-        );
+        let pattern = RelationPattern::new(binding_bag(
+            &["?x", "?y", "?z"],
+            &[
+                &["a", "1", "red"],
+                &["a", "1", "blue"],
+                &["a", "1", "red"],
+                &["a", "2", "green"],
+                &["b", "3", "black"],
+            ],
+        ));
         let input = binding_bag(&["?outer"], &[&["seed"], &["seed"]]);
         let added = ["?x".to_var(), "?y".to_var()];
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
-        pattern.count(&input, &added, &mut proposals).unwrap();
+        pattern.count(&input, &added, 7, &mut proposals).unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(7));
         assert_eq!(proposals[0].count(), 3);
@@ -323,18 +311,15 @@ mod tests {
 
     #[test]
     fn counts_and_proposes_multiple_variables_below_a_reordered_bound_prefix() {
-        let pattern = RelationPattern::new(
-            9,
-            binding_bag(
-                &["?w", "?x", "?y", "?z"],
-                &[
-                    &["a", "1", "m", "red"],
-                    &["a", "1", "m", "blue"],
-                    &["a", "1", "n", "green"],
-                    &["b", "2", "o", "black"],
-                ],
-            ),
-        );
+        let pattern = RelationPattern::new(binding_bag(
+            &["?w", "?x", "?y", "?z"],
+            &[
+                &["a", "1", "m", "red"],
+                &["a", "1", "m", "blue"],
+                &["a", "1", "n", "green"],
+                &["b", "2", "o", "black"],
+            ],
+        ));
         let input = binding_bag(
             &["?x", "?outer", "?w"],
             &[&["1", "first", "a"], &["9", "second", "a"]],
@@ -342,7 +327,7 @@ mod tests {
         let added = ["?y".to_var(), "?z".to_var()];
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
-        pattern.count(&input, &added, &mut proposals).unwrap();
+        pattern.count(&input, &added, 9, &mut proposals).unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(9));
         assert_eq!(proposals[0].count(), 3);
@@ -376,10 +361,10 @@ mod tests {
 
     #[test]
     fn proposing_join_preserves_outer_columns_multiplicity_and_target_order() {
-        let pattern = RelationPattern::new(
-            7,
-            binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"], &["b", "3"]]),
-        );
+        let pattern = RelationPattern::new(binding_bag(
+            &["?x", "?y"],
+            &[&["a", "1"], &["a", "2"], &["b", "3"]],
+        ));
         let input = binding_bag(
             &["?outer", "?x"],
             &[&["u", "a"], &["v", "a"], &["w", "missing"]],
@@ -409,8 +394,7 @@ mod tests {
 
     #[test]
     fn validating_join_filters_prefixes_without_changing_layout_or_bag_semantics() {
-        let pattern =
-            RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
+        let pattern = RelationPattern::new(binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
         let input = binding_bag(&["?outer", "?x"], &[&["u", "a"], &["u", "a"], &["v", "b"]]);
 
         let validated = pattern.join(&input, &[], &input.variables).unwrap();
@@ -426,13 +410,10 @@ mod tests {
 
     #[test]
     fn validating_join_matches_complete_rows_independent_of_input_column_order() {
-        let pattern = RelationPattern::new(
-            7,
-            binding_bag(
-                &["?x", "?y", "?z"],
-                &[&["a", "1", "red"], &["b", "2", "blue"]],
-            ),
-        );
+        let pattern = RelationPattern::new(binding_bag(
+            &["?x", "?y", "?z"],
+            &[&["a", "1", "red"], &["b", "2", "blue"]],
+        ));
         let input = binding_bag(
             &["?z", "?outer", "?x", "?y"],
             &[
@@ -456,8 +437,8 @@ mod tests {
     #[test]
     fn zero_column_relations_validate_by_existence() {
         let input = binding_bag(&["?x"], &[&["a"], &["a"]]);
-        let unit = RelationPattern::new(1, BindingBag::unit());
-        let empty = RelationPattern::new(2, BindingBag::empty(vec![]).unwrap());
+        let unit = RelationPattern::new(BindingBag::unit());
+        let empty = RelationPattern::new(BindingBag::empty(vec![]).unwrap());
 
         assert_eq!(unit.join(&input, &[], &input.variables).unwrap(), input);
         assert_eq!(

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn count_is_a_noop_for_non_prefix_proposals_and_checks_sidecar_length() {
+    fn count_is_a_noop_for_non_prefix_proposals_and_checks_proposal_length() {
         let pattern = RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"]]));
         let input = binding_bag(&["?y"], &[&["1"]]);
         let mut proposals = vec![Proposal::default()];

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -4,7 +4,7 @@ use edn::query::Variable;
 
 use crate::algo::trie::{Trie, TrieNode};
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
+use crate::query::exec_pattern::{ExecPattern, PatternIndex, Proposal};
 
 /// A pattern that matches a relation (set of rows) with a fixed set of variables.
 ///
@@ -13,6 +13,7 @@ use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
 /// followed by the introduced variables must form a relation prefix. Validation requires the bound
 /// variables themselves to form a relation prefix.
 pub(crate) struct RelationPattern {
+    index: PatternIndex,
     variables: Vec<Variable>,
     // The reason we have this field is to distinguish between an the unit relation`{()}` and an empty relation `{}`.
     // More generally, an empty bound prefix reaches the trie root whether the relation has
@@ -22,7 +23,7 @@ pub(crate) struct RelationPattern {
 }
 
 impl RelationPattern {
-    pub(crate) fn new(relation: BindingBag) -> Self {
+    pub(crate) fn new(index: PatternIndex, relation: BindingBag) -> Self {
         let has_rows = !relation.rows.is_empty();
         let variables = relation.variables;
         let mut trie = Trie::new();
@@ -30,6 +31,7 @@ impl RelationPattern {
             trie.insert(row);
         }
         Self {
+            index,
             variables,
             has_rows,
             trie,
@@ -105,6 +107,10 @@ impl RelationPattern {
 }
 
 impl ExecPattern for RelationPattern {
+    fn index(&self) -> PatternIndex {
+        self.index
+    }
+
     fn variables(&self) -> &[Variable] {
         &self.variables
     }
@@ -113,7 +119,6 @@ impl ExecPattern for RelationPattern {
         &self,
         input: &BindingBag,
         added: &[Variable],
-        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()> {
         ensure!(
@@ -134,7 +139,7 @@ impl ExecPattern for RelationPattern {
                 .trie_node_for(input_row, &prefix_indexes)
                 .map(|node| Self::count_extensions(node, added.len()))
                 .unwrap_or(0);
-            proposal.consider(participant_index, count);
+            proposal.consider(self.index, count);
         }
         Ok(())
     }
@@ -218,15 +223,18 @@ mod tests {
 
     #[test]
     fn count_updates_each_row_with_its_distinct_positive_candidate_count() {
-        let pattern = RelationPattern::new(binding_bag(
-            &["?x", "?y"],
-            &[&["a", "1"], &["a", "1"], &["a", "2"], &["b", "3"]],
-        ));
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y"],
+                &[&["a", "1"], &["a", "1"], &["a", "2"], &["b", "3"]],
+            ),
+        );
         let input = binding_bag(&["?x"], &[&["a"], &["b"], &["c"]]);
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
         pattern
-            .count(&input, &["?y".to_var()], 7, &mut proposals)
+            .count(&input, &["?y".to_var()], &mut proposals)
             .unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(7));
@@ -238,26 +246,27 @@ mod tests {
 
     #[test]
     fn count_is_a_noop_for_non_prefix_proposals_and_checks_proposal_length() {
-        let pattern = RelationPattern::new(binding_bag(&["?x", "?y"], &[&["a", "1"]]));
+        let pattern = RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"]]));
         let input = binding_bag(&["?y"], &[&["1"]]);
         let mut proposals = vec![Proposal::default()];
 
         pattern
-            .count(&input, &["?x".to_var()], 7, &mut proposals)
+            .count(&input, &["?x".to_var()], &mut proposals)
             .unwrap();
         assert_eq!(proposals, vec![Proposal::default()]);
 
-        assert!(pattern.count(&input, &["?x".to_var()], 7, &mut []).is_err());
+        assert!(pattern.count(&input, &["?x".to_var()], &mut []).is_err());
     }
 
     #[test]
     fn multi_variable_non_prefix_proposals_are_ignored_and_rejected() {
-        let pattern = RelationPattern::new(binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
+        let pattern =
+            RelationPattern::new(7, binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
         let input = BindingBag::unit();
         let added = ["?y".to_var(), "?z".to_var()];
         let mut proposals = vec![Proposal::default()];
 
-        pattern.count(&input, &added, 7, &mut proposals).unwrap();
+        pattern.count(&input, &added, &mut proposals).unwrap();
 
         assert_eq!(proposals, vec![Proposal::default()]);
         assert!(pattern.join(&input, &added, &added).is_err());
@@ -265,21 +274,24 @@ mod tests {
 
     #[test]
     fn counts_and_proposes_distinct_multi_variable_prefixes_from_the_root() {
-        let pattern = RelationPattern::new(binding_bag(
-            &["?x", "?y", "?z"],
-            &[
-                &["a", "1", "red"],
-                &["a", "1", "blue"],
-                &["a", "1", "red"],
-                &["a", "2", "green"],
-                &["b", "3", "black"],
-            ],
-        ));
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y", "?z"],
+                &[
+                    &["a", "1", "red"],
+                    &["a", "1", "blue"],
+                    &["a", "1", "red"],
+                    &["a", "2", "green"],
+                    &["b", "3", "black"],
+                ],
+            ),
+        );
         let input = binding_bag(&["?outer"], &[&["seed"], &["seed"]]);
         let added = ["?x".to_var(), "?y".to_var()];
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
-        pattern.count(&input, &added, 7, &mut proposals).unwrap();
+        pattern.count(&input, &added, &mut proposals).unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(7));
         assert_eq!(proposals[0].count(), 3);
@@ -311,15 +323,18 @@ mod tests {
 
     #[test]
     fn counts_and_proposes_multiple_variables_below_a_reordered_bound_prefix() {
-        let pattern = RelationPattern::new(binding_bag(
-            &["?w", "?x", "?y", "?z"],
-            &[
-                &["a", "1", "m", "red"],
-                &["a", "1", "m", "blue"],
-                &["a", "1", "n", "green"],
-                &["b", "2", "o", "black"],
-            ],
-        ));
+        let pattern = RelationPattern::new(
+            9,
+            binding_bag(
+                &["?w", "?x", "?y", "?z"],
+                &[
+                    &["a", "1", "m", "red"],
+                    &["a", "1", "m", "blue"],
+                    &["a", "1", "n", "green"],
+                    &["b", "2", "o", "black"],
+                ],
+            ),
+        );
         let input = binding_bag(
             &["?x", "?outer", "?w"],
             &[&["1", "first", "a"], &["9", "second", "a"]],
@@ -327,7 +342,7 @@ mod tests {
         let added = ["?y".to_var(), "?z".to_var()];
         let mut proposals = vec![Proposal::default(); input.rows.len()];
 
-        pattern.count(&input, &added, 9, &mut proposals).unwrap();
+        pattern.count(&input, &added, &mut proposals).unwrap();
 
         assert_eq!(proposals[0].proposer(), Some(9));
         assert_eq!(proposals[0].count(), 3);
@@ -361,10 +376,10 @@ mod tests {
 
     #[test]
     fn proposing_join_preserves_outer_columns_multiplicity_and_target_order() {
-        let pattern = RelationPattern::new(binding_bag(
-            &["?x", "?y"],
-            &[&["a", "1"], &["a", "2"], &["b", "3"]],
-        ));
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"], &["b", "3"]]),
+        );
         let input = binding_bag(
             &["?outer", "?x"],
             &[&["u", "a"], &["v", "a"], &["w", "missing"]],
@@ -394,7 +409,8 @@ mod tests {
 
     #[test]
     fn validating_join_filters_prefixes_without_changing_layout_or_bag_semantics() {
-        let pattern = RelationPattern::new(binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
+        let pattern =
+            RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
         let input = binding_bag(&["?outer", "?x"], &[&["u", "a"], &["u", "a"], &["v", "b"]]);
 
         let validated = pattern.join(&input, &[], &input.variables).unwrap();
@@ -410,10 +426,13 @@ mod tests {
 
     #[test]
     fn validating_join_matches_complete_rows_independent_of_input_column_order() {
-        let pattern = RelationPattern::new(binding_bag(
-            &["?x", "?y", "?z"],
-            &[&["a", "1", "red"], &["b", "2", "blue"]],
-        ));
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y", "?z"],
+                &[&["a", "1", "red"], &["b", "2", "blue"]],
+            ),
+        );
         let input = binding_bag(
             &["?z", "?outer", "?x", "?y"],
             &[
@@ -437,8 +456,8 @@ mod tests {
     #[test]
     fn zero_column_relations_validate_by_existence() {
         let input = binding_bag(&["?x"], &[&["a"], &["a"]]);
-        let unit = RelationPattern::new(BindingBag::unit());
-        let empty = RelationPattern::new(BindingBag::empty(vec![]).unwrap());
+        let unit = RelationPattern::new(7, BindingBag::unit());
+        let empty = RelationPattern::new(8, BindingBag::empty(vec![]).unwrap());
 
         assert_eq!(unit.join(&input, &[], &input.variables).unwrap(), input);
         assert_eq!(

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -4,7 +4,7 @@ use anyhow::{ensure, Result};
 use bytes::Bytes;
 use edn::query::Variable;
 
-use crate::query::binding_bag::{BindingRow, BindingBag};
+use crate::query::binding_bag::{BindingBag, BindingRow};
 use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 
 pub(crate) struct RelationPattern {
@@ -62,7 +62,7 @@ impl RelationPattern {
         let mut seen = HashSet::<Bytes>::new();
         let mut candidates = Vec::new();
 
-        for relation_row in self.relation.rows {
+        for relation_row in &self.relation.rows {
             let matches_prefix =
                 input_prefix_indexes
                     .iter()
@@ -243,7 +243,7 @@ mod tests {
             RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
         let input = binding_bag(&["?outer", "?x"], &[&["u", "a"], &["u", "a"], &["v", "b"]]);
 
-        let validated = pattern.join(&input, &[], input.variables).unwrap();
+        let validated = pattern.join(&input, &[], &input.variables).unwrap();
 
         assert_eq!(
             validated,
@@ -260,9 +260,9 @@ mod tests {
         let unit = RelationPattern::new(1, BindingBag::unit());
         let empty = RelationPattern::new(2, BindingBag::empty(vec![]).unwrap());
 
-        assert_eq!(unit.join(&input, &[], input.variables).unwrap(), input);
+        assert_eq!(unit.join(&input, &[], &input.variables).unwrap(), input);
         assert_eq!(
-            empty.join(&input, &[], input.variables).unwrap(),
+            empty.join(&input, &[], &input.variables).unwrap(),
             BindingBag::empty(vec!["?x".to_var()]).unwrap()
         );
     }

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -15,8 +15,9 @@ use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 pub(crate) struct RelationPattern {
     id: PatternId,
     variables: Vec<Variable>,
-    // The only reason we have this field is to distinguish between an empty relation `{}` and a relation with no rows `{()}`.
-    // An empty trie can not distinguish between the two.
+    // The reason we have this field is to distinguish between an the unit relation`{()}` and an empty relation `{}`.
+    // More generally, an empty bound prefix reaches the trie root whether the relation has
+    // columns or not, so emptiness must be tracked separately. An empty trie can not distinguish between the two.
     has_rows: bool,
     trie: Trie<Bytes>,
 }
@@ -60,7 +61,7 @@ impl RelationPattern {
         prefix_indexes: &[usize],
     ) -> Option<&TrieNode<Bytes>> {
         self.trie
-            .node(prefix_indexes.iter().map(|index| &input_row[*index]))
+            .node(prefix_indexes.iter().map(|&index| &input_row[index]))
     }
 
     fn count_extensions(node: &TrieNode<Bytes>, depth: usize) -> usize {

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -222,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn count_updates_each_row_with_its_distinct_positive_candidate_count() {
+    fn count_updates_each_row_with_its_distinct_candidate_count() {
         let pattern = RelationPattern::new(
             7,
             binding_bag(
@@ -241,7 +241,8 @@ mod tests {
         assert_eq!(proposals[0].count(), 2);
         assert_eq!(proposals[1].proposer(), Some(7));
         assert_eq!(proposals[1].count(), 1);
-        assert_eq!(proposals[2].proposer(), None);
+        assert_eq!(proposals[2].proposer(), Some(7));
+        assert_eq!(proposals[2].count(), 0);
     }
 
     #[test]
@@ -346,7 +347,8 @@ mod tests {
 
         assert_eq!(proposals[0].proposer(), Some(9));
         assert_eq!(proposals[0].count(), 3);
-        assert_eq!(proposals[1].proposer(), None);
+        assert_eq!(proposals[1].proposer(), Some(9));
+        assert_eq!(proposals[1].count(), 0);
 
         let joined = pattern
             .join(

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -1,0 +1,269 @@
+use std::collections::HashSet;
+
+use anyhow::{ensure, Result};
+use bytes::Bytes;
+use edn::query::Variable;
+
+use crate::query::binding_bag::{BindingRow, BindingBag};
+use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+
+pub(crate) struct RelationPattern {
+    id: PatternId,
+    variables: Vec<Variable>,
+    relation: BindingBag,
+}
+
+impl RelationPattern {
+    pub(crate) fn new(id: PatternId, relation: BindingBag) -> Self {
+        Self {
+            id,
+            variables: relation.variables.to_vec(),
+            relation: relation.distinct(),
+        }
+    }
+
+    fn bound_prefix_len(&self, input: &BindingBag) -> Option<usize> {
+        let mut prefix_len = 0;
+        let mut missing_prefix = false;
+        for variable in &self.variables {
+            if input.variables.contains(variable) {
+                if missing_prefix {
+                    return None;
+                }
+                prefix_len += 1;
+            } else {
+                missing_prefix = true;
+            }
+        }
+        Some(prefix_len)
+    }
+
+    fn proposal_index(&self, input: &BindingBag, added: &[Variable]) -> Option<usize> {
+        if added.len() != 1 {
+            return None;
+        }
+        let prefix_len = self.bound_prefix_len(input)?;
+        self.variables
+            .get(prefix_len)
+            .filter(|variable| *variable == &added[0])
+            .map(|_| prefix_len)
+    }
+
+    fn candidate_extensions(
+        &self,
+        input: &BindingBag,
+        input_row: &BindingRow,
+        proposal_index: usize,
+    ) -> Result<Vec<BindingRow>> {
+        let input_prefix_indexes = self.variables[..proposal_index]
+            .iter()
+            .map(|variable| input.column_index(variable))
+            .collect::<Result<Vec<_>>>()?;
+        let mut seen = HashSet::<Bytes>::new();
+        let mut candidates = Vec::new();
+
+        for relation_row in self.relation.rows {
+            let matches_prefix =
+                input_prefix_indexes
+                    .iter()
+                    .enumerate()
+                    .all(|(relation_index, input_index)| {
+                        relation_row[relation_index] == input_row[*input_index]
+                    });
+            if matches_prefix && seen.insert(relation_row[proposal_index].clone()) {
+                candidates.push(vec![relation_row[proposal_index].clone()]);
+            }
+        }
+        Ok(candidates)
+    }
+}
+
+impl ExecPattern for RelationPattern {
+    fn id(&self) -> PatternId {
+        self.id
+    }
+
+    fn variables(&self) -> &[Variable] {
+        &self.variables
+    }
+
+    fn count(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        proposals: &mut [Proposal],
+    ) -> Result<()> {
+        ensure!(
+            proposals.len() == input.rows.len(),
+            "Proposal sidecar has {} rows, expected {}",
+            proposals.len(),
+            input.rows.len()
+        );
+        let Some(proposal_index) = self.proposal_index(input, added) else {
+            return Ok(());
+        };
+
+        for (input_row, proposal) in input.rows.iter().zip(proposals) {
+            let count = self
+                .candidate_extensions(input, input_row, proposal_index)?
+                .len();
+            proposal.consider(self.id, count);
+        }
+        Ok(())
+    }
+
+    fn join(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        target_variables: &[Variable],
+    ) -> Result<BindingBag> {
+        if added.is_empty() {
+            ensure!(
+                target_variables == input.variables,
+                "Relation validation must preserve the input layout"
+            );
+            ensure!(
+                self.bound_prefix_len(input).is_some(),
+                "Relation validation requires bound variables to form a prefix"
+            );
+            return input.semijoin(&self.relation);
+        }
+
+        let proposal_index = self.proposal_index(input, added).ok_or_else(|| {
+            anyhow::anyhow!("Relation cannot propose the requested variables: {added:?}")
+        })?;
+        let extensions = input
+            .rows
+            .iter()
+            .map(|row| self.candidate_extensions(input, row, proposal_index))
+            .collect::<Result<Vec<_>>>()?;
+        input
+            .extend_rows(added.to_vec(), extensions)?
+            .reorder(target_variables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use edn::query::ToVariable;
+
+    use super::RelationPattern;
+    use crate::query::binding_bag::BindingBag;
+    use crate::query::exec_pattern::{ExecPattern, Proposal};
+
+    fn bytes(value: &str) -> Bytes {
+        Bytes::copy_from_slice(value.as_bytes())
+    }
+
+    fn binding_bag(variables: &[&str], rows: &[&[&str]]) -> BindingBag {
+        BindingBag::new(
+            variables.iter().map(|variable| variable.to_var()).collect(),
+            rows.iter()
+                .map(|row| row.iter().map(|value| bytes(value)).collect())
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn count_updates_each_row_with_its_distinct_positive_candidate_count() {
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y"],
+                &[&["a", "1"], &["a", "1"], &["a", "2"], &["b", "3"]],
+            ),
+        );
+        let input = binding_bag(&["?x"], &[&["a"], &["b"], &["c"]]);
+        let mut proposals = vec![Proposal::default(); input.rows.len()];
+
+        pattern
+            .count(&input, &["?y".to_var()], &mut proposals)
+            .unwrap();
+
+        assert_eq!(proposals[0].proposer(), Some(7));
+        assert_eq!(proposals[0].count(), 2);
+        assert_eq!(proposals[1].proposer(), Some(7));
+        assert_eq!(proposals[1].count(), 1);
+        assert_eq!(proposals[2].proposer(), None);
+    }
+
+    #[test]
+    fn count_is_a_noop_for_non_prefix_proposals_and_checks_sidecar_length() {
+        let pattern = RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"]]));
+        let input = binding_bag(&["?y"], &[&["1"]]);
+        let mut proposals = vec![Proposal::default()];
+
+        pattern
+            .count(&input, &["?x".to_var()], &mut proposals)
+            .unwrap();
+        assert_eq!(proposals, vec![Proposal::default()]);
+
+        assert!(pattern.count(&input, &["?x".to_var()], &mut []).is_err());
+    }
+
+    #[test]
+    fn proposing_join_preserves_outer_columns_multiplicity_and_target_order() {
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"], &["b", "3"]]),
+        );
+        let input = binding_bag(
+            &["?outer", "?x"],
+            &[&["u", "a"], &["v", "a"], &["w", "missing"]],
+        );
+
+        let joined = pattern
+            .join(
+                &input,
+                &["?y".to_var()],
+                &["?y".to_var(), "?outer".to_var(), "?x".to_var()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            joined,
+            binding_bag(
+                &["?y", "?outer", "?x"],
+                &[
+                    &["1", "u", "a"],
+                    &["2", "u", "a"],
+                    &["1", "v", "a"],
+                    &["2", "v", "a"],
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn validating_join_filters_prefixes_without_changing_layout_or_bag_semantics() {
+        let pattern =
+            RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"], &["a", "2"]]));
+        let input = binding_bag(&["?outer", "?x"], &[&["u", "a"], &["u", "a"], &["v", "b"]]);
+
+        let validated = pattern.join(&input, &[], input.variables).unwrap();
+
+        assert_eq!(
+            validated,
+            binding_bag(&["?outer", "?x"], &[&["u", "a"], &["u", "a"]])
+        );
+        assert!(pattern
+            .join(&input, &[], &["?x".to_var(), "?outer".to_var()],)
+            .is_err());
+    }
+
+    #[test]
+    fn zero_column_relations_validate_by_existence() {
+        let input = binding_bag(&["?x"], &[&["a"], &["a"]]);
+        let unit = RelationPattern::new(1, BindingBag::unit());
+        let empty = RelationPattern::new(2, BindingBag::empty(vec![]).unwrap());
+
+        assert_eq!(unit.join(&input, &[], input.variables).unwrap(), input);
+        assert_eq!(
+            empty.join(&input, &[], input.variables).unwrap(),
+            BindingBag::empty(vec!["?x".to_var()]).unwrap()
+        );
+    }
+}

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -1,24 +1,31 @@
-use std::collections::HashSet;
-
 use anyhow::{ensure, Result};
 use bytes::Bytes;
 use edn::query::Variable;
 
+use crate::algo::trie::{Trie, TrieNode};
 use crate::query::binding_bag::{BindingBag, BindingRow};
 use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 
 pub(crate) struct RelationPattern {
     id: PatternId,
     variables: Vec<Variable>,
-    relation: BindingBag,
+    has_rows: bool,
+    trie: Trie<Bytes>,
 }
 
 impl RelationPattern {
     pub(crate) fn new(id: PatternId, relation: BindingBag) -> Self {
+        let has_rows = !relation.rows.is_empty();
+        let variables = relation.variables;
+        let mut trie = Trie::new();
+        for row in relation.rows {
+            trie.insert(row);
+        }
         Self {
             id,
-            variables: relation.variables.to_vec(),
-            relation: relation.distinct(),
+            variables,
+            has_rows,
+            trie,
         }
     }
 
@@ -38,43 +45,72 @@ impl RelationPattern {
         Some(prefix_len)
     }
 
-    fn proposal_index(&self, input: &BindingBag, added: &[Variable]) -> Option<usize> {
-        if added.len() != 1 {
-            return None;
+    fn prefix_indexes_or_none(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+    ) -> Result<Option<Vec<usize>>> {
+        let Some(prefix_len) = self.bound_prefix_len(input) else {
+            return Ok(None);
+        };
+        if !self.variables[prefix_len..].starts_with(added) {
+            return Ok(None);
         }
-        let prefix_len = self.bound_prefix_len(input)?;
-        self.variables
-            .get(prefix_len)
-            .filter(|variable| *variable == &added[0])
-            .map(|_| prefix_len)
+        self.variables[..prefix_len]
+            .iter()
+            .map(|variable| input.column_index(variable))
+            .collect::<Result<Vec<_>>>()
+            .map(Some)
+    }
+
+    fn trie_node_for(
+        &self,
+        input_row: &BindingRow,
+        prefix_indexes: &[usize],
+    ) -> Option<&TrieNode<Bytes>> {
+        self.trie
+            .node(prefix_indexes.iter().map(|index| &input_row[*index]))
+    }
+
+    fn count_extensions(node: &TrieNode<Bytes>, depth: usize) -> usize {
+        if depth == 0 {
+            return 1;
+        }
+        node.children()
+            .map(|(_, child)| Self::count_extensions(child, depth - 1))
+            .sum()
+    }
+
+    fn add_extensions(
+        node: &TrieNode<Bytes>,
+        depth: usize,
+        values: &mut BindingRow,
+        extensions: &mut Vec<BindingRow>,
+    ) {
+        if depth == 0 {
+            extensions.push(values.clone());
+            return;
+        }
+        for (value, child) in node.children() {
+            values.push(value.clone());
+            Self::add_extensions(child, depth - 1, values, extensions);
+            values.pop().expect("extension value was just pushed");
+        }
     }
 
     fn candidate_extensions(
         &self,
-        input: &BindingBag,
         input_row: &BindingRow,
-        proposal_index: usize,
-    ) -> Result<Vec<BindingRow>> {
-        let input_prefix_indexes = self.variables[..proposal_index]
-            .iter()
-            .map(|variable| input.column_index(variable))
-            .collect::<Result<Vec<_>>>()?;
-        let mut seen = HashSet::<Bytes>::new();
-        let mut candidates = Vec::new();
-
-        for relation_row in &self.relation.rows {
-            let matches_prefix =
-                input_prefix_indexes
-                    .iter()
-                    .enumerate()
-                    .all(|(relation_index, input_index)| {
-                        relation_row[relation_index] == input_row[*input_index]
-                    });
-            if matches_prefix && seen.insert(relation_row[proposal_index].clone()) {
-                candidates.push(vec![relation_row[proposal_index].clone()]);
-            }
-        }
-        Ok(candidates)
+        prefix_indexes: &[usize],
+        depth: usize,
+    ) -> Vec<BindingRow> {
+        let Some(node) = self.trie_node_for(input_row, prefix_indexes) else {
+            return Vec::new();
+        };
+        let mut values = Vec::with_capacity(depth);
+        let mut extensions = Vec::new();
+        Self::add_extensions(node, depth, &mut values, &mut extensions);
+        extensions
     }
 }
 
@@ -99,14 +135,18 @@ impl ExecPattern for RelationPattern {
             proposals.len(),
             input.rows.len()
         );
-        let Some(proposal_index) = self.proposal_index(input, added) else {
+        if added.is_empty() {
+            return Ok(());
+        }
+        let Some(prefix_indexes) = self.prefix_indexes_or_none(input, added)? else {
             return Ok(());
         };
 
         for (input_row, proposal) in input.rows.iter().zip(proposals) {
             let count = self
-                .candidate_extensions(input, input_row, proposal_index)?
-                .len();
+                .trie_node_for(input_row, &prefix_indexes)
+                .map(|node| Self::count_extensions(node, added.len()))
+                .unwrap_or(0);
             proposal.consider(self.id, count);
         }
         Ok(())
@@ -123,21 +163,34 @@ impl ExecPattern for RelationPattern {
                 target_variables == input.variables,
                 "Relation validation must preserve the input layout"
             );
-            ensure!(
-                self.bound_prefix_len(input).is_some(),
-                "Relation validation requires bound variables to form a prefix"
-            );
-            return input.semijoin(&self.relation);
+            let prefix_indexes = self.prefix_indexes_or_none(input, added)?.ok_or_else(|| {
+                anyhow::anyhow!("Relation validation requires bound variables to form a prefix")
+            })?;
+            let matches = if self.has_rows {
+                input
+                    .rows
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, row)| {
+                        self.trie_node_for(row, &prefix_indexes)
+                            .is_some()
+                            .then_some(index)
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            return input.select_rows(&matches);
         }
 
-        let proposal_index = self.proposal_index(input, added).ok_or_else(|| {
+        let prefix_indexes = self.prefix_indexes_or_none(input, added)?.ok_or_else(|| {
             anyhow::anyhow!("Relation cannot propose the requested variables: {added:?}")
         })?;
         let extensions = input
             .rows
             .iter()
-            .map(|row| self.candidate_extensions(input, row, proposal_index))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|row| self.candidate_extensions(row, &prefix_indexes, added.len()))
+            .collect();
         input
             .extend_rows(added.to_vec(), extensions)?
             .reorder(target_variables)
@@ -165,6 +218,15 @@ mod tests {
                 .collect(),
         )
         .unwrap()
+    }
+
+    fn assert_bag_eq_unordered(actual: BindingBag, expected: BindingBag) {
+        assert_eq!(actual.variables, expected.variables);
+        let mut actual_rows = actual.rows;
+        let mut expected_rows = expected.rows;
+        actual_rows.sort();
+        expected_rows.sort();
+        assert_eq!(actual_rows, expected_rows);
     }
 
     #[test]
@@ -205,6 +267,122 @@ mod tests {
     }
 
     #[test]
+    fn multi_variable_non_prefix_proposals_are_ignored_and_rejected() {
+        let pattern =
+            RelationPattern::new(7, binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
+        let input = BindingBag::unit();
+        let added = ["?y".to_var(), "?z".to_var()];
+        let mut proposals = vec![Proposal::default()];
+
+        pattern.count(&input, &added, &mut proposals).unwrap();
+
+        assert_eq!(proposals, vec![Proposal::default()]);
+        assert!(pattern.join(&input, &added, &added).is_err());
+    }
+
+    #[test]
+    fn counts_and_proposes_distinct_multi_variable_prefixes_from_the_root() {
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y", "?z"],
+                &[
+                    &["a", "1", "red"],
+                    &["a", "1", "blue"],
+                    &["a", "1", "red"],
+                    &["a", "2", "green"],
+                    &["b", "3", "black"],
+                ],
+            ),
+        );
+        let input = binding_bag(&["?outer"], &[&["seed"], &["seed"]]);
+        let added = ["?x".to_var(), "?y".to_var()];
+        let mut proposals = vec![Proposal::default(); input.rows.len()];
+
+        pattern.count(&input, &added, &mut proposals).unwrap();
+
+        assert_eq!(proposals[0].proposer(), Some(7));
+        assert_eq!(proposals[0].count(), 3);
+        assert_eq!(proposals[1].proposer(), Some(7));
+        assert_eq!(proposals[1].count(), 3);
+
+        let joined = pattern
+            .join(
+                &input,
+                &added,
+                &["?y".to_var(), "?outer".to_var(), "?x".to_var()],
+            )
+            .unwrap();
+        assert_bag_eq_unordered(
+            joined,
+            binding_bag(
+                &["?y", "?outer", "?x"],
+                &[
+                    &["1", "seed", "a"],
+                    &["1", "seed", "a"],
+                    &["2", "seed", "a"],
+                    &["2", "seed", "a"],
+                    &["3", "seed", "b"],
+                    &["3", "seed", "b"],
+                ],
+            ),
+        );
+    }
+
+    #[test]
+    fn counts_and_proposes_multiple_variables_below_a_reordered_bound_prefix() {
+        let pattern = RelationPattern::new(
+            9,
+            binding_bag(
+                &["?w", "?x", "?y", "?z"],
+                &[
+                    &["a", "1", "m", "red"],
+                    &["a", "1", "m", "blue"],
+                    &["a", "1", "n", "green"],
+                    &["b", "2", "o", "black"],
+                ],
+            ),
+        );
+        let input = binding_bag(
+            &["?x", "?outer", "?w"],
+            &[&["1", "first", "a"], &["9", "second", "a"]],
+        );
+        let added = ["?y".to_var(), "?z".to_var()];
+        let mut proposals = vec![Proposal::default(); input.rows.len()];
+
+        pattern.count(&input, &added, &mut proposals).unwrap();
+
+        assert_eq!(proposals[0].proposer(), Some(9));
+        assert_eq!(proposals[0].count(), 3);
+        assert_eq!(proposals[1].proposer(), None);
+
+        let joined = pattern
+            .join(
+                &input,
+                &added,
+                &[
+                    "?outer".to_var(),
+                    "?z".to_var(),
+                    "?w".to_var(),
+                    "?y".to_var(),
+                    "?x".to_var(),
+                ],
+            )
+            .unwrap();
+        assert_bag_eq_unordered(
+            joined,
+            binding_bag(
+                &["?outer", "?z", "?w", "?y", "?x"],
+                &[
+                    &["first", "red", "a", "m", "1"],
+                    &["first", "blue", "a", "m", "1"],
+                    &["first", "green", "a", "n", "1"],
+                ],
+            ),
+        );
+    }
+
+    #[test]
     fn proposing_join_preserves_outer_columns_multiplicity_and_target_order() {
         let pattern = RelationPattern::new(
             7,
@@ -223,7 +401,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
+        assert_bag_eq_unordered(
             joined,
             binding_bag(
                 &["?y", "?outer", "?x"],
@@ -233,7 +411,7 @@ mod tests {
                     &["1", "v", "a"],
                     &["2", "v", "a"],
                 ],
-            )
+            ),
         );
     }
 
@@ -252,6 +430,35 @@ mod tests {
         assert!(pattern
             .join(&input, &[], &["?x".to_var(), "?outer".to_var()],)
             .is_err());
+    }
+
+    #[test]
+    fn validating_join_matches_complete_rows_independent_of_input_column_order() {
+        let pattern = RelationPattern::new(
+            7,
+            binding_bag(
+                &["?x", "?y", "?z"],
+                &[&["a", "1", "red"], &["b", "2", "blue"]],
+            ),
+        );
+        let input = binding_bag(
+            &["?z", "?outer", "?x", "?y"],
+            &[
+                &["red", "first", "a", "1"],
+                &["red", "first", "a", "1"],
+                &["wrong", "second", "a", "1"],
+            ],
+        );
+
+        let validated = pattern.join(&input, &[], &input.variables).unwrap();
+
+        assert_eq!(
+            validated,
+            binding_bag(
+                &["?z", "?outer", "?x", "?y"],
+                &[&["red", "first", "a", "1"], &["red", "first", "a", "1"],],
+            )
+        );
     }
 
     #[test]

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -232,56 +232,11 @@ where
         self.create_iterator(prefix, index_type, extractor)
     }
 
-    fn scan_components(&self, index_type: IndexType) -> Result<Vec<BindingRow>> {
-        let mut iterator = self.component_iterator(index_type)?;
-        let mut extensions = Vec::new();
-        while let Some(value) = iterator.get_value()? {
-            extensions.push(vec![value]);
-            iterator.next()?;
-        }
-        Ok(extensions)
-    }
-
-    fn grouped_extensions(
-        &self,
-        index_type: IndexType,
-        groups: BTreeMap<Bytes, Vec<usize>>,
-        row_count: usize,
-    ) -> Result<Vec<Vec<BindingRow>>> {
-        let mut extensions = vec![Vec::new(); row_count];
-        if groups.is_empty() {
-            return Ok(extensions);
-        }
-
-        let mut iterator = self.pair_iterator(index_type)?;
-        for (first, row_indexes) in groups {
-            if !iterator.has_next() {
-                break;
-            }
-            iterator.seek(first.clone())?;
-
-            let mut group_extensions = Vec::new();
-            while let Some(pair) = iterator.get_value()? {
-                if !pair.starts_with(&first) {
-                    break;
-                }
-                group_extensions.push(vec![pair.slice(first.len()..)]);
-                iterator.next()?;
-            }
-
-            for row_index in row_indexes {
-                extensions[row_index] = group_extensions.clone();
-            }
-        }
-        Ok(extensions)
-    }
-
     fn candidate_extensions(
         &self,
         input: &BindingBag,
         position: TriplePosition,
     ) -> Result<Vec<Vec<BindingRow>>> {
-
         if input.rows.is_empty() {
             return Ok(Vec::new());
         }
@@ -293,14 +248,47 @@ where
 
         let other_resolved = Self::term_is_resolved(other, input);
         let index_type = Self::index_type(position, other_resolved);
-        if other_resolved {
-            self.grouped_extensions(
-                index_type,
-                Self::group_rows_by_term(other, input)?,
-                input.rows.len(),
-            )
+
+        if let Some(other_var) = other.variable() {
+            let mut groups = BTreeMap::new();
+            let index = input.column_index(other_var)?;
+            for (row_index, row) in input.rows.iter().enumerate() {
+                groups.entry(&row[index]).or_insert_with(Vec::new).push(row_index);
+            }
+
+            let mut extensions = vec![Vec::new(); input.rows.len()];
+            if groups.is_empty() {
+                return Ok(extensions);
+            }
+
+            let mut iterator = self.pair_iterator(index_type)?;
+            for (first, row_indexes) in groups {
+                if !iterator.has_next() {
+                    break;
+                }
+                iterator.seek(first.clone())?;
+
+                let mut group_extensions = Vec::new();
+                while let Some(pair) = iterator.get_value()? {
+                    if !pair.starts_with(&first) {
+                        break;
+                    }
+                    group_extensions.push(vec![pair.slice(first.len()..)]);
+                    iterator.next()?;
+                }
+
+                for row_index in row_indexes {
+                    extensions[row_index] = group_extensions.clone();
+                }
+            }
+            Ok(extensions)
         } else {
-            let candidates = self.scan_components(index_type)?;
+            let mut iterator = self.component_iterator(index_type)?;
+            let mut candidates = Vec::new();
+            while let Some(value) = iterator.get_value()? {
+                candidates.push(vec![value]);
+                iterator.next()?;
+            }
             Ok(vec![candidates; input.rows.len()])
         }
     }
@@ -429,11 +417,7 @@ where
         input.select_rows(&self.matching_rows(input)?)
     }
 
-    fn propose(
-        &self,
-        input: &BindingBag,
-        added: &[Variable]
-    ) -> Result<BindingBag> {
+    fn propose(&self, input: &BindingBag, added: &[Variable]) -> Result<BindingBag> {
         ensure!(
             added.len() == 1,
             "Triple pattern {} can propose exactly one variable, got {added:?}",
@@ -506,7 +490,7 @@ where
 
         if let Some(other_var) = other.variable() {
             // 1 variable already bound
-            if input.variables.contains(&other_var) {
+            if input.variables.contains(other_var) {
                 let index = input.column_index(other_var)?;
                 for (row_index, row) in input.rows.iter().enumerate() {
                     let mut prefix = base_prefix.clone();

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -534,6 +534,7 @@ where
         &self.variables
     }
 
+    // NOTE: planning never introduces more than one variable for a TriplePattern.
     fn count(
         &self,
         input: &BindingBag,

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -854,7 +854,7 @@ mod tests {
     }
 
     #[test]
-    fn count_uses_one_range_estimate_for_duplicate_bound_terms() -> Result<()> {
+    fn count_applies_bound_term_estimate_to_each_duplicate_row() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(async {
@@ -1195,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn constants_propose_the_other_position_and_constant_only_patterns_validate() -> Result<()> {
+    fn constants_propose_the_variable_position() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(insert_version(
@@ -1226,20 +1226,13 @@ mod tests {
             entities,
             binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]])
         );
-        assert_eq!(
-            entity_pattern
-                .validate(&BindingBag::unit())
-                .unwrap_err()
-                .to_string(),
-            "Triple pattern 1 has no bound variables to validate"
-        );
 
         let value_pattern = TriplePattern::new(
             2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
             NAME,
             TripleTerm::Variable("?v".to_var()),
-            db.clone(),
+            db,
         )?;
         let values = value_pattern.join(&BindingBag::unit(), &["?v".to_var()], &["?v".to_var()])?;
         assert_eq!(
@@ -1248,37 +1241,6 @@ mod tests {
                 &["?v"],
                 vec![vec![encoded(DataType::String("alice".into()))]]
             )
-        );
-        assert_eq!(
-            value_pattern
-                .validate(&BindingBag::unit())
-                .unwrap_err()
-                .to_string(),
-            "Triple pattern 2 has no bound variables to validate"
-        );
-
-        let existing = TriplePattern::new(
-            3,
-            TripleTerm::Constant(encoded(DataType::Long(1))),
-            NAME,
-            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-            db.clone(),
-        )?;
-        assert_eq!(
-            existing.join(&BindingBag::unit(), &[], &[])?,
-            BindingBag::unit()
-        );
-
-        let missing = TriplePattern::new(
-            4,
-            TripleTerm::Constant(encoded(DataType::Long(2))),
-            NAME,
-            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-            db,
-        )?;
-        assert_eq!(
-            missing.join(&BindingBag::unit(), &[], &[])?,
-            BindingBag::empty(Vec::<Variable>::new())?
         );
         Ok(())
     }

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -19,14 +19,13 @@ use crate::util::make_extractor;
 pub(crate) enum TripleTerm {
     Variable(Variable),
     Constant(Bytes),
-    Placeholder,
 }
 
 impl TripleTerm {
     fn variable(&self) -> Option<&Variable> {
         match self {
             Self::Variable(variable) => Some(variable),
-            Self::Constant(_) | Self::Placeholder => None,
+            Self::Constant(_) => None,
         }
     }
 
@@ -40,7 +39,6 @@ impl TripleTerm {
                 }
             }
             Self::Constant(value) => Ok(Some(value.clone())),
-            Self::Placeholder => Ok(None),
         }
     }
 }
@@ -89,15 +87,6 @@ where
         as_of: i64,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self> {
-        ensure!(
-            !matches!(entity, TripleTerm::Placeholder),
-            "Triple pattern {index} does not support an entity placeholder"
-        );
-        ensure!(
-            !matches!(value, TripleTerm::Placeholder),
-            "Triple pattern {index} does not support a value placeholder"
-        );
-
         let mut variables = Vec::new();
         if let Some(variable) = entity.variable() {
             variables.push(variable.clone());
@@ -783,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    fn constructor_rejects_unsupported_and_repeated_shapes() -> Result<()> {
+    fn constructor_rejects_repeated_variables() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         let new = |entity, value| {
@@ -799,8 +788,6 @@ mod tests {
             )
         };
 
-        assert!(new(TripleTerm::Placeholder, TripleTerm::Variable("?v".to_var())).is_err());
-        assert!(new(TripleTerm::Variable("?e".to_var()), TripleTerm::Placeholder).is_err());
         assert!(new(
             TripleTerm::Variable("?x".to_var()),
             TripleTerm::Variable("?x".to_var())

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -281,6 +281,7 @@ where
         input: &BindingBag,
         position: TriplePosition,
     ) -> Result<Vec<Vec<BindingRow>>> {
+
         if input.rows.is_empty() {
             return Ok(Vec::new());
         }
@@ -289,6 +290,7 @@ where
             TriplePosition::Entity => &self.value,
             TriplePosition::Value => &self.entity,
         };
+
         let other_resolved = Self::term_is_resolved(other, input);
         let index_type = Self::index_type(position, other_resolved);
         if other_resolved {
@@ -423,20 +425,14 @@ where
             .collect())
     }
 
-    fn validate(&self, input: &BindingBag, target_variables: &[Variable]) -> Result<BindingBag> {
-        ensure!(
-            target_variables == input.variables,
-            "Triple pattern {} validation must preserve the input layout",
-            self.index
-        );
+    fn validate(&self, input: &BindingBag) -> Result<BindingBag> {
         input.select_rows(&self.matching_rows(input)?)
     }
 
     fn propose(
         &self,
         input: &BindingBag,
-        added: &[Variable],
-        target_variables: &[Variable],
+        added: &[Variable]
     ) -> Result<BindingBag> {
         ensure!(
             added.len() == 1,
@@ -456,9 +452,7 @@ where
                 added[0]
             )
         })?;
-        input
-            .extend_rows(added.to_vec(), self.candidate_extensions(input, position)?)?
-            .reorder(target_variables)
+        input.extend_rows(added.to_vec(), self.candidate_extensions(input, position)?)
     }
 }
 
@@ -549,11 +543,18 @@ where
         added: &[Variable],
         target_variables: &[Variable],
     ) -> Result<BindingBag> {
-        if added.is_empty() {
-            self.validate(input, target_variables)
+        let res = if added.is_empty() {
+            self.validate(input)
         } else {
-            self.propose(input, added, target_variables)
-        }
+            self.propose(input, added)
+        }?;
+        ensure!(
+            target_variables == res.variables,
+            "Triple pattern target_layout {:?} doesnt' match the computed layout {:?}",
+            target_variables,
+            res.variables
+        );
+        res.reorder(target_variables)
     }
 }
 

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -617,12 +617,18 @@ where
         added: &[Variable],
         target_variables: &[Variable],
     ) -> Result<BindingBag> {
-        let res = if added.is_empty() {
-            self.validate(input)
+        if added.is_empty() {
+            let res = self.validate(input)?;
+            ensure!(
+                target_variables == res.variables,
+                "Triple pattern target_layout {:?} doesnt' match the computed layout {:?}",
+                target_variables,
+                res.variables
+            );
+            Ok(res)
         } else {
             self.propose(input, added)
-        }?;
-        res.reorder(target_variables)
+        }
     }
 }
 

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -35,19 +35,6 @@ impl TripleTerm {
             Self::Constant(_) => None,
         }
     }
-
-    fn resolve(&self, input: &BindingBag, row: &BindingRow) -> Result<Option<Bytes>> {
-        match self {
-            Self::Variable(variable) => {
-                if input.variables.contains(variable) {
-                    Ok(Some(row[input.column_index(variable)?].clone()))
-                } else {
-                    Ok(None)
-                }
-            }
-            Self::Constant(value) => Ok(Some(value.clone())),
-        }
-    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -122,13 +122,6 @@ where
         Ok(prefix)
     }
 
-    fn term_is_resolved(term: &TripleTerm, input: &BindingBag) -> bool {
-        match term {
-            TripleTerm::Variable(variable) => input.column_indexes.contains_key(variable),
-            TripleTerm::Constant(_) => true,
-        }
-    }
-
     fn index_type(position: TriplePosition, other_resolved: bool) -> IndexType {
         match (position, other_resolved) {
             (TriplePosition::Entity, false) => IndexType::AE,
@@ -572,7 +565,10 @@ where
             TriplePosition::Entity => &self.value,
             TriplePosition::Value => &self.entity,
         };
-        let other_resolved = Self::term_is_resolved(other, input);
+        let other_resolved = match other {
+            TripleTerm::Variable(variable) => input.column_indexes.contains_key(variable),
+            TripleTerm::Constant(_) => true,
+        };
         let index_type = Self::index_type(position, other_resolved);
         let base_prefix = self.base_prefix(index_type)?;
 

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -296,6 +296,10 @@ where
         }
     }
 
+    // The code below is explicitly kept very dumb and with lots of code duplication. 
+    // We can optimize and refactor once things stabilize. It will very likely change anyway when 
+    // we introduce a columnar trie.
+
     // Partial two-variable checks use additive candidates; the full pair is validated later.
     fn validate(&self, input: &BindingBag) -> Result<BindingBag> {
         if input.rows.is_empty() {

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::{ensure, Result};
@@ -263,13 +262,10 @@ where
         position: TriplePosition,
     ) -> Result<Vec<BindingRow>> {
         let mut iterator = self.create_iterator(self.proposal_scan(input, row, position)?)?;
-        let mut seen = HashSet::new();
         let mut extensions = Vec::new();
 
         while let Some(value) = iterator.get_value()? {
-            if seen.insert(value.clone()) {
-                extensions.push(vec![value]);
-            }
+            extensions.push(vec![value]);
             iterator.next()?;
         }
         Ok(extensions)

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -627,7 +627,7 @@ where
             );
             Ok(res)
         } else {
-            self.propose(input, added)
+            self.propose(input, added)?.reorder(target_variables)
         }
     }
 }

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -617,12 +617,6 @@ where
         } else {
             self.propose(input, added)
         }?;
-        ensure!(
-            target_variables == res.variables,
-            "Triple pattern target_layout {:?} doesnt' match the computed layout {:?}",
-            target_variables,
-            res.variables
-        );
         res.reorder(target_variables)
     }
 }

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -814,37 +814,37 @@ mod tests {
         let joined = pattern.join(
             &input,
             &["?v".to_var()],
-            &["?v".to_var(), "?outer".to_var(), "?e".to_var()],
+            &["?outer".to_var(), "?e".to_var(), "?v".to_var()],
         )?;
         assert_eq!(
             joined,
             binding_bag(
-                &["?v", "?outer", "?e"],
+                &["?outer", "?e", "?v"],
                 vec![
                     vec![
+                        encoded(DataType::Long(90)),
+                        encoded(DataType::Long(1)),
                         encoded(DataType::String("alice".into())),
-                        encoded(DataType::Long(90)),
-                        encoded(DataType::Long(1)),
                     ],
                     vec![
+                        encoded(DataType::Long(90)),
+                        encoded(DataType::Long(1)),
                         encoded(DataType::String("ally".into())),
-                        encoded(DataType::Long(90)),
-                        encoded(DataType::Long(1)),
                     ],
                     vec![
-                        encoded(DataType::String("bob".into())),
                         encoded(DataType::Long(91)),
                         encoded(DataType::Long(2)),
+                        encoded(DataType::String("bob".into())),
                     ],
                     vec![
+                        encoded(DataType::Long(93)),
+                        encoded(DataType::Long(1)),
                         encoded(DataType::String("alice".into())),
-                        encoded(DataType::Long(93)),
-                        encoded(DataType::Long(1)),
                     ],
                     vec![
-                        encoded(DataType::String("ally".into())),
                         encoded(DataType::Long(93)),
                         encoded(DataType::Long(1)),
+                        encoded(DataType::String("ally".into())),
                     ],
                 ],
             )
@@ -871,20 +871,20 @@ mod tests {
             pattern.join(
                 &value_input,
                 &["?e".to_var()],
-                &["?e".to_var(), "?outer".to_var(), "?v".to_var()],
+                &["?outer".to_var(), "?v".to_var(), "?e".to_var()],
             )?,
             binding_bag(
-                &["?e", "?outer", "?v"],
+                &["?outer", "?v", "?e"],
                 vec![
                     vec![
-                        encoded(DataType::Long(2)),
                         encoded(DataType::Long(94)),
                         encoded(DataType::String("bob".into())),
+                        encoded(DataType::Long(2)),
                     ],
                     vec![
-                        encoded(DataType::Long(1)),
                         encoded(DataType::Long(95)),
                         encoded(DataType::String("alice".into())),
+                        encoded(DataType::Long(1)),
                     ],
                 ],
             )

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -12,7 +12,7 @@ use crate::index::IndexType;
 use crate::iterator::slate_iterator::{Extractor, Index, SlateIterator};
 use crate::iterator::temporal_filter_iterator::TemporalFilterIterator;
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
 use crate::util::make_extractor;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,7 +62,6 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    id: PatternId,
     variables: Vec<Variable>,
     entity: TripleTerm,
     attribute: i64,
@@ -78,9 +77,7 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        id: PatternId,
         entity: TripleTerm,
         attribute: i64,
         value: TripleTerm,
@@ -91,11 +88,11 @@ where
     ) -> Result<Self> {
         ensure!(
             !matches!(entity, TripleTerm::Placeholder),
-            "Triple pattern {id} does not support an entity placeholder"
+            "Triple pattern does not support an entity placeholder"
         );
         ensure!(
             !matches!(value, TripleTerm::Placeholder),
-            "Triple pattern {id} does not support a value placeholder"
+            "Triple pattern does not support a value placeholder"
         );
 
         let mut variables = Vec::new();
@@ -105,13 +102,12 @@ where
         if let Some(variable) = value.variable() {
             ensure!(
                 !variables.contains(variable),
-                "Triple pattern {id} repeats variable {variable}"
+                "Triple pattern repeats variable {variable}"
             );
             variables.push(variable.clone());
         }
 
         Ok(Self {
-            id,
             variables,
             entity,
             attribute,
@@ -283,10 +279,6 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    fn id(&self) -> PatternId {
-        self.id
-    }
-
     fn variables(&self) -> &[Variable] {
         &self.variables
     }
@@ -295,12 +287,12 @@ where
         &self,
         input: &BindingBag,
         added: &[Variable],
+        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()> {
         ensure!(
             proposals.len() == input.rows.len(),
-            "Triple pattern {} received {} proposals for {} input rows",
-            self.id,
+            "Triple pattern received {} proposals for {} input rows",
             proposals.len(),
             input.rows.len()
         );
@@ -313,7 +305,7 @@ where
 
         for (row, proposal) in input.rows.iter().zip(proposals) {
             let count = self.candidate_extensions(input, row, position)?.len();
-            proposal.consider(self.id, count);
+            proposal.consider(participant_index, count);
         }
         Ok(())
     }
@@ -327,8 +319,7 @@ where
         if added.is_empty() {
             ensure!(
                 target_variables == input.variables,
-                "Triple pattern {} validation must preserve the input layout",
-                self.id
+                "Triple pattern validation must preserve the input layout"
             );
             let mut matches = Vec::new();
             for (row_index, row) in input.rows.iter().enumerate() {
@@ -341,21 +332,15 @@ where
 
         ensure!(
             added.len() == 1,
-            "Triple pattern {} can propose exactly one variable, got {added:?}",
-            self.id
+            "Triple pattern can propose exactly one variable, got {added:?}"
         );
         ensure!(
             !input.variables.contains(&added[0]),
-            "Triple pattern {} cannot add already-bound variable {}",
-            self.id,
+            "Triple pattern cannot add already-bound variable {}",
             added[0]
         );
         let position = self.position_for_variable(&added[0]).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Triple pattern {} cannot propose variable {}",
-                self.id,
-                added[0]
-            )
+            anyhow::anyhow!("Triple pattern cannot propose variable {}", added[0])
         })?;
         let extensions = input
             .rows
@@ -481,7 +466,6 @@ mod tests {
 
         let (entity, value) = variables("?e", "?v");
         let pattern = TriplePattern::new(
-            7,
             entity,
             42,
             value,
@@ -492,7 +476,12 @@ mod tests {
         )?;
 
         let mut entity_proposal = vec![Proposal::default()];
-        pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
+        pattern.count(
+            &BindingBag::unit(),
+            &["?e".to_var()],
+            7,
+            &mut entity_proposal,
+        )?;
         assert_eq!(entity_proposal[0].count(), 2);
         assert_eq!(
             pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?,
@@ -506,7 +495,12 @@ mod tests {
         );
 
         let mut value_proposal = vec![Proposal::default()];
-        pattern.count(&BindingBag::unit(), &["?v".to_var()], &mut value_proposal)?;
+        pattern.count(
+            &BindingBag::unit(),
+            &["?v".to_var()],
+            7,
+            &mut value_proposal,
+        )?;
         assert_eq!(value_proposal[0].count(), 3);
 
         let input = binding_bag(
@@ -519,7 +513,7 @@ mod tests {
         );
         let mut proposals = vec![Proposal::default(); 3];
 
-        pattern.count(&input, &["?v".to_var()], &mut proposals)?;
+        pattern.count(&input, &["?v".to_var()], 7, &mut proposals)?;
         assert_eq!(proposals[0].count(), 2);
         assert_eq!(proposals[1].count(), 1);
         assert_eq!(proposals[2].proposer(), None);
@@ -591,7 +585,6 @@ mod tests {
 
         let (entity, value) = variables("?e", "?v");
         let pattern = TriplePattern::new(
-            7,
             entity,
             42,
             value,
@@ -662,7 +655,6 @@ mod tests {
         ))?;
 
         let entity_pattern = TriplePattern::new(
-            1,
             TripleTerm::Variable("?e".to_var()),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -679,7 +671,6 @@ mod tests {
         );
 
         let value_pattern = TriplePattern::new(
-            2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Variable("?v".to_var()),
@@ -698,7 +689,6 @@ mod tests {
         );
 
         let existing = TriplePattern::new(
-            3,
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -713,7 +703,6 @@ mod tests {
         );
 
         let missing = TriplePattern::new(
-            4,
             TripleTerm::Constant(encoded(DataType::Long(2))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -754,9 +743,8 @@ mod tests {
             .await
         })?;
 
-        let make_pattern = |id, as_of| {
+        let make_pattern = |as_of| {
             TriplePattern::new(
-                id,
                 TripleTerm::Constant(encoded(DataType::Long(1))),
                 42,
                 TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -768,15 +756,15 @@ mod tests {
         };
 
         assert_eq!(
-            make_pattern(1, 9)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(9)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::empty(Vec::<Variable>::new())?
         );
         assert_eq!(
-            make_pattern(2, 10)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(10)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::unit()
         );
         assert_eq!(
-            make_pattern(3, 20)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(20)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::empty(Vec::<Variable>::new())?
         );
         Ok(())
@@ -788,7 +776,6 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         let new = |entity, value| {
             TriplePattern::new(
-                7,
                 entity,
                 42,
                 value,

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -11,7 +11,7 @@ use crate::codec;
 use crate::index::IndexType;
 use crate::iterator::slate_iterator::{Extractor, Index, SlateIterator};
 use crate::iterator::temporal_filter_iterator::TemporalFilterIterator;
-use crate::query::binding_bag::{BindingRow, BindingBag};
+use crate::query::binding_bag::{BindingBag, BindingRow};
 use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
 use crate::util::make_extractor;
 
@@ -609,7 +609,7 @@ mod tests {
             ],
         );
         assert_eq!(
-            pattern.join(&partial, &[], partial.variables)?,
+            pattern.join(&partial, &[], &partial.variables)?,
             binding_bag(
                 &["?outer", "?e"],
                 vec![
@@ -635,7 +635,7 @@ mod tests {
             ],
         );
         assert_eq!(
-            pattern.join(&full, &[], full.variables)?,
+            pattern.join(&full, &[], &full.variables)?,
             binding_bag(
                 &["?v", "?outer", "?e"],
                 vec![vec![

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Result};
 use bytes::Bytes;
 use edn::query::Variable;
 use slatedb::{DbMetadataOps, DbReadOps};
@@ -129,16 +129,6 @@ where
         })
     }
 
-    fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
-        if self.entity.variable() == Some(variable) {
-            Some(TriplePosition::Entity)
-        } else if self.value.variable() == Some(variable) {
-            Some(TriplePosition::Value)
-        } else {
-            None
-        }
-    }
-
     fn base_prefix(&self, index_type: IndexType) -> Result<Vec<u8>> {
         let mut prefix = vec![codec::index_type_to_prefix(index_type)?];
         codec::encode_i64(self.attribute, &mut prefix);
@@ -149,6 +139,25 @@ where
         match term {
             TripleTerm::Variable(variable) => input.column_indexes.contains_key(variable),
             TripleTerm::Constant(_) => true,
+        }
+    }
+
+    fn index_type(position: TriplePosition, other_resolved: bool) -> IndexType {
+        match (position, other_resolved) {
+            (TriplePosition::Entity, false) => IndexType::AE,
+            (TriplePosition::Entity, true) => IndexType::AVE,
+            (TriplePosition::Value, false) => IndexType::AV,
+            (TriplePosition::Value, true) => IndexType::AEV,
+        }
+    }
+
+    fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
+        if self.entity.variable() == Some(variable) {
+            Some(TriplePosition::Entity)
+        } else if self.value.variable() == Some(variable) {
+            Some(TriplePosition::Value)
+        } else {
+            None
         }
     }
 
@@ -164,15 +173,6 @@ where
             groups.entry(value).or_insert_with(Vec::new).push(row_index);
         }
         Ok(groups)
-    }
-
-    fn proposal_index(position: TriplePosition, other_resolved: bool) -> IndexType {
-        match (position, other_resolved) {
-            (TriplePosition::Entity, false) => IndexType::AE,
-            (TriplePosition::Entity, true) => IndexType::AVE,
-            (TriplePosition::Value, false) => IndexType::AV,
-            (TriplePosition::Value, true) => IndexType::AEV,
-        }
     }
 
     fn estimate_count(&self, prefix: &[u8]) -> Result<usize> {
@@ -290,7 +290,7 @@ where
             TriplePosition::Value => &self.entity,
         };
         let other_resolved = Self::term_is_resolved(other, input);
-        let index_type = Self::proposal_index(position, other_resolved);
+        let index_type = Self::index_type(position, other_resolved);
         if other_resolved {
             self.grouped_extensions(
                 index_type,
@@ -488,11 +488,15 @@ where
             proposals.len(),
             input.rows.len()
         );
-        if added.len() != 1 || input.variables.contains(&added[0]) {
-            return Ok(());
-        }
+        ensure!(
+            added.len() == 1,
+            "Triple pattern {} can count exactly one variable, got {added:?}",
+            self.index
+        );
         let Some(position) = self.position_for_variable(&added[0]) else {
-            return Ok(());
+            let added = &added[0];
+            let vars = &self.variables;
+            bail!("Triple pattern can only count variables it can propose. Received {added}, variables {vars:?}")
         };
         if input.rows.is_empty() {
             return Ok(());
@@ -503,20 +507,35 @@ where
             TriplePosition::Value => &self.entity,
         };
         let other_resolved = Self::term_is_resolved(other, input);
-        let index_type = Self::proposal_index(position, other_resolved);
+        let index_type = Self::index_type(position, other_resolved);
         let base_prefix = self.base_prefix(index_type)?;
 
-        if other_resolved {
-            for (value, row_indexes) in Self::group_rows_by_term(other, input)? {
-                let mut prefix = base_prefix.clone();
-                prefix.extend_from_slice(&value);
-                let count = self.estimate_count(&prefix)?;
-                for row_index in row_indexes {
+        if let Some(other_var) = other.variable() {
+            // 1 variable already bound
+            if input.variables.contains(&other_var) {
+                let index = input.column_index(other_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let mut prefix = base_prefix.clone();
+                    prefix.extend_from_slice(&row[index]);
+                    let count = self.estimate_count(&prefix)?;
                     proposals[row_index].consider(self.index, count);
                 }
+            // nothing bound
+            } else {
+                let count = self.estimate_count(&base_prefix)?;
+                for proposal in proposals {
+                    proposal.consider(self.index, count);
+                }
             }
+        // other is a constant
         } else {
-            let count = self.estimate_count(&base_prefix)?;
+            let mut prefix = base_prefix.clone();
+            let constant = match other {
+                TripleTerm::Constant(bytes) => bytes,
+                TripleTerm::Variable(_) => unreachable!(),
+            };
+            prefix.extend_from_slice(constant);
+            let count = self.estimate_count(&prefix)?;
             for proposal in proposals {
                 proposal.consider(self.index, count);
             }

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -512,6 +512,10 @@ mod tests {
         ));
         let pattern = TriplePattern::new(7, entity, 42, value, db)?;
 
+        let mut entity_proposal = vec![Proposal::default()];
+        pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
+        assert_eq!(entity_proposal[0].proposer(), Some(7));
+        assert_eq!(entity_proposal[0].count(), 0);
         assert_eq!(
             pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?,
             binding_bag(

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -56,6 +56,7 @@ struct ScanSpec {
 }
 
 /// Immutable database value used by triple-pattern scans.
+/// Maybe unify with DB struct in node.rs
 pub(crate) struct DbValue<D, M>
 where
     D: DbReadOps + Send + Sync + 'static,

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -275,6 +275,16 @@ where
         Ok(extensions)
     }
 
+    fn candidate_count(
+        &self,
+        input: &BindingBag,
+        row: &BindingRow,
+        position: TriplePosition,
+    ) -> Result<usize> {
+        let iterator = self.create_iterator(self.proposal_scan(input, row, position)?)?;
+        Ok(usize::try_from(iterator.count()?)?)
+    }
+
     fn matches(&self, input: &BindingBag, row: &BindingRow) -> Result<bool> {
         let (scan, expected) = self.validation_scan(input, row)?;
         let mut iterator = self.create_iterator(scan)?;
@@ -324,7 +334,7 @@ where
         };
 
         for (row, proposal) in input.rows.iter().zip(proposals) {
-            let count = self.candidate_extensions(input, row, position)?.len();
+            let count = self.candidate_count(input, row, position)?;
             proposal.consider(self.index, count);
         }
         Ok(())
@@ -390,7 +400,7 @@ mod tests {
     use edn::query::{ToVariable, Variable};
     use slatedb::Db;
 
-    use super::{DbValue, TriplePattern, TripleTerm};
+    use super::{DbValue, TriplePattern, TriplePosition, TripleTerm};
     use crate::codec::{self, Encode};
     use crate::ops::DataType;
     use crate::query::binding_bag::BindingBag;
@@ -460,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn proposes_and_counts_each_row_through_the_matching_index() -> Result<()> {
+    fn proposes_each_row_through_the_matching_index() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(async {
@@ -502,9 +512,6 @@ mod tests {
         ));
         let pattern = TriplePattern::new(7, entity, 42, value, db)?;
 
-        let mut entity_proposal = vec![Proposal::default()];
-        pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
-        assert_eq!(entity_proposal[0].count(), 2);
         assert_eq!(
             pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?,
             binding_bag(
@@ -516,10 +523,6 @@ mod tests {
             )
         );
 
-        let mut value_proposal = vec![Proposal::default()];
-        pattern.count(&BindingBag::unit(), &["?v".to_var()], &mut value_proposal)?;
-        assert_eq!(value_proposal[0].count(), 3);
-
         let input = binding_bag(
             &["?outer", "?e"],
             vec![
@@ -528,13 +531,6 @@ mod tests {
                 vec![encoded(DataType::Long(92)), encoded(DataType::Long(3))],
             ],
         );
-        let mut proposals = vec![Proposal::default(); 3];
-
-        pattern.count(&input, &["?v".to_var()], &mut proposals)?;
-        assert_eq!(proposals[0].count(), 2);
-        assert_eq!(proposals[1].count(), 1);
-        assert_eq!(proposals[2].proposer(), None);
-
         let joined = pattern.join(
             &input,
             &["?v".to_var()],
@@ -563,6 +559,70 @@ mod tests {
                 ],
             )
         );
+        Ok(())
+    }
+
+    #[test]
+    fn count_uses_the_iterator_estimate_without_materializing_candidates() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(async {
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                20,
+                codec::RETRACT,
+            )
+            .await?;
+            components
+                .db
+                .flush_with_options(slatedb::config::FlushOptions {
+                    flush_type: slatedb::config::FlushType::MemTable,
+                })
+                .await?;
+            Ok::<_, anyhow::Error>(())
+        })?;
+
+        let (entity, value) = variables("?e", "?v");
+        let pattern = TriplePattern::new(
+            7,
+            entity,
+            42,
+            value,
+            Arc::new(DbValue::new(
+                components.db,
+                runtime.handle().clone(),
+                20,
+                components.range_stats,
+            )),
+        )?;
+        let input = binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]]);
+        let expected = usize::try_from(
+            pattern
+                .create_iterator(pattern.proposal_scan(
+                    &input,
+                    &input.rows[0],
+                    TriplePosition::Value,
+                )?)?
+                .count()?,
+        )?;
+        let mut proposals = vec![Proposal::default()];
+
+        pattern.count(&input, &["?v".to_var()], &mut proposals)?;
+
+        assert_eq!(proposals[0].proposer(), Some(7));
+        assert_eq!(proposals[0].count(), expected);
         Ok(())
     }
 

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -291,11 +291,16 @@ where
 
     // Partial two-variable checks use additive candidates; the full pair is validated later.
     fn validate(&self, input: &BindingBag) -> Result<BindingBag> {
+        let is_bound = |variable| input.column_indexes.contains_key(variable);
+
+        ensure!(
+            self.variables.iter().any(&is_bound),
+            "Triple pattern {} has no bound variables to validate",
+            self.index
+        );
         if input.rows.is_empty() {
             return input.select_rows(&Vec::new());
         }
-
-        let is_bound = |variable| input.column_indexes.contains_key(variable);
 
         let matches = match (&self.entity, &self.value) {
             // Constant entity, constant value.
@@ -1131,6 +1136,17 @@ mod tests {
                 .validate(&BindingBag::unit())
                 .unwrap_err()
                 .to_string(),
+            "Triple pattern 2 has no bound variables to validate"
+        );
+
+        // The rejection does not depend on the input having rows.
+        let no_rows = BindingBag::empty(vec!["?other".to_var()])?;
+        assert_eq!(
+            entity_unbound.validate(&no_rows).unwrap_err().to_string(),
+            "Triple pattern 1 has no bound variables to validate"
+        );
+        assert_eq!(
+            value_unbound.validate(&no_rows).unwrap_err().to_string(),
             "Triple pattern 2 has no bound variables to validate"
         );
         Ok(())

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -228,63 +228,79 @@ where
             TriplePosition::Value => &self.entity,
         };
 
-        let other_resolved = Self::term_is_resolved(other, input);
-        let index_type = Self::index_type(position, other_resolved);
-
-        if let Some(other_var) = other.variable() {
-            // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away
-            // We likely also can get rid of the to vec<index> mapping
-            let mut groups = BTreeMap::new();
-            let index = input.column_index(other_var)?;
-            for (row_index, row) in input.rows.iter().enumerate() {
-                groups
-                    .entry(&row[index])
-                    .or_insert_with(Vec::new)
-                    .push(row_index);
-            }
-
-            let mut extensions = vec![Vec::new(); input.rows.len()];
-            if groups.is_empty() {
-                return Ok(extensions);
-            }
-
-            let mut iterator = self.attr_var_pair_iterator(index_type)?;
-            // a bound E or V is constraining, we still scan once through a sorted iteration
-            for (first, row_indexes) in groups {
-                if !iterator.has_next() {
-                    break;
+        match other {
+            TripleTerm::Variable(other_var) if input.variables.contains(other_var) => {
+                let index_type = Self::index_type(position, true);
+                // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away
+                // We likely also can get rid of the to vec<index> mapping
+                let mut groups = BTreeMap::new();
+                let index = input.column_index(other_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry(&row[index])
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
-                iterator.seek(first.clone())?;
 
-                let mut group_extensions = Vec::new();
-                while let Some(var_pair) = iterator.get_value()? {
-                    if !var_pair.starts_with(first) {
+                let mut extensions = vec![Vec::new(); input.rows.len()];
+                if groups.is_empty() {
+                    return Ok(extensions);
+                }
+
+                let mut iterator = self.attr_var_pair_iterator(index_type)?;
+                // A bound E or V constrains the scan, which still advances only once.
+                for (first, row_indexes) in groups {
+                    if !iterator.has_next() {
                         break;
                     }
-                    // the second part of the pair are the new values
-                    group_extensions.push(vec![var_pair.slice(first.len()..)]);
+                    iterator.seek(first.clone())?;
+
+                    let mut group_extensions = Vec::new();
+                    while let Some(var_pair) = iterator.get_value()? {
+                        if !var_pair.starts_with(first) {
+                            break;
+                        }
+                        group_extensions.push(vec![var_pair.slice(first.len()..)]);
+                        iterator.next()?;
+                    }
+
+                    for row_index in row_indexes {
+                        extensions[row_index] = group_extensions.clone();
+                    }
+                }
+                Ok(extensions)
+            }
+            TripleTerm::Variable(_) => {
+                let index_type = Self::index_type(position, false);
+                let mut iterator = self.attr_var_iterator(index_type)?;
+                let mut candidates = Vec::new();
+                while let Some(value) = iterator.get_value()? {
+                    candidates.push(vec![value]);
                     iterator.next()?;
                 }
-
-                for row_index in row_indexes {
-                    extensions[row_index] = group_extensions.clone();
+                Ok(vec![candidates; input.rows.len()])
+            }
+            TripleTerm::Constant(constant) => {
+                let index_type = Self::index_type(position, true);
+                let mut prefix = self.base_prefix(index_type)?;
+                prefix.extend_from_slice(constant);
+                let prefix_len = prefix.len();
+                let extractor: Extractor =
+                    Box::new(move |key| key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX));
+                let mut iterator =
+                    self.create_iterator(Bytes::from(prefix), index_type, extractor)?;
+                let mut candidates = Vec::new();
+                while let Some(value) = iterator.get_value()? {
+                    candidates.push(vec![value]);
+                    iterator.next()?;
                 }
+                Ok(vec![candidates; input.rows.len()])
             }
-            Ok(extensions)
-        } else {
-            // only the attribute is constraining in this case. We simply walk the iterator.
-            let mut iterator = self.attr_var_iterator(index_type)?;
-            let mut candidates = Vec::new();
-            while let Some(value) = iterator.get_value()? {
-                candidates.push(vec![value]);
-                iterator.next()?;
-            }
-            Ok(vec![candidates; input.rows.len()])
         }
     }
 
-    // The code below is explicitly kept very dumb and with lots of code duplication. 
-    // We can optimize and refactor once things stabilize. It will very likely change anyway when 
+    // The code below is explicitly kept very dumb and with lots of code duplication.
+    // We can optimize and refactor once things stabilize. It will very likely change anyway when
     // we introduce a columnar trie.
 
     // Partial two-variable checks use additive candidates; the full pair is validated later.

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -621,7 +621,7 @@ where
             let res = self.validate(input)?;
             ensure!(
                 target_variables == res.variables,
-                "Triple pattern target_layout {:?} doesnt' match the computed layout {:?}",
+                "Triple pattern target_layout {:?} doesn't match the computed layout {:?}",
                 target_variables,
                 res.variables
             );

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::{ensure, Result};
@@ -46,12 +47,6 @@ impl TripleTerm {
 enum TriplePosition {
     Entity,
     Value,
-}
-
-struct ScanSpec {
-    prefix: Bytes,
-    index_type: IndexType,
-    extractor_position: usize,
 }
 
 /// Immutable database value used by triple-pattern scans.
@@ -150,93 +145,53 @@ where
         Ok(prefix)
     }
 
-    fn proposal_scan(
-        &self,
-        input: &BindingBag,
-        row: &BindingRow,
-        position: TriplePosition,
-    ) -> Result<ScanSpec> {
-        match position {
-            TriplePosition::Entity => {
-                if let Some(value) = self.value.resolve(input, row)? {
-                    let mut prefix = self.base_prefix(IndexType::AVE)?;
-                    prefix.extend_from_slice(&value);
-                    Ok(ScanSpec {
-                        prefix: Bytes::from(prefix),
-                        index_type: IndexType::AVE,
-                        extractor_position: 2,
-                    })
-                } else {
-                    Ok(ScanSpec {
-                        prefix: Bytes::from(self.base_prefix(IndexType::AE)?),
-                        index_type: IndexType::AE,
-                        extractor_position: 1,
-                    })
-                }
-            }
-            TriplePosition::Value => {
-                if let Some(entity) = self.entity.resolve(input, row)? {
-                    let mut prefix = self.base_prefix(IndexType::AEV)?;
-                    prefix.extend_from_slice(&entity);
-                    Ok(ScanSpec {
-                        prefix: Bytes::from(prefix),
-                        index_type: IndexType::AEV,
-                        extractor_position: 2,
-                    })
-                } else {
-                    Ok(ScanSpec {
-                        prefix: Bytes::from(self.base_prefix(IndexType::AV)?),
-                        index_type: IndexType::AV,
-                        extractor_position: 1,
-                    })
-                }
-            }
+    fn term_is_resolved(term: &TripleTerm, input: &BindingBag) -> bool {
+        match term {
+            TripleTerm::Variable(variable) => input.column_indexes.contains_key(variable),
+            TripleTerm::Constant(_) => true,
         }
     }
 
-    fn validation_scan(
-        &self,
+    fn group_rows_by_term(
+        term: &TripleTerm,
         input: &BindingBag,
-        row: &BindingRow,
-    ) -> Result<(ScanSpec, Option<Bytes>)> {
-        let entity = self.entity.resolve(input, row)?;
-        let value = self.value.resolve(input, row)?;
+    ) -> Result<BTreeMap<Bytes, Vec<usize>>> {
+        let mut groups = BTreeMap::new();
+        for (row_index, row) in input.rows.iter().enumerate() {
+            let value = term
+                .resolve(input, row)?
+                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound triple term"))?;
+            groups.entry(value).or_insert_with(Vec::new).push(row_index);
+        }
+        Ok(groups)
+    }
 
-        if let Some(entity) = entity {
-            let mut prefix = self.base_prefix(IndexType::AEV)?;
-            prefix.extend_from_slice(&entity);
-            Ok((
-                ScanSpec {
-                    prefix: Bytes::from(prefix),
-                    index_type: IndexType::AEV,
-                    extractor_position: 2,
-                },
-                value,
-            ))
-        } else {
-            let mut prefix = self.base_prefix(IndexType::AVE)?;
-            if let Some(value) = value {
-                prefix.extend_from_slice(&value);
-            }
-            Ok((
-                ScanSpec {
-                    prefix: Bytes::from(prefix),
-                    index_type: IndexType::AVE,
-                    extractor_position: 2,
-                },
-                None,
-            ))
+    fn proposal_index(position: TriplePosition, other_resolved: bool) -> IndexType {
+        match (position, other_resolved) {
+            (TriplePosition::Entity, false) => IndexType::AE,
+            (TriplePosition::Entity, true) => IndexType::AVE,
+            (TriplePosition::Value, false) => IndexType::AV,
+            (TriplePosition::Value, true) => IndexType::AEV,
         }
     }
 
-    fn create_iterator(&self, spec: ScanSpec) -> Result<Box<dyn Index>> {
-        let index_type = spec.index_type;
-        let position = spec.extractor_position;
-        let extractor: Extractor = Box::new(move |key| make_extractor(position, index_type)(key));
+    fn estimate_count(&self, prefix: &[u8]) -> Result<usize> {
+        let count = self
+            .db
+            .handle
+            .block_on(self.db.range_stats.estimate_key_count_with_prefix(prefix))?;
+        Ok(usize::try_from(count)?)
+    }
 
+    fn create_iterator(
+        &self,
+        prefix: Bytes,
+        index_type: IndexType,
+        extractor: Extractor,
+    ) -> Result<Box<dyn Index>> {
         match index_type {
             IndexType::AE | IndexType::AV => Ok(Box::new(SlateIterator::new(
-                &spec.prefix,
+                &prefix,
                 self.db.slate.as_ref(),
                 self.db.handle.clone(),
                 extractor,
@@ -244,7 +199,7 @@ where
             )?)),
             IndexType::EAV | IndexType::AVE | IndexType::AEV | IndexType::VAE => {
                 Ok(Box::new(TemporalFilterIterator::new(
-                    &spec.prefix,
+                    &prefix,
                     self.db.slate.as_ref(),
                     self.db.handle.clone(),
                     extractor,
@@ -255,15 +210,31 @@ where
         }
     }
 
-    fn candidate_extensions(
-        &self,
-        input: &BindingBag,
-        row: &BindingRow,
-        position: TriplePosition,
-    ) -> Result<Vec<BindingRow>> {
-        let mut iterator = self.create_iterator(self.proposal_scan(input, row, position)?)?;
-        let mut extensions = Vec::new();
+    fn component_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
+        ensure!(
+            matches!(index_type, IndexType::AE | IndexType::AV),
+            "Component iterator requires an AE or AV index"
+        );
+        let prefix = Bytes::from(self.base_prefix(index_type)?);
+        let extractor: Extractor = Box::new(move |key| make_extractor(1, index_type)(key));
+        self.create_iterator(prefix, index_type, extractor)
+    }
 
+    fn pair_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
+        ensure!(
+            matches!(index_type, IndexType::AEV | IndexType::AVE),
+            "Pair iterator requires an AEV or AVE index"
+        );
+        let prefix = Bytes::from(self.base_prefix(index_type)?);
+        let prefix_len = prefix.len();
+        let extractor: Extractor =
+            Box::new(move |key| key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX));
+        self.create_iterator(prefix, index_type, extractor)
+    }
+
+    fn scan_components(&self, index_type: IndexType) -> Result<Vec<BindingRow>> {
+        let mut iterator = self.component_iterator(index_type)?;
+        let mut extensions = Vec::new();
         while let Some(value) = iterator.get_value()? {
             extensions.push(vec![value]);
             iterator.next()?;
@@ -271,28 +242,223 @@ where
         Ok(extensions)
     }
 
-    fn candidate_count(
+    fn grouped_extensions(
         &self,
-        input: &BindingBag,
-        row: &BindingRow,
-        position: TriplePosition,
-    ) -> Result<usize> {
-        let iterator = self.create_iterator(self.proposal_scan(input, row, position)?)?;
-        Ok(usize::try_from(iterator.count()?)?)
+        index_type: IndexType,
+        groups: BTreeMap<Bytes, Vec<usize>>,
+        row_count: usize,
+    ) -> Result<Vec<Vec<BindingRow>>> {
+        let mut extensions = vec![Vec::new(); row_count];
+        if groups.is_empty() {
+            return Ok(extensions);
+        }
+
+        let mut iterator = self.pair_iterator(index_type)?;
+        for (first, row_indexes) in groups {
+            if !iterator.has_next() {
+                break;
+            }
+            iterator.seek(first.clone())?;
+
+            let mut group_extensions = Vec::new();
+            while let Some(pair) = iterator.get_value()? {
+                if !pair.starts_with(&first) {
+                    break;
+                }
+                group_extensions.push(vec![pair.slice(first.len()..)]);
+                iterator.next()?;
+            }
+
+            for row_index in row_indexes {
+                extensions[row_index] = group_extensions.clone();
+            }
+        }
+        Ok(extensions)
     }
 
-    fn matches(&self, input: &BindingBag, row: &BindingRow) -> Result<bool> {
-        let (scan, expected) = self.validation_scan(input, row)?;
-        let mut iterator = self.create_iterator(scan)?;
-        if let Some(expected) = expected {
+    fn candidate_extensions(
+        &self,
+        input: &BindingBag,
+        position: TriplePosition,
+    ) -> Result<Vec<Vec<BindingRow>>> {
+        if input.rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let other = match position {
+            TriplePosition::Entity => &self.value,
+            TriplePosition::Value => &self.entity,
+        };
+        let other_resolved = Self::term_is_resolved(other, input);
+        let index_type = Self::proposal_index(position, other_resolved);
+        if other_resolved {
+            self.grouped_extensions(
+                index_type,
+                Self::group_rows_by_term(other, input)?,
+                input.rows.len(),
+            )
+        } else {
+            let candidates = self.scan_components(index_type)?;
+            Ok(vec![candidates; input.rows.len()])
+        }
+    }
+
+    fn group_rows_by_pair(&self, input: &BindingBag) -> Result<BTreeMap<Bytes, Vec<usize>>> {
+        let mut groups = BTreeMap::new();
+        for (row_index, row) in input.rows.iter().enumerate() {
+            let entity = self
+                .entity
+                .resolve(input, row)?
+                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound entity"))?;
+            let value = self
+                .value
+                .resolve(input, row)?
+                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound value"))?;
+            let mut pair = entity.to_vec();
+            pair.extend_from_slice(&value);
+            groups
+                .entry(Bytes::from(pair))
+                .or_insert_with(Vec::new)
+                .push(row_index);
+        }
+        Ok(groups)
+    }
+
+    fn matching_group_rows<F>(
+        row_count: usize,
+        groups: BTreeMap<Bytes, Vec<usize>>,
+        mut iterator: Box<dyn Index>,
+        matches_expected: F,
+    ) -> Result<Vec<bool>>
+    where
+        F: Fn(&Bytes, &Bytes) -> bool,
+    {
+        let mut matches = vec![false; row_count];
+        for (expected, row_indexes) in groups {
             if !iterator.has_next() {
-                return Ok(false);
+                break;
             }
             iterator.seek(expected.clone())?;
-            Ok(iterator.get_value()?.as_ref() == Some(&expected))
-        } else {
-            Ok(iterator.has_next())
+            if iterator
+                .get_value()?
+                .as_ref()
+                .is_some_and(|actual| matches_expected(actual, &expected))
+            {
+                for row_index in row_indexes {
+                    matches[row_index] = true;
+                }
+            }
         }
+        Ok(matches)
+    }
+
+    fn matching_component_rows(
+        &self,
+        input: &BindingBag,
+        term: &TripleTerm,
+        index_type: IndexType,
+    ) -> Result<Vec<bool>> {
+        Self::matching_group_rows(
+            input.rows.len(),
+            Self::group_rows_by_term(term, input)?,
+            self.component_iterator(index_type)?,
+            |actual, expected| actual == expected,
+        )
+    }
+
+    fn matching_first_component_rows(
+        &self,
+        input: &BindingBag,
+        term: &TripleTerm,
+        index_type: IndexType,
+    ) -> Result<Vec<bool>> {
+        Self::matching_group_rows(
+            input.rows.len(),
+            Self::group_rows_by_term(term, input)?,
+            self.pair_iterator(index_type)?,
+            |actual, expected| actual.starts_with(expected),
+        )
+    }
+
+    fn matching_pair_rows(&self, input: &BindingBag) -> Result<Vec<bool>> {
+        Self::matching_group_rows(
+            input.rows.len(),
+            self.group_rows_by_pair(input)?,
+            self.pair_iterator(IndexType::AEV)?,
+            |actual, expected| actual == expected,
+        )
+    }
+
+    fn matching_rows(&self, input: &BindingBag) -> Result<Vec<usize>> {
+        if input.rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let entity_resolved = Self::term_is_resolved(&self.entity, input);
+        let value_resolved = Self::term_is_resolved(&self.value, input);
+        // Partial two-variable checks use additive candidates; the full pair is validated later.
+        let matches = match (entity_resolved, value_resolved) {
+            (true, true) => self.matching_pair_rows(input)?,
+            (true, false) if self.entity.variable().is_some() => {
+                self.matching_component_rows(input, &self.entity, IndexType::AE)?
+            }
+            (false, true) if self.value.variable().is_some() => {
+                self.matching_component_rows(input, &self.value, IndexType::AV)?
+            }
+            (true, false) => {
+                self.matching_first_component_rows(input, &self.entity, IndexType::AEV)?
+            }
+            (false, true) => {
+                self.matching_first_component_rows(input, &self.value, IndexType::AVE)?
+            }
+            (false, false) => {
+                let has_match = self.pair_iterator(IndexType::AEV)?.has_next();
+                vec![has_match; input.rows.len()]
+            }
+        };
+        Ok(matches
+            .into_iter()
+            .enumerate()
+            .filter_map(|(row_index, matches)| matches.then_some(row_index))
+            .collect())
+    }
+
+    fn validate(&self, input: &BindingBag, target_variables: &[Variable]) -> Result<BindingBag> {
+        ensure!(
+            target_variables == input.variables,
+            "Triple pattern {} validation must preserve the input layout",
+            self.index
+        );
+        input.select_rows(&self.matching_rows(input)?)
+    }
+
+    fn propose(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        target_variables: &[Variable],
+    ) -> Result<BindingBag> {
+        ensure!(
+            added.len() == 1,
+            "Triple pattern {} can propose exactly one variable, got {added:?}",
+            self.index
+        );
+        ensure!(
+            !input.variables.contains(&added[0]),
+            "Triple pattern {} cannot add already-bound variable {}",
+            self.index,
+            added[0]
+        );
+        let position = self.position_for_variable(&added[0]).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Triple pattern {} cannot propose variable {}",
+                self.index,
+                added[0]
+            )
+        })?;
+        input
+            .extend_rows(added.to_vec(), self.candidate_extensions(input, position)?)?
+            .reorder(target_variables)
     }
 }
 
@@ -328,10 +494,32 @@ where
         let Some(position) = self.position_for_variable(&added[0]) else {
             return Ok(());
         };
+        if input.rows.is_empty() {
+            return Ok(());
+        }
 
-        for (row, proposal) in input.rows.iter().zip(proposals) {
-            let count = self.candidate_count(input, row, position)?;
-            proposal.consider(self.index, count);
+        let other = match position {
+            TriplePosition::Entity => &self.value,
+            TriplePosition::Value => &self.entity,
+        };
+        let other_resolved = Self::term_is_resolved(other, input);
+        let index_type = Self::proposal_index(position, other_resolved);
+        let base_prefix = self.base_prefix(index_type)?;
+
+        if other_resolved {
+            for (value, row_indexes) in Self::group_rows_by_term(other, input)? {
+                let mut prefix = base_prefix.clone();
+                prefix.extend_from_slice(&value);
+                let count = self.estimate_count(&prefix)?;
+                for row_index in row_indexes {
+                    proposals[row_index].consider(self.index, count);
+                }
+            }
+        } else {
+            let count = self.estimate_count(&base_prefix)?;
+            for proposal in proposals {
+                proposal.consider(self.index, count);
+            }
         }
         Ok(())
     }
@@ -343,47 +531,10 @@ where
         target_variables: &[Variable],
     ) -> Result<BindingBag> {
         if added.is_empty() {
-            ensure!(
-                target_variables == input.variables,
-                "Triple pattern {} validation must preserve the input layout",
-                self.index
-            );
-            let mut matches = Vec::new();
-            for (row_index, row) in input.rows.iter().enumerate() {
-                if self.matches(input, row)? {
-                    matches.push(row_index);
-                }
-            }
-            return input.select_rows(&matches);
+            self.validate(input, target_variables)
+        } else {
+            self.propose(input, added, target_variables)
         }
-
-        ensure!(
-            added.len() == 1,
-            "Triple pattern {} can propose exactly one variable, got {added:?}",
-            self.index
-        );
-        ensure!(
-            !input.variables.contains(&added[0]),
-            "Triple pattern {} cannot add already-bound variable {}",
-            self.index,
-            added[0]
-        );
-        let position = self.position_for_variable(&added[0]).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Triple pattern {} cannot propose variable {}",
-                self.index,
-                added[0]
-            )
-        })?;
-        let extensions = input
-            .rows
-            .iter()
-            .map(|row| self.candidate_extensions(input, row, position))
-            .collect::<Result<Vec<_>>>()?;
-
-        input
-            .extend_rows(added.to_vec(), extensions)?
-            .reorder(target_variables)
     }
 }
 
@@ -396,7 +547,7 @@ mod tests {
     use edn::query::{ToVariable, Variable};
     use slatedb::Db;
 
-    use super::{DbValue, TriplePattern, TriplePosition, TripleTerm};
+    use super::{DbValue, TriplePattern, TripleTerm};
     use crate::codec::{self, Encode};
     use crate::ops::DataType;
     use crate::query::binding_bag::BindingBag;
@@ -528,6 +679,7 @@ mod tests {
             vec![
                 vec![encoded(DataType::Long(90)), encoded(DataType::Long(1))],
                 vec![encoded(DataType::Long(91)), encoded(DataType::Long(2))],
+                vec![encoded(DataType::Long(93)), encoded(DataType::Long(1))],
                 vec![encoded(DataType::Long(92)), encoded(DataType::Long(3))],
             ],
         );
@@ -556,6 +708,56 @@ mod tests {
                         encoded(DataType::Long(91)),
                         encoded(DataType::Long(2)),
                     ],
+                    vec![
+                        encoded(DataType::String("alice".into())),
+                        encoded(DataType::Long(93)),
+                        encoded(DataType::Long(1)),
+                    ],
+                    vec![
+                        encoded(DataType::String("ally".into())),
+                        encoded(DataType::Long(93)),
+                        encoded(DataType::Long(1)),
+                    ],
+                ],
+            )
+        );
+
+        let value_input = binding_bag(
+            &["?outer", "?v"],
+            vec![
+                vec![
+                    encoded(DataType::Long(94)),
+                    encoded(DataType::String("bob".into())),
+                ],
+                vec![
+                    encoded(DataType::Long(95)),
+                    encoded(DataType::String("alice".into())),
+                ],
+                vec![
+                    encoded(DataType::Long(96)),
+                    encoded(DataType::String("missing".into())),
+                ],
+            ],
+        );
+        assert_eq!(
+            pattern.join(
+                &value_input,
+                &["?e".to_var()],
+                &["?e".to_var(), "?outer".to_var(), "?v".to_var()],
+            )?,
+            binding_bag(
+                &["?e", "?outer", "?v"],
+                vec![
+                    vec![
+                        encoded(DataType::Long(2)),
+                        encoded(DataType::Long(94)),
+                        encoded(DataType::String("bob".into())),
+                    ],
+                    vec![
+                        encoded(DataType::Long(1)),
+                        encoded(DataType::Long(95)),
+                        encoded(DataType::String("alice".into())),
+                    ],
                 ],
             )
         );
@@ -563,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn count_uses_the_iterator_estimate_without_materializing_candidates() -> Result<()> {
+    fn count_uses_one_range_estimate_for_duplicate_bound_terms() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(async {
@@ -594,6 +796,18 @@ mod tests {
             Ok::<_, anyhow::Error>(())
         })?;
 
+        let entity_1 = encoded(DataType::Long(1));
+        let mut prefix = vec![codec::AEV];
+        prefix.extend_from_slice(&codec::encode_i64_bytes(42));
+        prefix.extend_from_slice(&entity_1);
+        let expected = usize::try_from(
+            runtime.block_on(
+                components
+                    .range_stats
+                    .estimate_key_count_with_prefix(&prefix),
+            )?,
+        )?;
+
         let (entity, value) = variables("?e", "?v");
         let pattern = TriplePattern::new(
             7,
@@ -607,27 +821,19 @@ mod tests {
                 components.range_stats,
             )),
         )?;
-        let input = binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]]);
-        let expected = usize::try_from(
-            pattern
-                .create_iterator(pattern.proposal_scan(
-                    &input,
-                    &input.rows[0],
-                    TriplePosition::Value,
-                )?)?
-                .count()?,
-        )?;
-        let mut proposals = vec![Proposal::default()];
+        let input = binding_bag(&["?e"], vec![vec![entity_1.clone()], vec![entity_1]]);
+        let mut proposals = vec![Proposal::default(); 2];
 
         pattern.count(&input, &["?v".to_var()], &mut proposals)?;
 
         assert_eq!(proposals[0].proposer(), Some(7));
         assert_eq!(proposals[0].count(), expected);
+        assert_eq!(proposals[1], proposals[0]);
         Ok(())
     }
 
     #[test]
-    fn validation_is_temporal_existential_and_layout_independent() -> Result<()> {
+    fn partial_validation_is_additive_and_full_validation_is_temporal() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(async {
@@ -676,15 +882,24 @@ mod tests {
                 vec![encoded(DataType::Long(8)), encoded(DataType::Long(2))],
             ],
         );
-        assert_eq!(
-            pattern.join(&partial, &[], &partial.variables)?,
-            binding_bag(
-                &["?outer", "?e"],
+        assert_eq!(pattern.join(&partial, &[], &partial.variables)?, partial);
+
+        let partial_values = binding_bag(
+            &["?outer", "?v"],
+            vec![
                 vec![
-                    vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
-                    vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
+                    encoded(DataType::Long(9)),
+                    encoded(DataType::String("alice".into())),
                 ],
-            )
+                vec![
+                    encoded(DataType::Long(8)),
+                    encoded(DataType::String("bob".into())),
+                ],
+            ],
+        );
+        assert_eq!(
+            pattern.join(&partial_values, &[], &partial_values.variables)?,
+            partial_values
         );
 
         let full = binding_bag(
@@ -699,6 +914,11 @@ mod tests {
                     encoded(DataType::String("wrong".into())),
                     encoded(DataType::Long(8)),
                     encoded(DataType::Long(1)),
+                ],
+                vec![
+                    encoded(DataType::String("bob".into())),
+                    encoded(DataType::Long(7)),
+                    encoded(DataType::Long(2)),
                 ],
             ],
         );
@@ -748,6 +968,10 @@ mod tests {
             entities,
             binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]])
         );
+        assert_eq!(
+            entity_pattern.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::unit()
+        );
 
         let value_pattern = TriplePattern::new(
             2,
@@ -763,6 +987,10 @@ mod tests {
                 &["?v"],
                 vec![vec![encoded(DataType::String("alice".into()))]]
             )
+        );
+        assert_eq!(
+            value_pattern.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::unit()
         );
 
         let existing = TriplePattern::new(

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -1,0 +1,811 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::{ensure, Result};
+use bytes::Bytes;
+use edn::query::Variable;
+use slatedb::{DbMetadataOps, DbReadOps};
+use tokio::runtime::Handle;
+
+use crate::codec;
+use crate::index::IndexType;
+use crate::iterator::slate_iterator::{Extractor, Index, SlateIterator};
+use crate::iterator::temporal_filter_iterator::TemporalFilterIterator;
+use crate::query::binding_bag::{BindingRow, BindingBag};
+use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+use crate::util::make_extractor;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TripleTerm {
+    Variable(Variable),
+    Constant(Bytes),
+    Placeholder,
+}
+
+impl TripleTerm {
+    fn variable(&self) -> Option<&Variable> {
+        match self {
+            Self::Variable(variable) => Some(variable),
+            Self::Constant(_) | Self::Placeholder => None,
+        }
+    }
+
+    fn resolve(&self, input: &BindingBag, row: &BindingRow) -> Result<Option<Bytes>> {
+        match self {
+            Self::Variable(variable) => {
+                if input.variables.contains(variable) {
+                    Ok(Some(row[input.column_index(variable)?].clone()))
+                } else {
+                    Ok(None)
+                }
+            }
+            Self::Constant(value) => Ok(Some(value.clone())),
+            Self::Placeholder => Ok(None),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TriplePosition {
+    Entity,
+    Value,
+}
+
+struct ScanSpec {
+    prefix: Bytes,
+    index_type: IndexType,
+    extractor_position: usize,
+}
+
+pub(crate) struct TriplePattern<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    id: PatternId,
+    variables: Vec<Variable>,
+    entity: TripleTerm,
+    attribute: i64,
+    value: TripleTerm,
+    slate: Arc<D>,
+    handle: Handle,
+    as_of: i64,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+}
+
+impl<D, M> TriplePattern<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        id: PatternId,
+        entity: TripleTerm,
+        attribute: i64,
+        value: TripleTerm,
+        slate: Arc<D>,
+        handle: Handle,
+        as_of: i64,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    ) -> Result<Self> {
+        ensure!(
+            !matches!(entity, TripleTerm::Placeholder),
+            "Triple pattern {id} does not support an entity placeholder"
+        );
+        ensure!(
+            !matches!(value, TripleTerm::Placeholder),
+            "Triple pattern {id} does not support a value placeholder"
+        );
+
+        let mut variables = Vec::new();
+        if let Some(variable) = entity.variable() {
+            variables.push(variable.clone());
+        }
+        if let Some(variable) = value.variable() {
+            ensure!(
+                !variables.contains(variable),
+                "Triple pattern {id} repeats variable {variable}"
+            );
+            variables.push(variable.clone());
+        }
+
+        Ok(Self {
+            id,
+            variables,
+            entity,
+            attribute,
+            value,
+            slate,
+            handle,
+            as_of,
+            range_stats,
+        })
+    }
+
+    fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
+        if self.entity.variable() == Some(variable) {
+            Some(TriplePosition::Entity)
+        } else if self.value.variable() == Some(variable) {
+            Some(TriplePosition::Value)
+        } else {
+            None
+        }
+    }
+
+    fn base_prefix(&self, index_type: IndexType) -> Result<Vec<u8>> {
+        let mut prefix = vec![codec::index_type_to_prefix(index_type)?];
+        codec::encode_i64(self.attribute, &mut prefix);
+        Ok(prefix)
+    }
+
+    fn proposal_scan(
+        &self,
+        input: &BindingBag,
+        row: &BindingRow,
+        position: TriplePosition,
+    ) -> Result<ScanSpec> {
+        match position {
+            TriplePosition::Entity => {
+                if let Some(value) = self.value.resolve(input, row)? {
+                    let mut prefix = self.base_prefix(IndexType::AVE)?;
+                    prefix.extend_from_slice(&value);
+                    Ok(ScanSpec {
+                        prefix: Bytes::from(prefix),
+                        index_type: IndexType::AVE,
+                        extractor_position: 2,
+                    })
+                } else {
+                    Ok(ScanSpec {
+                        prefix: Bytes::from(self.base_prefix(IndexType::AE)?),
+                        index_type: IndexType::AE,
+                        extractor_position: 1,
+                    })
+                }
+            }
+            TriplePosition::Value => {
+                if let Some(entity) = self.entity.resolve(input, row)? {
+                    let mut prefix = self.base_prefix(IndexType::AEV)?;
+                    prefix.extend_from_slice(&entity);
+                    Ok(ScanSpec {
+                        prefix: Bytes::from(prefix),
+                        index_type: IndexType::AEV,
+                        extractor_position: 2,
+                    })
+                } else {
+                    Ok(ScanSpec {
+                        prefix: Bytes::from(self.base_prefix(IndexType::AV)?),
+                        index_type: IndexType::AV,
+                        extractor_position: 1,
+                    })
+                }
+            }
+        }
+    }
+
+    fn validation_scan(
+        &self,
+        input: &BindingBag,
+        row: &BindingRow,
+    ) -> Result<(ScanSpec, Option<Bytes>)> {
+        let entity = self.entity.resolve(input, row)?;
+        let value = self.value.resolve(input, row)?;
+
+        if let Some(entity) = entity {
+            let mut prefix = self.base_prefix(IndexType::AEV)?;
+            prefix.extend_from_slice(&entity);
+            Ok((
+                ScanSpec {
+                    prefix: Bytes::from(prefix),
+                    index_type: IndexType::AEV,
+                    extractor_position: 2,
+                },
+                value,
+            ))
+        } else {
+            let mut prefix = self.base_prefix(IndexType::AVE)?;
+            if let Some(value) = value {
+                prefix.extend_from_slice(&value);
+            }
+            Ok((
+                ScanSpec {
+                    prefix: Bytes::from(prefix),
+                    index_type: IndexType::AVE,
+                    extractor_position: 2,
+                },
+                None,
+            ))
+        }
+    }
+
+    fn create_iterator(&self, spec: ScanSpec) -> Result<Box<dyn Index>> {
+        let index_type = spec.index_type;
+        let position = spec.extractor_position;
+        let extractor: Extractor = Box::new(move |key| make_extractor(position, index_type)(key));
+
+        match index_type {
+            IndexType::AE | IndexType::AV => Ok(Box::new(SlateIterator::new(
+                &spec.prefix,
+                self.slate.as_ref(),
+                self.handle.clone(),
+                extractor,
+                self.range_stats.clone(),
+            )?)),
+            IndexType::EAV | IndexType::AVE | IndexType::AEV | IndexType::VAE => {
+                Ok(Box::new(TemporalFilterIterator::new(
+                    &spec.prefix,
+                    self.slate.as_ref(),
+                    self.handle.clone(),
+                    extractor,
+                    self.as_of,
+                    self.range_stats.clone(),
+                )?))
+            }
+        }
+    }
+
+    fn candidate_extensions(
+        &self,
+        input: &BindingBag,
+        row: &BindingRow,
+        position: TriplePosition,
+    ) -> Result<Vec<BindingRow>> {
+        let mut iterator = self.create_iterator(self.proposal_scan(input, row, position)?)?;
+        let mut seen = HashSet::new();
+        let mut extensions = Vec::new();
+
+        while let Some(value) = iterator.get_value()? {
+            if seen.insert(value.clone()) {
+                extensions.push(vec![value]);
+            }
+            iterator.next()?;
+        }
+        Ok(extensions)
+    }
+
+    fn matches(&self, input: &BindingBag, row: &BindingRow) -> Result<bool> {
+        let (scan, expected) = self.validation_scan(input, row)?;
+        let mut iterator = self.create_iterator(scan)?;
+        if let Some(expected) = expected {
+            if !iterator.has_next() {
+                return Ok(false);
+            }
+            iterator.seek(expected.clone())?;
+            Ok(iterator.get_value()?.as_ref() == Some(&expected))
+        } else {
+            Ok(iterator.has_next())
+        }
+    }
+}
+
+impl<D, M> ExecPattern for TriplePattern<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    fn id(&self) -> PatternId {
+        self.id
+    }
+
+    fn variables(&self) -> &[Variable] {
+        &self.variables
+    }
+
+    fn count(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        proposals: &mut [Proposal],
+    ) -> Result<()> {
+        ensure!(
+            proposals.len() == input.rows.len(),
+            "Triple pattern {} received {} proposals for {} input rows",
+            self.id,
+            proposals.len(),
+            input.rows.len()
+        );
+        if added.len() != 1 || input.variables.contains(&added[0]) {
+            return Ok(());
+        }
+        let Some(position) = self.position_for_variable(&added[0]) else {
+            return Ok(());
+        };
+
+        for (row, proposal) in input.rows.iter().zip(proposals) {
+            let count = self.candidate_extensions(input, row, position)?.len();
+            proposal.consider(self.id, count);
+        }
+        Ok(())
+    }
+
+    fn join(
+        &self,
+        input: &BindingBag,
+        added: &[Variable],
+        target_variables: &[Variable],
+    ) -> Result<BindingBag> {
+        if added.is_empty() {
+            ensure!(
+                target_variables == input.variables,
+                "Triple pattern {} validation must preserve the input layout",
+                self.id
+            );
+            let mut matches = Vec::new();
+            for (row_index, row) in input.rows.iter().enumerate() {
+                if self.matches(input, row)? {
+                    matches.push(row_index);
+                }
+            }
+            return input.select_rows(&matches);
+        }
+
+        ensure!(
+            added.len() == 1,
+            "Triple pattern {} can propose exactly one variable, got {added:?}",
+            self.id
+        );
+        ensure!(
+            !input.variables.contains(&added[0]),
+            "Triple pattern {} cannot add already-bound variable {}",
+            self.id,
+            added[0]
+        );
+        let position = self.position_for_variable(&added[0]).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Triple pattern {} cannot propose variable {}",
+                self.id,
+                added[0]
+            )
+        })?;
+        let extensions = input
+            .rows
+            .iter()
+            .map(|row| self.candidate_extensions(input, row, position))
+            .collect::<Result<Vec<_>>>()?;
+
+        input
+            .extend_rows(added.to_vec(), extensions)?
+            .reorder(target_variables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use bytes::Bytes;
+    use edn::query::{ToVariable, Variable};
+    use slatedb::Db;
+
+    use super::{TriplePattern, TripleTerm};
+    use crate::codec::{self, Encode};
+    use crate::ops::DataType;
+    use crate::query::binding_bag::BindingBag;
+    use crate::query::exec_pattern::{ExecPattern, Proposal};
+    use crate::slate::in_memory_slate;
+
+    fn encoded(value: DataType) -> Bytes {
+        Bytes::from(value.encode())
+    }
+
+    fn binding_bag(variables: &[&str], rows: Vec<Vec<Bytes>>) -> BindingBag {
+        BindingBag::new(
+            variables.iter().map(|variable| variable.to_var()).collect(),
+            rows,
+        )
+        .unwrap()
+    }
+
+    async fn insert_version(
+        slate: &Db,
+        attribute: i64,
+        entity: i64,
+        value: &DataType,
+        tx_eid: i64,
+        op: u8,
+    ) -> Result<()> {
+        let entity = DataType::Long(entity).encode();
+        let value = value.encode();
+        let attribute = codec::encode_i64_bytes(attribute);
+        let tx_eid = codec::encode_i64_bytes(tx_eid);
+
+        let mut aev = vec![codec::AEV];
+        aev.extend_from_slice(&attribute);
+        aev.extend_from_slice(&entity);
+        aev.extend_from_slice(&value);
+        aev.extend_from_slice(&tx_eid);
+        aev.push(op);
+        slate.put(&aev, b"").await?;
+
+        let mut ave = vec![codec::AVE];
+        ave.extend_from_slice(&attribute);
+        ave.extend_from_slice(&value);
+        ave.extend_from_slice(&entity);
+        ave.extend_from_slice(&tx_eid);
+        ave.push(op);
+        slate.put(&ave, b"").await?;
+
+        if op == codec::ADD {
+            let mut ae = vec![codec::AE];
+            ae.extend_from_slice(&attribute);
+            ae.extend_from_slice(&entity);
+            slate.put(&ae, b"").await?;
+
+            let mut av = vec![codec::AV];
+            av.extend_from_slice(&attribute);
+            av.extend_from_slice(&value);
+            slate.put(&av, b"").await?;
+        }
+        Ok(())
+    }
+
+    fn variables(entity: &str, value: &str) -> (TripleTerm, TripleTerm) {
+        (
+            TripleTerm::Variable(entity.to_var()),
+            TripleTerm::Variable(value.to_var()),
+        )
+    }
+
+    #[test]
+    fn proposes_and_counts_each_row_through_the_matching_index() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(async {
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("ally".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                2,
+                &DataType::String("bob".into()),
+                10,
+                codec::ADD,
+            )
+            .await
+        })?;
+
+        let (entity, value) = variables("?e", "?v");
+        let pattern = TriplePattern::new(
+            7,
+            entity,
+            42,
+            value,
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        )?;
+
+        let mut entity_proposal = vec![Proposal::default()];
+        pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
+        assert_eq!(entity_proposal[0].count(), 2);
+        assert_eq!(
+            pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?,
+            binding_bag(
+                &["?e"],
+                vec![
+                    vec![encoded(DataType::Long(2))],
+                    vec![encoded(DataType::Long(1))]
+                ],
+            )
+        );
+
+        let mut value_proposal = vec![Proposal::default()];
+        pattern.count(&BindingBag::unit(), &["?v".to_var()], &mut value_proposal)?;
+        assert_eq!(value_proposal[0].count(), 3);
+
+        let input = binding_bag(
+            &["?outer", "?e"],
+            vec![
+                vec![encoded(DataType::Long(90)), encoded(DataType::Long(1))],
+                vec![encoded(DataType::Long(91)), encoded(DataType::Long(2))],
+                vec![encoded(DataType::Long(92)), encoded(DataType::Long(3))],
+            ],
+        );
+        let mut proposals = vec![Proposal::default(); 3];
+
+        pattern.count(&input, &["?v".to_var()], &mut proposals)?;
+        assert_eq!(proposals[0].count(), 2);
+        assert_eq!(proposals[1].count(), 1);
+        assert_eq!(proposals[2].proposer(), None);
+
+        let joined = pattern.join(
+            &input,
+            &["?v".to_var()],
+            &["?v".to_var(), "?outer".to_var(), "?e".to_var()],
+        )?;
+        assert_eq!(
+            joined,
+            binding_bag(
+                &["?v", "?outer", "?e"],
+                vec![
+                    vec![
+                        encoded(DataType::String("alice".into())),
+                        encoded(DataType::Long(90)),
+                        encoded(DataType::Long(1)),
+                    ],
+                    vec![
+                        encoded(DataType::String("ally".into())),
+                        encoded(DataType::Long(90)),
+                        encoded(DataType::Long(1)),
+                    ],
+                    vec![
+                        encoded(DataType::String("bob".into())),
+                        encoded(DataType::Long(91)),
+                        encoded(DataType::Long(2)),
+                    ],
+                ],
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn validation_is_temporal_existential_and_layout_independent() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(async {
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                2,
+                &DataType::String("bob".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                2,
+                &DataType::String("bob".into()),
+                20,
+                codec::RETRACT,
+            )
+            .await
+        })?;
+
+        let (entity, value) = variables("?e", "?v");
+        let pattern = TriplePattern::new(
+            7,
+            entity,
+            42,
+            value,
+            components.db,
+            runtime.handle().clone(),
+            20,
+            components.range_stats,
+        )?;
+        let partial = binding_bag(
+            &["?outer", "?e"],
+            vec![
+                vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
+                vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
+                vec![encoded(DataType::Long(8)), encoded(DataType::Long(2))],
+            ],
+        );
+        assert_eq!(
+            pattern.join(&partial, &[], partial.variables)?,
+            binding_bag(
+                &["?outer", "?e"],
+                vec![
+                    vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
+                    vec![encoded(DataType::Long(9)), encoded(DataType::Long(1))],
+                ],
+            )
+        );
+
+        let full = binding_bag(
+            &["?v", "?outer", "?e"],
+            vec![
+                vec![
+                    encoded(DataType::String("alice".into())),
+                    encoded(DataType::Long(9)),
+                    encoded(DataType::Long(1)),
+                ],
+                vec![
+                    encoded(DataType::String("wrong".into())),
+                    encoded(DataType::Long(8)),
+                    encoded(DataType::Long(1)),
+                ],
+            ],
+        );
+        assert_eq!(
+            pattern.join(&full, &[], full.variables)?,
+            binding_bag(
+                &["?v", "?outer", "?e"],
+                vec![vec![
+                    encoded(DataType::String("alice".into())),
+                    encoded(DataType::Long(9)),
+                    encoded(DataType::Long(1)),
+                ]],
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constants_propose_the_other_position_and_constant_only_patterns_validate() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(insert_version(
+            components.db.as_ref(),
+            42,
+            1,
+            &DataType::String("alice".into()),
+            10,
+            codec::ADD,
+        ))?;
+
+        let entity_pattern = TriplePattern::new(
+            1,
+            TripleTerm::Variable("?e".to_var()),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            components.db.clone(),
+            runtime.handle().clone(),
+            10,
+            components.range_stats.clone(),
+        )?;
+        let entities =
+            entity_pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?;
+        assert_eq!(
+            entities,
+            binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]])
+        );
+
+        let value_pattern = TriplePattern::new(
+            2,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Variable("?v".to_var()),
+            components.db.clone(),
+            runtime.handle().clone(),
+            10,
+            components.range_stats.clone(),
+        )?;
+        let values = value_pattern.join(&BindingBag::unit(), &["?v".to_var()], &["?v".to_var()])?;
+        assert_eq!(
+            values,
+            binding_bag(
+                &["?v"],
+                vec![vec![encoded(DataType::String("alice".into()))]]
+            )
+        );
+
+        let existing = TriplePattern::new(
+            3,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            components.db.clone(),
+            runtime.handle().clone(),
+            10,
+            components.range_stats.clone(),
+        )?;
+        assert_eq!(
+            existing.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::unit()
+        );
+
+        let missing = TriplePattern::new(
+            4,
+            TripleTerm::Constant(encoded(DataType::Long(2))),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        )?;
+        assert_eq!(
+            missing.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::empty(Vec::<Variable>::new())?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn historical_basis_observes_add_and_retract_boundaries() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(async {
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                20,
+                codec::RETRACT,
+            )
+            .await
+        })?;
+
+        let make_pattern = |id, as_of| {
+            TriplePattern::new(
+                id,
+                TripleTerm::Constant(encoded(DataType::Long(1))),
+                42,
+                TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+                components.db.clone(),
+                runtime.handle().clone(),
+                as_of,
+                components.range_stats.clone(),
+            )
+        };
+
+        assert_eq!(
+            make_pattern(1, 9)?.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::empty(Vec::<Variable>::new())?
+        );
+        assert_eq!(
+            make_pattern(2, 10)?.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::unit()
+        );
+        assert_eq!(
+            make_pattern(3, 20)?.join(&BindingBag::unit(), &[], &[])?,
+            BindingBag::empty(Vec::<Variable>::new())?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constructor_rejects_unsupported_and_repeated_shapes() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        let new = |entity, value| {
+            TriplePattern::new(
+                7,
+                entity,
+                42,
+                value,
+                components.db.clone(),
+                runtime.handle().clone(),
+                10,
+                components.range_stats.clone(),
+            )
+        };
+
+        assert!(new(TripleTerm::Placeholder, TripleTerm::Variable("?v".to_var())).is_err());
+        assert!(new(TripleTerm::Variable("?e".to_var()), TripleTerm::Placeholder).is_err());
+        assert!(new(
+            TripleTerm::Variable("?x".to_var()),
+            TripleTerm::Variable("?x".to_var())
+        )
+        .is_err());
+        Ok(())
+    }
+}

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -12,7 +12,7 @@ use crate::index::IndexType;
 use crate::iterator::slate_iterator::{Extractor, Index, SlateIterator};
 use crate::iterator::temporal_filter_iterator::TemporalFilterIterator;
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
+use crate::query::exec_pattern::{ExecPattern, PatternIndex, Proposal};
 use crate::util::make_extractor;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,6 +62,7 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
+    index: PatternIndex,
     variables: Vec<Variable>,
     entity: TripleTerm,
     attribute: i64,
@@ -77,7 +78,9 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        index: PatternIndex,
         entity: TripleTerm,
         attribute: i64,
         value: TripleTerm,
@@ -88,11 +91,11 @@ where
     ) -> Result<Self> {
         ensure!(
             !matches!(entity, TripleTerm::Placeholder),
-            "Triple pattern does not support an entity placeholder"
+            "Triple pattern {index} does not support an entity placeholder"
         );
         ensure!(
             !matches!(value, TripleTerm::Placeholder),
-            "Triple pattern does not support a value placeholder"
+            "Triple pattern {index} does not support a value placeholder"
         );
 
         let mut variables = Vec::new();
@@ -102,12 +105,13 @@ where
         if let Some(variable) = value.variable() {
             ensure!(
                 !variables.contains(variable),
-                "Triple pattern repeats variable {variable}"
+                "Triple pattern {index} repeats variable {variable}"
             );
             variables.push(variable.clone());
         }
 
         Ok(Self {
+            index,
             variables,
             entity,
             attribute,
@@ -279,6 +283,10 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
+    fn index(&self) -> PatternIndex {
+        self.index
+    }
+
     fn variables(&self) -> &[Variable] {
         &self.variables
     }
@@ -287,12 +295,12 @@ where
         &self,
         input: &BindingBag,
         added: &[Variable],
-        participant_index: ParticipantIndex,
         proposals: &mut [Proposal],
     ) -> Result<()> {
         ensure!(
             proposals.len() == input.rows.len(),
-            "Triple pattern received {} proposals for {} input rows",
+            "Triple pattern {} received {} proposals for {} input rows",
+            self.index,
             proposals.len(),
             input.rows.len()
         );
@@ -305,7 +313,7 @@ where
 
         for (row, proposal) in input.rows.iter().zip(proposals) {
             let count = self.candidate_extensions(input, row, position)?.len();
-            proposal.consider(participant_index, count);
+            proposal.consider(self.index, count);
         }
         Ok(())
     }
@@ -319,7 +327,8 @@ where
         if added.is_empty() {
             ensure!(
                 target_variables == input.variables,
-                "Triple pattern validation must preserve the input layout"
+                "Triple pattern {} validation must preserve the input layout",
+                self.index
             );
             let mut matches = Vec::new();
             for (row_index, row) in input.rows.iter().enumerate() {
@@ -332,15 +341,21 @@ where
 
         ensure!(
             added.len() == 1,
-            "Triple pattern can propose exactly one variable, got {added:?}"
+            "Triple pattern {} can propose exactly one variable, got {added:?}",
+            self.index
         );
         ensure!(
             !input.variables.contains(&added[0]),
-            "Triple pattern cannot add already-bound variable {}",
+            "Triple pattern {} cannot add already-bound variable {}",
+            self.index,
             added[0]
         );
         let position = self.position_for_variable(&added[0]).ok_or_else(|| {
-            anyhow::anyhow!("Triple pattern cannot propose variable {}", added[0])
+            anyhow::anyhow!(
+                "Triple pattern {} cannot propose variable {}",
+                self.index,
+                added[0]
+            )
         })?;
         let extensions = input
             .rows
@@ -466,6 +481,7 @@ mod tests {
 
         let (entity, value) = variables("?e", "?v");
         let pattern = TriplePattern::new(
+            7,
             entity,
             42,
             value,
@@ -476,12 +492,7 @@ mod tests {
         )?;
 
         let mut entity_proposal = vec![Proposal::default()];
-        pattern.count(
-            &BindingBag::unit(),
-            &["?e".to_var()],
-            7,
-            &mut entity_proposal,
-        )?;
+        pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
         assert_eq!(entity_proposal[0].count(), 2);
         assert_eq!(
             pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?,
@@ -495,12 +506,7 @@ mod tests {
         );
 
         let mut value_proposal = vec![Proposal::default()];
-        pattern.count(
-            &BindingBag::unit(),
-            &["?v".to_var()],
-            7,
-            &mut value_proposal,
-        )?;
+        pattern.count(&BindingBag::unit(), &["?v".to_var()], &mut value_proposal)?;
         assert_eq!(value_proposal[0].count(), 3);
 
         let input = binding_bag(
@@ -513,7 +519,7 @@ mod tests {
         );
         let mut proposals = vec![Proposal::default(); 3];
 
-        pattern.count(&input, &["?v".to_var()], 7, &mut proposals)?;
+        pattern.count(&input, &["?v".to_var()], &mut proposals)?;
         assert_eq!(proposals[0].count(), 2);
         assert_eq!(proposals[1].count(), 1);
         assert_eq!(proposals[2].proposer(), None);
@@ -585,6 +591,7 @@ mod tests {
 
         let (entity, value) = variables("?e", "?v");
         let pattern = TriplePattern::new(
+            7,
             entity,
             42,
             value,
@@ -655,6 +662,7 @@ mod tests {
         ))?;
 
         let entity_pattern = TriplePattern::new(
+            1,
             TripleTerm::Variable("?e".to_var()),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -671,6 +679,7 @@ mod tests {
         );
 
         let value_pattern = TriplePattern::new(
+            2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Variable("?v".to_var()),
@@ -689,6 +698,7 @@ mod tests {
         );
 
         let existing = TriplePattern::new(
+            3,
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -703,6 +713,7 @@ mod tests {
         );
 
         let missing = TriplePattern::new(
+            4,
             TripleTerm::Constant(encoded(DataType::Long(2))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -743,8 +754,9 @@ mod tests {
             .await
         })?;
 
-        let make_pattern = |as_of| {
+        let make_pattern = |index, as_of| {
             TriplePattern::new(
+                index,
                 TripleTerm::Constant(encoded(DataType::Long(1))),
                 42,
                 TripleTerm::Constant(encoded(DataType::String("alice".into()))),
@@ -756,15 +768,15 @@ mod tests {
         };
 
         assert_eq!(
-            make_pattern(9)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(1, 9)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::empty(Vec::<Variable>::new())?
         );
         assert_eq!(
-            make_pattern(10)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(2, 10)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::unit()
         );
         assert_eq!(
-            make_pattern(20)?.join(&BindingBag::unit(), &[], &[])?,
+            make_pattern(3, 20)?.join(&BindingBag::unit(), &[], &[])?,
             BindingBag::empty(Vec::<Variable>::new())?
         );
         Ok(())
@@ -776,6 +788,7 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         let new = |entity, value| {
             TriplePattern::new(
+                7,
                 entity,
                 42,
                 value,

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::{bail, ensure, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use edn::query::Variable;
 use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
@@ -308,216 +308,216 @@ where
         let entity_is_variable = self.entity.is_variable();
         let value_is_variable = self.value.is_variable();
 
-        let matches =
-            match (
-                entity_is_variable,
-                entity_has_value,
-                value_is_variable,
-                value_has_value,
-            ) {
-                // Constant entity, constant value.
-                (false, true, false, true) => {
+        let matches = match (
+            entity_is_variable,
+            entity_has_value,
+            value_is_variable,
+            value_has_value,
+        ) {
+            // Constant entity, constant value.
+            (false, true, false, true) => {
+                let TripleTerm::Constant(entity) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Constant(value) = &self.value else {
+                    unreachable!()
+                };
+                let mut prefix = self.base_prefix(IndexType::AEV)?;
+                prefix.extend_from_slice(entity);
+                let extractor: Extractor =
+                    Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
+                let mut iterator =
+                    self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
+                let has_match = if iterator.has_next() {
+                    iterator.seek(value.clone())?;
+                    iterator.get_value()?.as_ref() == Some(value)
+                } else {
+                    false
+                };
+                vec![has_match; input.rows.len()]
+            }
 
-                    let TripleTerm::Constant(entity) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Constant(value) = &self.value else {
-                        unreachable!()
-                    };
-                    let mut prefix = self.base_prefix(IndexType::AEV)?;
-                    prefix.extend_from_slice(entity);
-                    prefix.extend_from_slice(value);
-                    let prefix_len = prefix.len();
-                    // TODO: This could become a point lookup.
-                    // TODO: check if this combination of full AEV as prefix + extractor works with
-                    // temporal iterator.
-                    let extractor: Extractor = Box::new(move |key| {
-                        key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX)
-                    });
-                    let has_match = self
-                        .create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?
-                        .has_next();
-                    vec![has_match; input.rows.len()]
+            // Bound entity variable, constant value.
+            (true, true, false, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Variable(entity_var) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Constant(value) = &self.value else {
+                    unreachable!()
+                };
+                let entity_index = input.column_index(entity_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let mut pair = BytesMut::with_capacity(value.len() + row[entity_index].len());
+                    pair.extend_from_slice(value);
+                    pair.extend_from_slice(&row[entity_index]);
+                    groups
+                        .entry(pair.freeze())
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
 
-                // Bound entity variable, constant value.
-                (true, true, false, true) => {
-
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Variable(entity_var) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Constant(value) = &self.value else {
-                        unreachable!()
-                    };
-                    let pair = value.to_vec();
-                    let entity_index = input.column_index(entity_var)?;
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let mut pair = pair.clone();
-                        pair.extend_from_slice(&row[entity_index]);
-                        groups
-                            .entry(Bytes::from(pair))
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
+                let mut iterator = self.attr_var_pair_iterator(IndexType::AVE)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
                     }
-
-                    let mut iterator = self.attr_var_pair_iterator(IndexType::AVE)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
+                }
+                matches
+            }
+
+            // Constant entity, bound value variable.
+            (false, true, true, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Constant(entity) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Variable(value_var) = &self.value else {
+                    unreachable!()
+                };
+                let value_index = input.column_index(value_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let mut pair = BytesMut::with_capacity(entity.len() + row[value_index].len());
+                    pair.extend_from_slice(entity);
+                    pair.extend_from_slice(&row[value_index]);
+                    groups
+                        .entry(pair.freeze())
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
 
-                // Constant entity, bound value variable.
-                (false, true, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound entity")
-                        })?;
-                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound value")
-                        })?;
-                        let mut pair = entity.to_vec();
-                        pair.extend_from_slice(&value);
-                        groups
-                            .entry(Bytes::from(pair))
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
+                let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
                     }
-
-                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
                 }
-                // Bound entity variable, unbound value variable.
-                (true, true, true, false) => {
-                    let mut groups = BTreeMap::new();
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let value = self.entity.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound triple term")
-                        })?;
-                        groups.entry(value).or_insert_with(Vec::new).push(row_index);
-                    }
-
-                    let mut iterator = self.attr_var_iterator(IndexType::AE)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
-                        }
-                    }
-                    matches
+                matches
+            }
+            // Bound entity variable, unbound value variable.
+            (true, true, true, false) => {
+                let mut groups = BTreeMap::new();
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let value = self.entity.resolve(input, row)?.ok_or_else(|| {
+                        anyhow::anyhow!("Cannot group rows by an unbound triple term")
+                    })?;
+                    groups.entry(value).or_insert_with(Vec::new).push(row_index);
                 }
-                // Unbound entity variable, bound value variable.
-                (true, false, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound triple term")
-                        })?;
-                        groups.entry(value).or_insert_with(Vec::new).push(row_index);
-                    }
 
-                    let mut iterator = self.attr_var_iterator(IndexType::AV)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                let mut iterator = self.attr_var_iterator(IndexType::AE)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
                 }
-                // Bound entity variable, bound value variable.
-                (true, true, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound entity")
-                        })?;
-                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound value")
-                        })?;
-                        let mut pair = entity.to_vec();
-                        pair.extend_from_slice(&value);
-                        groups
-                            .entry(Bytes::from(pair))
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
-                    }
+                matches
+            }
+            // Unbound entity variable, bound value variable.
+            (true, false, true, true) => {
+                let mut groups = BTreeMap::new();
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let value = self.value.resolve(input, row)?.ok_or_else(|| {
+                        anyhow::anyhow!("Cannot group rows by an unbound triple term")
+                    })?;
+                    groups.entry(value).or_insert_with(Vec::new).push(row_index);
+                }
 
-                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                let mut iterator = self.attr_var_iterator(IndexType::AV)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
                 }
-                _ => bail!(
-                    "Triple pattern {} has no bound variables to validate",
-                    self.index
-                ),
-            };
+                matches
+            }
+            // Bound entity variable, bound value variable.
+            (true, true, true, true) => {
+                let mut groups = BTreeMap::new();
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    let entity = self
+                        .entity
+                        .resolve(input, row)?
+                        .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound entity"))?;
+                    let value = self
+                        .value
+                        .resolve(input, row)?
+                        .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound value"))?;
+                    let mut pair = entity.to_vec();
+                    pair.extend_from_slice(&value);
+                    groups
+                        .entry(Bytes::from(pair))
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
+                }
+
+                let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
+                        }
+                    }
+                }
+                matches
+            }
+            _ => bail!(
+                "Triple pattern {} has no bound variables to validate",
+                self.index
+            ),
+        };
         let matched: Vec<usize> = matches
             .into_iter()
             .enumerate()

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -22,6 +22,13 @@ pub(crate) enum TripleTerm {
 }
 
 impl TripleTerm {
+    fn is_variable(&self) -> bool {
+        match self {
+            Self::Variable(_) => true,
+            Self::Constant(_) => false,
+        }
+    }
+
     fn variable(&self) -> Option<&Variable> {
         match self {
             Self::Variable(variable) => Some(variable),
@@ -238,12 +245,15 @@ where
         let index_type = Self::index_type(position, other_resolved);
 
         if let Some(other_var) = other.variable() {
-            // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away 
+            // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away
             // We likely also can get rid of the to vec<index> mapping
             let mut groups = BTreeMap::new();
             let index = input.column_index(other_var)?;
             for (row_index, row) in input.rows.iter().enumerate() {
-                groups.entry(&row[index]).or_insert_with(Vec::new).push(row_index);
+                groups
+                    .entry(&row[index])
+                    .or_insert_with(Vec::new)
+                    .push(row_index);
             }
 
             let mut extensions = vec![Vec::new(); input.rows.len()];
@@ -261,7 +271,7 @@ where
 
                 let mut group_extensions = Vec::new();
                 while let Some(var_pair) = iterator.get_value()? {
-                    if !var_pair.starts_with(&first) {
+                    if !var_pair.starts_with(first) {
                         break;
                     }
                     // the second part of the pair are the new values
@@ -286,142 +296,235 @@ where
         }
     }
 
-    fn group_rows_by_term(
-        term: &TripleTerm,
-        input: &BindingBag,
-    ) -> Result<BTreeMap<Bytes, Vec<usize>>> {
-        let mut groups = BTreeMap::new();
-        for (row_index, row) in input.rows.iter().enumerate() {
-            let value = term
-                .resolve(input, row)?
-                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound triple term"))?;
-            groups.entry(value).or_insert_with(Vec::new).push(row_index);
-        }
-        Ok(groups)
-    }
-
-    fn group_rows_by_pair(&self, input: &BindingBag) -> Result<BTreeMap<Bytes, Vec<usize>>> {
-        let mut groups = BTreeMap::new();
-        for (row_index, row) in input.rows.iter().enumerate() {
-            let entity = self
-                .entity
-                .resolve(input, row)?
-                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound entity"))?;
-            let value = self
-                .value
-                .resolve(input, row)?
-                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound value"))?;
-            let mut pair = entity.to_vec();
-            pair.extend_from_slice(&value);
-            groups
-                .entry(Bytes::from(pair))
-                .or_insert_with(Vec::new)
-                .push(row_index);
-        }
-        Ok(groups)
-    }
-
-    fn matching_group_rows<F>(
-        row_count: usize,
-        groups: BTreeMap<Bytes, Vec<usize>>,
-        mut iterator: Box<dyn Index>,
-        matches_expected: F,
-    ) -> Result<Vec<bool>>
-    where
-        F: Fn(&Bytes, &Bytes) -> bool,
-    {
-        let mut matches = vec![false; row_count];
-        for (expected, row_indexes) in groups {
-            if !iterator.has_next() {
-                break;
-            }
-            iterator.seek(expected.clone())?;
-            if iterator
-                .get_value()?
-                .as_ref()
-                .is_some_and(|actual| matches_expected(actual, &expected))
-            {
-                for row_index in row_indexes {
-                    matches[row_index] = true;
-                }
-            }
-        }
-        Ok(matches)
-    }
-
-    fn matching_component_rows(
-        &self,
-        input: &BindingBag,
-        term: &TripleTerm,
-        index_type: IndexType,
-    ) -> Result<Vec<bool>> {
-        Self::matching_group_rows(
-            input.rows.len(),
-            Self::group_rows_by_term(term, input)?,
-            self.attr_var_iterator(index_type)?,
-            |actual, expected| actual == expected,
-        )
-    }
-
-    fn matching_first_component_rows(
-        &self,
-        input: &BindingBag,
-        term: &TripleTerm,
-        index_type: IndexType,
-    ) -> Result<Vec<bool>> {
-        Self::matching_group_rows(
-            input.rows.len(),
-            Self::group_rows_by_term(term, input)?,
-            self.attr_var_pair_iterator(index_type)?,
-            |actual, expected| actual.starts_with(expected),
-        )
-    }
-
-    fn matching_pair_rows(&self, input: &BindingBag) -> Result<Vec<bool>> {
-        Self::matching_group_rows(
-            input.rows.len(),
-            self.group_rows_by_pair(input)?,
-            self.attr_var_pair_iterator(IndexType::AEV)?,
-            |actual, expected| actual == expected,
-        )
-    }
-
-    fn matching_rows(&self, input: &BindingBag) -> Result<Vec<usize>> {
+    // Partial two-variable checks use additive candidates; the full pair is validated later.
+    fn validate(&self, input: &BindingBag) -> Result<BindingBag> {
         if input.rows.is_empty() {
-            return Ok(Vec::new());
+            return input.select_rows(&Vec::new());
         }
 
-        let entity_resolved = Self::term_is_resolved(&self.entity, input);
-        let value_resolved = Self::term_is_resolved(&self.value, input);
-        // Partial two-variable checks use additive candidates; the full pair is validated later.
-        let matches = match (entity_resolved, value_resolved) {
-            (true, true) => self.matching_pair_rows(input)?,
-            (true, false) if self.entity.variable().is_some() => {
-                self.matching_component_rows(input, &self.entity, IndexType::AE)?
-            }
-            (false, true) if self.value.variable().is_some() => {
-                self.matching_component_rows(input, &self.value, IndexType::AV)?
-            }
-            (true, false) => {
-                self.matching_first_component_rows(input, &self.entity, IndexType::AEV)?
-            }
-            (false, true) => {
-                self.matching_first_component_rows(input, &self.value, IndexType::AVE)?
-            }
-            (false, false) => {
-                let has_match = self.attr_var_pair_iterator(IndexType::AEV)?.has_next();
-                vec![has_match; input.rows.len()]
-            }
-        };
-        Ok(matches
+        let entity_has_value = Self::term_is_resolved(&self.entity, input);
+        let value_has_value = Self::term_is_resolved(&self.value, input);
+
+        let entity_is_variable = self.entity.is_variable();
+        let value_is_variable = self.value.is_variable();
+
+        let matches =
+            match (
+                entity_is_variable,
+                entity_has_value,
+                value_is_variable,
+                value_has_value,
+            ) {
+                // Constant entity, constant value.
+                (false, true, false, true) => {
+
+                    let TripleTerm::Constant(entity) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Constant(value) = &self.value else {
+                        unreachable!()
+                    };
+                    let mut prefix = self.base_prefix(IndexType::AEV)?;
+                    prefix.extend_from_slice(entity);
+                    prefix.extend_from_slice(value);
+                    let prefix_len = prefix.len();
+                    // TODO: This could become a point lookup.
+                    // TODO: check if this combination of full AEV as prefix + extractor works with
+                    // temporal iterator.
+                    let extractor: Extractor = Box::new(move |key| {
+                        key.slice(prefix_len..key.len() - codec::TX_EID_OP_SUFFIX)
+                    });
+                    let has_match = self
+                        .create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?
+                        .has_next();
+                    vec![has_match; input.rows.len()]
+                }
+
+                // Bound entity variable, constant value.
+                (true, true, false, true) => {
+
+                    let mut groups = BTreeMap::new();
+                    let TripleTerm::Variable(entity_var) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Constant(value) = &self.value else {
+                        unreachable!()
+                    };
+                    let pair = value.to_vec();
+                    let entity_index = input.column_index(entity_var)?;
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let mut pair = pair.clone();
+                        pair.extend_from_slice(&row[entity_index]);
+                        groups
+                            .entry(Bytes::from(pair))
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
+                    }
+
+                    let mut iterator = self.attr_var_pair_iterator(IndexType::AVE)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
+                        }
+                    }
+                    matches
+                }
+
+                // Constant entity, bound value variable.
+                (false, true, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound entity")
+                        })?;
+                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound value")
+                        })?;
+                        let mut pair = entity.to_vec();
+                        pair.extend_from_slice(&value);
+                        groups
+                            .entry(Bytes::from(pair))
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
+                    }
+
+                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
+                        }
+                    }
+                    matches
+                }
+                // Bound entity variable, unbound value variable.
+                (true, true, true, false) => {
+                    let mut groups = BTreeMap::new();
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let value = self.entity.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound triple term")
+                        })?;
+                        groups.entry(value).or_insert_with(Vec::new).push(row_index);
+                    }
+
+                    let mut iterator = self.attr_var_iterator(IndexType::AE)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
+                        }
+                    }
+                    matches
+                }
+                // Unbound entity variable, bound value variable.
+                (true, false, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound triple term")
+                        })?;
+                        groups.entry(value).or_insert_with(Vec::new).push(row_index);
+                    }
+
+                    let mut iterator = self.attr_var_iterator(IndexType::AV)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
+                        }
+                    }
+                    matches
+                }
+                // Bound entity variable, bound value variable.
+                (true, true, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound entity")
+                        })?;
+                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound value")
+                        })?;
+                        let mut pair = entity.to_vec();
+                        pair.extend_from_slice(&value);
+                        groups
+                            .entry(Bytes::from(pair))
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
+                    }
+
+                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
+                        }
+                    }
+                    matches
+                }
+                _ => bail!(
+                    "Triple pattern {} has no bound variables to validate",
+                    self.index
+                ),
+            };
+        let matched: Vec<usize> = matches
             .into_iter()
             .enumerate()
             .filter_map(|(row_index, matches)| matches.then_some(row_index))
-            .collect())
-    }
+            .collect();
 
-    fn validate(&self, input: &BindingBag) -> Result<BindingBag> {
-        input.select_rows(&self.matching_rows(input)?)
+        input.select_rows(&matched)
     }
 
     fn propose(&self, input: &BindingBag, added: &[Variable]) -> Result<BindingBag> {
@@ -948,6 +1051,101 @@ mod tests {
     }
 
     #[test]
+    fn validation_rejects_patterns_without_bound_variables() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        let db = Arc::new(DbValue::new(
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        ));
+        let entity_unbound = TriplePattern::new(
+            1,
+            TripleTerm::Variable("?e".to_var()),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            db.clone(),
+        )?;
+        let value_unbound = TriplePattern::new(
+            2,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Variable("?v".to_var()),
+            db,
+        )?;
+
+        assert_eq!(
+            entity_unbound
+                .validate(&BindingBag::unit())
+                .unwrap_err()
+                .to_string(),
+            "Triple pattern 1 has no bound variables to validate"
+        );
+        assert_eq!(
+            value_unbound
+                .validate(&BindingBag::unit())
+                .unwrap_err()
+                .to_string(),
+            "Triple pattern 2 has no bound variables to validate"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constant_pattern_validation_matches_exact_triple() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(insert_version(
+            components.db.as_ref(),
+            42,
+            1,
+            &DataType::String("alice".into()),
+            10,
+            codec::ADD,
+        ))?;
+
+        let db = Arc::new(DbValue::new(
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        ));
+        let existing = TriplePattern::new(
+            1,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            db.clone(),
+        )?;
+        let wrong_entity = TriplePattern::new(
+            2,
+            TripleTerm::Constant(encoded(DataType::Long(2))),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            db.clone(),
+        )?;
+        let wrong_value = TriplePattern::new(
+            3,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("bob".into()))),
+            db,
+        )?;
+
+        assert_eq!(existing.validate(&BindingBag::unit())?, BindingBag::unit());
+        assert_eq!(
+            wrong_entity.validate(&BindingBag::unit())?,
+            BindingBag::empty(Vec::<Variable>::new())?
+        );
+        assert_eq!(
+            wrong_value.validate(&BindingBag::unit())?,
+            BindingBag::empty(Vec::<Variable>::new())?
+        );
+        Ok(())
+    }
+
+    #[test]
     fn constants_propose_the_other_position_and_constant_only_patterns_validate() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
@@ -980,8 +1178,11 @@ mod tests {
             binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]])
         );
         assert_eq!(
-            entity_pattern.join(&BindingBag::unit(), &[], &[])?,
-            BindingBag::unit()
+            entity_pattern
+                .validate(&BindingBag::unit())
+                .unwrap_err()
+                .to_string(),
+            "Triple pattern 1 has no bound variables to validate"
         );
 
         let value_pattern = TriplePattern::new(
@@ -1000,8 +1201,11 @@ mod tests {
             )
         );
         assert_eq!(
-            value_pattern.join(&BindingBag::unit(), &[], &[])?,
-            BindingBag::unit()
+            value_pattern
+                .validate(&BindingBag::unit())
+                .unwrap_err()
+                .to_string(),
+            "Triple pattern 2 has no bound variables to validate"
         );
 
         let existing = TriplePattern::new(

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -1212,7 +1212,7 @@ mod tests {
     }
 
     #[test]
-    fn constants_propose_the_variable_position() -> Result<()> {
+    fn propose_with_constant_and_variable() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(insert_version(

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -482,13 +482,18 @@ where
                 // Bound entity variable, bound value variable.
                 (true, true, true, true) => {
                     let mut groups = BTreeMap::new();
+                    let TripleTerm::Variable(entity_var) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Variable(value_var) = &self.value else {
+                        unreachable!()
+                    };
+                    let entity_index = input.column_index(entity_var)?;
+                    let value_index = input.column_index(value_var)?;
+
                     for (row_index, row) in input.rows.iter().enumerate() {
-                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound entity")
-                        })?;
-                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
-                            anyhow::anyhow!("Cannot group rows by an unbound value")
-                        })?;
+                        let entity = &row[entity_index];
+                        let value = &row[value_index];
                         let mut pair = entity.to_vec();
                         pair.extend_from_slice(&value);
                         groups

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::{bail, ensure, Result};
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use edn::query::Variable;
 use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
@@ -308,216 +308,219 @@ where
         let entity_is_variable = self.entity.is_variable();
         let value_is_variable = self.value.is_variable();
 
-        let matches = match (
-            entity_is_variable,
-            entity_has_value,
-            value_is_variable,
-            value_has_value,
-        ) {
-            // Constant entity, constant value.
-            (false, true, false, true) => {
-                let TripleTerm::Constant(entity) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Constant(value) = &self.value else {
-                    unreachable!()
-                };
-                let mut prefix = self.base_prefix(IndexType::AEV)?;
-                prefix.extend_from_slice(entity);
-                let extractor: Extractor =
-                    Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
-                let mut iterator =
-                    self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
-                let has_match = if iterator.has_next() {
-                    iterator.seek(value.clone())?;
-                    iterator.get_value()?.as_ref() == Some(value)
-                } else {
-                    false
-                };
-                vec![has_match; input.rows.len()]
-            }
-
-            // Bound entity variable, constant value.
-            (true, true, false, true) => {
-                let mut groups = BTreeMap::new();
-                let TripleTerm::Variable(entity_var) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Constant(value) = &self.value else {
-                    unreachable!()
-                };
-                let entity_index = input.column_index(entity_var)?;
-                for (row_index, row) in input.rows.iter().enumerate() {
-                    let mut pair = BytesMut::with_capacity(value.len() + row[entity_index].len());
-                    pair.extend_from_slice(value);
-                    pair.extend_from_slice(&row[entity_index]);
-                    groups
-                        .entry(pair.freeze())
-                        .or_insert_with(Vec::new)
-                        .push(row_index);
+        let matches =
+            match (
+                entity_is_variable,
+                entity_has_value,
+                value_is_variable,
+                value_has_value,
+            ) {
+                // Constant entity, constant value.
+                (false, true, false, true) => {
+                    let TripleTerm::Constant(entity) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Constant(value) = &self.value else {
+                        unreachable!()
+                    };
+                    let mut prefix = self.base_prefix(IndexType::AEV)?;
+                    prefix.extend_from_slice(entity);
+                    let extractor: Extractor =
+                        Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
+                    let mut iterator =
+                        self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
+                    let has_match = if iterator.has_next() {
+                        iterator.seek(value.clone())?;
+                        iterator.get_value()?.as_ref() == Some(value)
+                    } else {
+                        false
+                    };
+                    vec![has_match; input.rows.len()]
                 }
 
-                let mut iterator = self.attr_var_pair_iterator(IndexType::AVE)?;
-                let mut matches = vec![false; input.rows.len()];
-                for (expected, row_indexes) in groups {
-                    if !iterator.has_next() {
-                        break;
+                // Bound entity variable, constant value.
+                (true, true, false, true) => {
+                    let mut groups = BTreeMap::new();
+                    let TripleTerm::Variable(entity_var) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Constant(value) = &self.value else {
+                        unreachable!()
+                    };
+                    let entity_index = input.column_index(entity_var)?;
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        groups
+                            .entry(&row[entity_index])
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
                     }
-                    iterator.seek(expected.clone())?;
-                    if iterator
-                        .get_value()?
-                        .as_ref()
-                        .is_some_and(|actual| actual == &expected)
-                    {
-                        for row_index in row_indexes {
-                            matches[row_index] = true;
+
+                    let mut prefix = self.base_prefix(IndexType::AVE)?;
+                    prefix.extend_from_slice(value);
+                    let extractor: Extractor =
+                        Box::new(move |key| make_extractor(2, IndexType::AVE)(key));
+                    let mut iterator =
+                        self.create_iterator(Bytes::from(prefix), IndexType::AVE, extractor)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator.get_value()?.as_ref() == Some(expected) {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
                         }
                     }
-                }
-                matches
-            }
-
-            // Constant entity, bound value variable.
-            (false, true, true, true) => {
-                let mut groups = BTreeMap::new();
-                let TripleTerm::Constant(entity) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Variable(value_var) = &self.value else {
-                    unreachable!()
-                };
-                let value_index = input.column_index(value_var)?;
-                for (row_index, row) in input.rows.iter().enumerate() {
-                    let mut pair = BytesMut::with_capacity(entity.len() + row[value_index].len());
-                    pair.extend_from_slice(entity);
-                    pair.extend_from_slice(&row[value_index]);
-                    groups
-                        .entry(pair.freeze())
-                        .or_insert_with(Vec::new)
-                        .push(row_index);
+                    matches
                 }
 
-                let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
-                let mut matches = vec![false; input.rows.len()];
-                for (expected, row_indexes) in groups {
-                    if !iterator.has_next() {
-                        break;
+                // Constant entity, bound value variable.
+                (false, true, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    let TripleTerm::Constant(entity) = &self.entity else {
+                        unreachable!()
+                    };
+                    let TripleTerm::Variable(value_var) = &self.value else {
+                        unreachable!()
+                    };
+                    let value_index = input.column_index(value_var)?;
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        groups
+                            .entry(&row[value_index])
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
                     }
-                    iterator.seek(expected.clone())?;
-                    if iterator
-                        .get_value()?
-                        .as_ref()
-                        .is_some_and(|actual| actual == &expected)
-                    {
-                        for row_index in row_indexes {
-                            matches[row_index] = true;
+
+                    let mut prefix = self.base_prefix(IndexType::AEV)?;
+                    prefix.extend_from_slice(entity);
+                    let extractor: Extractor =
+                        Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
+                    let mut iterator =
+                        self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator.get_value()?.as_ref() == Some(expected) {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
                         }
                     }
+                    matches
                 }
-                matches
-            }
-            // Bound entity variable, unbound value variable.
-            (true, true, true, false) => {
-                let mut groups = BTreeMap::new();
-                for (row_index, row) in input.rows.iter().enumerate() {
-                    let value = self.entity.resolve(input, row)?.ok_or_else(|| {
-                        anyhow::anyhow!("Cannot group rows by an unbound triple term")
-                    })?;
-                    groups.entry(value).or_insert_with(Vec::new).push(row_index);
-                }
-
-                let mut iterator = self.attr_var_iterator(IndexType::AE)?;
-                let mut matches = vec![false; input.rows.len()];
-                for (expected, row_indexes) in groups {
-                    if !iterator.has_next() {
-                        break;
+                // Bound entity variable, unbound value variable.
+                (true, true, true, false) => {
+                    let mut groups = BTreeMap::new();
+                    let TripleTerm::Variable(entity_var) = &self.entity else {
+                        unreachable!()
+                    };
+                    let entity_index = input.column_index(entity_var)?;
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        groups
+                            .entry(&row[entity_index])
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
                     }
-                    iterator.seek(expected.clone())?;
-                    if iterator
-                        .get_value()?
-                        .as_ref()
-                        .is_some_and(|actual| actual == &expected)
-                    {
-                        for row_index in row_indexes {
-                            matches[row_index] = true;
+
+                    let mut iterator = self.attr_var_iterator(IndexType::AE)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
                         }
                     }
+                    matches
                 }
-                matches
-            }
-            // Unbound entity variable, bound value variable.
-            (true, false, true, true) => {
-                let mut groups = BTreeMap::new();
-                for (row_index, row) in input.rows.iter().enumerate() {
-                    let value = self.value.resolve(input, row)?.ok_or_else(|| {
-                        anyhow::anyhow!("Cannot group rows by an unbound triple term")
-                    })?;
-                    groups.entry(value).or_insert_with(Vec::new).push(row_index);
-                }
-
-                let mut iterator = self.attr_var_iterator(IndexType::AV)?;
-                let mut matches = vec![false; input.rows.len()];
-                for (expected, row_indexes) in groups {
-                    if !iterator.has_next() {
-                        break;
+                // Unbound entity variable, bound value variable.
+                (true, false, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    let TripleTerm::Variable(value_var) = &self.value else {
+                        unreachable!()
+                    };
+                    let value_index = input.column_index(value_var)?;
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        groups
+                            .entry(&row[value_index])
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
                     }
-                    iterator.seek(expected.clone())?;
-                    if iterator
-                        .get_value()?
-                        .as_ref()
-                        .is_some_and(|actual| actual == &expected)
-                    {
-                        for row_index in row_indexes {
-                            matches[row_index] = true;
+
+                    let mut iterator = self.attr_var_iterator(IndexType::AV)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
                         }
                     }
+                    matches
                 }
-                matches
-            }
-            // Bound entity variable, bound value variable.
-            (true, true, true, true) => {
-                let mut groups = BTreeMap::new();
-                for (row_index, row) in input.rows.iter().enumerate() {
-                    let entity = self
-                        .entity
-                        .resolve(input, row)?
-                        .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound entity"))?;
-                    let value = self
-                        .value
-                        .resolve(input, row)?
-                        .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound value"))?;
-                    let mut pair = entity.to_vec();
-                    pair.extend_from_slice(&value);
-                    groups
-                        .entry(Bytes::from(pair))
-                        .or_insert_with(Vec::new)
-                        .push(row_index);
-                }
-
-                let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
-                let mut matches = vec![false; input.rows.len()];
-                for (expected, row_indexes) in groups {
-                    if !iterator.has_next() {
-                        break;
+                // Bound entity variable, bound value variable.
+                (true, true, true, true) => {
+                    let mut groups = BTreeMap::new();
+                    for (row_index, row) in input.rows.iter().enumerate() {
+                        let entity = self.entity.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound entity")
+                        })?;
+                        let value = self.value.resolve(input, row)?.ok_or_else(|| {
+                            anyhow::anyhow!("Cannot group rows by an unbound value")
+                        })?;
+                        let mut pair = entity.to_vec();
+                        pair.extend_from_slice(&value);
+                        groups
+                            .entry(Bytes::from(pair))
+                            .or_insert_with(Vec::new)
+                            .push(row_index);
                     }
-                    iterator.seek(expected.clone())?;
-                    if iterator
-                        .get_value()?
-                        .as_ref()
-                        .is_some_and(|actual| actual == &expected)
-                    {
-                        for row_index in row_indexes {
-                            matches[row_index] = true;
+
+                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                    let mut matches = vec![false; input.rows.len()];
+                    for (expected, row_indexes) in groups {
+                        if !iterator.has_next() {
+                            break;
+                        }
+                        iterator.seek(expected.clone())?;
+                        if iterator
+                            .get_value()?
+                            .as_ref()
+                            .is_some_and(|actual| actual == &expected)
+                        {
+                            for row_index in row_indexes {
+                                matches[row_index] = true;
+                            }
                         }
                     }
+                    matches
                 }
-                matches
-            }
-            _ => bail!(
-                "Triple pattern {} has no bound variables to validate",
-                self.index
-            ),
-        };
+                _ => bail!(
+                    "Triple pattern {} has no bound variables to validate",
+                    self.index
+                ),
+            };
         let matched: Vec<usize> = matches
             .into_iter()
             .enumerate()
@@ -1045,6 +1048,80 @@ mod tests {
                     encoded(DataType::Long(9)),
                     encoded(DataType::Long(1)),
                 ]],
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constant_term_validation_matches_bound_rows() -> Result<()> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        let components = runtime.block_on(in_memory_slate());
+        runtime.block_on(async {
+            insert_version(
+                components.db.as_ref(),
+                42,
+                1,
+                &DataType::String("alice".into()),
+                10,
+                codec::ADD,
+            )
+            .await?;
+            insert_version(
+                components.db.as_ref(),
+                42,
+                2,
+                &DataType::String("bob".into()),
+                10,
+                codec::ADD,
+            )
+            .await
+        })?;
+
+        let db = Arc::new(DbValue::new(
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        ));
+        let entity_pattern = TriplePattern::new(
+            1,
+            TripleTerm::Variable("?e".to_var()),
+            42,
+            TripleTerm::Constant(encoded(DataType::String("alice".into()))),
+            db.clone(),
+        )?;
+        let entities = binding_bag(
+            &["?e"],
+            vec![
+                vec![encoded(DataType::Long(1))],
+                vec![encoded(DataType::Long(2))],
+            ],
+        );
+        assert_eq!(
+            entity_pattern.validate(&entities)?,
+            binding_bag(&["?e"], vec![vec![encoded(DataType::Long(1))]])
+        );
+
+        let value_pattern = TriplePattern::new(
+            2,
+            TripleTerm::Constant(encoded(DataType::Long(1))),
+            42,
+            TripleTerm::Variable("?v".to_var()),
+            db,
+        )?;
+        let values = binding_bag(
+            &["?v"],
+            vec![
+                vec![encoded(DataType::String("alice".into()))],
+                vec![encoded(DataType::String("bob".into()))],
+            ],
+        );
+        assert_eq!(
+            value_pattern.validate(&values)?,
+            binding_bag(
+                &["?v"],
+                vec![vec![encoded(DataType::String("alice".into()))]]
             )
         );
         Ok(())

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -122,6 +122,16 @@ where
         Ok(prefix)
     }
 
+    fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
+        if self.entity.variable() == Some(variable) {
+            Some(TriplePosition::Entity)
+        } else if self.value.variable() == Some(variable) {
+            Some(TriplePosition::Value)
+        } else {
+            None
+        }
+    }
+
     fn index_type(position: TriplePosition, other_resolved: bool) -> IndexType {
         match (position, other_resolved) {
             (TriplePosition::Entity, false) => IndexType::AE,
@@ -137,16 +147,6 @@ where
             .handle
             .block_on(self.db.range_stats.estimate_key_count_with_prefix(prefix))?;
         Ok(usize::try_from(count)?)
-    }
-
-    fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
-        if self.entity.variable() == Some(variable) {
-            Some(TriplePosition::Entity)
-        } else if self.value.variable() == Some(variable) {
-            Some(TriplePosition::Value)
-        } else {
-            None
-        }
     }
 
     fn create_iterator(

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -22,13 +22,6 @@ pub(crate) enum TripleTerm {
 }
 
 impl TripleTerm {
-    fn is_variable(&self) -> bool {
-        match self {
-            Self::Variable(_) => true,
-            Self::Constant(_) => false,
-        }
-    }
-
     fn variable(&self) -> Option<&Variable> {
         match self {
             Self::Variable(variable) => Some(variable),
@@ -309,26 +302,11 @@ where
             return input.select_rows(&Vec::new());
         }
 
-        let entity_has_value = Self::term_is_resolved(&self.entity, input);
-        let value_has_value = Self::term_is_resolved(&self.value, input);
+        let is_bound = |variable| input.column_indexes.contains_key(variable);
 
-        let entity_is_variable = self.entity.is_variable();
-        let value_is_variable = self.value.is_variable();
-
-        let matches = match (
-            entity_is_variable,
-            entity_has_value,
-            value_is_variable,
-            value_has_value,
-        ) {
+        let matches = match (&self.entity, &self.value) {
             // Constant entity, constant value.
-            (false, true, false, true) => {
-                let TripleTerm::Constant(entity) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Constant(value) = &self.value else {
-                    unreachable!()
-                };
+            (TripleTerm::Constant(entity), TripleTerm::Constant(value)) => {
                 let mut prefix = self.base_prefix(IndexType::AEV)?;
                 prefix.extend_from_slice(entity);
                 let extractor: Extractor =
@@ -345,14 +323,10 @@ where
             }
 
             // Bound entity variable, constant value.
-            (true, true, false, true) => {
+            (TripleTerm::Variable(entity_var), TripleTerm::Constant(value))
+                if is_bound(entity_var) =>
+            {
                 let mut groups = BTreeMap::new();
-                let TripleTerm::Variable(entity_var) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Constant(value) = &self.value else {
-                    unreachable!()
-                };
                 let entity_index = input.column_index(entity_var)?;
                 for (row_index, row) in input.rows.iter().enumerate() {
                     groups
@@ -383,14 +357,10 @@ where
             }
 
             // Constant entity, bound value variable.
-            (false, true, true, true) => {
+            (TripleTerm::Constant(entity), TripleTerm::Variable(value_var))
+                if is_bound(value_var) =>
+            {
                 let mut groups = BTreeMap::new();
-                let TripleTerm::Constant(entity) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Variable(value_var) = &self.value else {
-                    unreachable!()
-                };
                 let value_index = input.column_index(value_var)?;
                 for (row_index, row) in input.rows.iter().enumerate() {
                     groups
@@ -420,11 +390,10 @@ where
                 matches
             }
             // Bound entity variable, unbound value variable.
-            (true, true, true, false) => {
+            (TripleTerm::Variable(entity_var), TripleTerm::Variable(value_var))
+                if is_bound(entity_var) && !is_bound(value_var) =>
+            {
                 let mut groups = BTreeMap::new();
-                let TripleTerm::Variable(entity_var) = &self.entity else {
-                    unreachable!()
-                };
                 let entity_index = input.column_index(entity_var)?;
                 for (row_index, row) in input.rows.iter().enumerate() {
                     groups
@@ -453,11 +422,10 @@ where
                 matches
             }
             // Unbound entity variable, bound value variable.
-            (true, false, true, true) => {
+            (TripleTerm::Variable(entity_var), TripleTerm::Variable(value_var))
+                if !is_bound(entity_var) && is_bound(value_var) =>
+            {
                 let mut groups = BTreeMap::new();
-                let TripleTerm::Variable(value_var) = &self.value else {
-                    unreachable!()
-                };
                 let value_index = input.column_index(value_var)?;
                 for (row_index, row) in input.rows.iter().enumerate() {
                     groups
@@ -486,14 +454,10 @@ where
                 matches
             }
             // Bound entity variable, bound value variable.
-            (true, true, true, true) => {
+            (TripleTerm::Variable(entity_var), TripleTerm::Variable(value_var))
+                if is_bound(entity_var) && is_bound(value_var) =>
+            {
                 let mut groups = BTreeMap::new();
-                let TripleTerm::Variable(entity_var) = &self.entity else {
-                    unreachable!()
-                };
-                let TripleTerm::Variable(value_var) = &self.value else {
-                    unreachable!()
-                };
                 let entity_index = input.column_index(entity_var)?;
                 let value_index = input.column_index(value_var)?;
 

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -308,224 +308,223 @@ where
         let entity_is_variable = self.entity.is_variable();
         let value_is_variable = self.value.is_variable();
 
-        let matches =
-            match (
-                entity_is_variable,
-                entity_has_value,
-                value_is_variable,
-                value_has_value,
-            ) {
-                // Constant entity, constant value.
-                (false, true, false, true) => {
-                    let TripleTerm::Constant(entity) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Constant(value) = &self.value else {
-                        unreachable!()
-                    };
-                    let mut prefix = self.base_prefix(IndexType::AEV)?;
-                    prefix.extend_from_slice(entity);
-                    let extractor: Extractor =
-                        Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
-                    let mut iterator =
-                        self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
-                    let has_match = if iterator.has_next() {
-                        iterator.seek(value.clone())?;
-                        iterator.get_value()?.as_ref() == Some(value)
-                    } else {
-                        false
-                    };
-                    vec![has_match; input.rows.len()]
+        let matches = match (
+            entity_is_variable,
+            entity_has_value,
+            value_is_variable,
+            value_has_value,
+        ) {
+            // Constant entity, constant value.
+            (false, true, false, true) => {
+                let TripleTerm::Constant(entity) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Constant(value) = &self.value else {
+                    unreachable!()
+                };
+                let mut prefix = self.base_prefix(IndexType::AEV)?;
+                prefix.extend_from_slice(entity);
+                let extractor: Extractor =
+                    Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
+                let mut iterator =
+                    self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
+                let has_match = if iterator.has_next() {
+                    iterator.seek(value.clone())?;
+                    iterator.get_value()?.as_ref() == Some(value)
+                } else {
+                    false
+                };
+                vec![has_match; input.rows.len()]
+            }
+
+            // Bound entity variable, constant value.
+            (true, true, false, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Variable(entity_var) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Constant(value) = &self.value else {
+                    unreachable!()
+                };
+                let entity_index = input.column_index(entity_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry(&row[entity_index])
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
 
-                // Bound entity variable, constant value.
-                (true, true, false, true) => {
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Variable(entity_var) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Constant(value) = &self.value else {
-                        unreachable!()
-                    };
-                    let entity_index = input.column_index(entity_var)?;
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        groups
-                            .entry(&row[entity_index])
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
+                let mut prefix = self.base_prefix(IndexType::AVE)?;
+                prefix.extend_from_slice(value);
+                let extractor: Extractor =
+                    Box::new(move |key| make_extractor(2, IndexType::AVE)(key));
+                let mut iterator =
+                    self.create_iterator(Bytes::from(prefix), IndexType::AVE, extractor)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
                     }
+                    iterator.seek(expected.clone())?;
+                    if iterator.get_value()?.as_ref() == Some(expected) {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
+                        }
+                    }
+                }
+                matches
+            }
 
-                    let mut prefix = self.base_prefix(IndexType::AVE)?;
-                    prefix.extend_from_slice(value);
-                    let extractor: Extractor =
-                        Box::new(move |key| make_extractor(2, IndexType::AVE)(key));
-                    let mut iterator =
-                        self.create_iterator(Bytes::from(prefix), IndexType::AVE, extractor)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator.get_value()?.as_ref() == Some(expected) {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
-                        }
-                    }
-                    matches
+            // Constant entity, bound value variable.
+            (false, true, true, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Constant(entity) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Variable(value_var) = &self.value else {
+                    unreachable!()
+                };
+                let value_index = input.column_index(value_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry(&row[value_index])
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
 
-                // Constant entity, bound value variable.
-                (false, true, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Constant(entity) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Variable(value_var) = &self.value else {
-                        unreachable!()
-                    };
-                    let value_index = input.column_index(value_var)?;
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        groups
-                            .entry(&row[value_index])
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
+                let mut prefix = self.base_prefix(IndexType::AEV)?;
+                prefix.extend_from_slice(entity);
+                let extractor: Extractor =
+                    Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
+                let mut iterator =
+                    self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
                     }
-
-                    let mut prefix = self.base_prefix(IndexType::AEV)?;
-                    prefix.extend_from_slice(entity);
-                    let extractor: Extractor =
-                        Box::new(move |key| make_extractor(2, IndexType::AEV)(key));
-                    let mut iterator =
-                        self.create_iterator(Bytes::from(prefix), IndexType::AEV, extractor)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator.get_value()?.as_ref() == Some(expected) {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                    iterator.seek(expected.clone())?;
+                    if iterator.get_value()?.as_ref() == Some(expected) {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
                 }
-                // Bound entity variable, unbound value variable.
-                (true, true, true, false) => {
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Variable(entity_var) = &self.entity else {
-                        unreachable!()
-                    };
-                    let entity_index = input.column_index(entity_var)?;
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        groups
-                            .entry(&row[entity_index])
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
-                    }
-
-                    let mut iterator = self.attr_var_iterator(IndexType::AE)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
-                        }
-                    }
-                    matches
+                matches
+            }
+            // Bound entity variable, unbound value variable.
+            (true, true, true, false) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Variable(entity_var) = &self.entity else {
+                    unreachable!()
+                };
+                let entity_index = input.column_index(entity_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry(&row[entity_index])
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
-                // Unbound entity variable, bound value variable.
-                (true, false, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Variable(value_var) = &self.value else {
-                        unreachable!()
-                    };
-                    let value_index = input.column_index(value_var)?;
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        groups
-                            .entry(&row[value_index])
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
-                    }
 
-                    let mut iterator = self.attr_var_iterator(IndexType::AV)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
+                let mut iterator = self.attr_var_iterator(IndexType::AE)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
                         }
                     }
-                    matches
                 }
-                // Bound entity variable, bound value variable.
-                (true, true, true, true) => {
-                    let mut groups = BTreeMap::new();
-                    let TripleTerm::Variable(entity_var) = &self.entity else {
-                        unreachable!()
-                    };
-                    let TripleTerm::Variable(value_var) = &self.value else {
-                        unreachable!()
-                    };
-                    let entity_index = input.column_index(entity_var)?;
-                    let value_index = input.column_index(value_var)?;
-
-                    for (row_index, row) in input.rows.iter().enumerate() {
-                        let entity = &row[entity_index];
-                        let value = &row[value_index];
-                        let mut pair = entity.to_vec();
-                        pair.extend_from_slice(&value);
-                        groups
-                            .entry(Bytes::from(pair))
-                            .or_insert_with(Vec::new)
-                            .push(row_index);
-                    }
-
-                    let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
-                    let mut matches = vec![false; input.rows.len()];
-                    for (expected, row_indexes) in groups {
-                        if !iterator.has_next() {
-                            break;
-                        }
-                        iterator.seek(expected.clone())?;
-                        if iterator
-                            .get_value()?
-                            .as_ref()
-                            .is_some_and(|actual| actual == &expected)
-                        {
-                            for row_index in row_indexes {
-                                matches[row_index] = true;
-                            }
-                        }
-                    }
-                    matches
+                matches
+            }
+            // Unbound entity variable, bound value variable.
+            (true, false, true, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Variable(value_var) = &self.value else {
+                    unreachable!()
+                };
+                let value_index = input.column_index(value_var)?;
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry(&row[value_index])
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
                 }
-                _ => bail!(
-                    "Triple pattern {} has no bound variables to validate",
-                    self.index
-                ),
-            };
+
+                let mut iterator = self.attr_var_iterator(IndexType::AV)?;
+                let mut matches = vec![false; input.rows.len()];
+                for (expected, row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
+                        }
+                    }
+                }
+                matches
+            }
+            // Bound entity variable, bound value variable.
+            (true, true, true, true) => {
+                let mut groups = BTreeMap::new();
+                let TripleTerm::Variable(entity_var) = &self.entity else {
+                    unreachable!()
+                };
+                let TripleTerm::Variable(value_var) = &self.value else {
+                    unreachable!()
+                };
+                let entity_index = input.column_index(entity_var)?;
+                let value_index = input.column_index(value_var)?;
+
+                for (row_index, row) in input.rows.iter().enumerate() {
+                    groups
+                        .entry((&row[entity_index], &row[value_index]))
+                        .or_insert_with(Vec::new)
+                        .push(row_index);
+                }
+
+                let mut iterator = self.attr_var_pair_iterator(IndexType::AEV)?;
+                let mut matches = vec![false; input.rows.len()];
+                for ((entity, value), row_indexes) in groups {
+                    if !iterator.has_next() {
+                        break;
+                    }
+                    let mut expected = Vec::with_capacity(entity.len() + value.len());
+                    expected.extend_from_slice(entity);
+                    expected.extend_from_slice(value);
+                    let expected = Bytes::from(expected);
+                    iterator.seek(expected.clone())?;
+                    if iterator
+                        .get_value()?
+                        .as_ref()
+                        .is_some_and(|actual| actual == &expected)
+                    {
+                        for row_index in row_indexes {
+                            matches[row_index] = true;
+                        }
+                    }
+                }
+                matches
+            }
+            _ => bail!(
+                "Triple pattern {} has no bound variables to validate",
+                self.index
+            ),
+        };
         let matched: Vec<usize> = matches
             .into_iter()
             .enumerate()

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -169,21 +169,6 @@ where
         }
     }
 
-    fn group_rows_by_term(
-        term: &TripleTerm,
-        input: &BindingBag,
-    ) -> Result<BTreeMap<Bytes, Vec<usize>>> {
-        let mut groups = BTreeMap::new();
-        for (row_index, row) in input.rows.iter().enumerate() {
-            let value = term
-                .resolve(input, row)?
-                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound triple term"))?;
-            groups.entry(value).or_insert_with(Vec::new).push(row_index);
-        }
-        Ok(groups)
-    }
-
-
     fn create_iterator(
         &self,
         prefix: Bytes,
@@ -211,7 +196,8 @@ where
         }
     }
 
-    fn component_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
+    // serves to iterate AE/AV indexes
+    fn attr_var_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
         ensure!(
             matches!(index_type, IndexType::AE | IndexType::AV),
             "Component iterator requires an AE or AV index"
@@ -221,7 +207,8 @@ where
         self.create_iterator(prefix, index_type, extractor)
     }
 
-    fn pair_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
+    // serves to iterate AVE/AEV indexes
+    fn attr_var_pair_iterator(&self, index_type: IndexType) -> Result<Box<dyn Index>> {
         ensure!(
             matches!(index_type, IndexType::AEV | IndexType::AVE),
             "Pair iterator requires an AEV or AVE index"
@@ -252,6 +239,7 @@ where
 
         if let Some(other_var) = other.variable() {
             // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away 
+            // We likely also can get rid of the to vec<index> mapping
             let mut groups = BTreeMap::new();
             let index = input.column_index(other_var)?;
             for (row_index, row) in input.rows.iter().enumerate() {
@@ -263,7 +251,8 @@ where
                 return Ok(extensions);
             }
 
-            let mut iterator = self.pair_iterator(index_type)?;
+            let mut iterator = self.attr_var_pair_iterator(index_type)?;
+            // a bound E or V is constraining, we still scan once through a sorted iteration
             for (first, row_indexes) in groups {
                 if !iterator.has_next() {
                     break;
@@ -271,11 +260,12 @@ where
                 iterator.seek(first.clone())?;
 
                 let mut group_extensions = Vec::new();
-                while let Some(pair) = iterator.get_value()? {
-                    if !pair.starts_with(&first) {
+                while let Some(var_pair) = iterator.get_value()? {
+                    if !var_pair.starts_with(&first) {
                         break;
                     }
-                    group_extensions.push(vec![pair.slice(first.len()..)]);
+                    // the second part of the pair are the new values
+                    group_extensions.push(vec![var_pair.slice(first.len()..)]);
                     iterator.next()?;
                 }
 
@@ -286,7 +276,7 @@ where
             Ok(extensions)
         } else {
             // only the attribute is constraining in this case. We simply walk the iterator.
-            let mut iterator = self.component_iterator(index_type)?;
+            let mut iterator = self.attr_var_iterator(index_type)?;
             let mut candidates = Vec::new();
             while let Some(value) = iterator.get_value()? {
                 candidates.push(vec![value]);
@@ -294,6 +284,20 @@ where
             }
             Ok(vec![candidates; input.rows.len()])
         }
+    }
+
+    fn group_rows_by_term(
+        term: &TripleTerm,
+        input: &BindingBag,
+    ) -> Result<BTreeMap<Bytes, Vec<usize>>> {
+        let mut groups = BTreeMap::new();
+        for (row_index, row) in input.rows.iter().enumerate() {
+            let value = term
+                .resolve(input, row)?
+                .ok_or_else(|| anyhow::anyhow!("Cannot group rows by an unbound triple term"))?;
+            groups.entry(value).or_insert_with(Vec::new).push(row_index);
+        }
+        Ok(groups)
     }
 
     fn group_rows_by_pair(&self, input: &BindingBag) -> Result<BTreeMap<Bytes, Vec<usize>>> {
@@ -354,7 +358,7 @@ where
         Self::matching_group_rows(
             input.rows.len(),
             Self::group_rows_by_term(term, input)?,
-            self.component_iterator(index_type)?,
+            self.attr_var_iterator(index_type)?,
             |actual, expected| actual == expected,
         )
     }
@@ -368,7 +372,7 @@ where
         Self::matching_group_rows(
             input.rows.len(),
             Self::group_rows_by_term(term, input)?,
-            self.pair_iterator(index_type)?,
+            self.attr_var_pair_iterator(index_type)?,
             |actual, expected| actual.starts_with(expected),
         )
     }
@@ -377,7 +381,7 @@ where
         Self::matching_group_rows(
             input.rows.len(),
             self.group_rows_by_pair(input)?,
-            self.pair_iterator(IndexType::AEV)?,
+            self.attr_var_pair_iterator(IndexType::AEV)?,
             |actual, expected| actual == expected,
         )
     }
@@ -405,7 +409,7 @@ where
                 self.matching_first_component_rows(input, &self.value, IndexType::AVE)?
             }
             (false, false) => {
-                let has_match = self.pair_iterator(IndexType::AEV)?.has_next();
+                let has_match = self.attr_var_pair_iterator(IndexType::AEV)?.has_next();
                 vec![has_match; input.rows.len()]
             }
         };

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -151,6 +151,14 @@ where
         }
     }
 
+    fn estimate_count(&self, prefix: &[u8]) -> Result<usize> {
+        let count = self
+            .db
+            .handle
+            .block_on(self.db.range_stats.estimate_key_count_with_prefix(prefix))?;
+        Ok(usize::try_from(count)?)
+    }
+
     fn position_for_variable(&self, variable: &Variable) -> Option<TriplePosition> {
         if self.entity.variable() == Some(variable) {
             Some(TriplePosition::Entity)
@@ -175,13 +183,6 @@ where
         Ok(groups)
     }
 
-    fn estimate_count(&self, prefix: &[u8]) -> Result<usize> {
-        let count = self
-            .db
-            .handle
-            .block_on(self.db.range_stats.estimate_key_count_with_prefix(prefix))?;
-        Ok(usize::try_from(count)?)
-    }
 
     fn create_iterator(
         &self,
@@ -250,6 +251,7 @@ where
         let index_type = Self::index_type(position, other_resolved);
 
         if let Some(other_var) = other.variable() {
+            // TODO: once we pass to a sorted columnar trie, the BTreeMap will likely go away 
             let mut groups = BTreeMap::new();
             let index = input.column_index(other_var)?;
             for (row_index, row) in input.rows.iter().enumerate() {
@@ -283,6 +285,7 @@ where
             }
             Ok(extensions)
         } else {
+            // only the attribute is constraining in this case. We simply walk the iterator.
             let mut iterator = self.component_iterator(index_type)?;
             let mut candidates = Vec::new();
             while let Some(value) = iterator.get_value()? {

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -637,6 +637,7 @@ mod tests {
 
     use super::{DbValue, TriplePattern, TripleTerm};
     use crate::codec::{self, Encode};
+    use crate::inc_query::test_support::NAME_ATTR_ID as NAME;
     use crate::ops::DataType;
     use crate::query::binding_bag::BindingBag;
     use crate::query::exec_pattern::{ExecPattern, Proposal};
@@ -711,7 +712,7 @@ mod tests {
         runtime.block_on(async {
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 10,
@@ -720,7 +721,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("ally".into()),
                 10,
@@ -729,7 +730,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 2,
                 &DataType::String("bob".into()),
                 10,
@@ -745,7 +746,7 @@ mod tests {
             10,
             components.range_stats,
         ));
-        let pattern = TriplePattern::new(7, entity, 42, value, db)?;
+        let pattern = TriplePattern::new(7, entity, NAME, value, db)?;
 
         let mut entity_proposal = vec![Proposal::default()];
         pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
@@ -859,7 +860,7 @@ mod tests {
         runtime.block_on(async {
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 10,
@@ -868,7 +869,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 20,
@@ -886,7 +887,7 @@ mod tests {
 
         let entity_1 = encoded(DataType::Long(1));
         let mut prefix = vec![codec::AEV];
-        prefix.extend_from_slice(&codec::encode_i64_bytes(42));
+        prefix.extend_from_slice(&codec::encode_i64_bytes(NAME));
         prefix.extend_from_slice(&entity_1);
         let expected = usize::try_from(
             runtime.block_on(
@@ -900,7 +901,7 @@ mod tests {
         let pattern = TriplePattern::new(
             7,
             entity,
-            42,
+            NAME,
             value,
             Arc::new(DbValue::new(
                 components.db,
@@ -927,7 +928,7 @@ mod tests {
         runtime.block_on(async {
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 10,
@@ -936,7 +937,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 2,
                 &DataType::String("bob".into()),
                 10,
@@ -945,7 +946,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 2,
                 &DataType::String("bob".into()),
                 20,
@@ -961,7 +962,7 @@ mod tests {
             20,
             components.range_stats,
         ));
-        let pattern = TriplePattern::new(7, entity, 42, value, db)?;
+        let pattern = TriplePattern::new(7, entity, NAME, value, db)?;
         let partial = binding_bag(
             &["?outer", "?e"],
             vec![
@@ -1031,7 +1032,7 @@ mod tests {
         runtime.block_on(async {
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 10,
@@ -1040,7 +1041,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 2,
                 &DataType::String("bob".into()),
                 10,
@@ -1058,7 +1059,7 @@ mod tests {
         let entity_pattern = TriplePattern::new(
             1,
             TripleTerm::Variable("?e".to_var()),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
@@ -1077,7 +1078,7 @@ mod tests {
         let value_pattern = TriplePattern::new(
             2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Variable("?v".to_var()),
             db,
         )?;
@@ -1111,14 +1112,14 @@ mod tests {
         let entity_unbound = TriplePattern::new(
             1,
             TripleTerm::Variable("?e".to_var()),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
         let value_unbound = TriplePattern::new(
             2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Variable("?v".to_var()),
             db,
         )?;
@@ -1146,7 +1147,7 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(insert_version(
             components.db.as_ref(),
-            42,
+            NAME,
             1,
             &DataType::String("alice".into()),
             10,
@@ -1162,21 +1163,21 @@ mod tests {
         let existing = TriplePattern::new(
             1,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
         let wrong_entity = TriplePattern::new(
             2,
             TripleTerm::Constant(encoded(DataType::Long(2))),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
         let wrong_value = TriplePattern::new(
             3,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("bob".into()))),
             db,
         )?;
@@ -1199,7 +1200,7 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         runtime.block_on(insert_version(
             components.db.as_ref(),
-            42,
+            NAME,
             1,
             &DataType::String("alice".into()),
             10,
@@ -1215,7 +1216,7 @@ mod tests {
         let entity_pattern = TriplePattern::new(
             1,
             TripleTerm::Variable("?e".to_var()),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
@@ -1236,7 +1237,7 @@ mod tests {
         let value_pattern = TriplePattern::new(
             2,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Variable("?v".to_var()),
             db.clone(),
         )?;
@@ -1259,7 +1260,7 @@ mod tests {
         let existing = TriplePattern::new(
             3,
             TripleTerm::Constant(encoded(DataType::Long(1))),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db.clone(),
         )?;
@@ -1271,7 +1272,7 @@ mod tests {
         let missing = TriplePattern::new(
             4,
             TripleTerm::Constant(encoded(DataType::Long(2))),
-            42,
+            NAME,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
             db,
         )?;
@@ -1289,7 +1290,7 @@ mod tests {
         runtime.block_on(async {
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 10,
@@ -1298,7 +1299,7 @@ mod tests {
             .await?;
             insert_version(
                 components.db.as_ref(),
-                42,
+                NAME,
                 1,
                 &DataType::String("alice".into()),
                 20,
@@ -1311,7 +1312,7 @@ mod tests {
             TriplePattern::new(
                 index,
                 TripleTerm::Constant(encoded(DataType::Long(1))),
-                42,
+                NAME,
                 TripleTerm::Constant(encoded(DataType::String("alice".into()))),
                 Arc::new(DbValue::new(
                     components.db.clone(),
@@ -1347,7 +1348,7 @@ mod tests {
             10,
             components.range_stats,
         ));
-        let new = |entity, value| TriplePattern::new(7, entity, 42, value, db.clone());
+        let new = |entity, value| TriplePattern::new(7, entity, NAME, value, db.clone());
 
         assert!(new(
             TripleTerm::Variable("?x".to_var()),

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -294,7 +294,7 @@ where
         let is_bound = |variable| input.column_indexes.contains_key(variable);
 
         ensure!(
-            self.variables.iter().any(&is_bound),
+            self.variables.is_empty() || self.variables.iter().any(&is_bound),
             "Triple pattern {} has no bound variables to validate",
             self.index
         );

--- a/src/query/patterns/triple.rs
+++ b/src/query/patterns/triple.rs
@@ -55,6 +55,38 @@ struct ScanSpec {
     extractor_position: usize,
 }
 
+/// Immutable database value used by triple-pattern scans.
+pub(crate) struct DbValue<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    slate: Arc<D>,
+    handle: Handle,
+    as_of: i64,
+    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+}
+
+impl<D, M> DbValue<D, M>
+where
+    D: DbReadOps + Send + Sync + 'static,
+    M: DbMetadataOps + Send + Sync + 'static,
+{
+    pub(crate) fn new(
+        slate: Arc<D>,
+        handle: Handle,
+        as_of: i64,
+        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    ) -> Self {
+        Self {
+            slate,
+            handle,
+            as_of,
+            range_stats,
+        }
+    }
+}
+
 pub(crate) struct TriplePattern<D, M>
 where
     D: DbReadOps + Send + Sync + 'static,
@@ -65,10 +97,7 @@ where
     entity: TripleTerm,
     attribute: i64,
     value: TripleTerm,
-    slate: Arc<D>,
-    handle: Handle,
-    as_of: i64,
-    range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+    db: Arc<DbValue<D, M>>,
 }
 
 impl<D, M> TriplePattern<D, M>
@@ -76,16 +105,12 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         index: PatternIndex,
         entity: TripleTerm,
         attribute: i64,
         value: TripleTerm,
-        slate: Arc<D>,
-        handle: Handle,
-        as_of: i64,
-        range_stats: Arc<slatedb_estimates::RangeStats<M>>,
+        db: Arc<DbValue<D, M>>,
     ) -> Result<Self> {
         let mut variables = Vec::new();
         if let Some(variable) = entity.variable() {
@@ -105,10 +130,7 @@ where
             entity,
             attribute,
             value,
-            slate,
-            handle,
-            as_of,
-            range_stats,
+            db,
         })
     }
 
@@ -215,19 +237,19 @@ where
         match index_type {
             IndexType::AE | IndexType::AV => Ok(Box::new(SlateIterator::new(
                 &spec.prefix,
-                self.slate.as_ref(),
-                self.handle.clone(),
+                self.db.slate.as_ref(),
+                self.db.handle.clone(),
                 extractor,
-                self.range_stats.clone(),
+                self.db.range_stats.clone(),
             )?)),
             IndexType::EAV | IndexType::AVE | IndexType::AEV | IndexType::VAE => {
                 Ok(Box::new(TemporalFilterIterator::new(
                     &spec.prefix,
-                    self.slate.as_ref(),
-                    self.handle.clone(),
+                    self.db.slate.as_ref(),
+                    self.db.handle.clone(),
                     extractor,
-                    self.as_of,
-                    self.range_stats.clone(),
+                    self.db.as_of,
+                    self.db.range_stats.clone(),
                 )?))
             }
         }
@@ -360,12 +382,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use anyhow::Result;
     use bytes::Bytes;
     use edn::query::{ToVariable, Variable};
     use slatedb::Db;
 
-    use super::{TriplePattern, TripleTerm};
+    use super::{DbValue, TriplePattern, TripleTerm};
     use crate::codec::{self, Encode};
     use crate::ops::DataType;
     use crate::query::binding_bag::BindingBag;
@@ -469,16 +493,13 @@ mod tests {
         })?;
 
         let (entity, value) = variables("?e", "?v");
-        let pattern = TriplePattern::new(
-            7,
-            entity,
-            42,
-            value,
+        let db = Arc::new(DbValue::new(
             components.db,
             runtime.handle().clone(),
             10,
             components.range_stats,
-        )?;
+        ));
+        let pattern = TriplePattern::new(7, entity, 42, value, db)?;
 
         let mut entity_proposal = vec![Proposal::default()];
         pattern.count(&BindingBag::unit(), &["?e".to_var()], &mut entity_proposal)?;
@@ -579,16 +600,13 @@ mod tests {
         })?;
 
         let (entity, value) = variables("?e", "?v");
-        let pattern = TriplePattern::new(
-            7,
-            entity,
-            42,
-            value,
+        let db = Arc::new(DbValue::new(
             components.db,
             runtime.handle().clone(),
             20,
             components.range_stats,
-        )?;
+        ));
+        let pattern = TriplePattern::new(7, entity, 42, value, db)?;
         let partial = binding_bag(
             &["?outer", "?e"],
             vec![
@@ -650,15 +668,18 @@ mod tests {
             codec::ADD,
         ))?;
 
+        let db = Arc::new(DbValue::new(
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        ));
         let entity_pattern = TriplePattern::new(
             1,
             TripleTerm::Variable("?e".to_var()),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-            components.db.clone(),
-            runtime.handle().clone(),
-            10,
-            components.range_stats.clone(),
+            db.clone(),
         )?;
         let entities =
             entity_pattern.join(&BindingBag::unit(), &["?e".to_var()], &["?e".to_var()])?;
@@ -672,10 +693,7 @@ mod tests {
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Variable("?v".to_var()),
-            components.db.clone(),
-            runtime.handle().clone(),
-            10,
-            components.range_stats.clone(),
+            db.clone(),
         )?;
         let values = value_pattern.join(&BindingBag::unit(), &["?v".to_var()], &["?v".to_var()])?;
         assert_eq!(
@@ -691,10 +709,7 @@ mod tests {
             TripleTerm::Constant(encoded(DataType::Long(1))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-            components.db.clone(),
-            runtime.handle().clone(),
-            10,
-            components.range_stats.clone(),
+            db.clone(),
         )?;
         assert_eq!(
             existing.join(&BindingBag::unit(), &[], &[])?,
@@ -706,10 +721,7 @@ mod tests {
             TripleTerm::Constant(encoded(DataType::Long(2))),
             42,
             TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-            components.db,
-            runtime.handle().clone(),
-            10,
-            components.range_stats,
+            db,
         )?;
         assert_eq!(
             missing.join(&BindingBag::unit(), &[], &[])?,
@@ -749,10 +761,12 @@ mod tests {
                 TripleTerm::Constant(encoded(DataType::Long(1))),
                 42,
                 TripleTerm::Constant(encoded(DataType::String("alice".into()))),
-                components.db.clone(),
-                runtime.handle().clone(),
-                as_of,
-                components.range_stats.clone(),
+                Arc::new(DbValue::new(
+                    components.db.clone(),
+                    runtime.handle().clone(),
+                    as_of,
+                    components.range_stats.clone(),
+                )),
             )
         };
 
@@ -775,18 +789,13 @@ mod tests {
     fn constructor_rejects_repeated_variables() -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
-        let new = |entity, value| {
-            TriplePattern::new(
-                7,
-                entity,
-                42,
-                value,
-                components.db.clone(),
-                runtime.handle().clone(),
-                10,
-                components.range_stats.clone(),
-            )
-        };
+        let db = Arc::new(DbValue::new(
+            components.db,
+            runtime.handle().clone(),
+            10,
+            components.range_stats,
+        ));
+        let new = |entity, value| TriplePattern::new(7, entity, 42, value, db.clone());
 
         assert!(new(
             TripleTerm::Variable("?x".to_var()),

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -44,6 +44,15 @@ impl Stage {
             );
         }
 
+        let mut participant_indexes = HashSet::with_capacity(participants.len());
+        for participant in &participants {
+            ensure!(
+                participant_indexes.insert(participant.index()),
+                "Stage participant indexes must be distinct: {}",
+                participant.index()
+            );
+        }
+
         Ok(Self {
             added,
             participants,
@@ -92,21 +101,27 @@ mod tests {
 
     use super::Stage;
     use crate::query::binding_bag::BindingBag;
-    use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
+    use crate::query::exec_pattern::{ExecPattern, PatternIndex, Proposal};
 
     struct TestPattern {
+        index: PatternIndex,
         variables: Vec<Variable>,
     }
 
     impl TestPattern {
-        fn shared(variables: &[&str]) -> Arc<dyn ExecPattern> {
+        fn shared(index: PatternIndex, variables: &[&str]) -> Arc<dyn ExecPattern> {
             Arc::new(Self {
+                index,
                 variables: variables.iter().map(|variable| variable.to_var()).collect(),
             })
         }
     }
 
     impl ExecPattern for TestPattern {
+        fn index(&self) -> PatternIndex {
+            self.index
+        }
+
         fn variables(&self) -> &[Variable] {
             &self.variables
         }
@@ -115,7 +130,6 @@ mod tests {
             &self,
             _input: &BindingBag,
             _added: &[Variable],
-            _participant_index: ParticipantIndex,
             _proposals: &mut [Proposal],
         ) -> Result<()> {
             Ok(())
@@ -133,7 +147,7 @@ mod tests {
 
     #[test]
     fn stage_construction_enforces_static_invariants() {
-        let pattern = TestPattern::shared(&["?x"]);
+        let pattern = TestPattern::shared(1, &["?x"]);
 
         assert!(Stage::new(vec![], vec![], vec![]).is_err());
         assert!(Stage::new(
@@ -150,7 +164,13 @@ mod tests {
         .is_err());
         assert!(Stage::new(
             vec!["?missing".to_var()],
-            vec![pattern],
+            vec![Arc::clone(&pattern)],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            vec![Arc::clone(&pattern), pattern],
             vec!["?x".to_var()],
         )
         .is_err());
@@ -160,7 +180,7 @@ mod tests {
     fn stage_validates_each_input_layout_transition() {
         let stage = Stage::new(
             vec!["?y".to_var()],
-            vec![TestPattern::shared(&["?x", "?y"])],
+            vec![TestPattern::shared(1, &["?x", "?y"])],
             vec!["?y".to_var(), "?x".to_var()],
         )
         .unwrap();

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -44,15 +44,6 @@ impl Stage {
             );
         }
 
-        let mut participant_ids = HashSet::with_capacity(participants.len());
-        for participant in &participants {
-            ensure!(
-                participant_ids.insert(participant.id()),
-                "Stage participant IDs must be distinct: {}",
-                participant.id()
-            );
-        }
-
         Ok(Self {
             added,
             participants,
@@ -101,27 +92,21 @@ mod tests {
 
     use super::Stage;
     use crate::query::binding_bag::BindingBag;
-    use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+    use crate::query::exec_pattern::{ExecPattern, ParticipantIndex, Proposal};
 
     struct TestPattern {
-        id: PatternId,
         variables: Vec<Variable>,
     }
 
     impl TestPattern {
-        fn shared(id: PatternId, variables: &[&str]) -> Arc<dyn ExecPattern> {
+        fn shared(variables: &[&str]) -> Arc<dyn ExecPattern> {
             Arc::new(Self {
-                id,
                 variables: variables.iter().map(|variable| variable.to_var()).collect(),
             })
         }
     }
 
     impl ExecPattern for TestPattern {
-        fn id(&self) -> PatternId {
-            self.id
-        }
-
         fn variables(&self) -> &[Variable] {
             &self.variables
         }
@@ -130,6 +115,7 @@ mod tests {
             &self,
             _input: &BindingBag,
             _added: &[Variable],
+            _participant_index: ParticipantIndex,
             _proposals: &mut [Proposal],
         ) -> Result<()> {
             Ok(())
@@ -147,7 +133,7 @@ mod tests {
 
     #[test]
     fn stage_construction_enforces_static_invariants() {
-        let pattern = TestPattern::shared(1, &["?x"]);
+        let pattern = TestPattern::shared(&["?x"]);
 
         assert!(Stage::new(vec![], vec![], vec![]).is_err());
         assert!(Stage::new(
@@ -164,13 +150,7 @@ mod tests {
         .is_err());
         assert!(Stage::new(
             vec!["?missing".to_var()],
-            vec![Arc::clone(&pattern)],
-            vec!["?x".to_var()],
-        )
-        .is_err());
-        assert!(Stage::new(
-            vec!["?x".to_var()],
-            vec![Arc::clone(&pattern), pattern],
+            vec![pattern],
             vec!["?x".to_var()],
         )
         .is_err());
@@ -180,7 +160,7 @@ mod tests {
     fn stage_validates_each_input_layout_transition() {
         let stage = Stage::new(
             vec!["?y".to_var()],
-            vec![TestPattern::shared(1, &["?x", "?y"])],
+            vec![TestPattern::shared(&["?x", "?y"])],
             vec!["?y".to_var(), "?x".to_var()],
         )
         .unwrap();

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -72,6 +72,7 @@ impl Stage {
         &self.target_variables
     }
 
+    // TODO: Is this necessary? Currently it's only used in tests.
     pub(crate) fn validate_input(&self, input: &BindingBag) -> Result<()> {
         for variable in &self.added {
             ensure!(

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -1,0 +1,196 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::{ensure, Result};
+use edn::query::Variable;
+
+use super::binding_bag::BindingBag;
+use super::exec_pattern::ExecPattern;
+
+fn ensure_unique(label: &str, variables: &[Variable]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(variables.len());
+    for variable in variables {
+        ensure!(
+            seen.insert(variable),
+            "{label} variables must be unique: {variable}"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) struct Stage {
+    added: Vec<Variable>,
+    participants: Vec<Arc<dyn ExecPattern>>,
+    target_variables: Vec<Variable>,
+}
+
+impl Stage {
+    pub(crate) fn new(
+        added: Vec<Variable>,
+        participants: Vec<Arc<dyn ExecPattern>>,
+        target_variables: Vec<Variable>,
+    ) -> Result<Self> {
+        ensure_unique("Added", &added)?;
+        ensure_unique("Target", &target_variables)?;
+        ensure!(
+            !participants.is_empty(),
+            "Stage participants must not be empty"
+        );
+
+        for variable in &added {
+            ensure!(
+                target_variables.contains(variable),
+                "Added variable {variable} is missing from the target layout"
+            );
+        }
+
+        let mut participant_ids = HashSet::with_capacity(participants.len());
+        for participant in &participants {
+            ensure!(
+                participant_ids.insert(participant.id()),
+                "Stage participant IDs must be distinct: {}",
+                participant.id()
+            );
+        }
+
+        Ok(Self {
+            added,
+            participants,
+            target_variables,
+        })
+    }
+
+    pub(crate) fn added(&self) -> &[Variable] {
+        &self.added
+    }
+
+    pub(crate) fn participants(&self) -> &[Arc<dyn ExecPattern>] {
+        &self.participants
+    }
+
+    pub(crate) fn target_variables(&self) -> &[Variable] {
+        &self.target_variables
+    }
+
+    pub(crate) fn validate_input(&self, input: &BindingBag) -> Result<()> {
+        for variable in &self.added {
+            ensure!(
+                !input.variables.contains(variable),
+                "Stage cannot add already-bound variable {variable}"
+            );
+        }
+
+        let expected: HashSet<&Variable> =
+            input.variables.iter().chain(self.added.iter()).collect();
+        let target: HashSet<&Variable> = self.target_variables.iter().collect();
+        ensure!(
+            expected == target,
+            "Stage target layout must equal the input variables plus added variables"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use edn::query::{ToVariable, Variable};
+
+    use super::Stage;
+    use crate::query::binding_bag::BindingBag;
+    use crate::query::exec_pattern::{ExecPattern, PatternId, Proposal};
+
+    struct TestPattern {
+        id: PatternId,
+        variables: Vec<Variable>,
+    }
+
+    impl TestPattern {
+        fn shared(id: PatternId, variables: &[&str]) -> Arc<dyn ExecPattern> {
+            Arc::new(Self {
+                id,
+                variables: variables.iter().map(|variable| variable.to_var()).collect(),
+            })
+        }
+    }
+
+    impl ExecPattern for TestPattern {
+        fn id(&self) -> PatternId {
+            self.id
+        }
+
+        fn variables(&self) -> &[Variable] {
+            &self.variables
+        }
+
+        fn count(
+            &self,
+            _input: &BindingBag,
+            _added: &[Variable],
+            _proposals: &mut [Proposal],
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn join(
+            &self,
+            input: &BindingBag,
+            _added: &[Variable],
+            target_variables: &[Variable],
+        ) -> Result<BindingBag> {
+            input.reorder(target_variables)
+        }
+    }
+
+    #[test]
+    fn stage_construction_enforces_static_invariants() {
+        let pattern = TestPattern::shared(1, &["?x"]);
+
+        assert!(Stage::new(vec![], vec![], vec![]).is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var(), "?x".to_var()],
+            vec![Arc::clone(&pattern)],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            vec![Arc::clone(&pattern)],
+            vec!["?x".to_var(), "?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?missing".to_var()],
+            vec![Arc::clone(&pattern)],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            vec![Arc::clone(&pattern), pattern],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn stage_validates_each_input_layout_transition() {
+        let stage = Stage::new(
+            vec!["?y".to_var()],
+            vec![TestPattern::shared(1, &["?x", "?y"])],
+            vec!["?y".to_var(), "?x".to_var()],
+        )
+        .unwrap();
+
+        let input = BindingBag::empty(vec!["?x".to_var()]).unwrap();
+        assert!(stage.validate_input(&input).is_ok());
+
+        let already_added = BindingBag::empty(vec!["?x".to_var(), "?y".to_var()]).unwrap();
+        assert!(stage.validate_input(&already_added).is_err());
+
+        let wrong_input = BindingBag::empty(vec!["?z".to_var()]).unwrap();
+        assert!(stage.validate_input(&wrong_input).is_err());
+    }
+}


### PR DESCRIPTION
This is the second extraction from #422. It includes the `ExecPattern` trait extraction, the implementation for intermediate results `RelationPattern` and the implementation for base patterns, called a `TriplePattern`.  