### PR TITLE
Make `FunctionPattern` and `PredicatePattern` `count` a no-op

### DIFF
--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -45,12 +45,15 @@ pub(crate) trait ExecPattern: Send + Sync {
     fn variables(&self) -> &[Variable];
 
     // Updates proposals without a proposer or with a strictly higher count.
+    // Patterns that can only validate inherit this no-op default.
     fn count(
         &self,
-        input: &BindingBag,
-        added: &[Variable],
-        proposals: &mut [Proposal],
-    ) -> Result<()>;
+        _input: &BindingBag,
+        _added: &[Variable],
+        _proposals: &mut [Proposal],
+    ) -> Result<()> {
+        Ok(())
+    }
 
     // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
     /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.

--- a/src/query/patterns/function.rs
+++ b/src/query/patterns/function.rs
@@ -48,6 +48,15 @@ impl FunctionPattern {
         Ok(())
     }
 
+    fn can_propose(&self, input: &BindingBag, added: &[Variable]) -> bool {
+        added == std::slice::from_ref(&self.output)
+            && !input.variables.contains(&self.output)
+            && self
+                .input_variables
+                .iter()
+                .all(|variable| input.variables.contains(variable))
+    }
+
     fn ensure_can_propose(&self, input: &BindingBag, added: &[Variable]) -> Result<()> {
         self.ensure_inputs_bound(input)?;
         ensure!(
@@ -98,8 +107,11 @@ impl ExecPattern for FunctionPattern {
             proposals.len(),
             input.rows.len()
         );
-        self.ensure_can_propose(input, added)?;
+        if !self.can_propose(input, added) {
+            return Ok(());
+        }
 
+        // Every row yields one candidate; `join` drops the rows whose expression has no value.
         for proposal in proposals {
             proposal.consider(self.index, 1);
         }
@@ -289,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn reports_invalid_contracts_and_malformed_join_inputs() {
+    fn declines_to_propose_and_reports_malformed_join_inputs() {
         assert!(FunctionPattern::new(8, Expr::Variable("?x".to_var()), "?x".to_var()).is_err());
         let pattern = FunctionPattern::new(8, add("?x", 1), "?y".to_var()).unwrap();
         let malformed = BindingBag::new(
@@ -299,7 +311,12 @@ mod tests {
         .unwrap();
         let mut proposals = vec![Proposal::default()];
 
-        assert!(pattern.count(&malformed, &[], &mut proposals).is_err());
+        // Validation stages add nothing, so the pattern leaves the proposals alone.
+        pattern.count(&malformed, &[], &mut proposals).unwrap();
+        assert_eq!(proposals, vec![Proposal::default()]);
+        assert!(pattern
+            .count(&malformed, &["?y".to_var()], &mut [])
+            .is_err());
         assert!(pattern
             .join(
                 &malformed,
@@ -308,11 +325,13 @@ mod tests {
             )
             .is_err());
 
+        // Unbound inputs cannot be evaluated, so the pattern declines instead of proposing.
         let unbound = BindingBag::unit();
         let mut unbound_proposals = vec![Proposal::default()];
-        assert!(pattern
+        pattern
             .count(&unbound, &["?y".to_var()], &mut unbound_proposals)
-            .is_err());
+            .unwrap();
+        assert_eq!(unbound_proposals, vec![Proposal::default()]);
         assert!(pattern
             .join(&unbound, &["?y".to_var()], &["?y".to_var()])
             .is_err());
@@ -338,14 +357,16 @@ mod tests {
             ]],
         )
         .unwrap();
+        // An already-bound output leaves nothing to introduce.
         let mut bound_output_proposals = vec![Proposal::default()];
-        assert!(pattern
+        pattern
             .count(
                 &malformed_output,
                 &["?y".to_var()],
                 &mut bound_output_proposals,
             )
-            .is_err());
+            .unwrap();
+        assert_eq!(bound_output_proposals, vec![Proposal::default()]);
         assert!(pattern
             .join(&malformed_output, &[], &malformed_output.variables)
             .is_err());

--- a/src/query/patterns/predicate.rs
+++ b/src/query/patterns/predicate.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use edn::query::Variable;
 
 use super::evaluation::{binding_positions, update_bindings};
 use crate::expr::{evaluate_as_bool, expr_variables, EvalContext, Expr};
 use crate::ops::DataType;
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, PatternIndex, Proposal};
+use crate::query::exec_pattern::{ExecPattern, PatternIndex};
 
 pub(crate) struct PredicatePattern {
     index: PatternIndex,
@@ -45,15 +45,6 @@ impl ExecPattern for PredicatePattern {
 
     fn variables(&self) -> &[Variable] {
         &self.variables
-    }
-
-    fn count(
-        &self,
-        input: &BindingBag,
-        _added: &[Variable],
-        proposals: &mut [Proposal],
-    ) -> Result<()> {
-        bail!("Predicate pattern {} can't propose.", self.index);
     }
 
     fn join(
@@ -171,9 +162,9 @@ mod tests {
         .unwrap();
         let mut proposals = vec![Proposal::default()];
 
-        assert!(pattern
+        pattern
             .count(&input, &["?z".to_var()], &mut proposals)
-            .is_err());
+            .unwrap();
         assert_eq!(proposals, vec![Proposal::default()]);
         assert!(pattern
             .join(&input, &["?z".to_var()], &input.variables)


### PR DESCRIPTION
We default the `ExecPattern::count` method to a no-op that gets used in `FunctionPattern` and `PredicatePattern`. 