### PR TITLE
Standard Engine rewrite [4/N]: Adding `Stage::propsers()`. 

### DIFF
--- a/src/query/exec_pattern.rs
+++ b/src/query/exec_pattern.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use edn::query::Variable;
 
 use super::binding_bag::BindingBag;
@@ -47,10 +47,12 @@ pub(crate) trait ExecPattern: Send + Sync {
     // Updates proposals without a proposer or with a strictly higher count.
     fn count(
         &self,
-        input: &BindingBag,
-        added: &[Variable],
-        proposals: &mut [Proposal],
-    ) -> Result<()>;
+        _input: &BindingBag,
+        _added: &[Variable],
+        _proposals: &mut [Proposal],
+    ) -> Result<()> {
+        bail!("Pattern {} cannot propose", self.index())
+    }
 
     // Extends the `input`` when `added` is non-empty; otherwise filters `input` without changing its layout.
     /// An empty `added` existentially validates the current `input` binding prefix; unbound pattern variables remain for later stages.

--- a/src/query/patterns/predicate.rs
+++ b/src/query/patterns/predicate.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use edn::query::Variable;
 
 use super::evaluation::{binding_positions, update_bindings};
 use crate::expr::{evaluate_as_bool, expr_variables, EvalContext, Expr};
 use crate::ops::DataType;
 use crate::query::binding_bag::{BindingBag, BindingRow};
-use crate::query::exec_pattern::{ExecPattern, PatternIndex, Proposal};
+use crate::query::exec_pattern::{ExecPattern, PatternIndex};
 
 pub(crate) struct PredicatePattern {
     index: PatternIndex,
@@ -45,15 +45,6 @@ impl ExecPattern for PredicatePattern {
 
     fn variables(&self) -> &[Variable] {
         &self.variables
-    }
-
-    fn count(
-        &self,
-        input: &BindingBag,
-        _added: &[Variable],
-        proposals: &mut [Proposal],
-    ) -> Result<()> {
-        bail!("Predicate pattern {} can't propose.", self.index);
     }
 
     fn join(

--- a/src/query/patterns/relation.rs
+++ b/src/query/patterns/relation.rs
@@ -127,12 +127,14 @@ impl ExecPattern for RelationPattern {
             proposals.len(),
             input.rows.len()
         );
-        if added.is_empty() {
-            return Ok(());
-        }
-        let Some(prefix_indexes) = self.prefix_indexes(input, added) else {
-            return Ok(());
-        };
+        ensure!(
+            !added.is_empty(),
+            "Relation pattern {} cannot count an empty proposal",
+            self.index
+        );
+        let prefix_indexes = self.prefix_indexes(input, added).ok_or_else(|| {
+            anyhow::anyhow!("Relation cannot propose the requested variables: {added:?}")
+        })?;
 
         for (input_row, proposal) in input.rows.iter().zip(proposals) {
             let count = self
@@ -246,28 +248,29 @@ mod tests {
     }
 
     #[test]
-    fn count_is_a_noop_for_non_prefix_proposals_and_checks_proposal_length() {
+    fn count_rejects_non_prefix_proposals_and_checks_proposal_length() {
         let pattern = RelationPattern::new(7, binding_bag(&["?x", "?y"], &[&["a", "1"]]));
         let input = binding_bag(&["?y"], &[&["1"]]);
         let mut proposals = vec![Proposal::default()];
 
-        pattern
+        assert!(pattern
             .count(&input, &["?x".to_var()], &mut proposals)
-            .unwrap();
+            .is_err());
         assert_eq!(proposals, vec![Proposal::default()]);
 
         assert!(pattern.count(&input, &["?x".to_var()], &mut []).is_err());
+        assert!(pattern.count(&input, &[], &mut proposals).is_err());
     }
 
     #[test]
-    fn multi_variable_non_prefix_proposals_are_ignored_and_rejected() {
+    fn multi_variable_non_prefix_proposals_are_rejected_by_count_and_join() {
         let pattern =
             RelationPattern::new(7, binding_bag(&["?x", "?y", "?z"], &[&["a", "1", "red"]]));
         let input = BindingBag::unit();
         let added = ["?y".to_var(), "?z".to_var()];
         let mut proposals = vec![Proposal::default()];
 
-        pattern.count(&input, &added, &mut proposals).unwrap();
+        assert!(pattern.count(&input, &added, &mut proposals).is_err());
 
         assert_eq!(proposals, vec![Proposal::default()]);
         assert!(pattern.join(&input, &added, &added).is_err());

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -18,9 +18,34 @@ fn ensure_unique(label: &str, variables: &[Variable]) -> Result<()> {
     Ok(())
 }
 
+fn ensure_proposer_positions(
+    added: &[Variable],
+    participant_count: usize,
+    proposer_positions: &[usize],
+) -> Result<()> {
+    for positions in proposer_positions.windows(2) {
+        ensure!(
+            positions[0] < positions[1],
+            "Stage proposer positions must be unique and ordered"
+        );
+    }
+    for position in proposer_positions {
+        ensure!(
+            *position < participant_count,
+            "Stage proposer position {position} is out of bounds for {participant_count} participants"
+        );
+    }
+    ensure!(
+        added.is_empty() == proposer_positions.is_empty(),
+        "A stage must have proposers if and only if it adds variables"
+    );
+    Ok(())
+}
+
 pub(crate) struct Stage {
     added: Vec<Variable>,
     participants: Vec<Arc<dyn ExecPattern>>,
+    proposer_positions: Vec<usize>,
     target_variables: Vec<Variable>,
 }
 
@@ -28,6 +53,7 @@ impl Stage {
     pub(crate) fn new(
         added: Vec<Variable>,
         participants: Vec<Arc<dyn ExecPattern>>,
+        proposer_positions: Vec<usize>,
         target_variables: Vec<Variable>,
     ) -> Result<Self> {
         ensure_unique("Added", &added)?;
@@ -36,6 +62,7 @@ impl Stage {
             !participants.is_empty(),
             "Stage participants must not be empty"
         );
+        ensure_proposer_positions(&added, participants.len(), &proposer_positions)?;
 
         for variable in &added {
             ensure!(
@@ -56,6 +83,7 @@ impl Stage {
         Ok(Self {
             added,
             participants,
+            proposer_positions,
             target_variables,
         })
     }
@@ -66,6 +94,12 @@ impl Stage {
 
     pub(crate) fn participants(&self) -> &[Arc<dyn ExecPattern>] {
         &self.participants
+    }
+
+    pub(crate) fn proposers(&self) -> impl ExactSizeIterator<Item = &Arc<dyn ExecPattern>> {
+        self.proposer_positions
+            .iter()
+            .map(|position| &self.participants[*position])
     }
 
     pub(crate) fn target_variables(&self) -> &[Variable] {
@@ -149,28 +183,69 @@ mod tests {
     fn stage_construction_enforces_static_invariants() {
         let pattern = TestPattern::shared(1, &["?x"]);
 
-        assert!(Stage::new(vec![], vec![], vec![]).is_err());
+        assert!(Stage::new(vec![], vec![], vec![], vec![]).is_err());
         assert!(Stage::new(
             vec!["?x".to_var(), "?x".to_var()],
             vec![Arc::clone(&pattern)],
+            vec![0],
             vec!["?x".to_var()],
         )
         .is_err());
         assert!(Stage::new(
             vec!["?x".to_var()],
             vec![Arc::clone(&pattern)],
+            vec![0],
             vec!["?x".to_var(), "?x".to_var()],
         )
         .is_err());
         assert!(Stage::new(
             vec!["?missing".to_var()],
             vec![Arc::clone(&pattern)],
+            vec![0],
             vec!["?x".to_var()],
         )
         .is_err());
         assert!(Stage::new(
             vec!["?x".to_var()],
             vec![Arc::clone(&pattern), pattern],
+            vec![0],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn stage_construction_enforces_proposer_roles() {
+        let first = TestPattern::shared(1, &["?x"]);
+        let second = TestPattern::shared(2, &["?x"]);
+        let participants = || vec![Arc::clone(&first), Arc::clone(&second)];
+
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            participants(),
+            vec![],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(vec![], participants(), vec![0], vec![]).is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            participants(),
+            vec![2],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            participants(),
+            vec![0, 0],
+            vec!["?x".to_var()],
+        )
+        .is_err());
+        assert!(Stage::new(
+            vec!["?x".to_var()],
+            participants(),
+            vec![1, 0],
             vec!["?x".to_var()],
         )
         .is_err());
@@ -181,6 +256,7 @@ mod tests {
         let stage = Stage::new(
             vec!["?y".to_var()],
             vec![TestPattern::shared(1, &["?x", "?y"])],
+            vec![0],
             vec!["?y".to_var(), "?x".to_var()],
         )
         .unwrap();

--- a/src/query/stage.rs
+++ b/src/query/stage.rs
@@ -220,6 +220,7 @@ mod tests {
         let second = TestPattern::shared(2, &["?x"]);
         let participants = || vec![Arc::clone(&first), Arc::clone(&second)];
 
+        // A stage that adds variables must declare at least one proposer.
         assert!(Stage::new(
             vec!["?x".to_var()],
             participants(),
@@ -227,7 +228,9 @@ mod tests {
             vec!["?x".to_var()],
         )
         .is_err());
+        // A stage that adds no variables must not declare a proposer.
         assert!(Stage::new(vec![], participants(), vec![0], vec![]).is_err());
+        // Every proposer position must refer to an existing participant.
         assert!(Stage::new(
             vec!["?x".to_var()],
             participants(),
@@ -235,6 +238,7 @@ mod tests {
             vec!["?x".to_var()],
         )
         .is_err());
+        // Each participant can be declared as a proposer only once.
         assert!(Stage::new(
             vec!["?x".to_var()],
             participants(),
@@ -242,6 +246,7 @@ mod tests {
             vec!["?x".to_var()],
         )
         .is_err());
+        // Proposer positions must follow participant order.
         assert!(Stage::new(
             vec!["?x".to_var()],
             participants(),


### PR DESCRIPTION
Make proposal capability explicit in runtime stages and restore strict count contracts for patterns that cannot propose.