### PR TITLE
Add functions for incremental queries

### DIFF
--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -106,6 +106,7 @@ Descriptor {
     groundable: [Variable],
     kind: Pattern
         | Predicate { expr: Expr }
+        | Function { expr: Expr, output_var: Variable }
         | Not { scope: ScopeDescriptor }
         | Or { branches: [ScopeDescriptor] },
 }
@@ -119,9 +120,11 @@ child descriptors and has no descriptor representation of its own. An implicit
 `variables` lists the variables mentioned by a descriptor in stable semantic
 order. `groundable` lists the variables that the descriptor can produce
 without receiving them from an incoming relation. A pattern can ground all of
-its variables. An `or` can ground the intersection of variables groundable by
-all branches. Predicates and `not` ground no variables, so every variable they
-mention must already be available from the enclosing positive relation.
+its variables. A function grounds its result variable unless the expression
+also reads that variable. An `or` can ground the intersection of variables
+groundable by all branches. Predicates and `not` ground no variables, so every
+variable they mention must already be available from the enclosing positive
+relation.
 
 The planner derives a descriptor's required bindings as
 `variables - groundable`. A descriptor is eligible once all required variables
@@ -137,7 +140,7 @@ Every physical relation plan records:
 RelPlan {
     incoming_vars: optional [Variable],
     output_vars: [Variable],
-    kind: Pattern | Filter | Chain | Difference | Union,
+    kind: Pattern | Filter | Function | Chain | Difference | Union,
 }
 ```
 
@@ -150,6 +153,8 @@ zero-column relation.
   using the plan's incoming, pattern, and output layouts.
 - `Filter` evaluates one compiled predicate against each incoming row and
   preserves the row and its weight only when the predicate returns true.
+- `Function` evaluates one compiled expression against each incoming row. It
+  appends a new result column or filters against an existing result binding.
 - `Chain` represents a scope with multiple descriptors and passes each child's
   output relation to the next child.
 - `Difference` preserves the incoming relation and removes rows whose selected
@@ -169,6 +174,9 @@ incoming relation preserves that layout and appends only newly produced
 variables in semantic order. Join keys are the variables shared by both sides,
 in incoming-layout order. A join without shared variables is a Cartesian
 product over the empty key.
+
+A function preserves its incoming layout when its result variable is already
+present. Otherwise it appends the result variable as the final column.
 
 A chain's output layout is its last child's output layout. A standalone union
 uses its descriptor variable order. A union with an incoming relation preserves
@@ -191,6 +199,9 @@ and the optional incoming relation:
   incoming rows when present.
 - a filter decodes its referenced columns, evaluates the compiled expression,
   and filters the incoming rows without changing their layout or weights.
+- a function decodes its inputs and either appends the encoded result with
+  `flat_map` or filters rows whose existing result binding differs. Failed
+  expression evaluation drops the row.
 - a chain folds the running relation through its children.
 - a difference projects the incoming rows to the negative key, evaluates the
   negative scope from that raw projection, and antijoins the original incoming

--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -175,9 +175,6 @@ variables in semantic order. Join keys are the variables shared by both sides,
 in incoming-layout order. A join without shared variables is a Cartesian
 product over the empty key.
 
-A function preserves its incoming layout when its result variable is already
-present. Otherwise it appends the result variable as the final column.
-
 A chain's output layout is its last child's output layout. A standalone union
 uses its descriptor variable order. A union with an incoming relation preserves
 the incoming layout and appends its remaining descriptor variables; descriptor

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -861,7 +861,7 @@ mod tests {
     }
 
     #[test]
-    fn plans_function_applications_as_filters_for_bound_results() {
+    fn plans_bound_function_result_without_extending_layout() {
         let schema = test_schema();
         let plan = plan_query(
             &parse_query(

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -89,7 +89,7 @@ fn reject_unsupported_pattern_shape(pattern: &Pattern) -> Result<()> {
 fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
     match clause {
         WhereClause::Pattern(pattern) => reject_unsupported_pattern_shape(pattern),
-        WhereClause::Pred(_) => Ok(()),
+        WhereClause::Pred(_) | WhereClause::WhereFn(_) => Ok(()),
         WhereClause::NotJoin(not) => {
             for clause in &not.clauses {
                 reject_unsupported_where_clause(clause)?;
@@ -98,7 +98,7 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
         }
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
         _ => bail!(
-            "Incremental queries currently support only triple patterns, predicate clauses, implicit `not` clauses, `or` clauses, and `and` clauses in :where"
+            "Incremental queries currently support only triple patterns, predicate clauses, function clauses, implicit `not` clauses, `or` clauses, and `and` clauses in :where"
         ),
     }
 }
@@ -819,6 +819,89 @@ mod tests {
     }
 
     #[test]
+    fn plans_function_applications_after_their_inputs_are_bound() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                "[:find ?quarter-age
+                  :where
+                  [(quot ?age 2) ?half-age]
+                  [(quot ?half-age 2) ?quarter-age]
+                  [?e :age ?age]]",
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Chain { children } = &plan.where_plan.kind else {
+            panic!("expected chain plan");
+        };
+        assert!(matches!(children[0].kind, RelPlanKind::Pattern(_)));
+        let RelPlanKind::Function { output_var, .. } = &children[1].kind else {
+            panic!("expected first function plan");
+        };
+        assert_eq!(output_var, &"?half-age".to_var());
+        assert_eq!(
+            children[1].output_vars,
+            vec!["?e".to_var(), "?age".to_var(), "?half-age".to_var()]
+        );
+        let RelPlanKind::Function { output_var, .. } = &children[2].kind else {
+            panic!("expected second function plan");
+        };
+        assert_eq!(output_var, &"?quarter-age".to_var());
+        assert_eq!(
+            children[2].output_vars,
+            vec![
+                "?e".to_var(),
+                "?age".to_var(),
+                "?half-age".to_var(),
+                "?quarter-age".to_var()
+            ]
+        );
+    }
+
+    #[test]
+    fn plans_function_applications_as_filters_for_bound_results() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query(
+                "[:find ?name
+                  :where
+                  [?e :age ?age]
+                  [?e :name ?name]
+                  [(str ?age) ?name]]",
+            ),
+            &schema,
+        )
+        .unwrap();
+
+        let RelPlanKind::Chain { children } = &plan.where_plan.kind else {
+            panic!("expected chain plan");
+        };
+        let function = &children[2];
+        assert_eq!(
+            function.incoming_vars,
+            Some(vec!["?e".to_var(), "?age".to_var(), "?name".to_var()])
+        );
+        assert_eq!(
+            function.output_vars,
+            vec!["?e".to_var(), "?age".to_var(), "?name".to_var()]
+        );
+        let RelPlanKind::Function { output_var, .. } = &function.kind else {
+            panic!("expected function plan");
+        };
+        assert_eq!(output_var, &"?name".to_var());
+    }
+
+    #[test]
+    fn rejects_function_without_a_positive_relation() {
+        assert_plan_err(
+            "[:find ?result :where [(+ 1 2) ?result]]",
+            "Cannot plan function without a positive relation",
+        );
+    }
+
+    #[test]
     fn accepts_entid_attribute() {
         let schema = test_schema();
         let plan = plan_query(&parse_query("[:find ?e :where [?e 10 ?name]]"), &schema).unwrap();
@@ -869,8 +952,8 @@ mod tests {
     #[test]
     fn rejects_unsupported_where_forms() {
         assert_plan_err(
-            r#"[:find ?e :where [?e :name "Alice"] [(+ 1 2) ?sum]]"#,
-            "only triple patterns, predicate clauses, implicit `not` clauses, `or` clauses, and `and` clauses",
+            "[:find ?e :where [?e :age ?age] [(type ?age :db.type/long)]]",
+            "only triple patterns, predicate clauses, function clauses, implicit `not` clauses, `or` clauses, and `and` clauses",
         );
         assert_plan_err(
             r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -97,9 +97,8 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
             Ok(())
         }
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
-        _ => bail!(
-            "Incremental queries currently support only triple patterns, predicate clauses, function clauses, implicit `not` clauses, `or` clauses, and `and` clauses in :where"
-        ),
+        // Shared validation rejects unsupported language-wide clauses.
+        WhereClause::TypeAnnotation(_) | WhereClause::RuleExpr => Ok(()),
     }
 }
 
@@ -950,14 +949,17 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_where_forms() {
-        assert_plan_err(
-            "[:find ?e :where [?e :age ?age] [(type ?age :db.type/long)]]",
-            "only triple patterns, predicate clauses, function clauses, implicit `not` clauses, `or` clauses, and `and` clauses",
-        );
-        assert_plan_err(
-            r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#,
-            "explicit or-join",
+    fn rejects_rule_expressions() {
+        let schema = test_schema();
+        let mut query = parse_query("[:find ?e :where [?e :age ?age]]");
+        query.where_clauses.push(WhereClause::RuleExpr);
+
+        let err = plan_query(&query, &schema).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Queries do not support rule expressions"),
+            "unexpected error: {}",
+            err
         );
     }
 

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -97,7 +97,7 @@ fn reject_unsupported_where_clause(clause: &WhereClause) -> Result<()> {
             Ok(())
         }
         WhereClause::OrJoin(or) => reject_unsupported_or_join(or),
-        // Shared validation rejects unsupported language-wide clauses.
+        // Rejected by `validate_query` before planning, not supported here.
         WhereClause::TypeAnnotation(_) | WhereClause::RuleExpr => Ok(()),
     }
 }

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -3,14 +3,14 @@ use std::collections::HashSet;
 use anyhow::{anyhow, Result};
 use edn::query::{
     NotJoin, OrJoin, OrWhereClause, Pattern, PatternNonValuePlace, PatternValuePlace, Predicate,
-    Variable, WhereClause,
+    Variable, WhereClause, WhereFn,
 };
 
 use crate::codec::Encode;
 use crate::expr::{expr_variables, Expr};
 use crate::incremental::EncodedValue;
 use crate::ops::DataType;
-use crate::query::{convert_predicate, non_integer_constant_to_datatype};
+use crate::query::{convert_predicate, convert_where_fn, non_integer_constant_to_datatype};
 use crate::schema::Schema;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -37,6 +37,7 @@ pub(super) struct Descriptor {
 pub(super) enum DescriptorKind {
     Pattern(PatternDescriptor),
     Predicate { expr: Expr },
+    Function { expr: Expr, output_var: Variable },
     Not { scope: ScopeDescriptor },
     Or { branches: Vec<ScopeDescriptor> },
 }
@@ -138,6 +139,29 @@ fn describe_predicate(predicate: &Predicate) -> Result<Descriptor> {
     })
 }
 
+fn describe_function(function: &WhereFn) -> Result<Descriptor> {
+    let function = convert_where_fn(function)?;
+    let mut variables = function.input_variables();
+    let output_is_input = variables.contains(&function.output);
+    if !output_is_input {
+        variables.push(function.output.clone());
+    }
+    let groundable = if output_is_input {
+        Vec::new()
+    } else {
+        vec![function.output.clone()]
+    };
+
+    Ok(Descriptor {
+        variables,
+        groundable,
+        kind: DescriptorKind::Function {
+            expr: function.expr,
+            output_var: function.output,
+        },
+    })
+}
+
 fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descriptor> {
     match clause {
         WhereClause::Pattern(pattern) => {
@@ -150,6 +174,7 @@ fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descri
             })
         }
         WhereClause::Pred(predicate) => describe_predicate(predicate),
+        WhereClause::WhereFn(function) => describe_function(function),
         WhereClause::NotJoin(not) => describe_not(not, schema),
         WhereClause::OrJoin(or) => describe_or(or, schema),
         _ => unreachable!("unsupported clauses are rejected before planning"),
@@ -305,5 +330,32 @@ mod tests {
             panic!("expected predicate descriptor");
         };
         assert_eq!(crate::expr::expr_variables(expr), vec!["?age".to_var()]);
+    }
+
+    #[test]
+    fn function_metadata_grounds_only_new_result_variables() {
+        let query = parse_query(
+            "[:find ?next
+              :where
+              [(+ ?age 1) ?next]
+              [(+ ?next 1) ?next]]",
+        );
+        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+
+        let new_result = &scope.descriptors[0];
+        assert_eq!(
+            new_result.variables,
+            vec!["?age".to_var(), "?next".to_var()]
+        );
+        assert_eq!(new_result.groundable, vec!["?next".to_var()]);
+        let DescriptorKind::Function { expr, output_var } = &new_result.kind else {
+            panic!("expected function descriptor");
+        };
+        assert_eq!(crate::expr::expr_variables(expr), vec!["?age".to_var()]);
+        assert_eq!(output_var, &"?next".to_var());
+
+        let self_referential = &scope.descriptors[1];
+        assert_eq!(self_referential.variables, vec!["?next".to_var()]);
+        assert!(self_referential.groundable.is_empty());
     }
 }

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -177,7 +177,9 @@ fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descri
         WhereClause::WhereFn(function) => describe_function(function),
         WhereClause::NotJoin(not) => describe_not(not, schema),
         WhereClause::OrJoin(or) => describe_or(or, schema),
-        _ => unreachable!("unsupported clauses are rejected before planning"),
+        WhereClause::TypeAnnotation(_) | WhereClause::RuleExpr => {
+            unreachable!("unsupported clauses are rejected before planning")
+        }
     }
 }
 

--- a/src/inc_query/planner.rs
+++ b/src/inc_query/planner.rs
@@ -21,6 +21,10 @@ pub(crate) enum RelPlanKind {
     Filter {
         expr: Expr,
     },
+    Function {
+        expr: Expr,
+        output_var: Variable,
+    },
     Chain {
         children: Vec<RelPlan>,
     },
@@ -158,6 +162,24 @@ fn plan_filter(expr: &Expr, incoming_vars: Option<Vec<Variable>>) -> Result<RelP
     })
 }
 
+fn plan_function(
+    expr: &Expr,
+    output_var: &Variable,
+    incoming_vars: Option<Vec<Variable>>,
+) -> Result<RelPlan> {
+    let incoming_vars =
+        incoming_vars.ok_or_else(|| anyhow!("Cannot plan function without a positive relation"))?;
+    let output_vars = append_new_variables(&incoming_vars, std::slice::from_ref(output_var));
+    Ok(RelPlan {
+        incoming_vars: Some(incoming_vars),
+        output_vars,
+        kind: RelPlanKind::Function {
+            expr: expr.clone(),
+            output_var: output_var.clone(),
+        },
+    })
+}
+
 fn plan_union(
     descriptor: &Descriptor,
     branches: &[ScopeDescriptor],
@@ -212,6 +234,9 @@ fn plan_descriptor(
     match &descriptor.kind {
         DescriptorKind::Pattern(pattern) => Ok(plan_pattern(descriptor, pattern, incoming_vars)),
         DescriptorKind::Predicate { expr } => plan_filter(expr, incoming_vars),
+        DescriptorKind::Function { expr, output_var } => {
+            plan_function(expr, output_var, incoming_vars)
+        }
         DescriptorKind::Not { scope } => plan_difference(descriptor, scope, incoming_vars),
         DescriptorKind::Or { branches } => plan_union(descriptor, branches, incoming_vars),
     }
@@ -255,6 +280,7 @@ pub(super) fn collect_leaf_patterns<'a>(plan: &'a RelPlan, patterns: &mut Vec<&'
     match &plan.kind {
         RelPlanKind::Pattern(pattern) => patterns.push(pattern),
         RelPlanKind::Filter { .. } => {}
+        RelPlanKind::Function { .. } => {}
         RelPlanKind::Chain { children } => {
             for child in children {
                 collect_leaf_patterns(child, patterns);

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -11,8 +11,8 @@ use dbsp::{
 };
 use edn::query::Variable;
 
-use crate::codec::Decode;
-use crate::expr::{evaluate_as_bool, expr_variables, EvalContext, Expr};
+use crate::codec::{Decode, Encode};
+use crate::expr::{evaluate, evaluate_as_bool, expr_variables, EvalContext, Expr};
 use crate::inc_query::{IncrementalQueryPlan, PatternPlan, PatternSlot, RelPlan, RelPlanKind};
 use crate::incremental::{EncodedRow, EncodedTriple};
 use crate::ops::DataType;
@@ -183,33 +183,74 @@ fn assert_incoming_layout(plan: &RelPlan, incoming: &Option<PlannedWhereStream>)
     );
 }
 
-fn filter_predicate_stream(
-    stream: Stream<RootCircuit, RowZSet>,
-    vars: &[Variable],
-    expr: Expr,
-) -> Stream<RootCircuit, RowZSet> {
-    let variable_positions = expr_variables(&expr)
+fn expression_variable_positions(vars: &[Variable], expr: &Expr) -> Vec<(Variable, usize)> {
+    expr_variables(expr)
         .into_iter()
         .map(|variable| {
             let position = vars
                 .iter()
                 .position(|candidate| candidate == &variable)
-                .expect("predicate variable must be present in the incoming row");
+                .expect("expression variable must be present in the incoming row");
             (variable, position)
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn expression_bindings(
+    row: &EncodedRow,
+    variable_positions: &[(Variable, usize)],
+) -> HashMap<Variable, DataType> {
+    variable_positions
+        .iter()
+        .map(|(variable, position)| {
+            let value = DataType::decode(&row[*position])
+                .expect("incremental expression value should decode");
+            (variable.clone(), value)
+        })
+        .collect()
+}
+
+fn evaluate_row_expression(
+    row: &EncodedRow,
+    variable_positions: &[(Variable, usize)],
+    expr: &Expr,
+) -> Option<DataType> {
+    let bindings = expression_bindings(row, variable_positions);
+    evaluate(expr, &EvalContext::new(&bindings)).map(|result| result.into_owned())
+}
+
+fn filter_predicate_stream(
+    stream: Stream<RootCircuit, RowZSet>,
+    vars: &[Variable],
+    expr: Expr,
+) -> Stream<RootCircuit, RowZSet> {
+    let variable_positions = expression_variable_positions(vars, &expr);
 
     stream.filter(move |row| {
-        let values = variable_positions
-            .iter()
-            .map(|(variable, position)| {
-                let value = DataType::decode(&row[*position])
-                    .expect("incremental predicate value should decode");
-                (variable.clone(), value)
-            })
-            .collect::<HashMap<_, _>>();
-        evaluate_as_bool(&expr, &EvalContext::new(&values))
+        let bindings = expression_bindings(row, &variable_positions);
+        evaluate_as_bool(&expr, &EvalContext::new(&bindings))
     })
+}
+
+fn apply_function_stream(
+    stream: Stream<RootCircuit, RowZSet>,
+    vars: &[Variable],
+    expr: Expr,
+    output_var: &Variable,
+) -> Stream<RootCircuit, RowZSet> {
+    let variable_positions = expression_variable_positions(vars, &expr);
+    match vars.iter().position(|variable| variable == output_var) {
+        Some(output_position) => stream.filter(move |row| {
+            evaluate_row_expression(row, &variable_positions, &expr)
+                .is_some_and(|result| result.encode().as_slice() == row[output_position].as_slice())
+        }),
+        None => stream.flat_map(move |row| {
+            let result = evaluate_row_expression(row, &variable_positions, &expr)?;
+            let mut output = row.clone();
+            output.push(result.encode());
+            Some(output)
+        }),
+    }
 }
 
 fn difference_stream(
@@ -259,6 +300,10 @@ fn rel_stream(
         RelPlanKind::Filter { expr } => {
             let incoming = incoming.expect("filter plan requires an incoming relation");
             filter_predicate_stream(incoming.stream, &incoming.vars, expr.clone())
+        }
+        RelPlanKind::Function { expr, output_var } => {
+            let incoming = incoming.expect("function plan requires an incoming relation");
+            apply_function_stream(incoming.stream, &incoming.vars, expr.clone(), output_var)
         }
         RelPlanKind::Chain { children } => {
             let relation = children
@@ -721,6 +766,139 @@ mod tests {
         assert_eq!(
             decode_output_rows(&output.consolidate()).unwrap(),
             vec![(vec![DataType::Long(30)], -1)]
+        );
+    }
+
+    #[test]
+    fn function_stream_appends_results_and_preserves_retractions() {
+        let plan = query_plan("[:find ?half :where [?e :age ?age] [(quot ?age 2) ?half]]");
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(
+            &handle,
+            [
+                (triple(1, AGE, DataType::Long(30)), 1),
+                (triple(2, AGE, DataType::Long(40)), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+        let mut rows = decode_output_rows(&output.consolidate()).unwrap();
+        rows.sort_by_key(|(row, _weight)| format!("{:?}", row));
+        assert_eq!(
+            rows,
+            vec![(vec![DataType::Long(15)], 1), (vec![DataType::Long(20)], 1)]
+        );
+
+        append(&handle, [(triple(1, AGE, DataType::Long(30)), -1)]);
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::Long(15)], -1)]
+        );
+    }
+
+    #[test]
+    fn function_stream_filters_already_bound_results() {
+        let plan = query_plan(
+            "[:find ?name
+              :where
+              [?e :age ?age]
+              [?e :name ?name]
+              [(str ?age) ?name]]",
+        );
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(
+            &handle,
+            [
+                (triple(1, AGE, DataType::Long(30)), 1),
+                (triple(1, NAME, DataType::String("30".to_string())), 1),
+                (triple(2, AGE, DataType::Long(40)), 1),
+                (triple(2, NAME, DataType::String("forty".to_string())), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::String("30".to_string())], 1)]
+        );
+
+        append(
+            &handle,
+            [(triple(2, NAME, DataType::String("40".to_string())), 1)],
+        );
+        circuit.transaction().unwrap();
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::String("40".to_string())], 1)]
+        );
+    }
+
+    #[test]
+    fn function_stream_drops_rows_when_evaluation_fails() {
+        let plan = query_plan("[:find ?result :where [?e :age ?age] [(quot ?age 0) ?result]]");
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(&handle, [(triple(1, AGE, DataType::Long(30)), 1)]);
+        circuit.transaction().unwrap();
+
+        assert!(decode_output_rows(&output.consolidate())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn function_stream_composes_with_union() {
+        let plan = query_plan(
+            "[:find ?result
+              :where
+              [?e :age ?age]
+              (or [(+ ?age 1) ?result]
+                  [(- ?age 1) ?result])]",
+        );
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(&handle, [(triple(1, AGE, DataType::Long(30)), 1)]);
+        circuit.transaction().unwrap();
+
+        let mut rows = decode_output_rows(&output.consolidate()).unwrap();
+        rows.sort_by_key(|(row, _weight)| format!("{:?}", row));
+        assert_eq!(
+            rows,
+            vec![(vec![DataType::Long(29)], 1), (vec![DataType::Long(31)], 1)]
+        );
+    }
+
+    #[test]
+    fn function_stream_composes_with_difference() {
+        let plan = query_plan(
+            "[:find ?name
+              :where
+              [?e :age ?age]
+              [?e :name ?name]
+              (not [(str ?age) ?name])]",
+        );
+        let (mut circuit, (handle, output), _storage) =
+            build_test_circuit(move |circuit| build_find_circuit(circuit, plan.clone()));
+
+        append(
+            &handle,
+            [
+                (triple(1, AGE, DataType::Long(30)), 1),
+                (triple(1, NAME, DataType::String("30".to_string())), 1),
+                (triple(2, AGE, DataType::Long(40)), 1),
+                (triple(2, NAME, DataType::String("forty".to_string())), 1),
+            ],
+        );
+        circuit.transaction().unwrap();
+
+        assert_eq!(
+            decode_output_rows(&output.consolidate()).unwrap(),
+            vec![(vec![DataType::String("forty".to_string())], 1)]
         );
     }
 

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -196,60 +197,77 @@ fn expression_variable_positions(vars: &[Variable], expr: &Expr) -> Vec<(Variabl
         .collect()
 }
 
-fn expression_bindings(
+fn update_expression_bindings(
     row: &EncodedRow,
     variable_positions: &[(Variable, usize)],
-) -> HashMap<Variable, DataType> {
-    variable_positions
-        .iter()
-        .map(|(variable, position)| {
-            let value = DataType::decode(&row[*position])
-                .expect("incremental expression value should decode");
-            (variable.clone(), value)
-        })
-        .collect()
+    bindings: &mut HashMap<Variable, DataType>,
+) {
+    for (variable, position) in variable_positions {
+        let value =
+            DataType::decode(&row[*position]).expect("incremental expression value should decode");
+        if let Some(binding) = bindings.get_mut(variable) {
+            *binding = value;
+        } else {
+            bindings.insert(variable.clone(), value);
+        }
+    }
 }
 
 fn evaluate_row_expression(
     row: &EncodedRow,
     variable_positions: &[(Variable, usize)],
+    bindings: &mut HashMap<Variable, DataType>,
     expr: &Expr,
 ) -> Option<DataType> {
-    let bindings = expression_bindings(row, variable_positions);
-    evaluate(expr, &EvalContext::new(&bindings)).map(|result| result.into_owned())
+    update_expression_bindings(row, variable_positions, bindings);
+    evaluate(expr, &EvalContext::new(bindings)).map(|result| result.into_owned())
 }
 
 fn filter_predicate_stream(
     stream: Stream<RootCircuit, RowZSet>,
-    vars: &[Variable],
+    incoming_vars: &[Variable],
     expr: Expr,
 ) -> Stream<RootCircuit, RowZSet> {
-    let variable_positions = expression_variable_positions(vars, &expr);
+    let variable_positions = expression_variable_positions(incoming_vars, &expr);
+    let bindings = RefCell::new(HashMap::with_capacity(variable_positions.len()));
 
     stream.filter(move |row| {
-        let bindings = expression_bindings(row, &variable_positions);
+        let mut bindings = bindings.borrow_mut();
+        update_expression_bindings(row, &variable_positions, &mut bindings);
         evaluate_as_bool(&expr, &EvalContext::new(&bindings))
     })
 }
 
 fn apply_function_stream(
     stream: Stream<RootCircuit, RowZSet>,
-    vars: &[Variable],
+    incoming_vars: &[Variable],
     expr: Expr,
     output_var: &Variable,
 ) -> Stream<RootCircuit, RowZSet> {
-    let variable_positions = expression_variable_positions(vars, &expr);
-    match vars.iter().position(|variable| variable == output_var) {
-        Some(output_position) => stream.filter(move |row| {
-            evaluate_row_expression(row, &variable_positions, &expr)
-                .is_some_and(|result| result.encode().as_slice() == row[output_position].as_slice())
-        }),
-        None => stream.flat_map(move |row| {
-            let result = evaluate_row_expression(row, &variable_positions, &expr)?;
-            let mut output = row.clone();
-            output.push(result.encode());
-            Some(output)
-        }),
+    let variable_positions = expression_variable_positions(incoming_vars, &expr);
+    match incoming_vars
+        .iter()
+        .position(|variable| variable == output_var)
+    {
+        Some(output_position) => {
+            let bindings = RefCell::new(HashMap::with_capacity(variable_positions.len()));
+            stream.filter(move |row| {
+                let mut bindings = bindings.borrow_mut();
+                evaluate_row_expression(row, &variable_positions, &mut bindings, &expr).is_some_and(
+                    |result| result.encode().as_slice() == row[output_position].as_slice(),
+                )
+            })
+        }
+        None => {
+            let mut bindings = HashMap::with_capacity(variable_positions.len());
+            stream.flat_map(move |row| {
+                let result =
+                    evaluate_row_expression(row, &variable_positions, &mut bindings, &expr)?;
+                let mut output = row.clone();
+                output.push(result.encode());
+                Some(output)
+            })
+        }
     }
 }
 

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -70,6 +70,18 @@ where
     }
 }
 
+fn validate_supported_where_clauses(where_clauses: &[WhereClause]) -> Result<(), Error> {
+    validate_where_clauses_recursively(where_clauses, &mut |clause| match clause {
+        WhereClause::TypeAnnotation(_) => bail!("Queries do not support type annotations"),
+        WhereClause::RuleExpr => bail!("Queries do not support rule expressions"),
+        WhereClause::Pattern(_)
+        | WhereClause::Pred(_)
+        | WhereClause::WhereFn(_)
+        | WhereClause::NotJoin(_)
+        | WhereClause::OrJoin(_) => Ok(()),
+    })
+}
+
 /// Validate that all variables in NOT clauses are bound by positive clauses.
 fn validate_not_clauses(
     where_clauses: &[WhereClause],
@@ -324,6 +336,7 @@ fn validate_in_bindings(in_bindings: &[Binding], args: &[QueryArg]) -> Result<()
 // queries are rejected at parse time rather than at execution time.
 pub(crate) fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Error> {
     validate_in_bindings(&query.in_bindings, args)?;
+    validate_supported_where_clauses(&query.where_clauses)?;
 
     let join_order = query_variable_order(&query.in_bindings, &query.where_clauses);
     if join_order.is_empty() {

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -210,47 +210,46 @@
         (is (= [[["Cara"] -1]]
                (take-delta! sub)))))))
 
-(deftest functions-append-computed-values
+(deftest datalog-functions
   (with-open [conn (connect)]
     (api/transact conn people-schema)
-    (with-open [sub (api/subscribe conn '{:find [?name ?half]
-                                          :where [[?e :name ?name]
-                                                  [?e :age ?age]
-                                                  [(quot ?age 2) ?half]
-                                                  [(< ?half 20)]]})]
-      (api/transact conn [{:name "Ivan" :age 30}
-                          {:name "Bob" :age 40}])
-      (is (= [[["Ivan" 15] 1]] (take-delta! sub)))
+    (testing "Function produces the variable"
+      (with-open [sub (api/subscribe conn '{:find [?name ?half]
+                                            :where [[?e :name ?name]
+                                                    [?e :age ?age]
+                                                    [(quot ?age 2) ?half]
+                                                    [(< ?half 20)]]})]
+        (api/transact conn [{:name "Ivan" :age 30}
+                            {:name "Bob" :age 40}])
+        (is (= [[["Ivan" 15] 1]] (take-delta! sub)))
 
-      (let [ivan-id (single-value conn '{:find [?e]
-                                         :where [[?e :name "Ivan"]]})]
-        (api/transact conn [[:db/add ivan-id :age 31]])
-        (is (= ::api/timeout (take-delta! sub 300)))
+        (let [ivan-id (single-value conn '{:find [?e]
+                                           :where [[?e :name "Ivan"]]})]
+          (api/transact conn [[:db/add ivan-id :age 31]])
+          (is (= ::api/timeout (take-delta! sub 300)))
 
-        (api/transact conn [[:db/add ivan-id :age 32]])
-        (is (= #{[["Ivan" 15] -1]
-                 [["Ivan" 16] 1]}
-               (set (take-delta! sub))))))))
+          (api/transact conn [[:db/add ivan-id :age 32]])
+          (is (= #{[["Ivan" 15] -1]
+                   [["Ivan" 16] 1]}
+                 (set (take-delta! sub)))))))
 
-(deftest functions-filter-already-bound-results
-  (with-open [conn (connect)]
-    (api/transact conn people-schema)
-    (with-open [sub (api/subscribe conn '{:find [?name]
-                                          :where [[?e :age ?age]
-                                                  [?e :name ?name]
-                                                  [?e :salary ?salary]
-                                                  [(quot ?age 2) ?salary]]})]
-      (api/transact conn [{:name "Eq" :age 30 :salary 15}
-                          {:name "Neq" :age 30 :salary 20}])
-      (is (= [[["Eq"] 1]] (take-delta! sub)))
+    (testing "function filters the variable"
+      (with-open [sub (api/subscribe conn '{:find [?name]
+                                            :where [[?e :age ?age]
+                                                    [?e :name ?name]
+                                                    [?e :salary ?salary]
+                                                    [(quot ?age 2) ?salary]]})]
+        (api/transact conn [{:name "Eq" :age 30 :salary 15}
+                            {:name "Neq" :age 30 :salary 20}])
+        (is (= [[["Eq"] 1]] (take-delta! sub)))
 
-      (let [eq-id (single-value conn '{:find [?e] :where [[?e :name "Eq"]]})
-            neq-id (single-value conn '{:find [?e] :where [[?e :name "Neq"]]})]
-        (api/transact conn [[:db/add neq-id :salary 15]])
-        (is (= [[["Neq"] 1]] (take-delta! sub)))
+        (let [eq-id (single-value conn '{:find [?e] :where [[?e :name "Eq"]]})
+              neq-id (single-value conn '{:find [?e] :where [[?e :name "Neq"]]})]
+          (api/transact conn [[:db/add neq-id :salary 15]])
+          (is (= [[["Neq"] 1]] (take-delta! sub)))
 
-        (api/transact conn [[:db/add eq-id :salary 20]])
-        (is (= [[["Eq"] -1]] (take-delta! sub)))))))
+          (api/transact conn [[:db/add eq-id :salary 20]])
+          (is (= [[["Eq"] -1]] (take-delta! sub))))))))
 
 (deftest test-not-negative-scope-layouts
   (testing "Multi-clause negative scope"

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -15,6 +15,7 @@
    {:db/ident :last-name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
    {:db/ident :city :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
    {:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :salary :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
    {:db/ident :friend :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
    {:db/ident :alias :db/valueType :db.type/string :db/cardinality :db.cardinality/many}])
 
@@ -208,6 +209,48 @@
         (api/transact conn [[:db/retract cara-id :age 35]])
         (is (= [[["Cara"] -1]]
                (take-delta! sub)))))))
+
+(deftest functions-append-computed-values
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (with-open [sub (api/subscribe conn '{:find [?name ?half]
+                                          :where [[?e :name ?name]
+                                                  [?e :age ?age]
+                                                  [(quot ?age 2) ?half]
+                                                  [(< ?half 20)]]})]
+      (api/transact conn [{:name "Ivan" :age 30}
+                          {:name "Bob" :age 40}])
+      (is (= [[["Ivan" 15] 1]] (take-delta! sub)))
+
+      (let [ivan-id (single-value conn '{:find [?e]
+                                         :where [[?e :name "Ivan"]]})]
+        (api/transact conn [[:db/add ivan-id :age 31]])
+        (is (= ::api/timeout (take-delta! sub 300)))
+
+        (api/transact conn [[:db/add ivan-id :age 32]])
+        (is (= #{[["Ivan" 15] -1]
+                 [["Ivan" 16] 1]}
+               (set (take-delta! sub))))))))
+
+(deftest functions-filter-already-bound-results
+  (with-open [conn (connect)]
+    (api/transact conn people-schema)
+    (with-open [sub (api/subscribe conn '{:find [?name]
+                                          :where [[?e :age ?age]
+                                                  [?e :name ?name]
+                                                  [?e :salary ?salary]
+                                                  [(quot ?age 2) ?salary]]})]
+      (api/transact conn [{:name "Eq" :age 30 :salary 15}
+                          {:name "Neq" :age 30 :salary 20}])
+      (is (= [[["Eq"] 1]] (take-delta! sub)))
+
+      (let [eq-id (single-value conn '{:find [?e] :where [[?e :name "Eq"]]})
+            neq-id (single-value conn '{:find [?e] :where [[?e :name "Neq"]]})]
+        (api/transact conn [[:db/add neq-id :salary 15]])
+        (is (= [[["Neq"] 1]] (take-delta! sub)))
+
+        (api/transact conn [[:db/add eq-id :salary 20]])
+        (is (= [[["Eq"] -1]] (take-delta! sub)))))))
 
 (deftest test-not-negative-scope-layouts
   (testing "Multi-clause negative scope"


### PR DESCRIPTION
Similar to https://github.com/FiV0/triplox/pull/431 and based on a similar PR in hooray https://github.com/FiV0/hooray2/pull/38. We are adding functions to incremental queries. All variables that the functions needs, need to be bound before the function gets applied. If the output variable is already bound the `fn` gets applied as `filter` operation, otherwise the running relation gets extended by the output variable.