### PR TITLE
Fix 313: Resolve ident constants in ref-atttribute value position

### DIFF
--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -153,6 +153,7 @@ pub(crate) mod test_support {
     pub(crate) const AGE_ATTR_ID: Entid = 11;
     pub(crate) const FOLLOWS_ATTR_ID: Entid = 12;
     pub(crate) const TYPE_ATTR_ID: Entid = 13;
+    pub(crate) const STATUS_OPEN_ID: Entid = 20;
 
     pub(crate) fn parse_query(input: &str) -> ParsedQuery {
         edn::parse::parse_query(input).expect("query should parse")
@@ -180,6 +181,8 @@ pub(crate) mod test_support {
                 },
             );
         }
+        ident_map.insert(kw!(:status/open), STATUS_OPEN_ID);
+        entid_map.insert(STATUS_OPEN_ID, kw!(:status/open));
         Schema {
             entid_map,
             ident_map,
@@ -191,7 +194,7 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use edn::query::ToVariable;
-    use edn::Keyword;
+    use edn::{kw, Keyword};
 
     use super::test_support::{parse_query, test_schema};
     use super::*;
@@ -342,6 +345,44 @@ mod tests {
             &PatternSlot::Variable("?other".to_var())
         );
         assert_eq!(&leaf_patterns[1].value, &encoded_long(30));
+    }
+
+    #[test]
+    fn plans_ref_ident_constants_as_eids() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query("[:find ?e :where [?e :follows :status/open]]"),
+            &schema,
+        )
+        .unwrap();
+
+        assert_eq!(
+            &plan.leaf_patterns()[0].value,
+            &encoded_long(test_support::STATUS_OPEN_ID)
+        );
+    }
+
+    #[test]
+    fn keeps_ident_constants_as_keywords_for_keyword_attributes() {
+        let schema = test_schema();
+        let plan = plan_query(
+            &parse_query("[:find ?e :where [?e :type :status/open]]"),
+            &schema,
+        )
+        .unwrap();
+
+        assert_eq!(
+            &plan.leaf_patterns()[0].value,
+            &PatternSlot::Constant(DataType::Keyword(kw!(:status/open)).encode())
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_ref_ident_constants() {
+        assert_plan_err(
+            "[:find ?e :where [?e :follows :status/missing]]",
+            "Unknown ident in ref value position: :status/missing",
+        );
     }
 
     #[test]

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -10,8 +10,10 @@ use crate::codec::Encode;
 use crate::expr::{expr_variables, Expr};
 use crate::incremental::EncodedValue;
 use crate::ops::DataType;
-use crate::query::{convert_predicate, convert_where_fn, non_integer_constant_to_datatype};
-use crate::schema::Schema;
+use crate::query::{
+    convert_predicate, convert_where_fn, non_integer_constant_to_datatype, resolve_ident_or_keyword,
+};
+use crate::schema::{Schema, ValueType};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PatternSlot {
@@ -65,15 +67,14 @@ fn non_value_slot(place: &PatternNonValuePlace) -> PatternSlot {
     }
 }
 
-fn value_slot(place: &PatternValuePlace) -> Result<PatternSlot> {
+fn value_slot(place: &PatternValuePlace, is_ref: bool, schema: &Schema) -> Result<PatternSlot> {
     match place {
         PatternValuePlace::Variable(var) => Ok(PatternSlot::Variable(var.clone())),
         PatternValuePlace::EntidOrInteger(value) => {
             Ok(PatternSlot::Constant(DataType::Long(*value).encode()))
         }
-        // TODO This needs proper ident resolution for refs
         PatternValuePlace::IdentOrKeyword(ident) => Ok(PatternSlot::Constant(
-            DataType::Keyword(ident.as_ref().clone()).encode(),
+            resolve_ident_or_keyword(ident.as_ref(), is_ref, schema)?.encode(),
         )),
         PatternValuePlace::Constant(constant) => Ok(PatternSlot::Constant(
             non_integer_constant_to_datatype(constant)
@@ -100,10 +101,15 @@ fn pattern_descriptor(pattern: &Pattern, schema: &Schema) -> Result<PatternDescr
         }
     };
 
+    let is_ref = schema
+        .attribute_map
+        .get(&attribute)
+        .is_some_and(|attribute| attribute.value_type == ValueType::Ref);
+
     Ok(PatternDescriptor {
         attribute,
         entity: non_value_slot(&pattern.entity),
-        value: value_slot(&pattern.value)?,
+        value: value_slot(&pattern.value, is_ref, schema)?,
     })
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1790,10 +1790,10 @@ mod tests {
         let query: ParsedQuery = r#"[:find ?e ?name :where [?e :name ?name]]"#.parse()?;
         let sdb = slate.clone();
         let handle = tokio::runtime::Handle::current();
-        let ident_map = indexer.metadata().schema.ident_map.clone();
+        let schema = indexer.metadata().schema.clone();
         let range_stats = components.range_stats.clone();
         let rows = tokio::task::spawn_blocking(move || {
-            execute_query(&query, &[], sdb, handle, &ident_map, i64::MAX, range_stats)
+            execute_query(&query, &[], sdb, handle, &schema, i64::MAX, range_stats)
         })
         .await??;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ use crate::ops::{Entid, QueryArg, TxOp};
 use crate::partition::tx_eid_from_tx_id;
 use crate::query::{execute_query, QueryResult};
 use crate::query_validation::validate_query;
-use crate::schema::{IdentMap, Schema};
+use crate::schema::Schema;
 use crate::slate::{in_memory_slate, local_slate, remote_slate, SlateComponents};
 use edn::query::ParsedQuery;
 use tokio_util::sync::CancellationToken;
@@ -42,7 +42,7 @@ where
     M: slatedb::DbMetadataOps + Send + Sync + 'static,
 {
     sdb: Arc<D>,
-    ident_map: IdentMap,
+    schema: Schema,
     handle: Handle,
     tx_key: TxKey,
     range_stats: Arc<slatedb_estimates::RangeStats<M>>,
@@ -54,16 +54,16 @@ where
     D: slatedb::DbReadOps + Send + Sync + 'static,
     M: slatedb::DbMetadataOps + Send + Sync + 'static,
 {
-    pub fn new(
+    pub(crate) fn new(
         sdb: Arc<D>,
-        ident_map: IdentMap,
+        schema: Schema,
         handle: Handle,
         tx_key: TxKey,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Self {
         Self {
             sdb,
-            ident_map,
+            schema,
             handle,
             tx_key,
             range_stats,
@@ -71,16 +71,16 @@ where
     }
 
     /// Construct a DB from a Db by scanning EAV for TX_PARTITION entities to find the latest TxKey.
-    pub async fn from_latest_sdb(
+    pub(crate) async fn from_latest_sdb(
         sdb: Arc<D>,
-        ident_map: IdentMap,
+        schema: Schema,
         handle: Handle,
         range_stats: Arc<slatedb_estimates::RangeStats<M>>,
     ) -> Result<Self, Error> {
         let tx_key = latest_tx_key_from_sdb(sdb.as_ref()).await?;
         Ok(Self {
             sdb,
-            ident_map,
+            schema,
             handle,
             tx_key,
             range_stats,
@@ -117,14 +117,14 @@ where
 
         let sdb = self.sdb.clone();
         let handle = self.handle.clone();
-        let ident_map = self.ident_map.clone();
+        let schema = self.schema.clone();
         let query = query.clone();
         let args = args.to_vec();
         let as_of = tx_eid_from_tx_id(self.tx_key.tx_id);
         let range_stats = self.range_stats.clone();
 
         tokio::task::spawn_blocking(move || {
-            execute_query(&query, &args, sdb, handle, &ident_map, as_of, range_stats)
+            execute_query(&query, &args, sdb, handle, &schema, as_of, range_stats)
         })
         .await
         .map_err(|e| anyhow::anyhow!("Query task failed: {}", e))?
@@ -342,19 +342,12 @@ impl<L: TxLog> Node<L> {
                 timeout,
             })??;
 
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let schema = self.indexer.read().await.metadata().schema.clone();
         let handle = Handle::current();
         let range_stats = self.slate.range_stats.clone();
         Ok(DB::new(
             self.slate.db.clone(),
-            ident_map,
+            schema,
             handle,
             tx_key,
             range_stats,
@@ -418,17 +411,10 @@ impl<L: TxLog> QueryNode for Node<L> {
     type DB = DB;
 
     async fn db(&self) -> Result<DB, Error> {
-        let ident_map = self
-            .indexer
-            .read()
-            .await
-            .metadata()
-            .schema
-            .ident_map
-            .clone();
+        let schema = self.indexer.read().await.metadata().schema.clone();
         let handle = Handle::current();
         let range_stats = self.slate.range_stats.clone();
-        DB::from_latest_sdb(self.slate.db.clone(), ident_map, handle, range_stats).await
+        DB::from_latest_sdb(self.slate.db.clone(), schema, handle, range_stats).await
     }
 
     async fn db_as_of(&self, tx_key: TxKey) -> Result<DB, Error> {
@@ -1925,6 +1911,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_ref_ident_constant() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        node.execute_tx(vec![TxOp::put([
+            (kw!(:db/ident), DataType::Keyword(kw!(:person/bob))),
+            (kw!(:name), DataType::String("Bob".to_string())),
+        ])])
+        .await
+        .unwrap();
+        node.execute_tx(vec![TxOp::put([
+            (kw!(:name), DataType::String("Alice".to_string())),
+            (kw!(:follows), DataType::Keyword(kw!(:person/bob))),
+        ])])
+        .await
+        .unwrap();
+
+        let db = node.db().await.unwrap();
+        let result = db
+            .query("[:find ?name :where [?e :name ?name] [?e :follows :person/bob]]")
+            .await
+            .unwrap();
+        assert_eq!(result, vec![vec![DataType::String("Alice".to_string())]]);
+
+        let err = db
+            .query("[:find ?e :where [?e :follows :person/missing]]")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unknown ident in ref value position: :person/missing"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query_literal_entity_id_in_triple() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
@@ -2603,6 +2626,41 @@ mod tests {
                 vec![DataType::String("Alice".to_string()), DataType::Long(40)],
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_incremental_query_ref_ident_constant() {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+
+        execute_and_flush(
+            &node,
+            vec![TxOp::put([
+                (kw!(:db/ident), DataType::Keyword(kw!(:person/bob))),
+                (kw!(:name), DataType::String("Bob".to_string())),
+            ])],
+        )
+        .await;
+
+        let query = "[:find ?name :where [?e :name ?name] [?e :follows :person/bob]]";
+        let mut subscription = node
+            .register_incremental_query(parse_query(query), &[])
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+
+        let basis = execute_and_flush(
+            &node,
+            vec![TxOp::put([
+                (kw!(:name), DataType::String("Alice".to_string())),
+                (kw!(:follows), DataType::Keyword(kw!(:person/bob))),
+            ])],
+        )
+        .await;
+        integrate_delta(&mut rows, recv_incremental_delta(&mut subscription).await);
+
+        assert_eq!(rows, vec![vec![DataType::String("Alice".to_string())]]);
+        assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
     }
 
     #[tokio::test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,10 +10,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Error;
+use edn::symbols::Keyword;
 use slatedb::{DbMetadataOps, DbReadOps};
 use tokio::runtime::Handle;
 
-use crate::schema::IdentMap;
+use crate::schema::{IdentMap, Schema, ValueType};
 
 use edn::query::{
     Binding, ContainsVariables, Direction, Element, FindSpec, Limit, NonIntegerConstant, NotJoin,
@@ -141,13 +142,36 @@ fn non_value_place_to_datatype(place: &PatternNonValuePlace) -> Option<DataType>
     }
 }
 
+pub(crate) fn resolve_ident_or_keyword(
+    ident: &Keyword,
+    is_ref: bool,
+    schema: &Schema,
+) -> Result<DataType, Error> {
+    if !is_ref {
+        return Ok(DataType::Keyword(ident.clone()));
+    }
+
+    schema
+        .ident_map
+        .get(ident)
+        .copied()
+        .map(DataType::Long)
+        .ok_or_else(|| anyhow::anyhow!("Unknown ident in ref value position: {}", ident))
+}
+
 /// Convert a PatternValuePlace to a DataType (for constant positions).
-fn value_place_to_datatype(place: &PatternValuePlace) -> Option<DataType> {
+fn value_place_to_datatype(
+    place: &PatternValuePlace,
+    is_ref: bool,
+    schema: &Schema,
+) -> Result<Option<DataType>, Error> {
     match place {
-        PatternValuePlace::EntidOrInteger(i) => Some(DataType::Long(*i)),
-        PatternValuePlace::IdentOrKeyword(ref kw) => Some(DataType::Keyword((**kw).clone())),
-        PatternValuePlace::Constant(ref c) => non_integer_constant_to_datatype(c),
-        _ => None,
+        PatternValuePlace::EntidOrInteger(i) => Ok(Some(DataType::Long(*i))),
+        PatternValuePlace::IdentOrKeyword(ref kw) => {
+            resolve_ident_or_keyword(kw.as_ref(), is_ref, schema).map(Some)
+        }
+        PatternValuePlace::Constant(ref c) => Ok(non_integer_constant_to_datatype(c)),
+        _ => Ok(None),
     }
 }
 
@@ -621,12 +645,21 @@ fn determine_index_types(
 }
 
 /// Compute the constant prefix bytes for a pattern based on index type.
-fn compute_constant_prefix(pattern: &Pattern, index_type: IndexType) -> Result<Vec<u8>, Error> {
+fn compute_constant_prefix(
+    pattern: &Pattern,
+    index_type: IndexType,
+    attribute_id: i64,
+    schema: &Schema,
+) -> Result<Vec<u8>, Error> {
     match index_type {
         IndexType::AVE => {
             // AVE key order: [attr, value, entity]
             // If value is constant, include it in prefix
-            if let Some(dt) = value_place_to_datatype(&pattern.value) {
+            let is_ref = schema
+                .attribute_map
+                .get(&attribute_id)
+                .is_some_and(|attribute| attribute.value_type == ValueType::Ref);
+            if let Some(dt) = value_place_to_datatype(&pattern.value, is_ref, schema)? {
                 Ok(dt.encode())
             } else {
                 Ok(vec![])
@@ -656,6 +689,7 @@ pub fn compile_pattern<D, M>(
     join_order: &[Variable],
     var_index: &HashMap<&Variable, usize>,
     attribute_id: i64,
+    schema: &Schema,
     slate: Arc<D>,
     handle: Handle,
     as_of: i64,
@@ -680,7 +714,7 @@ where
 
     // Compute constant prefix (for patterns with constant entity or value)
     let constant_prefix = if !index_types.is_empty() {
-        compute_constant_prefix(pattern, index_types[0])?
+        compute_constant_prefix(pattern, index_types[0], attribute_id, schema)?
     } else {
         vec![]
     };
@@ -1024,7 +1058,7 @@ fn compile_or_branch<D, M>(
     var_index: &HashMap<&Variable, usize>,
     slate: &Arc<D>,
     handle: &Handle,
-    ident_map: &IdentMap,
+    schema: &Schema,
     as_of: i64,
     range_stats: &Arc<slatedb_estimates::RangeStats<M>>,
 ) -> Result<Box<dyn PrefixExtender>, Error>
@@ -1039,7 +1073,7 @@ where
             var_index,
             slate,
             handle,
-            ident_map,
+            schema,
             as_of,
             range_stats,
         ),
@@ -1053,7 +1087,7 @@ where
                         var_index,
                         slate,
                         handle,
-                        ident_map,
+                        schema,
                         as_of,
                         range_stats,
                     )
@@ -1072,7 +1106,7 @@ fn compile_where_clause<D, M>(
     var_index: &HashMap<&Variable, usize>,
     slate: &Arc<D>,
     handle: &Handle,
-    ident_map: &IdentMap,
+    schema: &Schema,
     as_of: i64,
     range_stats: &Arc<slatedb_estimates::RangeStats<M>>,
 ) -> Result<Box<dyn PrefixExtender>, Error>
@@ -1082,12 +1116,13 @@ where
 {
     match clause {
         WhereClause::Pattern(pattern) => {
-            let attr_id = resolve_attribute_from_pattern(&pattern.attribute, ident_map)?;
+            let attr_id = resolve_attribute_from_pattern(&pattern.attribute, &schema.ident_map)?;
             let extender = compile_pattern(
                 pattern,
                 join_order,
                 var_index,
                 attr_id,
+                schema,
                 slate.clone(),
                 handle.clone(),
                 as_of,
@@ -1106,7 +1141,7 @@ where
                         var_index,
                         slate,
                         handle,
-                        ident_map,
+                        schema,
                         as_of,
                         range_stats,
                     )
@@ -1125,7 +1160,7 @@ where
                         var_index,
                         slate,
                         handle,
-                        ident_map,
+                        schema,
                         as_of,
                         range_stats,
                     )
@@ -1176,7 +1211,7 @@ pub fn execute_query<D, M>(
     args: &[QueryArg],
     slate: Arc<D>,
     handle: Handle,
-    ident_map: &IdentMap,
+    schema: &Schema,
     as_of: i64,
     range_stats: Arc<slatedb_estimates::RangeStats<M>>,
 ) -> Result<QueryResult, Error>
@@ -1200,7 +1235,7 @@ where
             &var_index,
             &slate,
             &handle,
-            ident_map,
+            schema,
             as_of,
             &range_stats,
         )?);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -833,12 +833,8 @@ pub fn bootstrap_schema_tx() -> Vec<TxOp> {
 /// at startup so the inefficiency is minor, but a single-pass approach would be
 /// cleaner. Could likely be done with an `optional` clause.
 pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponents) -> Schema {
-    // Build attribute map from bootstrap constants — sufficient to query schema entities
-    let mut bootstrap_ident_map: IdentMap = HashMap::new();
-    bootstrap_ident_map.insert(kw!(:db/ident), DB_IDENT);
-    bootstrap_ident_map.insert(kw!(:db/valueType), DB_VALUE_TYPE);
-    bootstrap_ident_map.insert(kw!(:db/cardinality), DB_CARDINALITY);
-    bootstrap_ident_map.insert(kw!(:db/unique), DB_UNIQUE);
+    // Bootstrap metadata is sufficient to query schema entities.
+    let query_schema = bootstrap_schema();
     let sdb = slate.db.clone();
     let range_stats = slate.range_stats.clone();
     let handle = Handle::current();
@@ -860,7 +856,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             &[],
             sdb.clone(),
             handle.clone(),
-            &bootstrap_ident_map,
+            &query_schema,
             i64::MAX,
             range_stats.clone(),
         )?;
@@ -869,7 +865,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             &[],
             sdb.clone(),
             handle.clone(),
-            &bootstrap_ident_map,
+            &query_schema,
             i64::MAX,
             range_stats.clone(),
         )?;
@@ -878,7 +874,7 @@ pub(crate) async fn load_schema_from_indices(slate: &crate::slate::SlateComponen
             &[],
             sdb,
             handle,
-            &bootstrap_ident_map,
+            &query_schema,
             i64::MAX,
             range_stats,
         )?;

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/query_test.clj
@@ -763,7 +763,6 @@
                   :where [[(>= ?age 21)]]}
                 22))))))
 
-#_
 (deftest ident-constants-in-ref-value-position
   (tc/transact *conn* issues-schema)
   (tc/transact *conn*


### PR DESCRIPTION
Should address #313. Ident constants in eid position, in other constant positions and args are still not supported.