### PR TITLE
Add runtime for DBSP circuit transaction application (Claude)

### DIFF
--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -263,17 +263,16 @@ triplox-incremental-query thread
     builds one QueryCircuit for the plan
     primes it with the initial triples
     queues the non-empty priming result at the registration basis
-    stores the plan, circuit, basis, WAL cursor, and subscription sender
+    stores the basis, routed WAL cursor, inbox sender, and subscription liveness
+    spawns a per-query worker task that owns the circuit
     returns an IncrementalQuerySubscription
 ```
 
-Node should stay relative clean and should not know anything about internal circuit maintenance and
-initialization logic. The `IncrementalQueryService` should deal with the lifecycle of incremental
-queries and their state. The dedicated service thread is where things get executed. This is currently
-single threaded which won't scale we add incremental queries to the service and we should pass to some
-executor service in the future. The `IncrementalQueryService`
-sends `IncrementalCommand`s to the one dedicated service thread. That thread owns the registry
-of active queries and every query's DBSP circuit.
+`IncrementalQueryService` owns circuit initialization and query lifecycle. Its dedicated
+router thread owns the registry and handles `IncrementalCommand`s in order. Building and
+priming a circuit still happen synchronously on that thread, preserving registration
+errors. After registration, one task per query owns and steps its circuit on the
+service's own Tokio runtime.
 
 Live WAL application reaches the dedicated service thread through the same
 command channel, but it enters from the internal side rather than the node side.
@@ -292,32 +291,56 @@ Tokio CDC task
 triplox-incremental-query thread
     loops over registered queries
     skips transactions at or before each query basis
-    steps each relevant QueryCircuit
+    try_sends the same Arc-backed batch to each relevant query's bounded inbox
+    acknowledges fan-out without waiting for circuit steps or delivery
+
+per-query worker task
+    consumes its inbox in FIFO order
+    acquires a shared semaphore permit
+    copies and applies the batch inside spawn_blocking
+    releases the permit
     sends non-empty IncrementalQueryDelta values to that query's receiver
 ```
 
-There are two channel directions:
+The channels have distinct roles:
 
 - `std::sync::mpsc` carries commands into the service thread. It fits the
-  blocking `receiver.recv()` loop used by the dedicated thread.
-- `tokio::sync::mpsc` carries `Result<IncrementalQueryDelta>` values back to
-  async subscribers. The service thread retries bounded sends, so a slow
-  subscriber applies backpressure instead of losing deltas; node cancellation
-  breaks that wait during shutdown.
+  dedicated thread, which periodically checks a separate retirement channel.
+- Bounded `tokio::sync::mpsc` inboxes carry shared transaction batches to workers.
+  One producer and one consumer per inbox preserve WAL order for each query.
+- Bounded `tokio::sync::mpsc` result channels carry `Result<IncrementalQueryDelta>`
+  to subscribers. Delivery awaits channel capacity outside the semaphore permit,
+  so a stalled receiver occupies neither a step permit nor a runtime thread.
+- A separate `std::sync::mpsc` channel reports completed worker teardown. Workers
+  hold no command senders, so dropping the last service handle can stop the router.
 
-In the future the server should drain these subscribers eagerly server side and send
-the appropriate deltas to the corresponding clients. The clients then need to deal
-with the backpressure themselves, depending on the client implementation.
+A slow subscriber receives every delta while its worker inbox stays within capacity.
+Overflow terminates that subscription with a typed `SubscriptionLagError`; other
+queries and CDC continue. Sending the terminal error has a timeout because the result
+channel may also be full. If it times out, buffered deltas are followed by end-of-stream
+without an error frame. The server forwards deltas subject to HTTP/2 flow control.
+
+Batches are shared via `Arc` across inboxes. Each inbox holds at most its configured
+number of pending batches, plus one transaction can be in flight per worker. Each
+step makes its own copy because DBSP's input API requires an owned buffer. Result
+channels and circuit state consume additional memory; queue capacities bound batch
+counts, not bytes.
 
 `IncrementalQueryDelta` is a subscriber-facing result batch emitted after a
 circuit step. The first delta is the non-empty priming result at the registration
 basis; later deltas describe transactions after that basis. An aggregate failure
 is preserved as a typed error through the circuit and service channel. A priming
 failure rejects registration. A live failure removes only the affected query,
-sends one error through its channel, and closes that subscription. The server
-encodes the error as a terminal `QueryError` frame. The command protocol exists
-to serialize mutations to the query registry and DBSP circuits onto the single
-service thread.
+sends an error subject to the terminal-send timeout, and closes that subscription.
+The server encodes terminal errors, including lag and worker panics, as `QueryError`
+(2001); no new wire error code is required. A supervisor isolates worker panics and
+completes retirement. Registry mutations are serialized by the router, while each
+worker serializes its own circuit steps.
+
+The internal `Flush` command captures each active query's routed transaction count.
+It waits for workers to report delivery through that count, or to retire. Barriers
+use delivery progress notifications rather than inbox slots, so flushing a full inbox
+does not itself trigger lag termination. A flush does not wait for future transactions.
 
 Registration is serialized against the application of CDC changes by a registration gate owned
 by `IncrementalQueryService`. `register_query` holds the gate across its whole
@@ -327,9 +350,11 @@ snapshot/register cutover atomic with respect to CDC application: a transaction
 after the registration basis cannot be consumed by the global CDC loop before the
 new query is present in the service registry. The cutover boundary itself is the
 registration `TxKey` — the global CDC loop reads the WAL from the beginning and
-each query skips transactions at or before its own `tx_id`. I think in the future
-this serialization across WAL application, basis capture and circuit initialization
-is too restrictive and we need to built something more multi-threaded.
+the router skips transactions at or before each query's basis `tx_id` before enqueueing.
+Filtering before enqueueing prevents historical WAL replay from overflowing a new
+query's inbox. The gate still covers the initial scan, circuit build, and priming;
+moving registration work off the router is deferred. Re-registering a terminated
+query therefore still pauses CDC routing during its scan and initialization.
 
 ---
 
@@ -390,10 +415,10 @@ For each transaction:
 2. EAV entries are decoded into datoms.
 3. Transaction metadata is converted into a `TxKey` when possible.
 4. Datoms become a weighted batch of encoded triples.
-5. The incremental service steps each registered query circuit that has not
-   already advanced past this transaction.
-6. Non-empty result deltas are sent on each subscription channel.
-7. The live stream cursor advances as rows are read.
+5. The router enqueues the batch for queries whose registration basis precedes it.
+6. Workers independently step circuits and deliver non-empty result deltas in order.
+7. The live stream cursor advances as rows are read; the service acknowledges enqueueing,
+   so cursor progress does not imply that all subscribers have received the transaction.
 
 ---
 
@@ -406,9 +431,25 @@ Each registration returns:
 - a bounded Tokio channel of result deltas.
 
 DBSP query state is trace-backed and stored in a per-query directory instead of
-being accumulated in ordinary Rust memory. The service deletes that directory
-when registration fails, a query is explicitly unregistered, its receiver is
-dropped, its circuit returns an error, or the service shuts down.
+being accumulated in ordinary Rust memory. Registration failure removes its directory
+synchronously. After registration, receiver closure, circuit failure, inbox overflow,
+worker panic, explicit unregistration, and shutdown all retire the affected query.
+
+Retirement drops the circuit, joining its DBSP threads, before removing its directory.
+Normal teardown runs in `spawn_blocking`. Only then does the worker report retirement
+to the router. Cleanup errors reach a pending unregister caller, or are logged for
+asynchronous retirement; they do not fail unrelated commands. An unregister reply waits
+for that query's teardown while the router continues processing other commands.
+
+Receiver closure is detected even without another transaction. The router keeps a weak
+subscriber sender so it can inspect liveness without delaying end-of-stream. Query IDs
+are monotone within a service, so retiring queries cannot remove a newer query's storage.
+
+Shutdown cancels workers and waits up to `RETIRE_TIMEOUT` for retirements. Dropping the
+service uses the shorter `DROP_TIMEOUT`, and runtime shutdown also has a bounded wait.
+A DBSP step or teardown cannot be forcibly interrupted. Workers still running at the
+deadline are logged with their storage paths; their directories are left intact until
+safe cleanup is possible. A later build reclaims stale storage at its query path.
 
 ---
 
@@ -416,18 +457,24 @@ dropped, its circuit returns an error, or the service shuts down.
 
 The current tuning knobs:
 
-- `SUBSCRIPTION_CAPACITY` controls each result channel's bounded capacity.
+- `SUBSCRIPTION_CAPACITY` defaults to 128 and controls each result channel's capacity.
   Raising it absorbs longer subscriber pauses at the cost of memory and lag;
-  lowering it applies backpressure sooner.
+  lowering it makes the worker wait on delivery sooner.
+- `QUERY_INBOX_CAPACITY` defaults to 256 pending transactions per query. Overflow
+  terminates that subscription instead of blocking the router.
+- `MAX_CONCURRENT_STEPS` defaults to 4. A FIFO-fair semaphore bounds concurrent
+  `spawn_blocking` circuit steps. The service has two async runtime threads and
+  a blocking pool sized to the step limit plus four teardown slots.
+- `RETIRE_TIMEOUT` defaults to ten seconds for terminal error delivery and shutdown
+  retirement. `DROP_TIMEOUT` limits best-effort drop cleanup to one second.
+- `IncrementalServiceConfig` supplies these service limits at construction time;
+  tests use small capacities. They are not TOML configuration options.
 - `CDC_POLL_INTERVAL` controls how often the CDC stream polls for new WAL
   transactions when no transaction is immediately available.
 - `CircuitConfig::with_workers(1)` makes each query circuit single-worker
   today. Increasing DBSP workers would require checking circuit handle
-  ownership, storage layout, and whether one service thread should still drive
-  all query steps.
-- The current service has one command loop for all queries. Future scaling
-  options include sharding registered queries across service threads
-  or introducing a worker pool for circuit stepping.
+  ownership and storage layout. Each circuit still owns its DBSP threads; the
+  service runtime multiplexes driver tasks and does not reduce DBSP thread count.
 
 ---
 

--- a/design/INCREMENTAL_QUERIES.md
+++ b/design/INCREMENTAL_QUERIES.md
@@ -439,13 +439,16 @@ Retirement drops the circuit, joining its DBSP threads, before removing its dire
 Normal teardown runs in `spawn_blocking`. Only then does the worker report retirement
 to the router. Cleanup errors reach a pending unregister caller, or are logged for
 asynchronous retirement; they do not fail unrelated commands. An unregister reply waits
-for that query's teardown while the router continues processing other commands.
+for that query's teardown while the router continues processing other commands. The
+router returns a timeout error if cleanup has not completed within `RETIRE_TIMEOUT`
+of processing the unregister request, and keeps tracking the worker for eventual cleanup.
 
 Receiver closure is detected even without another transaction. The router keeps a weak
 subscriber sender so it can inspect liveness without delaying end-of-stream. Query IDs
 are monotone within a service, so retiring queries cannot remove a newer query's storage.
 
-Shutdown cancels workers and waits up to `RETIRE_TIMEOUT` for retirements. Dropping the
+Shutdown cancels workers and waits up to `RETIRE_TIMEOUT` for retirements. If workers
+remain at the deadline, shutdown returns an error listing their handles. Dropping the
 service uses the shorter `DROP_TIMEOUT`, and runtime shutdown also has a bounded wait.
 A DBSP step or teardown cannot be forcibly interrupted. Workers still running at the
 deadline are logged with their storage paths; their directories are left intact until
@@ -465,8 +468,8 @@ The current tuning knobs:
 - `MAX_CONCURRENT_STEPS` defaults to 4. A FIFO-fair semaphore bounds concurrent
   `spawn_blocking` circuit steps. The service has two async runtime threads and
   a blocking pool sized to the step limit plus four teardown slots.
-- `RETIRE_TIMEOUT` defaults to ten seconds for terminal error delivery and shutdown
-  retirement. `DROP_TIMEOUT` limits best-effort drop cleanup to one second.
+- `RETIRE_TIMEOUT` defaults to ten seconds for terminal error delivery, unregister,
+  and shutdown retirement. `DROP_TIMEOUT` limits best-effort drop cleanup to one second.
 - `IncrementalServiceConfig` supplies these service limits at construction time;
   tests use small capacities. They are not TOML configuration options.
 - `CDC_POLL_INTERVAL` controls how often the CDC stream polls for new WAL

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -73,12 +73,18 @@ pub(crate) struct IncrementalQueryDelta {
 
 type ServiceResult<T> = Result<T>;
 
+struct RegisterRequest {
+    plan: IncrementalQueryPlan,
+    tx_key: TxKey,
+    wal_cursor: CdcCursor,
+    initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
+}
+
 enum IncrementalCommand {
+    // Boxed because registration is rare while `ApplyTriples` crosses this channel once per
+    // WAL transaction and would otherwise pay for the registration payload's size.
     Register {
-        plan: IncrementalQueryPlan,
-        tx_key: TxKey,
-        wal_cursor: CdcCursor,
-        initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
+        request: Box<RegisterRequest>,
         response: oneshot::Sender<ServiceResult<IncrementalQuerySubscription>>,
     },
     Unregister {
@@ -88,7 +94,8 @@ enum IncrementalCommand {
     ApplyTriples {
         tx_key: TxKey,
         wal_seq: u64,
-        triples: Vec<Tup2<EncodedTriple, ZWeight>>,
+        // Shared so fan-out to every registered query is a refcount bump, not a deep clone.
+        triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
         response: oneshot::Sender<ServiceResult<()>>,
     },
     Shutdown {
@@ -204,10 +211,12 @@ impl IncrementalQueryService {
         let (response, result) = oneshot::channel();
         self.commands
             .send(IncrementalCommand::Register {
-                plan,
-                tx_key,
-                wal_cursor,
-                initial_triples,
+                request: Box::new(RegisterRequest {
+                    plan,
+                    tx_key,
+                    wal_cursor,
+                    initial_triples,
+                }),
                 response,
             })
             .map_err(|_| anyhow!("Incremental query service stopped"))?;
@@ -233,7 +242,8 @@ impl IncrementalQueryService {
             .send(IncrementalCommand::ApplyTriples {
                 tx_key,
                 wal_seq,
-                triples,
+                // Convert on the caller's task so the service thread only moves refcounts.
+                triples: Arc::from(triples),
                 response,
             })
             .map_err(|_| anyhow!("Incremental query service stopped"))?;
@@ -321,13 +331,13 @@ impl IncrementalQueryServiceInner {
     fn run(mut self, receiver: std_mpsc::Receiver<IncrementalCommand>) {
         while let Ok(command) = receiver.recv() {
             match command {
-                IncrementalCommand::Register {
-                    plan,
-                    tx_key,
-                    wal_cursor,
-                    initial_triples,
-                    response,
-                } => {
+                IncrementalCommand::Register { request, response } => {
+                    let RegisterRequest {
+                        plan,
+                        tx_key,
+                        wal_cursor,
+                        initial_triples,
+                    } = *request;
                     let _ = response.send(self.register(plan, tx_key, wal_cursor, initial_triples));
                 }
                 IncrementalCommand::Unregister { handle, response } => {
@@ -409,7 +419,7 @@ impl IncrementalQueryServiceInner {
         &mut self,
         tx_key: TxKey,
         wal_seq: u64,
-        triples: Vec<Tup2<EncodedTriple, ZWeight>>,
+        triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
     ) -> ServiceResult<()> {
         self.cleanup_closed_subscriptions()?;
         let mut closed = Vec::new();
@@ -422,7 +432,8 @@ impl IncrementalQueryServiceInner {
                 continue;
             }
 
-            let rows = match query.circuit.apply(triples.clone()) {
+            // DBSP's `append` steals the buffer, so each circuit needs its own copy.
+            let rows = match query.circuit.apply(triples.to_vec()) {
                 Ok(rows) => rows,
                 Err(err) => {
                     failed.push((*id, err));
@@ -721,7 +732,7 @@ mod tests {
             .unwrap();
 
         service
-            .apply_triples(future_basis, 2, vec![name_triple(43, "Bob")])
+            .apply_triples(future_basis, 2, vec![name_triple(43, "Bob")].into())
             .unwrap();
 
         assert_eq!(
@@ -822,10 +833,18 @@ mod tests {
         aggregate_subscription.deltas.try_recv().unwrap();
 
         service
-            .apply_triples(test_tx_key_with_tx_id(2), 2, vec![age_triple(42, 10)])
+            .apply_triples(
+                test_tx_key_with_tx_id(2),
+                2,
+                vec![age_triple(42, 10)].into(),
+            )
             .unwrap();
         service
-            .apply_triples(test_tx_key_with_tx_id(3), 3, vec![name_triple(43, "Alice")])
+            .apply_triples(
+                test_tx_key_with_tx_id(3),
+                3,
+                vec![name_triple(43, "Alice")].into(),
+            )
             .unwrap();
 
         assert_eq!(
@@ -846,7 +865,11 @@ mod tests {
         assert!(!dir.path().join("query-1").exists());
 
         service
-            .apply_triples(test_tx_key_with_tx_id(4), 4, vec![name_triple(44, "Bob")])
+            .apply_triples(
+                test_tx_key_with_tx_id(4),
+                4,
+                vec![name_triple(44, "Bob")].into(),
+            )
             .unwrap();
         assert_eq!(
             expect_delta(names_subscription.deltas.try_recv().unwrap()).rows,
@@ -887,7 +910,7 @@ mod tests {
         new_subscription.deltas.try_recv().unwrap();
 
         service
-            .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")])
+            .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")].into())
             .unwrap();
 
         assert_eq!(
@@ -940,7 +963,7 @@ mod tests {
                 .apply_triples(
                     test_tx_key_with_tx_id(seq as i64 + 1),
                     seq as u64,
-                    vec![name_triple(seq as i64, &name)],
+                    vec![name_triple(seq as i64, &name)].into(),
                 )
                 .unwrap();
         }
@@ -951,7 +974,7 @@ mod tests {
             let result = service.apply_triples(
                 test_tx_key_with_tx_id(SUBSCRIPTION_CAPACITY as i64 + 2),
                 (SUBSCRIPTION_CAPACITY + 1) as u64,
-                vec![name_triple((SUBSCRIPTION_CAPACITY + 1) as i64, &name)],
+                vec![name_triple((SUBSCRIPTION_CAPACITY + 1) as i64, &name)].into(),
             );
             done_tx.send(result).unwrap();
         });

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1,18 +1,19 @@
 //! Writer-node incremental query service.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::partition::tx_eid_from_tx_id;
 use anyhow::{anyhow, Context, Error, Result};
 use dbsp::{utils::Tup2, ZWeight};
 use slatedb::object_store::ObjectStore;
-use tokio::runtime::Handle;
-use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
+use tokio::runtime::Runtime;
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -21,6 +22,9 @@ use triplox_client::transaction::TxKey;
 use crate::inc_query::{plan_query, IncrementalQueryPlan};
 use crate::incremental::cdc::{scan_current_triples, spawn_cdc_loop};
 use crate::incremental::circuit::QueryCircuit;
+use crate::incremental::worker::{
+    spawn_query_worker, QueryWorker, RetireOutcome, RetireReason, WorkerMessage,
+};
 use crate::indexer::Indexer;
 use crate::ops::DataType;
 use crate::slate::cdc::CdcCursor;
@@ -28,8 +32,16 @@ use edn::query::ParsedQuery;
 
 pub(crate) mod cdc;
 pub(crate) mod circuit;
+pub(crate) mod worker;
 
 const SUBSCRIPTION_CAPACITY: usize = 128;
+// How many transactions a query may fall behind before its subscription is terminated.
+// Batches are shared, so depth costs one `Arc` per queued transaction per query.
+const QUERY_INBOX_CAPACITY: usize = 256;
+// How many circuits may step at once. Kept well under the runtime's blocking pool.
+const MAX_CONCURRENT_STEPS: usize = 4;
+// How long shutdown and unregister wait for a worker to drop its circuit and clean up.
+const RETIRE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(crate) type EncodedValue = Vec<u8>;
 pub(crate) type EncodedRow = Vec<EncodedValue>;
@@ -98,6 +110,11 @@ enum IncrementalCommand {
         triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
         response: oneshot::Sender<ServiceResult<()>>,
     },
+    // Barrier: hands back one ack per live query, resolved once that worker has drained
+    // everything queued ahead of it.
+    Flush {
+        response: oneshot::Sender<ServiceResult<Vec<oneshot::Receiver<()>>>>,
+    },
     Shutdown {
         response: oneshot::Sender<ServiceResult<()>>,
     },
@@ -119,7 +136,7 @@ pub(crate) struct IncrementalQueryService {
 impl IncrementalQueryService {
     pub(crate) fn new(
         storage_root: PathBuf,
-        runtime: Handle,
+        config: IncrementalServiceConfig,
         cancel: CancellationToken,
         cdc_object_path: String,
         cdc_object_store: Arc<dyn ObjectStore>,
@@ -130,7 +147,7 @@ impl IncrementalQueryService {
         thread::Builder::new()
             .name("triplox-incremental-query".to_string())
             .spawn(move || {
-                IncrementalQueryServiceInner::new(storage_root, runtime, inner_cancel).run(receiver)
+                IncrementalQueryServiceInner::new(storage_root, config, inner_cancel).run(receiver)
             })
             .expect("incremental query service thread should start");
 
@@ -250,6 +267,23 @@ impl IncrementalQueryService {
         result.await.context("Incremental query service stopped")?
     }
 
+    /// Resolves once every query registered right now has stepped and delivered everything
+    /// already routed to it. Routing is ordered, so a preceding `apply_triples` is covered.
+    pub(crate) async fn flush(&self) -> Result<()> {
+        let (response, result) = oneshot::channel();
+        self.commands
+            .send(IncrementalCommand::Flush { response })
+            .map_err(|_| anyhow!("Incremental query service stopped"))?;
+        let acks = result
+            .await
+            .context("Incremental query service stopped")??;
+        for ack in acks {
+            // A query that retired before reaching the barrier just drops its ack.
+            let _ = ack.await;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn shutdown(&self) -> Result<()> {
         self.cancel.cancel();
         let cdc_result = self.await_cdc_task().await;
@@ -275,61 +309,187 @@ impl IncrementalQueryService {
     }
 }
 
-enum DeltaDelivery {
-    Delivered,
-    Closed,
-    Cancelled,
-}
-
-fn send_delta(
-    runtime: &Handle,
-    sender: &mpsc::Sender<Result<IncrementalQueryDelta>>,
-    delta: Result<IncrementalQueryDelta>,
-    cancel: &CancellationToken,
-) -> DeltaDelivery {
-    runtime.block_on(async {
-        tokio::select! {
-            biased;
-            _ = cancel.cancelled() => DeltaDelivery::Cancelled,
-            result = sender.send(delta) => {
-                match result {
-                    Ok(()) => DeltaDelivery::Delivered,
-                    Err(_) => DeltaDelivery::Closed,
-                }
-            }
-        }
-    })
-}
-
 struct RegisteredQuery {
-    _plan: IncrementalQueryPlan,
-    circuit: QueryCircuit,
-    sender: mpsc::Sender<Result<IncrementalQueryDelta>>,
+    inbox: mpsc::Sender<WorkerMessage>,
+    terminate: Option<oneshot::Sender<RetireReason>>,
+    // Weak so the router can spot a dropped receiver without keeping the subscription open:
+    // a strong clone here would delay end-of-stream until the next command reaped it.
+    subscriber: mpsc::WeakSender<Result<IncrementalQueryDelta>>,
     tx_key: TxKey,
     wal_cursor: CdcCursor,
 }
 
+/// Sizing for the service. The defaults are the production values; tests shrink them to
+/// force lag and contention deterministically.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct IncrementalServiceConfig {
+    pub subscription_capacity: usize,
+    pub inbox_capacity: usize,
+    pub max_concurrent_steps: usize,
+    pub retire_timeout: Duration,
+}
+
+impl Default for IncrementalServiceConfig {
+    fn default() -> Self {
+        Self {
+            subscription_capacity: SUBSCRIPTION_CAPACITY,
+            inbox_capacity: QUERY_INBOX_CAPACITY,
+            max_concurrent_steps: MAX_CONCURRENT_STEPS,
+            retire_timeout: RETIRE_TIMEOUT,
+        }
+    }
+}
+
+// Routes transactions to per-query workers and owns the registry. Nothing here waits on a
+// circuit step or a subscriber, so one slow query cannot hold up the others.
 struct IncrementalQueryServiceInner {
     next_query_id: u64,
     storage_root: PathBuf,
     queries: HashMap<IncrementalQueryHandle, RegisteredQuery>,
-    runtime: Handle,
+    // Retired here but not yet acked by their worker, so their storage may still exist.
+    retiring: HashSet<IncrementalQueryHandle>,
+    // Owned rather than borrowed from the node, so circuit work cannot starve request
+    // serving and workers can still retire while the node's runtime is going away.
+    // `None` only while dropping.
+    runtime: Option<Runtime>,
+    steps: Arc<Semaphore>,
+    config: IncrementalServiceConfig,
+    // Deliberately not the command channel: workers holding a command sender would keep it
+    // alive for ever, and `run` would never see it disconnect.
+    retirements: std_mpsc::Sender<RetireOutcome>,
+    retired: std_mpsc::Receiver<RetireOutcome>,
     cancel: CancellationToken,
 }
 
 impl IncrementalQueryServiceInner {
-    fn new(storage_root: PathBuf, runtime: Handle, cancel: CancellationToken) -> Self {
+    fn new(
+        storage_root: PathBuf,
+        config: IncrementalServiceConfig,
+        cancel: CancellationToken,
+    ) -> Self {
+        // Worker tasks are almost pure `await` - the circuit steps go to the blocking pool -
+        // so a couple of async threads is plenty.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .max_blocking_threads(config.max_concurrent_steps + 4)
+            .thread_name("triplox-iq-worker")
+            .enable_all()
+            .build()
+            .expect("incremental query runtime should start");
+        let (retirements, retired) = std_mpsc::channel();
+
         Self {
             next_query_id: 1,
             storage_root,
             queries: HashMap::new(),
-            runtime,
+            retiring: HashSet::new(),
+            runtime: Some(runtime),
+            steps: Arc::new(Semaphore::new(config.max_concurrent_steps)),
+            config,
+            retirements,
+            retired,
             cancel,
+        }
+    }
+
+    fn allocate_query_id(&mut self) -> IncrementalQueryHandle {
+        let id = self.next_query_id;
+        self.next_query_id += 1;
+        id
+    }
+
+    fn query_storage_path(&self, id: IncrementalQueryHandle) -> PathBuf {
+        self.storage_root.join(format!("query-{}", id))
+    }
+
+    // Drops a query from the registry and tells its worker to stop. The worker still owns the
+    // circuit, so the storage directory only goes once it acks.
+    fn retire(&mut self, id: IncrementalQueryHandle, reason: RetireReason) -> bool {
+        let Some(query) = self.queries.remove(&id) else {
+            return false;
+        };
+        if let Some(terminate) = query.terminate {
+            let _ = terminate.send(reason);
+        }
+        self.retiring.insert(id);
+        true
+    }
+
+    fn apply_retirement(&mut self, outcome: RetireOutcome) -> ServiceResult<()> {
+        self.retiring.remove(&outcome.id);
+        self.queries.remove(&outcome.id);
+        outcome.storage
+    }
+
+    // Applies whatever retirements have already arrived, and retires queries whose subscriber
+    // went away. Never blocks.
+    fn reap(&mut self) {
+        while let Ok(outcome) = self.retired.try_recv() {
+            if let Err(error) = self.apply_retirement(outcome) {
+                warn!("{}", error);
+            }
+        }
+
+        // `upgrade` fails once the worker has dropped its own sender, which means it is
+        // already retiring and its outcome is on the way.
+        let gone = self
+            .queries
+            .iter()
+            .filter_map(|(id, query)| {
+                let closed = query
+                    .subscriber
+                    .upgrade()
+                    .is_some_and(|subscriber| subscriber.is_closed());
+                closed.then_some(*id)
+            })
+            .collect::<Vec<_>>();
+        for id in gone {
+            self.retire(id, RetireReason::SubscriberGone);
+        }
+    }
+
+    // Blocks the router until every retiring worker has dropped its circuit and cleaned up.
+    // Only unregister and shutdown reach this, and it is bounded by `retire_timeout`.
+    fn await_retirements(&mut self) -> ServiceResult<()> {
+        let deadline = Instant::now() + self.config.retire_timeout;
+        let mut failure: Option<Error> = None;
+
+        while !self.retiring.is_empty() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match self.retired.recv_timeout(remaining) {
+                Ok(outcome) => {
+                    if let Err(error) = self.apply_retirement(outcome) {
+                        failure.get_or_insert(error);
+                    }
+                }
+                // The service holds a sender, so this only fires on timeout.
+                Err(_) => break,
+            }
+        }
+
+        // A worker wedged inside a circuit step cannot be interrupted - DBSP exposes no
+        // external kill - so leave its storage rather than unlinking under a live circuit.
+        for id in self.retiring.drain().collect::<Vec<_>>() {
+            warn!(
+                "Incremental query {} did not retire within {:?}; leaving {} behind",
+                id,
+                self.config.retire_timeout,
+                self.query_storage_path(id).display()
+            );
+        }
+
+        match failure {
+            Some(error) => Err(error),
+            None => Ok(()),
         }
     }
 
     fn run(mut self, receiver: std_mpsc::Receiver<IncrementalCommand>) {
         while let Ok(command) = receiver.recv() {
+            self.reap();
             match command {
                 IncrementalCommand::Register { request, response } => {
                     let RegisterRequest {
@@ -351,6 +511,9 @@ impl IncrementalQueryServiceInner {
                 } => {
                     let _ = response.send(self.apply_triples(tx_key, wal_seq, triples));
                 }
+                IncrementalCommand::Flush { response } => {
+                    let _ = response.send(self.flush());
+                }
                 IncrementalCommand::Shutdown { response } => {
                     let _ = response.send(self.remove_all_queries());
                     break;
@@ -366,11 +529,9 @@ impl IncrementalQueryServiceInner {
         wal_cursor: CdcCursor,
         initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
     ) -> ServiceResult<IncrementalQuerySubscription> {
-        self.cleanup_closed_subscriptions()?;
-
         let handle = self.allocate_query_id();
-        let mut circuit = match QueryCircuit::build(plan.clone(), &self.query_storage_path(handle))
-        {
+        let storage_path = self.query_storage_path(handle);
+        let mut circuit = match QueryCircuit::build(plan, &storage_path) {
             Ok(circuit) => circuit,
             Err(err) => return Err(self.cleanup_failed_registration(handle, err)),
         };
@@ -382,22 +543,48 @@ impl IncrementalQueryServiceInner {
                 return Err(self.cleanup_failed_registration(handle, err));
             }
         };
-        let (sender, receiver) = mpsc::channel(SUBSCRIPTION_CAPACITY);
+
+        let (subscriber, receiver) = mpsc::channel(self.config.subscription_capacity);
         if !priming_rows.is_empty() {
-            sender
-                .try_send(Ok(IncrementalQueryDelta {
-                    tx_key,
-                    rows: priming_rows,
-                }))
-                .map_err(|err| anyhow!("Failed to enqueue priming result set: {}", err))?;
+            if let Err(err) = subscriber.try_send(Ok(IncrementalQueryDelta {
+                tx_key,
+                rows: priming_rows,
+            })) {
+                drop(circuit);
+                let err = anyhow!("Failed to enqueue priming result set: {}", err);
+                return Err(self.cleanup_failed_registration(handle, err));
+            }
         }
+
+        let (inbox, inbox_receiver) = mpsc::channel(self.config.inbox_capacity);
+        let (terminate, terminate_receiver) = oneshot::channel();
+        spawn_query_worker(
+            self.runtime
+                .as_ref()
+                .expect("the runtime is only taken while dropping")
+                .handle(),
+            QueryWorker {
+                id: handle,
+                circuit: Some(circuit),
+                storage_path,
+                inbox: inbox_receiver,
+                // The worker holds the only strong sender, so the subscription ends the
+                // moment it retires.
+                subscriber: subscriber.clone(),
+                terminate: terminate_receiver,
+                retirements: self.retirements.clone(),
+                steps: self.steps.clone(),
+                cancel: self.cancel.clone(),
+                retire_timeout: self.config.retire_timeout,
+            },
+        );
 
         self.queries.insert(
             handle,
             RegisteredQuery {
-                _plan: plan,
-                circuit,
-                sender,
+                inbox,
+                terminate: Some(terminate),
+                subscriber: subscriber.downgrade(),
                 tx_key,
                 wal_cursor,
             },
@@ -411,8 +598,13 @@ impl IncrementalQueryServiceInner {
     }
 
     fn unregister(&mut self, handle: IncrementalQueryHandle) -> ServiceResult<()> {
-        self.cleanup_closed_subscriptions()?;
-        self.remove_query(handle)
+        let known = self.retire(handle, RetireReason::Unregistered);
+        // Wait either way, so storage really is gone by the time the caller hears back.
+        let cleanup = self.await_retirements();
+        if !known {
+            return Err(anyhow!("Unknown incremental query handle: {:?}", handle));
+        }
+        cleanup
     }
 
     fn apply_triples(
@@ -421,94 +613,56 @@ impl IncrementalQueryServiceInner {
         wal_seq: u64,
         triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
     ) -> ServiceResult<()> {
-        self.cleanup_closed_subscriptions()?;
-        let mut closed = Vec::new();
-        let mut failed = Vec::new();
-        let cancel = self.cancel.clone();
+        let mut lagged = Vec::new();
 
         for (id, query) in &mut self.queries {
+            // The CDC loop replays the WAL from the start, so skipping here rather than in the
+            // worker keeps replayed history from filling inboxes and terminating fresh queries.
             if tx_key.tx_id <= query.tx_key.tx_id {
                 query.wal_cursor.last_seq = wal_seq;
                 continue;
             }
-
-            // DBSP's `append` steals the buffer, so each circuit needs its own copy.
-            let rows = match query.circuit.apply(triples.to_vec()) {
-                Ok(rows) => rows,
-                Err(err) => {
-                    failed.push((*id, err));
-                    continue;
-                }
+            let work = WorkerMessage::Apply {
+                tx_key,
+                triples: triples.clone(),
             };
-            if rows.is_empty() {
-                query.wal_cursor.last_seq = wal_seq;
-                continue;
-            }
-            let delta = Ok(IncrementalQueryDelta { tx_key, rows });
-            match send_delta(&self.runtime, &query.sender, delta, &cancel) {
-                DeltaDelivery::Delivered => query.wal_cursor.last_seq = wal_seq,
-                DeltaDelivery::Closed => closed.push(*id),
-                DeltaDelivery::Cancelled => break,
+            match query.inbox.try_send(work) {
+                Ok(()) => query.wal_cursor.last_seq = wal_seq,
+                // Full means the query is behind; closed means its worker already stopped.
+                Err(_) => lagged.push(*id),
             }
         }
 
-        for id in closed {
-            self.remove_query(id)?;
-        }
-        for (id, error) in failed {
-            if let Some(sender) = self.remove_failed_query(id) {
-                let _ = send_delta(&self.runtime, &sender, Err(error), &cancel);
-            }
+        let capacity = self.config.inbox_capacity;
+        for id in lagged {
+            self.retire(id, RetireReason::Lagged { capacity });
         }
         Ok(())
     }
 
-    fn allocate_query_id(&mut self) -> IncrementalQueryHandle {
-        let id = self.next_query_id;
-        self.next_query_id += 1;
-        id
-    }
+    // Hands back one ack per live query, resolved when that worker has drained everything
+    // queued ahead of the barrier.
+    fn flush(&mut self) -> ServiceResult<Vec<oneshot::Receiver<()>>> {
+        let mut acks = Vec::new();
+        let mut lagged = Vec::new();
 
-    fn query_storage_path(&self, id: IncrementalQueryHandle) -> PathBuf {
-        self.storage_root.join(format!("query-{}", id))
-    }
-
-    fn remove_query(&mut self, id: IncrementalQueryHandle) -> ServiceResult<()> {
-        let query = self
-            .queries
-            .remove(&id)
-            .ok_or_else(|| anyhow!("Unknown incremental query handle: {:?}", id))?;
-        drop(query);
-        self.remove_query_storage(id)
-    }
-
-    fn remove_failed_query(
-        &mut self,
-        id: IncrementalQueryHandle,
-    ) -> Option<mpsc::Sender<Result<IncrementalQueryDelta>>> {
-        let sender = self.queries.remove(&id).map(|query| {
-            let sender = query.sender.clone();
-            drop(query);
-            sender
-        });
-        if let Err(error) = self.remove_query_storage(id) {
-            warn!("{}", error);
+        for (id, query) in &self.queries {
+            let (ack, wait) = oneshot::channel();
+            match query.inbox.try_send(WorkerMessage::Flush(ack)) {
+                Ok(()) => acks.push(wait),
+                Err(_) => lagged.push(*id),
+            }
         }
-        sender
-    }
 
-    fn remove_query_storage(&self, id: IncrementalQueryHandle) -> ServiceResult<()> {
-        match std::fs::remove_dir_all(self.query_storage_path(id)) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err).with_context(|| {
-                format!("Failed to remove incremental query storage for {:?}", id)
-            }),
+        let capacity = self.config.inbox_capacity;
+        for id in lagged {
+            self.retire(id, RetireReason::Lagged { capacity });
         }
+        Ok(acks)
     }
 
     fn cleanup_failed_registration(&self, id: IncrementalQueryHandle, error: Error) -> Error {
-        match self.remove_query_storage(id) {
+        match remove_query_storage(&self.query_storage_path(id)) {
             Ok(()) => error,
             Err(cleanup_error) => error.context(format!(
                 "Incremental query registration cleanup failed: {cleanup_error:#}"
@@ -517,41 +671,35 @@ impl IncrementalQueryServiceInner {
     }
 
     fn remove_all_queries(&mut self) -> ServiceResult<()> {
-        let ids = self.queries.keys().copied().collect::<Vec<_>>();
-        let mut errors = Vec::new();
-        for id in ids {
-            if let Err(err) = self.remove_query(id) {
-                errors.push(err);
-            }
+        for id in self.queries.keys().copied().collect::<Vec<_>>() {
+            self.retire(id, RetireReason::Shutdown);
         }
-        let mut errors = errors.into_iter();
-        let Some(mut error) = errors.next() else {
-            return Ok(());
-        };
-        for parallel_error in errors {
-            error = error.context(format!(
-                "An additional incremental query cleanup failed: {parallel_error:#}"
-            ));
-        }
-        Err(error)
-    }
-
-    fn cleanup_closed_subscriptions(&mut self) -> ServiceResult<()> {
-        let closed = self
-            .queries
-            .iter()
-            .filter_map(|(id, query)| query.sender.is_closed().then_some(*id))
-            .collect::<Vec<_>>();
-        for id in closed {
-            self.remove_query(id)?;
-        }
-        Ok(())
+        self.await_retirements()
     }
 }
 
 impl Drop for IncrementalQueryServiceInner {
     fn drop(&mut self) {
-        let _ = self.remove_all_queries();
+        if let Err(error) = self.remove_all_queries() {
+            warn!("{}", error);
+        }
+        // Bounded, because a worker wedged in a circuit step would otherwise block for ever.
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_timeout(self.config.retire_timeout);
+        }
+    }
+}
+
+fn remove_query_storage(path: &Path) -> Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "Failed to remove incremental query storage at {}",
+                path.display()
+            )
+        }),
     }
 }
 
@@ -657,83 +805,93 @@ mod tests {
             .is_some()
     }
 
-    #[test]
-    fn unregister_removes_query_storage() {
-        let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
+    fn test_service(dir: &Path, config: IncrementalServiceConfig) -> IncrementalQueryService {
+        IncrementalQueryService::new(
+            dir.to_path_buf(),
+            config,
             CancellationToken::new(),
-        );
-        let subscription = service
-            .register(
-                single_pattern_plan(),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                vec![name_triple(42, "Alice")],
-            )
-            .unwrap();
+            format!("/test_incremental_{}", crate::util::random_string(8)),
+            Arc::new(InMemory::new()),
+        )
+    }
+
+    async fn register(
+        service: &IncrementalQueryService,
+        plan: IncrementalQueryPlan,
+        tx_key: TxKey,
+        initial_triples: Vec<Tup2<EncodedTriple, ZWeight>>,
+    ) -> Result<IncrementalQuerySubscription> {
+        service
+            .register_prepared_query(plan, tx_key, test_cursor(), initial_triples)
+            .await
+    }
+
+    #[tokio::test]
+    async fn unregister_removes_query_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
+        let subscription = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            vec![name_triple(42, "Alice")],
+        )
+        .await
+        .unwrap();
         let storage_path = dir.path().join("query-1");
 
         assert!(path_has_entries(&storage_path));
 
-        service.unregister(subscription.handle).unwrap();
+        service.unregister(subscription.handle).await.unwrap();
 
         assert!(!storage_path.exists());
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn dropped_receiver_cleanup_removes_query_storage() {
+    #[tokio::test]
+    async fn dropped_receiver_cleanup_removes_query_storage() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
-        let subscription = service
-            .register(
-                single_pattern_plan(),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                vec![name_triple(42, "Alice")],
-            )
-            .unwrap();
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
+        let subscription = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            vec![name_triple(42, "Alice")],
+        )
+        .await
+        .unwrap();
         let storage_path = dir.path().join("query-1");
 
         assert!(path_has_entries(&storage_path));
         let handle = subscription.handle;
         drop(subscription);
 
-        let err = service.unregister(handle).unwrap_err();
+        let err = service.unregister(handle).await.unwrap_err();
         assert!(err.to_string().contains("Unknown incremental query handle"));
         assert!(!storage_path.exists());
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn register_enqueues_non_empty_priming_result_before_future_deltas() {
+    #[tokio::test]
+    async fn register_enqueues_non_empty_priming_result_before_future_deltas() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
         let registration_basis = test_tx_key_with_tx_id(1);
         let future_basis = test_tx_key_with_tx_id(2);
-        let mut subscription = service
-            .register(
-                single_pattern_plan(),
-                registration_basis,
-                test_cursor(),
-                vec![name_triple(42, "Alice")],
-            )
-            .unwrap();
+        let mut subscription = register(
+            &service,
+            single_pattern_plan(),
+            registration_basis,
+            vec![name_triple(42, "Alice")],
+        )
+        .await
+        .unwrap();
 
         service
-            .apply_triples(future_basis, 2, vec![name_triple(43, "Bob")].into())
+            .apply_triples(future_basis, 2, vec![name_triple(43, "Bob")])
+            .await
             .unwrap();
+        service.flush().await.unwrap();
 
         assert_eq!(
             expect_delta(subscription.deltas.try_recv().unwrap()),
@@ -749,103 +907,89 @@ mod tests {
                 rows: vec![(vec![DataType::String("Bob".to_string())], 1)],
             }
         );
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn register_skips_empty_priming_result() {
+    #[tokio::test]
+    async fn register_skips_empty_priming_result() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
-        let mut subscription = service
-            .register(
-                single_pattern_plan(),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                Vec::new(),
-            )
-            .unwrap();
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
+        let mut subscription = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
 
         assert!(matches!(
             subscription.deltas.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
         ));
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn invalid_aggregate_priming_rejects_registration_and_cleans_storage() {
+    #[tokio::test]
+    async fn invalid_aggregate_priming_rejects_registration_and_cleans_storage() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
 
-        let err = service
-            .register(
-                aggregate_plan("[:find (sum ?name) :where [?e :name ?name]]"),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                vec![name_triple(42, "Alice")],
-            )
-            .unwrap_err();
+        let err = register(
+            &service,
+            aggregate_plan("[:find (sum ?name) :where [?e :name ?name]]"),
+            test_tx_key_with_tx_id(1),
+            vec![name_triple(42, "Alice")],
+        )
+        .await
+        .unwrap_err();
 
         assert!(err
             .to_string()
             .contains("sum: cannot aggregate non-numeric value"));
         assert!(err.downcast_ref::<circuit::AggregateError>().is_some());
-        assert!(service.queries.is_empty());
+        // Priming failed before a worker existed, so nothing is registered under that handle.
+        assert!(service.unregister(1).await.is_err());
         assert!(!dir.path().join("query-1").exists());
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn live_aggregate_error_removes_only_the_affected_subscription() {
+    #[tokio::test]
+    async fn live_aggregate_error_removes_only_the_affected_subscription() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
-        let mut aggregate_subscription = service
-            .register(
-                aggregate_plan(
-                    "[:find (sum ?value)
-                      :where (or [?e :age ?value] [?e :name ?value])]",
-                ),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                Vec::new(),
-            )
-            .unwrap();
-        let mut names_subscription = service
-            .register(
-                single_pattern_plan(),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                Vec::new(),
-            )
-            .unwrap();
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
+        let mut aggregate_subscription = register(
+            &service,
+            aggregate_plan(
+                "[:find (sum ?value)
+                  :where (or [?e :age ?value] [?e :name ?value])]",
+            ),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+        let mut names_subscription = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+        // An aggregate over an empty snapshot still primes with a row, so drain it first.
         aggregate_subscription.deltas.try_recv().unwrap();
 
         service
-            .apply_triples(
-                test_tx_key_with_tx_id(2),
-                2,
-                vec![age_triple(42, 10)].into(),
-            )
+            .apply_triples(test_tx_key_with_tx_id(2), 2, vec![age_triple(42, 10)])
+            .await
             .unwrap();
+        service.flush().await.unwrap();
         service
-            .apply_triples(
-                test_tx_key_with_tx_id(3),
-                3,
-                vec![name_triple(43, "Alice")].into(),
-            )
+            .apply_triples(test_tx_key_with_tx_id(3), 3, vec![name_triple(43, "Alice")])
+            .await
             .unwrap();
+        service.flush().await.unwrap();
 
         assert_eq!(
             expect_delta(names_subscription.deltas.try_recv().unwrap()).rows,
@@ -853,140 +997,144 @@ mod tests {
         );
         let prior_delta = expect_delta(aggregate_subscription.deltas.try_recv().unwrap());
         assert!(prior_delta.rows.contains(&(vec![DataType::Long(10)], 1)));
-        let error = expect_error(aggregate_subscription.deltas.try_recv().unwrap());
+        let error = expect_error(aggregate_subscription.deltas.recv().await.unwrap());
         assert_eq!(error.to_string(), "sum: cannot aggregate non-numeric value");
         assert!(error.downcast_ref::<circuit::AggregateError>().is_some());
-        assert!(matches!(
-            aggregate_subscription.deltas.try_recv(),
-            Err(mpsc::error::TryRecvError::Disconnected)
-        ));
-        assert!(!service.queries.contains_key(&aggregate_subscription.handle));
-        assert!(service.queries.contains_key(&names_subscription.handle));
-        assert!(!dir.path().join("query-1").exists());
+        assert!(aggregate_subscription.deltas.recv().await.is_none());
+        assert!(service
+            .unregister(aggregate_subscription.handle)
+            .await
+            .is_err());
 
         service
-            .apply_triples(
-                test_tx_key_with_tx_id(4),
-                4,
-                vec![name_triple(44, "Bob")].into(),
-            )
+            .apply_triples(test_tx_key_with_tx_id(4), 4, vec![name_triple(44, "Bob")])
+            .await
             .unwrap();
+        service.flush().await.unwrap();
         assert_eq!(
             expect_delta(names_subscription.deltas.try_recv().unwrap()).rows,
             vec![(vec![DataType::String("Bob".to_string())], 1)]
         );
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn apply_triples_skips_transactions_at_or_before_query_basis() {
+    #[tokio::test]
+    async fn apply_triples_skips_transactions_at_or_before_query_basis() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            CancellationToken::new(),
-        );
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
         let old_basis = test_tx_key_with_tx_id(1);
         let new_basis = test_tx_key_with_tx_id(2);
-        let mut old_subscription = service
-            .register(
-                single_pattern_plan(),
-                old_basis,
-                test_cursor(),
-                vec![name_triple(42, "Alice")],
-            )
-            .unwrap();
-        let mut new_subscription = service
-            .register(
-                single_pattern_plan(),
-                new_basis,
-                test_cursor(),
-                vec![name_triple(42, "Alice"), name_triple(43, "Bob")],
-            )
-            .unwrap();
+        let mut old_subscription = register(
+            &service,
+            single_pattern_plan(),
+            old_basis,
+            vec![name_triple(42, "Alice")],
+        )
+        .await
+        .unwrap();
+        let mut new_subscription = register(
+            &service,
+            single_pattern_plan(),
+            new_basis,
+            vec![name_triple(42, "Alice"), name_triple(43, "Bob")],
+        )
+        .await
+        .unwrap();
 
         // Drain priming deltas before testing application relative to each basis.
         old_subscription.deltas.try_recv().unwrap();
         new_subscription.deltas.try_recv().unwrap();
 
         service
-            .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")].into())
+            .apply_triples(new_basis, 2, vec![name_triple(43, "Bob")])
+            .await
             .unwrap();
+        service.flush().await.unwrap();
 
         assert_eq!(
             expect_delta(old_subscription.deltas.try_recv().unwrap()).rows,
             vec![(vec![DataType::String("Bob".to_string())], 1)]
         );
+        // The flush barrier passed through the second query too, so an empty inbox here means
+        // the transaction was skipped at the router rather than merely still in flight.
         assert!(new_subscription.deltas.try_recv().is_err());
-        assert_eq!(
-            service
-                .queries
-                .get(&old_subscription.handle)
-                .unwrap()
-                .wal_cursor
-                .last_seq,
-            2
-        );
-        assert_eq!(
-            service
-                .queries
-                .get(&new_subscription.handle)
-                .unwrap()
-                .wal_cursor
-                .last_seq,
-            2
-        );
+        service.shutdown().await.unwrap();
     }
 
-    #[test]
-    fn apply_triples_stops_waiting_on_full_subscription_when_cancelled() {
+    // Replaces the old "apply_triples blocks until cancelled" test: fanning out no longer
+    // waits on any subscriber, which is the point of the whole change.
+    #[tokio::test]
+    async fn apply_triples_returns_while_a_subscriber_is_full() {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = test_runtime();
-        let cancel = CancellationToken::new();
-        let mut service = IncrementalQueryServiceInner::new(
-            dir.path().to_path_buf(),
-            runtime.handle().clone(),
-            cancel.clone(),
-        );
-        let _subscription = service
-            .register(
-                single_pattern_plan(),
-                test_tx_key_with_tx_id(1),
-                test_cursor(),
-                Vec::new(),
-            )
-            .unwrap();
+        let config = IncrementalServiceConfig {
+            subscription_capacity: 1,
+            inbox_capacity: 8,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let _wedged = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
 
-        for seq in 1..=SUBSCRIPTION_CAPACITY {
+        // Nobody reads `_wedged`, so its worker parks on the first send and its inbox fills.
+        for seq in 1..=config.inbox_capacity {
+            let name = format!("Alice {seq}");
+            let applied = tokio::time::timeout(
+                Duration::from_secs(5),
+                service.apply_triples(
+                    test_tx_key_with_tx_id(seq as i64 + 1),
+                    seq as u64,
+                    vec![name_triple(seq as i64, &name)],
+                ),
+            )
+            .await
+            .expect("fan-out must not wait on a full subscriber");
+            applied.unwrap();
+        }
+
+        service.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_bounded_when_a_worker_is_parked_on_a_full_subscriber() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = IncrementalServiceConfig {
+            subscription_capacity: 1,
+            inbox_capacity: 4,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let _wedged = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+        for seq in 1..=config.inbox_capacity {
             let name = format!("Alice {seq}");
             service
                 .apply_triples(
                     test_tx_key_with_tx_id(seq as i64 + 1),
                     seq as u64,
-                    vec![name_triple(seq as i64, &name)].into(),
+                    vec![name_triple(seq as i64, &name)],
                 )
+                .await
                 .unwrap();
         }
 
-        let (done_tx, done_rx) = std_mpsc::channel();
-        let handle = thread::spawn(move || {
-            let name = format!("Alice {}", SUBSCRIPTION_CAPACITY + 1);
-            let result = service.apply_triples(
-                test_tx_key_with_tx_id(SUBSCRIPTION_CAPACITY as i64 + 2),
-                (SUBSCRIPTION_CAPACITY + 1) as u64,
-                vec![name_triple((SUBSCRIPTION_CAPACITY + 1) as i64, &name)].into(),
-            );
-            done_tx.send(result).unwrap();
-        });
-
-        thread::sleep(Duration::from_millis(50));
-        cancel.cancel();
-
-        let result = done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("apply_triples should stop waiting after cancellation");
-        assert!(result.is_ok());
-        handle.join().unwrap();
+        tokio::time::timeout(Duration::from_secs(10), service.shutdown())
+            .await
+            .expect("shutdown must not wait on a parked worker")
+            .unwrap();
+        assert!(!dir.path().join("query-1").exists());
     }
 
     #[tokio::test]
@@ -994,7 +1142,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let service = IncrementalQueryService::new(
             dir.path().to_path_buf(),
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             CancellationToken::new(),
             "/test_incremental_cdc_error".to_string(),
             Arc::new(InMemory::new()),
@@ -1015,7 +1163,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let service = IncrementalQueryService::new(
             dir.path().to_path_buf(),
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             CancellationToken::new(),
             "/test_incremental_cdc_join_error".to_string(),
             Arc::new(InMemory::new()),
@@ -1039,7 +1187,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let service = IncrementalQueryService::new(
             dir.path().to_path_buf(),
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             CancellationToken::new(),
             "/test_incremental_shutdown_cdc_error".to_string(),
             Arc::new(InMemory::new()),
@@ -1086,7 +1234,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let service = IncrementalQueryService::new(
             dir.path().to_path_buf(),
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             CancellationToken::new(),
             "/test_incremental_registration_gate".to_string(),
             Arc::new(InMemory::new()),

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -40,7 +40,7 @@ const SUBSCRIPTION_CAPACITY: usize = 128;
 const QUERY_INBOX_CAPACITY: usize = 256;
 // How many circuits may step at once. Kept well under the runtime's blocking pool.
 const MAX_CONCURRENT_STEPS: usize = 4;
-// How long shutdown waits for workers, and terminal errors wait for delivery.
+// How long shutdown and unregister wait for workers, and terminal errors for delivery.
 const RETIRE_TIMEOUT: Duration = Duration::from_secs(10);
 const RETIRE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const DROP_TIMEOUT: Duration = Duration::from_secs(1);
@@ -341,6 +341,7 @@ struct RegisteredQuery {
 struct PendingUnregister {
     response: oneshot::Sender<ServiceResult<()>>,
     known: bool,
+    deadline: Instant,
 }
 
 /// Sizing for the service. The defaults are the production values; tests shrink them to
@@ -463,6 +464,21 @@ impl IncrementalQueryServiceInner {
         outcome.storage
     }
 
+    fn expire_unregisters(&mut self) {
+        let now = Instant::now();
+        let expired = self
+            .pending_unregister
+            .iter()
+            .filter_map(|(id, pending)| (pending.deadline <= now).then_some(*id))
+            .collect::<Vec<_>>();
+        for id in expired {
+            let pending = self.pending_unregister.remove(&id).unwrap();
+            let _ = pending.response.send(Err(anyhow!(
+                "Incremental query {id} unregister timed out; cleanup is still pending"
+            )));
+        }
+    }
+
     // Applies whatever retirements have already arrived, and retires queries whose subscriber
     // went away. Never blocks.
     fn reap(&mut self) {
@@ -488,6 +504,7 @@ impl IncrementalQueryServiceInner {
         for id in gone {
             self.retire(id, RetireReason::SubscriberGone);
         }
+        self.expire_unregisters();
     }
 
     // Shutdown waits for teardown; ordinary unregister leaves the router running.
@@ -496,18 +513,22 @@ impl IncrementalQueryServiceInner {
         let mut failure: Option<Error> = None;
 
         while !self.retiring.is_empty() {
+            self.expire_unregisters();
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 break;
             }
-            match self.retired.recv_timeout(remaining) {
+            match self
+                .retired
+                .recv_timeout(remaining.min(RETIRE_POLL_INTERVAL))
+            {
                 Ok(outcome) => {
                     if let Err(error) = self.apply_retirement(outcome) {
                         failure.get_or_insert(error);
                     }
                 }
-                // The service holds a sender, so this only fires on timeout.
-                Err(_) => break,
+                Err(std_mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
             }
         }
 
@@ -525,6 +546,18 @@ impl IncrementalQueryServiceInner {
             let _ = pending.response.send(Err(anyhow!(
                 "Incremental query {id} did not retire before shutdown timed out"
             )));
+        }
+
+        if !self.retiring.is_empty() {
+            let mut handles = self.retiring.iter().copied().collect::<Vec<_>>();
+            handles.sort_unstable();
+            let message = format!(
+                "Incremental query shutdown timed out; queries still retiring: {handles:?}"
+            );
+            return match failure {
+                Some(error) => Err(error.context(message)),
+                None => Err(anyhow!(message)),
+            };
         }
 
         match failure {
@@ -685,8 +718,14 @@ impl IncrementalQueryServiceInner {
                 .is_some_and(|subscriber| !subscriber.is_closed())
         });
         self.retire(handle, RetireReason::Unregistered);
-        self.pending_unregister
-            .insert(handle, PendingUnregister { response, known });
+        self.pending_unregister.insert(
+            handle,
+            PendingUnregister {
+                response,
+                known,
+                deadline: Instant::now() + self.config.retire_timeout,
+            },
+        );
     }
 
     fn apply_triples(
@@ -1318,6 +1357,132 @@ mod tests {
         drop(commands);
         router.join().unwrap();
         assert!(!dir.path().join("query-2").exists());
+    }
+
+    #[test]
+    fn shutdown_timeout_preserves_live_storage_until_worker_retires() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig {
+                retire_timeout: Duration::from_millis(20),
+                ..IncrementalServiceConfig::default()
+            },
+            CancellationToken::new(),
+        );
+        let subscription = inner
+            .register(
+                single_pattern_plan(),
+                test_tx_key_with_tx_id(1),
+                test_cursor(),
+                Vec::new(),
+            )
+            .unwrap();
+        let resume = pause_worker(&inner, subscription.handle);
+
+        let error = inner.remove_all_queries().unwrap_err();
+        assert!(error.to_string().contains("shutdown timed out"));
+        assert!(inner.retiring.contains(&subscription.handle));
+        assert!(dir.path().join("query-1").exists());
+
+        resume.send(()).unwrap();
+        let outcome = inner.retired.recv_timeout(Duration::from_secs(5)).unwrap();
+        inner.apply_retirement(outcome).unwrap();
+        assert!(inner.retiring.is_empty());
+        assert!(!dir.path().join("query-1").exists());
+        inner.remove_all_queries().unwrap();
+    }
+
+    #[test]
+    fn unregister_timeout_leaves_worker_tracked_for_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig {
+                retire_timeout: Duration::ZERO,
+                ..IncrementalServiceConfig::default()
+            },
+            CancellationToken::new(),
+        );
+        let subscription = inner
+            .register(
+                single_pattern_plan(),
+                test_tx_key_with_tx_id(1),
+                test_cursor(),
+                Vec::new(),
+            )
+            .unwrap();
+        let resume = pause_worker(&inner, subscription.handle);
+        let (response, result) = oneshot::channel();
+        inner.unregister(subscription.handle, response);
+        inner.reap();
+        let error = test_runtime().block_on(async {
+            tokio::time::timeout(Duration::from_secs(1), result)
+                .await
+                .expect("expired unregister must resolve")
+                .unwrap()
+                .unwrap_err()
+        });
+        assert!(error.to_string().contains("unregister timed out"));
+        assert!(inner.pending_unregister.is_empty());
+        assert!(inner.retiring.contains(&subscription.handle));
+        assert!(dir.path().join("query-1").exists());
+
+        resume.send(()).unwrap();
+        let outcome = inner.retired.recv_timeout(Duration::from_secs(5)).unwrap();
+        inner.apply_retirement(outcome).unwrap();
+        assert!(inner.retiring.is_empty());
+        assert!(!dir.path().join("query-1").exists());
+    }
+
+    #[test]
+    fn unregister_deadline_expires_without_another_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig {
+                retire_timeout: Duration::from_millis(100),
+                ..IncrementalServiceConfig::default()
+            },
+            CancellationToken::new(),
+        );
+        let mut subscription = inner
+            .register(
+                single_pattern_plan(),
+                test_tx_key_with_tx_id(1),
+                test_cursor(),
+                Vec::new(),
+            )
+            .unwrap();
+        let resume = pause_worker(&inner, subscription.handle);
+        let (commands, receiver) = std_mpsc::channel();
+        let router = thread::spawn(move || inner.run(receiver));
+        let (response, result) = oneshot::channel();
+        commands
+            .send(IncrementalCommand::Unregister {
+                handle: subscription.handle,
+                response,
+            })
+            .unwrap();
+        test_runtime().block_on(async {
+            let error = tokio::time::timeout(Duration::from_secs(5), result)
+                .await
+                .expect("unregister must time out without another command")
+                .unwrap()
+                .unwrap_err();
+            assert!(error.to_string().contains("unregister timed out"));
+            assert!(dir.path().join("query-1").exists());
+            resume.send(()).unwrap();
+            assert!(
+                tokio::time::timeout(Duration::from_secs(5), subscription.deltas.recv())
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+        });
+        drop(commands);
+        router.join().unwrap();
+        assert!(!dir.path().join("query-1").exists());
     }
 
     #[test]

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -13,7 +13,7 @@ use anyhow::{anyhow, Context, Error, Result};
 use dbsp::{utils::Tup2, ZWeight};
 use slatedb::object_store::ObjectStore;
 use tokio::runtime::Runtime;
-use tokio::sync::{mpsc, oneshot, Mutex, RwLock, Semaphore};
+use tokio::sync::{mpsc, oneshot, watch, Mutex, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -40,8 +40,10 @@ const SUBSCRIPTION_CAPACITY: usize = 128;
 const QUERY_INBOX_CAPACITY: usize = 256;
 // How many circuits may step at once. Kept well under the runtime's blocking pool.
 const MAX_CONCURRENT_STEPS: usize = 4;
-// How long shutdown and unregister wait for a worker to drop its circuit and clean up.
+// How long shutdown waits for workers, and terminal errors wait for delivery.
 const RETIRE_TIMEOUT: Duration = Duration::from_secs(10);
+const RETIRE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const DROP_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub(crate) type EncodedValue = Vec<u8>;
 pub(crate) type EncodedRow = Vec<EncodedValue>;
@@ -114,6 +116,11 @@ enum IncrementalCommand {
     // everything queued ahead of it.
     Flush {
         response: oneshot::Sender<ServiceResult<Vec<oneshot::Receiver<()>>>>,
+    },
+    #[cfg(test)]
+    InjectPanic {
+        handle: IncrementalQueryHandle,
+        response: oneshot::Sender<ServiceResult<()>>,
     },
     Shutdown {
         response: oneshot::Sender<ServiceResult<()>>,
@@ -284,6 +291,16 @@ impl IncrementalQueryService {
         Ok(())
     }
 
+    /// Makes one worker panic, so its isolation from the service can be tested for real.
+    #[cfg(test)]
+    pub(crate) async fn inject_panic(&self, handle: IncrementalQueryHandle) -> Result<()> {
+        let (response, result) = oneshot::channel();
+        self.commands
+            .send(IncrementalCommand::InjectPanic { handle, response })
+            .map_err(|_| anyhow!("Incremental query service stopped"))?;
+        result.await.context("Incremental query service stopped")?
+    }
+
     pub(crate) async fn shutdown(&self) -> Result<()> {
         self.cancel.cancel();
         let cdc_result = self.await_cdc_task().await;
@@ -311,12 +328,19 @@ impl IncrementalQueryService {
 
 struct RegisteredQuery {
     inbox: mpsc::Sender<WorkerMessage>,
+    routed: u64,
+    delivered: watch::Receiver<u64>,
     terminate: Option<oneshot::Sender<RetireReason>>,
     // Weak so the router can spot a dropped receiver without keeping the subscription open:
     // a strong clone here would delay end-of-stream until the next command reaped it.
     subscriber: mpsc::WeakSender<Result<IncrementalQueryDelta>>,
     tx_key: TxKey,
     wal_cursor: CdcCursor,
+}
+
+struct PendingUnregister {
+    response: oneshot::Sender<ServiceResult<()>>,
+    known: bool,
 }
 
 /// Sizing for the service. The defaults are the production values; tests shrink them to
@@ -348,6 +372,7 @@ struct IncrementalQueryServiceInner {
     queries: HashMap<IncrementalQueryHandle, RegisteredQuery>,
     // Retired here but not yet acked by their worker, so their storage may still exist.
     retiring: HashSet<IncrementalQueryHandle>,
+    pending_unregister: HashMap<IncrementalQueryHandle, PendingUnregister>,
     // Owned rather than borrowed from the node, so circuit work cannot starve request
     // serving and workers can still retire while the node's runtime is going away.
     // `None` only while dropping.
@@ -383,6 +408,7 @@ impl IncrementalQueryServiceInner {
             storage_root,
             queries: HashMap::new(),
             retiring: HashSet::new(),
+            pending_unregister: HashMap::new(),
             runtime: Some(runtime),
             steps: Arc::new(Semaphore::new(config.max_concurrent_steps)),
             config,
@@ -418,6 +444,22 @@ impl IncrementalQueryServiceInner {
     fn apply_retirement(&mut self, outcome: RetireOutcome) -> ServiceResult<()> {
         self.retiring.remove(&outcome.id);
         self.queries.remove(&outcome.id);
+        if let Some(pending) = self.pending_unregister.remove(&outcome.id) {
+            let result = outcome.storage.and_then(|()| {
+                if pending.known {
+                    Ok(())
+                } else {
+                    Err(anyhow!(
+                        "Unknown incremental query handle: {:?}",
+                        outcome.id
+                    ))
+                }
+            });
+            if let Err(Err(error)) = pending.response.send(result) {
+                warn!("{}", error);
+            }
+            return Ok(());
+        }
         outcome.storage
     }
 
@@ -448,8 +490,7 @@ impl IncrementalQueryServiceInner {
         }
     }
 
-    // Blocks the router until every retiring worker has dropped its circuit and cleaned up.
-    // Only unregister and shutdown reach this, and it is bounded by `retire_timeout`.
+    // Shutdown waits for teardown; ordinary unregister leaves the router running.
     fn await_retirements(&mut self) -> ServiceResult<()> {
         let deadline = Instant::now() + self.config.retire_timeout;
         let mut failure: Option<Error> = None;
@@ -472,13 +513,18 @@ impl IncrementalQueryServiceInner {
 
         // A worker wedged inside a circuit step cannot be interrupted - DBSP exposes no
         // external kill - so leave its storage rather than unlinking under a live circuit.
-        for id in self.retiring.drain().collect::<Vec<_>>() {
+        for id in &self.retiring {
             warn!(
                 "Incremental query {} did not retire within {:?}; leaving {} behind",
                 id,
                 self.config.retire_timeout,
-                self.query_storage_path(id).display()
+                self.query_storage_path(*id).display()
             );
+        }
+        for (id, pending) in self.pending_unregister.drain() {
+            let _ = pending.response.send(Err(anyhow!(
+                "Incremental query {id} did not retire before shutdown timed out"
+            )));
         }
 
         match failure {
@@ -488,7 +534,14 @@ impl IncrementalQueryServiceInner {
     }
 
     fn run(mut self, receiver: std_mpsc::Receiver<IncrementalCommand>) {
-        while let Ok(command) = receiver.recv() {
+        loop {
+            self.reap();
+            // Retirements use a separate channel so workers cannot keep commands alive.
+            let command = match receiver.recv_timeout(RETIRE_POLL_INTERVAL) {
+                Ok(command) => command,
+                Err(std_mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
+            };
             self.reap();
             match command {
                 IncrementalCommand::Register { request, response } => {
@@ -501,7 +554,7 @@ impl IncrementalQueryServiceInner {
                     let _ = response.send(self.register(plan, tx_key, wal_cursor, initial_triples));
                 }
                 IncrementalCommand::Unregister { handle, response } => {
-                    let _ = response.send(self.unregister(handle));
+                    self.unregister(handle, response);
                 }
                 IncrementalCommand::ApplyTriples {
                     tx_key,
@@ -513,6 +566,17 @@ impl IncrementalQueryServiceInner {
                 }
                 IncrementalCommand::Flush { response } => {
                     let _ = response.send(self.flush());
+                }
+                #[cfg(test)]
+                IncrementalCommand::InjectPanic { handle, response } => {
+                    let result = match self.queries.get(&handle) {
+                        Some(query) => query
+                            .inbox
+                            .try_send(WorkerMessage::Panic)
+                            .map_err(|err| anyhow!("Failed to inject worker panic: {}", err)),
+                        None => Err(anyhow!("Unknown incremental query handle: {:?}", handle)),
+                    };
+                    let _ = response.send(result);
                 }
                 IncrementalCommand::Shutdown { response } => {
                     let _ = response.send(self.remove_all_queries());
@@ -557,6 +621,7 @@ impl IncrementalQueryServiceInner {
         }
 
         let (inbox, inbox_receiver) = mpsc::channel(self.config.inbox_capacity);
+        let (delivered, delivery_progress) = watch::channel(0);
         let (terminate, terminate_receiver) = oneshot::channel();
         spawn_query_worker(
             self.runtime
@@ -568,8 +633,8 @@ impl IncrementalQueryServiceInner {
                 circuit: Some(circuit),
                 storage_path,
                 inbox: inbox_receiver,
-                // The worker holds the only strong sender, so the subscription ends the
-                // moment it retires.
+                delivered,
+                // Only the worker and supervisor keep the subscription open.
                 subscriber: subscriber.clone(),
                 terminate: terminate_receiver,
                 retirements: self.retirements.clone(),
@@ -583,6 +648,8 @@ impl IncrementalQueryServiceInner {
             handle,
             RegisteredQuery {
                 inbox,
+                routed: 0,
+                delivered: delivery_progress,
                 terminate: Some(terminate),
                 subscriber: subscriber.downgrade(),
                 tx_key,
@@ -597,14 +664,29 @@ impl IncrementalQueryServiceInner {
         })
     }
 
-    fn unregister(&mut self, handle: IncrementalQueryHandle) -> ServiceResult<()> {
-        let known = self.retire(handle, RetireReason::Unregistered);
-        // Wait either way, so storage really is gone by the time the caller hears back.
-        let cleanup = self.await_retirements();
-        if !known {
-            return Err(anyhow!("Unknown incremental query handle: {:?}", handle));
+    fn unregister(
+        &mut self,
+        handle: IncrementalQueryHandle,
+        response: oneshot::Sender<ServiceResult<()>>,
+    ) {
+        if self.pending_unregister.contains_key(&handle)
+            || (!self.queries.contains_key(&handle) && !self.retiring.contains(&handle))
+        {
+            let _ = response.send(Err(anyhow!(
+                "Unknown incremental query handle: {:?}",
+                handle
+            )));
+            return;
         }
-        cleanup
+        let known = self.queries.get(&handle).is_some_and(|query| {
+            query
+                .subscriber
+                .upgrade()
+                .is_some_and(|subscriber| !subscriber.is_closed())
+        });
+        self.retire(handle, RetireReason::Unregistered);
+        self.pending_unregister
+            .insert(handle, PendingUnregister { response, known });
     }
 
     fn apply_triples(
@@ -627,7 +709,10 @@ impl IncrementalQueryServiceInner {
                 triples: triples.clone(),
             };
             match query.inbox.try_send(work) {
-                Ok(()) => query.wal_cursor.last_seq = wal_seq,
+                Ok(()) => {
+                    query.routed += 1;
+                    query.wal_cursor.last_seq = wal_seq;
+                }
                 // Full means the query is behind; closed means its worker already stopped.
                 Err(_) => lagged.push(*id),
             }
@@ -644,19 +729,20 @@ impl IncrementalQueryServiceInner {
     // queued ahead of the barrier.
     fn flush(&mut self) -> ServiceResult<Vec<oneshot::Receiver<()>>> {
         let mut acks = Vec::new();
-        let mut lagged = Vec::new();
-
-        for (id, query) in &self.queries {
+        for query in self.queries.values() {
             let (ack, wait) = oneshot::channel();
-            match query.inbox.try_send(WorkerMessage::Flush(ack)) {
-                Ok(()) => acks.push(wait),
-                Err(_) => lagged.push(*id),
-            }
-        }
-
-        let capacity = self.config.inbox_capacity;
-        for id in lagged {
-            self.retire(id, RetireReason::Lagged { capacity });
+            let target = query.routed;
+            let mut delivered = query.delivered.clone();
+            // A barrier must not consume inbox capacity or terminate a busy query.
+            self.runtime.as_ref().unwrap().spawn(async move {
+                while *delivered.borrow_and_update() < target {
+                    if delivered.changed().await.is_err() {
+                        return;
+                    }
+                }
+                let _ = ack.send(());
+            });
+            acks.push(wait);
         }
         Ok(acks)
     }
@@ -671,6 +757,7 @@ impl IncrementalQueryServiceInner {
     }
 
     fn remove_all_queries(&mut self) -> ServiceResult<()> {
+        self.cancel.cancel();
         for id in self.queries.keys().copied().collect::<Vec<_>>() {
             self.retire(id, RetireReason::Shutdown);
         }
@@ -680,12 +767,14 @@ impl IncrementalQueryServiceInner {
 
 impl Drop for IncrementalQueryServiceInner {
     fn drop(&mut self) {
+        self.config.retire_timeout = self.config.retire_timeout.min(DROP_TIMEOUT);
+        let deadline = Instant::now() + self.config.retire_timeout;
         if let Err(error) = self.remove_all_queries() {
             warn!("{}", error);
         }
         // Bounded, because a worker wedged in a circuit step would otherwise block for ever.
         if let Some(runtime) = self.runtime.take() {
-            runtime.shutdown_timeout(self.config.retire_timeout);
+            runtime.shutdown_timeout(deadline.saturating_duration_since(Instant::now()));
         }
     }
 }
@@ -1135,6 +1224,462 @@ mod tests {
             .expect("shutdown must not wait on a parked worker")
             .unwrap();
         assert!(!dir.path().join("query-1").exists());
+    }
+
+    // Bound delivery waits so a stalled worker fails the test instead of hanging it.
+    async fn recv_delta(
+        subscription: &mut IncrementalQuerySubscription,
+    ) -> Result<IncrementalQueryDelta> {
+        tokio::time::timeout(Duration::from_secs(10), subscription.deltas.recv())
+            .await
+            .expect("a delta should arrive")
+            .expect("the subscription should still be open")
+    }
+
+    fn pause_worker(
+        inner: &IncrementalQueryServiceInner,
+        handle: IncrementalQueryHandle,
+    ) -> oneshot::Sender<()> {
+        let (started, wait) = oneshot::channel();
+        let (resume, paused) = oneshot::channel();
+        inner.queries[&handle]
+            .inbox
+            .try_send(WorkerMessage::Pause {
+                started,
+                resume: paused,
+            })
+            .unwrap();
+        test_runtime().block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), wait)
+                .await
+                .unwrap()
+                .unwrap();
+        });
+        resume
+    }
+
+    #[test]
+    fn unregister_waits_for_its_worker_without_blocking_the_router() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig::default(),
+            CancellationToken::new(),
+        );
+        let basis = test_tx_key_with_tx_id(1);
+        let paused = inner
+            .register(single_pattern_plan(), basis, test_cursor(), Vec::new())
+            .unwrap();
+        let mut healthy = inner
+            .register(single_pattern_plan(), basis, test_cursor(), Vec::new())
+            .unwrap();
+        let resume = pause_worker(&inner, paused.handle);
+        let (commands, receiver) = std_mpsc::channel();
+        let router = thread::spawn(move || inner.run(receiver));
+
+        test_runtime().block_on(async {
+            let (response, mut unregistered) = oneshot::channel();
+            commands
+                .send(IncrementalCommand::Unregister {
+                    handle: paused.handle,
+                    response,
+                })
+                .unwrap();
+            let (response, applied) = oneshot::channel();
+            commands
+                .send(IncrementalCommand::ApplyTriples {
+                    tx_key: test_tx_key_with_tx_id(2),
+                    wal_seq: 2,
+                    triples: Arc::from(vec![name_triple(42, "Alice")]),
+                    response,
+                })
+                .unwrap();
+            tokio::time::timeout(Duration::from_secs(5), applied)
+                .await
+                .expect("unregister must leave the router responsive")
+                .unwrap()
+                .unwrap();
+            assert_eq!(expect_delta(recv_delta(&mut healthy).await).tx_key.tx_id, 2);
+            assert!(matches!(
+                unregistered.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+            assert!(dir.path().join("query-1").exists());
+
+            resume.send(()).unwrap();
+            tokio::time::timeout(Duration::from_secs(5), unregistered)
+                .await
+                .expect("retirement must be reaped without another command")
+                .unwrap()
+                .unwrap();
+            assert!(!dir.path().join("query-1").exists());
+        });
+
+        drop(commands);
+        router.join().unwrap();
+        assert!(!dir.path().join("query-2").exists());
+    }
+
+    #[test]
+    fn flush_does_not_overflow_a_full_worker_inbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig {
+                inbox_capacity: 2,
+                ..IncrementalServiceConfig::default()
+            },
+            CancellationToken::new(),
+        );
+        let mut subscription = inner
+            .register(
+                single_pattern_plan(),
+                test_tx_key_with_tx_id(1),
+                test_cursor(),
+                Vec::new(),
+            )
+            .unwrap();
+        let resume = pause_worker(&inner, subscription.handle);
+        for seq in 2..=3 {
+            inner
+                .apply_triples(
+                    test_tx_key_with_tx_id(seq),
+                    seq as u64,
+                    Arc::from(vec![name_triple(seq, "Alice")]),
+                )
+                .unwrap();
+        }
+        assert_eq!(inner.queries[&subscription.handle].inbox.capacity(), 0);
+        let mut ack = inner.flush().unwrap().pop().unwrap();
+        assert!(inner.queries.contains_key(&subscription.handle));
+        assert!(matches!(
+            ack.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        resume.send(()).unwrap();
+        test_runtime().block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), ack)
+                .await
+                .unwrap()
+                .unwrap();
+            for seq in 2..=3 {
+                assert_eq!(
+                    expect_delta(recv_delta(&mut subscription).await)
+                        .tx_key
+                        .tx_id,
+                    seq
+                );
+            }
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn deltas_arrive_in_wal_order_for_a_slow_subscriber() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = IncrementalServiceConfig {
+            // Small enough that the worker parks on the subscriber between transactions.
+            subscription_capacity: 2,
+            inbox_capacity: 64,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let mut subscription = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(1),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+        let applied = 24;
+        for seq in 1..=applied {
+            let name = format!("Alice {seq}");
+            service
+                .apply_triples(
+                    test_tx_key_with_tx_id(seq as i64 + 1),
+                    seq as u64,
+                    vec![name_triple(seq as i64, &name)],
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut seen = Vec::new();
+        while seen.len() < applied {
+            let delta = expect_delta(recv_delta(&mut subscription).await);
+            seen.push(delta.tx_key.tx_id);
+            // Drain slowly, so the worker keeps parking on a full subscriber channel.
+            tokio::task::yield_now().await;
+        }
+
+        let mut ordered = seen.clone();
+        ordered.sort_unstable();
+        assert_eq!(seen, ordered, "deltas must arrive in WAL order");
+        assert_eq!(seen, (2..=applied as i64 + 1).collect::<Vec<_>>());
+        service.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn lag_error_timeout_closes_the_subscription_and_cleans_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut inner = IncrementalQueryServiceInner::new(
+            dir.path().to_path_buf(),
+            IncrementalServiceConfig {
+                subscription_capacity: 1,
+                inbox_capacity: 1,
+                retire_timeout: Duration::from_millis(50),
+                ..IncrementalServiceConfig::default()
+            },
+            CancellationToken::new(),
+        );
+        let mut subscription = inner
+            .register(
+                single_pattern_plan(),
+                test_tx_key_with_tx_id(1),
+                test_cursor(),
+                vec![name_triple(1, "Priming")],
+            )
+            .unwrap();
+        let resume = pause_worker(&inner, subscription.handle);
+        for seq in 2..=3 {
+            inner
+                .apply_triples(
+                    test_tx_key_with_tx_id(seq),
+                    seq as u64,
+                    Arc::from(vec![name_triple(seq, "Alice")]),
+                )
+                .unwrap();
+        }
+        resume.send(()).unwrap();
+        let outcome = inner.retired.recv_timeout(Duration::from_secs(5)).unwrap();
+        inner.apply_retirement(outcome).unwrap();
+        assert!(!dir.path().join("query-1").exists());
+        assert_eq!(
+            expect_delta(subscription.deltas.try_recv().unwrap())
+                .tx_key
+                .tx_id,
+            1
+        );
+        test_runtime().block_on(async {
+            assert!(
+                tokio::time::timeout(Duration::from_secs(5), subscription.deltas.recv())
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_slow_query_does_not_stall_a_fast_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = IncrementalServiceConfig {
+            subscription_capacity: 1,
+            inbox_capacity: 32,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let basis = test_tx_key_with_tx_id(1);
+        // Nobody ever reads `_wedged`, so its worker parks on the very first delivery.
+        let _wedged = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+        let mut healthy = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+
+        let applied = 8;
+        for seq in 1..=applied {
+            let name = format!("Alice {seq}");
+            service
+                .apply_triples(
+                    test_tx_key_with_tx_id(seq as i64 + 1),
+                    seq as u64,
+                    vec![name_triple(seq as i64, &name)],
+                )
+                .await
+                .unwrap();
+        }
+
+        // The old lock-step service could not pass this: the wedged subscriber held the
+        // single service thread and no other query made progress.
+        for seq in 1..=applied {
+            let delta = expect_delta(recv_delta(&mut healthy).await);
+            assert_eq!(delta.tx_key.tx_id, seq as i64 + 1);
+        }
+        service.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn inbox_overflow_terminates_only_the_lagging_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = IncrementalServiceConfig {
+            subscription_capacity: 1,
+            inbox_capacity: 2,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let basis = test_tx_key_with_tx_id(1);
+        let mut lagging = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+        let mut healthy = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+
+        // Far more than `lagging` can buffer while nobody reads it.
+        let applied = 12;
+        for seq in 1..=applied {
+            let name = format!("Alice {seq}");
+            service
+                .apply_triples(
+                    test_tx_key_with_tx_id(seq as i64 + 1),
+                    seq as u64,
+                    vec![name_triple(seq as i64, &name)],
+                )
+                .await
+                .unwrap();
+            // Drain `healthy` as it goes - on this deliberately tiny config it would
+            // otherwise fall behind too, and both queries would be terminated.
+            let delta = expect_delta(recv_delta(&mut healthy).await);
+            assert_eq!(delta.tx_key.tx_id, seq as i64 + 1);
+        }
+
+        // The lagging subscription ends with a terminal error rather than silently gapping.
+        let mut delivered = 0;
+        let error = loop {
+            match tokio::time::timeout(Duration::from_secs(10), lagging.deltas.recv())
+                .await
+                .expect("the lagging subscription should resolve")
+            {
+                Some(Ok(_)) => delivered += 1,
+                Some(Err(error)) => break error,
+                None => panic!(
+                    "lagging subscription closed after {delivered} deltas without a \
+                     terminal error"
+                ),
+            }
+        };
+        assert!(
+            error.to_string().contains("fell behind"),
+            "unexpected terminal error: {error}"
+        );
+        assert!(error
+            .downcast_ref::<crate::incremental::worker::SubscriptionLagError>()
+            .is_some());
+        assert!(delivered < applied, "the lagging query should have gapped");
+        assert!(lagging.deltas.recv().await.is_none());
+        assert!(service.unregister(lagging.handle).await.is_err());
+        assert!(!dir.path().join("query-1").exists());
+
+        // The healthy neighbour is untouched and still receiving.
+        service
+            .apply_triples(
+                test_tx_key_with_tx_id(applied as i64 + 2),
+                applied as u64 + 1,
+                vec![name_triple(99, "Zoe")],
+            )
+            .await
+            .unwrap();
+        let delta = expect_delta(recv_delta(&mut healthy).await);
+        assert_eq!(
+            delta.rows,
+            vec![(vec![DataType::String("Zoe".to_string())], 1)]
+        );
+        service.shutdown().await.unwrap();
+    }
+
+    // The CDC loop replays the WAL from the beginning, so a query registered on a node with
+    // history sees a burst of transactions at or below its basis. Those must be skipped at
+    // the router; routing them would fill the inbox and terminate a healthy new query.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn replayed_history_does_not_terminate_a_fresh_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = IncrementalServiceConfig {
+            subscription_capacity: 1,
+            inbox_capacity: 2,
+            ..IncrementalServiceConfig::default()
+        };
+        let service = test_service(dir.path(), config);
+        let basis = test_tx_key_with_tx_id(500);
+        let mut subscription = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+
+        // Replay far more history than the inbox could ever hold.
+        for tx_id in 1..=100 {
+            let name = format!("Historic {tx_id}");
+            service
+                .apply_triples(
+                    test_tx_key_with_tx_id(tx_id),
+                    tx_id as u64,
+                    vec![name_triple(tx_id, &name)],
+                )
+                .await
+                .unwrap();
+        }
+        service.flush().await.unwrap();
+
+        // Still alive, and still able to receive a transaction after its basis.
+        let live = test_tx_key_with_tx_id(501);
+        service
+            .apply_triples(live, 501, vec![name_triple(1000, "Live")])
+            .await
+            .unwrap();
+        let delta = expect_delta(recv_delta(&mut subscription).await);
+        assert_eq!(delta.tx_key, live);
+        assert_eq!(
+            delta.rows,
+            vec![(vec![DataType::String("Live".to_string())], 1)]
+        );
+        service.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn worker_panic_retires_only_that_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = test_service(dir.path(), IncrementalServiceConfig::default());
+        let basis = test_tx_key_with_tx_id(1);
+        let mut panicking = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+        let mut healthy = register(&service, single_pattern_plan(), basis, Vec::new())
+            .await
+            .unwrap();
+
+        service.inject_panic(panicking.handle).await.unwrap();
+
+        let error = expect_error(recv_delta(&mut panicking).await);
+        assert!(
+            error.to_string().contains("panicked"),
+            "unexpected terminal error: {error}"
+        );
+        assert!(panicking.deltas.recv().await.is_none());
+        // Whether this reports the handle as unknown depends on whether the retirement was
+        // already reaped, but either way it waits for the teardown to finish.
+        let _ = service.unregister(panicking.handle).await;
+        assert!(!dir.path().join("query-1").exists());
+
+        // The service survived, the neighbour still works, and new queries still register.
+        service
+            .apply_triples(test_tx_key_with_tx_id(2), 2, vec![name_triple(42, "Alice")])
+            .await
+            .unwrap();
+        let delta = expect_delta(recv_delta(&mut healthy).await);
+        assert_eq!(
+            delta.rows,
+            vec![(vec![DataType::String("Alice".to_string())], 1)]
+        );
+        let _fresh = register(
+            &service,
+            single_pattern_plan(),
+            test_tx_key_with_tx_id(2),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+        service.shutdown().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/incremental/cdc.rs
+++ b/src/incremental/cdc.rs
@@ -214,7 +214,7 @@ mod tests {
         )));
         let service = IncrementalQueryService::new(
             tempfile::tempdir().unwrap().path().to_path_buf(),
-            tokio::runtime::Handle::current(),
+            crate::incremental::IncrementalServiceConfig::default(),
             CancellationToken::new(),
             slate.object_path.clone(),
             slate.object_store.clone(),

--- a/src/incremental/worker.rs
+++ b/src/incremental/worker.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Error, Result};
 use dbsp::{utils::Tup2, ZWeight};
 use tokio::runtime::Handle;
-use tokio::sync::{mpsc, oneshot, Semaphore};
+use tokio::sync::{mpsc, oneshot, watch, Semaphore};
 use tokio::task::spawn_blocking;
 use tokio_util::sync::CancellationToken;
 use triplox_client::transaction::TxKey;
@@ -35,11 +35,14 @@ pub(in crate::incremental) enum WorkerMessage {
         tx_key: TxKey,
         triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
     },
-    /// Barrier: acked once everything queued ahead of it has been stepped and delivered.
-    Flush(oneshot::Sender<()>),
     /// Injects a worker panic, so the supervisor's isolation can be tested for real.
     #[cfg(test)]
     Panic,
+    #[cfg(test)]
+    Pause {
+        started: oneshot::Sender<()>,
+        resume: oneshot::Receiver<()>,
+    },
 }
 
 /// Why a worker stopped. Only the first two reach the subscriber as a terminal error.
@@ -75,6 +78,7 @@ pub(in crate::incremental) struct QueryWorker {
     pub circuit: Option<QueryCircuit>,
     pub storage_path: PathBuf,
     pub inbox: mpsc::Receiver<WorkerMessage>,
+    pub delivered: watch::Sender<u64>,
     pub subscriber: mpsc::Sender<Result<IncrementalQueryDelta>>,
     pub terminate: oneshot::Receiver<RetireReason>,
     pub retirements: std_mpsc::Sender<RetireOutcome>,
@@ -110,6 +114,7 @@ pub(in crate::incremental) fn spawn_query_worker(runtime: &Handle, worker: Query
     let subscriber = worker.subscriber.clone();
     let retirements = worker.retirements.clone();
     let retire_timeout = worker.retire_timeout;
+    let cancel = worker.cancel.clone();
 
     runtime.spawn(async move {
         if tokio::spawn(worker.run()).await.is_ok() {
@@ -118,7 +123,11 @@ pub(in crate::incremental) fn spawn_query_worker(runtime: &Handle, worker: Query
         // The worker panicked, so its circuit was already dropped while unwinding; only the
         // subscriber notice, the storage directory and the ack are left to do.
         let error = anyhow!("Incremental query circuit worker panicked");
-        let _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))).await;
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {},
+            _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))) => {},
+        }
         drop(subscriber);
         finish_retirement(id, None, storage_path, retirements).await;
     });
@@ -151,13 +160,16 @@ impl QueryWorker {
             match message {
                 #[cfg(test)]
                 WorkerMessage::Panic => panic!("injected incremental query worker panic"),
-                WorkerMessage::Flush(ack) => {
-                    let _ = ack.send(());
+                #[cfg(test)]
+                WorkerMessage::Pause { started, resume } => {
+                    let _ = started.send(());
+                    let _ = resume.await;
                 }
                 WorkerMessage::Apply { tx_key, triples } => {
                     if let Err(reason) = self.step(tx_key, triples).await {
                         return reason;
                     }
+                    self.delivered.send_modify(|count| *count += 1);
                 }
             }
         }
@@ -231,13 +243,18 @@ impl QueryWorker {
             subscriber,
             retirements,
             retire_timeout,
+            cancel,
             ..
         } = self;
 
         if let Some(error) = reason.into_subscriber_error() {
             // A lagging query is precisely the one whose channel is full, so bound the wait
             // rather than parking here forever; the subscriber then just sees a clean end.
-            let _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))).await;
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {},
+                _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))) => {},
+            }
         }
         drop(subscriber);
         finish_retirement(id, circuit, storage_path, retirements).await;

--- a/src/incremental/worker.rs
+++ b/src/incremental/worker.rs
@@ -1,0 +1,245 @@
+//! Per-query circuit driver tasks.
+//!
+//! One worker task owns one `QueryCircuit`. The router fans a transaction into every
+//! query's inbox and never blocks on a circuit step or a subscriber send, so a slow or
+//! wedged query cannot stall the other queries or the CDC loop.
+
+use std::path::PathBuf;
+use std::sync::mpsc as std_mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Error, Result};
+use dbsp::{utils::Tup2, ZWeight};
+use tokio::runtime::Handle;
+use tokio::sync::{mpsc, oneshot, Semaphore};
+use tokio::task::spawn_blocking;
+use tokio_util::sync::CancellationToken;
+use triplox_client::transaction::TxKey;
+
+use crate::incremental::circuit::QueryCircuit;
+use crate::incremental::{
+    remove_query_storage, EncodedTriple, IncrementalQueryDelta, IncrementalQueryHandle,
+};
+use crate::ops::DataType;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Incremental query fell behind by more than {capacity} pending transactions")]
+pub(in crate::incremental) struct SubscriptionLagError {
+    pub capacity: usize,
+}
+
+/// Work routed to one query, in WAL order.
+pub(in crate::incremental) enum WorkerMessage {
+    Apply {
+        tx_key: TxKey,
+        triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
+    },
+    /// Barrier: acked once everything queued ahead of it has been stepped and delivered.
+    Flush(oneshot::Sender<()>),
+    /// Injects a worker panic, so the supervisor's isolation can be tested for real.
+    #[cfg(test)]
+    Panic,
+}
+
+/// Why a worker stopped. Only the first two reach the subscriber as a terminal error.
+pub(in crate::incremental) enum RetireReason {
+    CircuitFailed(Error),
+    Lagged { capacity: usize },
+    Unregistered,
+    SubscriberGone,
+    Shutdown,
+}
+
+impl RetireReason {
+    fn into_subscriber_error(self) -> Option<Error> {
+        match self {
+            RetireReason::CircuitFailed(error) => Some(error),
+            RetireReason::Lagged { capacity } => Some(SubscriptionLagError { capacity }.into()),
+            RetireReason::Unregistered | RetireReason::SubscriberGone | RetireReason::Shutdown => {
+                None
+            }
+        }
+    }
+}
+
+/// Reported back to the router once the circuit is gone and its storage is cleaned up.
+pub(in crate::incremental) struct RetireOutcome {
+    pub id: IncrementalQueryHandle,
+    pub storage: Result<()>,
+}
+
+pub(in crate::incremental) struct QueryWorker {
+    pub id: IncrementalQueryHandle,
+    /// Only `None` while the circuit is on loan to the blocking pool for a step.
+    pub circuit: Option<QueryCircuit>,
+    pub storage_path: PathBuf,
+    pub inbox: mpsc::Receiver<WorkerMessage>,
+    pub subscriber: mpsc::Sender<Result<IncrementalQueryDelta>>,
+    pub terminate: oneshot::Receiver<RetireReason>,
+    pub retirements: std_mpsc::Sender<RetireOutcome>,
+    pub steps: Arc<Semaphore>,
+    pub cancel: CancellationToken,
+    pub retire_timeout: Duration,
+}
+
+// Drops the circuit and its storage off the async runtime, then acks the router.
+async fn finish_retirement(
+    id: IncrementalQueryHandle,
+    circuit: Option<QueryCircuit>,
+    storage_path: PathBuf,
+    retirements: std_mpsc::Sender<RetireOutcome>,
+) {
+    // Dropping a circuit joins its DBSP threads, so it must not run on the async runtime,
+    // and the directory can only go once those threads are gone.
+    let storage = spawn_blocking(move || {
+        drop(circuit);
+        remove_query_storage(&storage_path)
+    })
+    .await
+    .unwrap_or_else(|err| Err(anyhow!("Incremental query teardown task failed: {err}")));
+
+    let _ = retirements.send(RetireOutcome { id, storage });
+}
+
+/// Spawns the worker under a supervisor so a panic still retires the query and cleans up
+/// instead of taking the service down with it.
+pub(in crate::incremental) fn spawn_query_worker(runtime: &Handle, worker: QueryWorker) {
+    let id = worker.id;
+    let storage_path = worker.storage_path.clone();
+    let subscriber = worker.subscriber.clone();
+    let retirements = worker.retirements.clone();
+    let retire_timeout = worker.retire_timeout;
+
+    runtime.spawn(async move {
+        if tokio::spawn(worker.run()).await.is_ok() {
+            return;
+        }
+        // The worker panicked, so its circuit was already dropped while unwinding; only the
+        // subscriber notice, the storage directory and the ack are left to do.
+        let error = anyhow!("Incremental query circuit worker panicked");
+        let _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))).await;
+        drop(subscriber);
+        finish_retirement(id, None, storage_path, retirements).await;
+    });
+}
+
+impl QueryWorker {
+    async fn run(mut self) {
+        let reason = self.drive().await;
+        self.retire(reason).await;
+    }
+
+    // Consumes the inbox in order until something ends the subscription.
+    async fn drive(&mut self) -> RetireReason {
+        loop {
+            // Control arms are biased ahead of the inbox so termination is never queued
+            // behind pending work. They all leave the loop, so deltas cannot be reordered.
+            let message = tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => return RetireReason::Shutdown,
+                reason = &mut self.terminate => {
+                    return reason.unwrap_or(RetireReason::Unregistered);
+                }
+                _ = self.subscriber.closed() => return RetireReason::SubscriberGone,
+                message = self.inbox.recv() => match message {
+                    Some(message) => message,
+                    None => return RetireReason::Unregistered,
+                },
+            };
+
+            match message {
+                #[cfg(test)]
+                WorkerMessage::Panic => panic!("injected incremental query worker panic"),
+                WorkerMessage::Flush(ack) => {
+                    let _ = ack.send(());
+                }
+                WorkerMessage::Apply { tx_key, triples } => {
+                    if let Err(reason) = self.step(tx_key, triples).await {
+                        return reason;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn step(
+        &mut self,
+        tx_key: TxKey,
+        triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
+    ) -> Result<(), RetireReason> {
+        let rows = self.apply(triples).await?;
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        // Parking here is the normal way a slow subscriber shows up, so the control arms have
+        // to stay live: without them a wedged send would ignore lag termination and
+        // unregister until the retire deadline.
+        let delta = IncrementalQueryDelta { tx_key, rows };
+        tokio::select! {
+            biased;
+            _ = self.cancel.cancelled() => Err(RetireReason::Shutdown),
+            reason = &mut self.terminate => Err(reason.unwrap_or(RetireReason::Unregistered)),
+            result = self.subscriber.send(Ok(delta)) => result
+                .map_err(|_| RetireReason::SubscriberGone),
+        }
+    }
+
+    // Steps the circuit on the blocking pool; the semaphore caps how many circuits do that
+    // at once. `block_in_place` is not usable here because it panics on the current-thread
+    // runtimes that much of the test suite uses.
+    async fn apply(
+        &mut self,
+        triples: Arc<[Tup2<EncodedTriple, ZWeight>]>,
+    ) -> Result<Vec<(Vec<DataType>, isize)>, RetireReason> {
+        // Waiting for a permit is bounded by the other circuits, but stay interruptible so a
+        // queue of pending steps cannot delay termination.
+        let permit = tokio::select! {
+            biased;
+            _ = self.cancel.cancelled() => return Err(RetireReason::Shutdown),
+            reason = &mut self.terminate => {
+                return Err(reason.unwrap_or(RetireReason::Unregistered));
+            }
+            permit = self.steps.clone().acquire_owned() => {
+                permit.map_err(|_| RetireReason::Shutdown)?
+            }
+        };
+
+        let mut circuit = self
+            .circuit
+            .take()
+            .expect("the circuit is only on loan during a step");
+        let (circuit, rows) = spawn_blocking(move || {
+            // DBSP's `append` steals the buffer, so the circuit needs its own copy.
+            let rows = circuit.apply(triples.to_vec());
+            (circuit, rows)
+        })
+        .await
+        .expect("a panicking circuit step propagates to the worker's supervisor");
+        drop(permit);
+        self.circuit = Some(circuit);
+
+        rows.map_err(RetireReason::CircuitFailed)
+    }
+
+    async fn retire(self, reason: RetireReason) {
+        let QueryWorker {
+            id,
+            circuit,
+            storage_path,
+            subscriber,
+            retirements,
+            retire_timeout,
+            ..
+        } = self;
+
+        if let Some(error) = reason.into_subscriber_error() {
+            // A lagging query is precisely the one whose channel is full, so bound the wait
+            // rather than parking here forever; the subscriber then just sees a clean end.
+            let _ = tokio::time::timeout(retire_timeout, subscriber.send(Err(error))).await;
+        }
+        drop(subscriber);
+        finish_retirement(id, circuit, storage_path, retirements).await;
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,6 +14,7 @@ use crate::error::TriploxError;
 use crate::file_log::FileLog;
 use crate::incremental::{
     IncrementalQueryHandle, IncrementalQueryService, IncrementalQuerySubscription,
+    IncrementalServiceConfig,
 };
 use crate::indexer::{latest_tx_key_from_sdb, Indexer, TxOutcome, DEFAULT_TX_COMPLETION_CAPACITY};
 #[cfg(feature = "kafka")]
@@ -90,7 +91,7 @@ impl<L: TxLog> Node<L> {
         let subscription = subscribe(log.clone(), after_tx_id, indexer.clone()).await;
         let incremental = IncrementalQueryService::new(
             incremental_storage_path,
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             subscription.clone(),
             slate.object_path.clone(),
             slate.object_store.clone(),
@@ -132,7 +133,7 @@ impl Node<MemoryLog> {
                 "triplox-dbsp-incremental-{}",
                 crate::util::random_string(10)
             )),
-            Handle::current(),
+            IncrementalServiceConfig::default(),
             subscription.clone(),
             slate.object_path.clone(),
             slate.object_store.clone(),

--- a/tests/subscription_test.rs
+++ b/tests/subscription_test.rs
@@ -100,7 +100,7 @@ async fn subscription_returns_existing_rows_as_priming_delta() {
     token.cancel();
 }
 
-/// A slow consumer (transactions made before the client reads) loses no deltas:
+/// A slow consumer within the server's buffering limits loses no deltas:
 /// every transaction's change is delivered once the client drains.
 #[tokio::test(flavor = "multi_thread")]
 async fn subscription_loses_no_deltas_under_slow_consumer() {

--- a/triplox-jvm/src/main/clojure/xyz/triplox/view.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/view.clj
@@ -3,6 +3,7 @@
   subscriptions. This namespace may change or be removed without notice."
   (:require
    [clojure.core.async :as async]
+   [clojure.tools.logging :as log]
    [xyz.triplox.api :as api])
   (:import
    [java.io Closeable]
@@ -25,15 +26,20 @@
 (defn- start-worker [sub view]
   (let [stop (async/chan)
         done (async/chan)]
-    (async/go-loop []
-      (let [[_ channel] (async/alts! [stop (async/timeout 300)])]
-        (if (= channel stop)
-          (async/close! done)
-          (do (loop [delta (api/take! sub 10)]
-                (when (and delta (not= delta ::api/timeout))
-                  (update-view! view delta)
-                  (recur (api/take! sub 10))))
-              (recur)))))
+    (async/thread
+      (try
+        (loop []
+          (let [[_ channel] (async/alts!! [stop] :default ::running)]
+            (when (not= channel stop)
+              (let [delta (api/take! sub 100)]
+                (when delta
+                  (when (not= delta ::api/timeout)
+                    (update-view! view delta))
+                  (recur))))))
+        (catch Exception error
+          (log/error error "Materialized view subscription failed"))
+        (finally
+          (async/close! done))))
     {:stop stop :done done}))
 
 (defrecord View [sub view stop-chan done-chan]

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/view_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/view_test.clj
@@ -1,5 +1,6 @@
 (ns xyz.triplox.integration.view-test
   (:require
+   [clojure.core.async :as async]
    [clojure.test :as t :refer [deftest is]]
    [xyz.triplox.api :as api]
    [xyz.triplox.view :as view]
@@ -17,3 +18,17 @@
     (is (:committed? (api/transact *conn* [{:name "Bob"}])))
     (Thread/sleep 500)
     (is (= [[8796093022208 "Alice"] [8796093022209 "Bob"]] (view/get-view mv)))))
+
+(deftest terminal-error-stops-view-worker-and-allows-close
+  (api/transact *conn* [{:age 10}])
+  (let [mv (view/->view *conn* '{:find [(sum ?value)]
+                                :where [(or [?e :age ?value]
+                                            [?e :name ?value])]})]
+    (api/transact *conn* [{:name "Alice"}])
+    (let [[_ channel] (async/alts!! [(:done-chan mv) (async/timeout 5000)])]
+      (is (= (:done-chan mv) channel) "The worker finishes after a terminal error"))
+    (let [closed (future (.close mv) :closed)]
+      (try
+        (is (= :closed (deref closed 5000 :timeout)) "Closing the failed view returns")
+        (finally
+          (future-cancel closed))))))


### PR DESCRIPTION
This is not runtime sharing for the DBSP circuits themselves, but only for the application of the changes (see #334 and #477). An attempt started with Claude.