### PR TITLE
Add predicates for incremental queries

### DIFF
--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -29,12 +29,6 @@ incremental queries and a further more retraining check for incremental queries
 that at some point should get removed when parity between the two query paths
 is reached.
 
-Predicate clauses reuse the standard query engine's compiled expression tree
-and boolean evaluation semantics. Every variable referenced by a predicate
-must already be bound by a positive relation. A row passes the predicate only
-when evaluation produces boolean `true`; incompatible types, unbound values,
-and non-boolean results do not pass.
-
 Any approach for incremental query compilation should be first tested in hooray
 (https://github.com/FiV0/hooray2), it is the test bed for new join algorithms
 in Triplox.

--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -29,6 +29,12 @@ incremental queries and a further more retraining check for incremental queries
 that at some point should get removed when parity between the two query paths
 is reached.
 
+Predicate clauses reuse the standard query engine's compiled expression tree
+and boolean evaluation semantics. Every variable referenced by a predicate
+must already be bound by a positive relation. A row passes the predicate only
+when evaluation produces boolean `true`; incompatible types, unbound values,
+and non-boolean results do not pass.
+
 Any approach for incremental query compilation should be first tested in hooray
 (https://github.com/FiV0/hooray2), it is the test bed for new join algorithms
 in Triplox.
@@ -105,6 +111,7 @@ Descriptor {
     variables: [Variable],
     groundable: [Variable],
     kind: Pattern
+        | Predicate { expr: Expr }
         | Not { scope: ScopeDescriptor }
         | Or { branches: [ScopeDescriptor] },
 }
@@ -119,8 +126,8 @@ child descriptors and has no descriptor representation of its own. An implicit
 order. `groundable` lists the variables that the descriptor can produce
 without receiving them from an incoming relation. A pattern can ground all of
 its variables. An `or` can ground the intersection of variables groundable by
-all branches. A `not` grounds no variables, so every variable it mentions must
-already be available from the enclosing positive relation.
+all branches. Predicates and `not` ground no variables, so every variable they
+mention must already be available from the enclosing positive relation.
 
 The planner derives a descriptor's required bindings as
 `variables - groundable`. A descriptor is eligible once all required variables
@@ -136,7 +143,7 @@ Every physical relation plan records:
 RelPlan {
     incoming_vars: optional [Variable],
     output_vars: [Variable],
-    kind: Pattern | Chain | Difference | Union,
+    kind: Pattern | Filter | Chain | Difference | Union,
 }
 ```
 
@@ -147,6 +154,8 @@ zero-column relation.
 - `Pattern` filters the fact input by attribute and constants. With an incoming
   relation, circuit assembly joins the filtered pattern rows to that relation
   using the plan's incoming, pattern, and output layouts.
+- `Filter` evaluates one compiled predicate against each incoming row and
+  preserves the row and its weight only when the predicate returns true.
 - `Chain` represents a scope with multiple descriptors and passes each child's
   output relation to the next child.
 - `Difference` preserves the incoming relation and removes rows whose selected
@@ -156,7 +165,8 @@ zero-column relation.
   output layout for all branch results.
 
 `Chain` is a physical plan shape rather than a DBSP operator. Circuit assembly
-uses the existing `flat_map`, join, projection, sum, and distinct operators.
+uses the existing `flat_map`, filter, join, projection, antijoin, sum, and
+distinct operators.
 
 ### Row layouts
 
@@ -185,6 +195,8 @@ and the optional incoming relation:
 
 - a pattern creates matching rows with `flat_map` and joins them to the
   incoming rows when present.
+- a filter decodes its referenced columns, evaluates the compiled expression,
+  and filters the incoming rows without changing their layout or weights.
 - a chain folds the running relation through its children.
 - a difference projects the incoming rows to the negative key, evaluates the
   negative scope from that raw projection, and antijoins the original incoming

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -15,7 +15,7 @@ mod planner;
 pub(crate) use descriptor::PatternSlot;
 pub(crate) use planner::{PatternPlan, RelPlan, RelPlanKind};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct IncrementalQueryPlan {
     pub find_vars: Vec<Variable>,
     pub where_plan: RelPlan,
@@ -89,6 +89,7 @@ fn reject_unsupported_pattern_shape(pattern: &Pattern) -> Result<()> {
 fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
     match clause {
         WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
+        WhereClause::Pred(_) => Ok(()),
         WhereClause::NotJoin(not) => {
             for clause in &not.clauses {
                 reject_unsupported_where_clause(clause)?;
@@ -97,7 +98,7 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
         }
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
         _ => bail!(
-            "Incremental queries currently support only triple patterns, implicit `not` clauses, `or` clauses, and `and` clauses in :where"
+            "Incremental queries currently support only triple patterns, predicate clauses, implicit `not` clauses, `or` clauses, and `and` clauses in :where"
         ),
     }
 }
@@ -753,6 +754,71 @@ mod tests {
     }
 
     #[test]
+    fn plans_predicates_as_bound_filter_leaves() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                "[:find ?age
+                  :where
+                  [(< ?age 50)]
+                  [?e :age ?age]
+                  [?e :name ?name]]",
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Chain { children } = &plan.where_plan.kind else {
+            panic!("expected chain plan");
+        };
+        assert!(matches!(children[0].kind, RelPlanKind::Pattern(_)));
+        let filter = &children[1];
+        assert_eq!(
+            filter.incoming_vars,
+            Some(vec!["?e".to_var(), "?age".to_var()])
+        );
+        assert_eq!(filter.output_vars, vec!["?e".to_var(), "?age".to_var()]);
+        assert!(matches!(filter.kind, RelPlanKind::Filter { .. }));
+        assert!(matches!(children[2].kind, RelPlanKind::Pattern(_)));
+
+        let plan = plan_query(
+            &parse_query(
+                "[:find ?age
+                  :where
+                  [?e :age ?age]
+                  (or
+                    (and [(> ?age 10)]
+                         (not [(< ?age 30)]))
+                    [(= ?age 42)])]",
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Chain { children } = &plan.where_plan.kind else {
+            panic!("expected top-level chain");
+        };
+        let RelPlanKind::Union { branches } = &children[1].kind else {
+            panic!("expected union");
+        };
+        let RelPlanKind::Chain {
+            children: branch_children,
+        } = &branches[0].kind
+        else {
+            panic!("expected and branch");
+        };
+        assert!(matches!(
+            branch_children[0].kind,
+            RelPlanKind::Filter { .. }
+        ));
+        let RelPlanKind::Difference { negative, .. } = &branch_children[1].kind else {
+            panic!("expected difference");
+        };
+        assert!(matches!(negative.kind, RelPlanKind::Filter { .. }));
+        assert!(matches!(branches[1].kind, RelPlanKind::Filter { .. }));
+    }
+
+    #[test]
     fn accepts_entid_attribute() {
         let schema = test_schema();
         let plan = plan_query(&parse_query("[:find ?e :where [?e 10 ?name]]"), &schema).unwrap();
@@ -803,8 +869,8 @@ mod tests {
     #[test]
     fn rejects_unsupported_where_forms() {
         assert_plan_err(
-            r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#,
-            "only triple patterns, implicit `not` clauses, `or` clauses, and `and` clauses",
+            r#"[:find ?e :where [?e :name "Alice"] [(+ 1 2) ?sum]]"#,
+            "only triple patterns, predicate clauses, implicit `not` clauses, `or` clauses, and `and` clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -2,14 +2,15 @@ use std::collections::HashSet;
 
 use anyhow::{anyhow, Result};
 use edn::query::{
-    NotJoin, OrJoin, OrWhereClause, Pattern, PatternNonValuePlace, PatternValuePlace, Variable,
-    WhereClause,
+    NotJoin, OrJoin, OrWhereClause, Pattern, PatternNonValuePlace, PatternValuePlace, Predicate,
+    Variable, WhereClause,
 };
 
 use crate::codec::Encode;
+use crate::expr::{expr_variables, Expr};
 use crate::incremental::EncodedValue;
 use crate::ops::DataType;
-use crate::query::non_integer_constant_to_datatype;
+use crate::query::{convert_predicate, non_integer_constant_to_datatype};
 use crate::schema::Schema;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,23 +19,24 @@ pub(crate) enum PatternSlot {
     Constant(EncodedValue),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct ScopeDescriptor {
     pub descriptors: Vec<Descriptor>,
     pub variables: Vec<Variable>,
     pub groundable: Vec<Variable>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct Descriptor {
     pub variables: Vec<Variable>,
     pub groundable: Vec<Variable>,
     pub kind: DescriptorKind,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) enum DescriptorKind {
     Pattern(PatternDescriptor),
+    Predicate { expr: Expr },
     Not { scope: ScopeDescriptor },
     Or { branches: Vec<ScopeDescriptor> },
 }
@@ -126,6 +128,16 @@ fn ordered_union<'a>(variables: impl IntoIterator<Item = &'a Variable>) -> Vec<V
     result
 }
 
+fn describe_predicate(predicate: &Predicate) -> Result<Descriptor> {
+    let expr = convert_predicate(predicate)?;
+    let variables = expr_variables(&expr);
+    Ok(Descriptor {
+        variables,
+        groundable: Vec::new(),
+        kind: DescriptorKind::Predicate { expr },
+    })
+}
+
 fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descriptor> {
     match clause {
         WhereClause::Pattern(pattern) => {
@@ -137,6 +149,7 @@ fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descri
                 kind: DescriptorKind::Pattern(pattern),
             })
         }
+        WhereClause::Pred(predicate) => describe_predicate(predicate),
         WhereClause::NotJoin(not) => describe_not(not, schema),
         WhereClause::OrJoin(or) => describe_or(or, schema),
         _ => unreachable!("unsupported clauses are rejected before planning"),
@@ -278,5 +291,19 @@ mod tests {
         };
         assert_eq!(scope.variables, vec!["?e".to_var(), "?age".to_var()]);
         assert_eq!(scope.groundable, scope.variables);
+    }
+
+    #[test]
+    fn predicate_metadata_mentions_variables_without_grounding_them() {
+        let query = parse_query("[:find ?age :where [?e :age ?age] [(< ?age 30)]]");
+        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let descriptor = &scope.descriptors[1];
+
+        assert_eq!(descriptor.variables, vec!["?age".to_var()]);
+        assert!(descriptor.groundable.is_empty());
+        let DescriptorKind::Predicate { expr } = &descriptor.kind else {
+            panic!("expected predicate descriptor");
+        };
+        assert_eq!(crate::expr::expr_variables(expr), vec!["?age".to_var()]);
     }
 }

--- a/src/inc_query/planner.rs
+++ b/src/inc_query/planner.rs
@@ -6,17 +6,21 @@ use edn::query::Variable;
 
 use super::descriptor::{Descriptor, DescriptorKind, PatternDescriptor, ScopeDescriptor};
 use super::PatternSlot;
+use crate::expr::Expr;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RelPlan {
     pub incoming_vars: Option<Vec<Variable>>,
     pub output_vars: Vec<Variable>,
     pub kind: RelPlanKind,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum RelPlanKind {
     Pattern(PatternPlan),
+    Filter {
+        expr: Expr,
+    },
     Chain {
         children: Vec<RelPlan>,
     },
@@ -144,6 +148,16 @@ fn plan_pattern(
     }
 }
 
+fn plan_filter(expr: &Expr, incoming_vars: Option<Vec<Variable>>) -> Result<RelPlan> {
+    let incoming_vars = incoming_vars
+        .ok_or_else(|| anyhow!("Cannot plan predicate without a positive relation"))?;
+    Ok(RelPlan {
+        incoming_vars: Some(incoming_vars.clone()),
+        output_vars: incoming_vars,
+        kind: RelPlanKind::Filter { expr: expr.clone() },
+    })
+}
+
 fn plan_union(
     descriptor: &Descriptor,
     branches: &[ScopeDescriptor],
@@ -197,6 +211,7 @@ fn plan_descriptor(
 ) -> Result<RelPlan> {
     match &descriptor.kind {
         DescriptorKind::Pattern(pattern) => Ok(plan_pattern(descriptor, pattern, incoming_vars)),
+        DescriptorKind::Predicate { expr } => plan_filter(expr, incoming_vars),
         DescriptorKind::Not { scope } => plan_difference(descriptor, scope, incoming_vars),
         DescriptorKind::Or { branches } => plan_union(descriptor, branches, incoming_vars),
     }
@@ -239,6 +254,7 @@ pub(super) fn plan_scope(
 pub(super) fn collect_leaf_patterns<'a>(plan: &'a RelPlan, patterns: &mut Vec<&'a PatternPlan>) {
     match &plan.kind {
         RelPlanKind::Pattern(pattern) => patterns.push(pattern),
+        RelPlanKind::Filter { .. } => {}
         RelPlanKind::Chain { children } => {
             for child in children {
                 collect_leaf_patterns(child, patterns);

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -197,7 +197,7 @@ fn filter_predicate_stream(
                 .expect("predicate variable must be present in the incoming row");
             (variable, position)
         })
-        .collect::<Vec<_>>();
+        .collect::<HashMap<_, _>>();
 
     stream.filter(move |row| {
         let values = variable_positions
@@ -207,12 +207,8 @@ fn filter_predicate_stream(
                     .expect("incremental predicate value should decode");
                 (variable.clone(), value)
             })
-            .collect::<Vec<_>>();
-        let bindings = values
-            .iter()
-            .map(|(variable, value)| (variable.clone(), value))
             .collect::<HashMap<_, _>>();
-        evaluate_as_bool(&expr, &EvalContext::new(bindings))
+        evaluate_as_bool(&expr, &EvalContext::new(&values))
     })
 }
 

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -197,7 +197,7 @@ fn filter_predicate_stream(
                 .expect("predicate variable must be present in the incoming row");
             (variable, position)
         })
-        .collect::<HashMap<_, _>>();
+        .collect::<Vec<_>>();
 
     stream.filter(move |row| {
         let values = variable_positions

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
@@ -11,6 +12,7 @@ use dbsp::{
 use edn::query::Variable;
 
 use crate::codec::Decode;
+use crate::expr::{evaluate_as_bool, expr_variables, EvalContext, Expr};
 use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot, RelPlan, RelPlanKind};
 use crate::incremental::{EncodedRow, EncodedTriple};
 use crate::ops::DataType;
@@ -181,6 +183,39 @@ fn assert_incoming_layout(plan: &RelPlan, incoming: &Option<PlannedWhereStream>)
     );
 }
 
+fn filter_predicate_stream(
+    stream: Stream<RootCircuit, RowZSet>,
+    vars: &[Variable],
+    expr: Expr,
+) -> Stream<RootCircuit, RowZSet> {
+    let variable_positions = expr_variables(&expr)
+        .into_iter()
+        .map(|variable| {
+            let position = vars
+                .iter()
+                .position(|candidate| candidate == &variable)
+                .expect("predicate variable must be present in the incoming row");
+            (variable, position)
+        })
+        .collect::<Vec<_>>();
+
+    stream.filter(move |row| {
+        let values = variable_positions
+            .iter()
+            .map(|(variable, position)| {
+                let value = DataType::decode(&row[*position])
+                    .expect("incremental predicate value should decode");
+                (variable.clone(), value)
+            })
+            .collect::<Vec<_>>();
+        let bindings = values
+            .iter()
+            .map(|(variable, value)| (variable.clone(), value))
+            .collect::<HashMap<_, _>>();
+        evaluate_as_bool(&expr, &EvalContext::new(bindings))
+    })
+}
+
 fn difference_stream(
     positive: PlannedWhereStream,
     negative: PlannedWhereStream,
@@ -224,6 +259,10 @@ fn rel_stream(
                 ),
                 None => pattern_stream,
             }
+        }
+        RelPlanKind::Filter { expr } => {
+            let incoming = incoming.expect("filter plan requires an incoming relation");
+            filter_predicate_stream(incoming.stream, &incoming.vars, expr.clone())
         }
         RelPlanKind::Chain { children } => {
             let relation = children
@@ -659,6 +698,33 @@ mod tests {
         assert_eq!(
             decode_output_rows(&output.consolidate()).unwrap(),
             vec![(vec![DataType::Long(43), DataType::Long(30)], 1)]
+        );
+    }
+
+    #[test]
+    fn predicate_stream_filters_rows_and_preserves_retractions() {
+        let plan = query_plan("[:find ?age :where [?e :age ?age] [(< ?age 50)]]");
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(
+            &handle,
+            [
+                (triple(1, AGE, DataType::Long(30)), 1),
+                (triple(2, AGE, DataType::Long(50)), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::Long(30)], 1)]
+        );
+
+        append(&handle, [(triple(1, AGE, DataType::Long(30)), -1)]);
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::Long(30)], -1)]
         );
     }
 

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -184,6 +184,30 @@
         (api/transact conn [[:db/retract alice-id :age 30]])
         (is (= [[["Alicia"] 1]] (take-delta! sub)))))))
 
+(deftest predicates-compose-with-and+or+not
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (with-open [sub (api/subscribe conn '{:find [?name]
+                                          :where [[?e :name ?name]
+                                                  [?e :age ?age]
+                                                  (or
+                                                   (and [(> ?age 20)]
+                                                        [(< ?age 40)])
+                                                   (not [(< ?age 30)]))]})]
+      (api/transact conn [{:name "Alice" :age 20}
+                          {:name "Bob" :age 25}
+                          {:name "Cara" :age 35}
+                          {:name "Dave" :age 50}])
+      (is (= #{[["Bob"] 1]
+               [["Cara"] 1]
+               [["Dave"] 1]}
+             (delta-set! sub)))
+
+      (let [cara-id (single-value conn '{:find [?e]
+                                          :where [[?e :name "Cara"]]})]
+        (api/transact conn [[:db/retract cara-id :age 35]])
+        (is (= [[["Cara"] -1]] (take-delta! sub)))))))
+
 (deftest test-not-negative-scope-layouts
   (testing "Multi-clause negative scope"
     (with-open [conn (connect)]

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -198,15 +198,16 @@
                           {:name "Bob" :age 25}
                           {:name "Cara" :age 35}
                           {:name "Dave" :age 50}])
-      (is (= #{[["Bob"] 1]
-               [["Cara"] 1]
-               [["Dave"] 1]}
-             (delta-set! sub)))
+      (is (= [[["Bob"] 1]
+              [["Cara"] 1]
+              [["Dave"] 1]]
+             (take-delta! sub)))
 
       (let [cara-id (single-value conn '{:find [?e]
-                                          :where [[?e :name "Cara"]]})]
+                                         :where [[?e :name "Cara"]]})]
         (api/transact conn [[:db/retract cara-id :age 35]])
-        (is (= [[["Cara"] -1]] (take-delta! sub)))))))
+        (is (= [[["Cara"] -1]]
+               (take-delta! sub)))))))
 
 (deftest test-not-negative-scope-layouts
   (testing "Multi-clause negative scope"


### PR DESCRIPTION
Mainly inspired by https://github.com/FiV0/hooray2/pull/28 we are adding support for predicates in incremental circuit compilation. All variables needed for the predicate need to be bound in the `incoming` relation. A predicate purely acts as a filter.