### PR TITLE
Track consumed transaction keys on subscriptions

### DIFF
--- a/examples/clojure/src/streaming_example.clj
+++ b/examples/clojure/src/streaming_example.clj
@@ -12,11 +12,14 @@
                        '{:find [?e ?name]
                          :where [[?e :name ?name]]}))
 
-(tc/tx-key sub)
+(tc/registration-tx-key sub)
 ;; => {:tx-id 1,
 ;;     :system-time
 ;;     #object[java.time.Instant 0x7c107312 "2026-09-02T12:31:24.534987Z"]}
 
+
+(tc/tx-key sub)
+;; => nil
 
 ;; Transact a name; the subscription receives a delta.
 ;; `take!` blocks for the next delta to arrive.
@@ -24,6 +27,9 @@
   (tc/transact conn [{:name "Ivan"}])
   (tc/take! sub))
 ;; => [[[8796093022208 "Ivan"] 1]]
+
+(tc/tx-key sub)
+;; => The transaction key of the delta returned by take! above.
 
 ;; The 2-arity bounds the wait and returns ::timeout when nothing changed.
 (tc/take! sub 200)

--- a/examples/clojure/src/streaming_example.clj
+++ b/examples/clojure/src/streaming_example.clj
@@ -17,19 +17,12 @@
 ;;     :system-time
 ;;     #object[java.time.Instant 0x7c107312 "2026-09-02T12:31:24.534987Z"]}
 
-
-(tc/tx-key sub)
-;; => nil
-
 ;; Transact a name; the subscription receives a delta.
 ;; `take!` blocks for the next delta to arrive.
 (do
   (tc/transact conn [{:name "Ivan"}])
   (tc/take! sub))
 ;; => [[[8796093022208 "Ivan"] 1]]
-
-(tc/tx-key sub)
-;; => The transaction key of the delta returned by take! above.
 
 ;; The 2-arity bounds the wait and returns ::timeout when nothing changed.
 (tc/take! sub 200)

--- a/examples/java/src/main/java/StreamingExample.java
+++ b/examples/java/src/main/java/StreamingExample.java
@@ -37,7 +37,7 @@ public final class StreamingExample {
 
             // Subscribe at the latest indexed basis; closing the subscription unsubscribes.
             try (Subscription sub = node.subscribe("[:find ?name :where [?e :name ?name]]")) {
-                System.out.println("Subscribed at tx_id=" + sub.txKey().txId() + ".");
+                System.out.println("Subscribed at tx_id=" + sub.registrationTxKey().txId() + ".");
 
                 for (var name : new String[] {"alice", "bob", "carol"}) {
                     node.executeTx(list(new TxOp.Put(map(":name", name))));
@@ -50,6 +50,7 @@ public final class StreamingExample {
                         System.out.println("No more deltas.");
                         break;
                     }
+                    System.out.println("Consumed through tx_id=" + sub.txKey().txId() + ".");
                     for (Row row : delta.rows()) {
                         System.out.println("  " + row.values() + "  (weight " + row.weight() + ")");
                     }

--- a/examples/rust/src/streaming_example.rs
+++ b/examples/rust/src/streaming_example.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     let mut sub = node
         .subscribe("[:find ?name :where [?e :name ?name]]")
         .await?;
-    println!("Subscribed at tx_id={}.", sub.tx_key().tx_id);
+    println!("Subscribed at tx_id={}.", sub.registration_tx_key().tx_id);
 
     // Transact three names; each produces a delta on the subscription.
     for name in ["alice", "bob", "carol"] {
@@ -61,6 +61,7 @@ async fn main() -> Result<()> {
     for _ in 0..3 {
         match sub.next().await {
             Some(Ok(delta)) => {
+                println!("Consumed through {:?}.", sub.tx_key().unwrap());
                 for (row, weight) in delta.rows {
                     println!("  {row:?}  (weight {weight})");
                 }

--- a/tests/subscription_test.rs
+++ b/tests/subscription_test.rs
@@ -67,9 +67,11 @@ async fn subscribe_receives_transaction_delta() {
     client.execute_tx(test_schema_tx()).await.unwrap();
 
     let mut sub = client.subscribe(NAMES_QUERY).await.unwrap();
+    assert_eq!(sub.tx_key(), None);
     client.execute_tx(add_name("alice", "Alice")).await.unwrap();
 
     let delta = next_delta(&mut sub).await;
+    assert_eq!(sub.tx_key(), Some(delta.tx_key));
     assert_eq!(
         delta.rows,
         vec![(vec![DataType::String("Alice".to_string())], 1)]
@@ -88,10 +90,12 @@ async fn subscription_returns_existing_rows_as_priming_delta() {
     client.execute_tx(add_name("alice", "Alice")).await.unwrap();
 
     let mut sub = client.subscribe(NAMES_QUERY).await.unwrap();
-    let registration_basis = sub.tx_key();
+    let registration_basis = sub.registration_tx_key();
+    assert_eq!(sub.tx_key(), None);
     let delta = next_delta(&mut sub).await;
 
     assert_eq!(delta.tx_key, registration_basis);
+    assert_eq!(sub.tx_key(), Some(delta.tx_key));
     assert_eq!(
         delta.rows,
         vec![(vec![DataType::String("Alice".to_string())], 1)]
@@ -116,10 +120,19 @@ async fn subscription_loses_no_deltas_under_slow_consumer() {
         client.execute_tx(add_name(n, n)).await.unwrap();
     }
 
+    assert_eq!(sub.tx_key(), None);
+    let registration = sub.registration_tx_key();
+
     // Drain: one delta per transaction, none dropped.
     let mut seen: BTreeSet<String> = BTreeSet::new();
     while seen.len() < names.len() {
+        let previous = sub.tx_key();
         let delta = next_delta(&mut sub).await;
+        assert_eq!(sub.tx_key(), Some(delta.tx_key));
+        assert_eq!(sub.registration_tx_key(), registration);
+        if let Some(previous) = previous {
+            assert!(delta.tx_key.tx_id > previous.tx_id);
+        }
         for (row, weight) in delta.rows {
             assert_eq!(weight, 1, "each name is added once");
             if let [DataType::String(name)] = row.as_slice() {
@@ -218,7 +231,8 @@ async fn dropping_a_subscription_keeps_the_server_serving() {
     // A fresh subscription still works.
     let mut sub = client.subscribe(NAMES_QUERY).await.unwrap();
     let priming_delta = next_delta(&mut sub).await;
-    assert_eq!(priming_delta.tx_key, sub.tx_key());
+    assert_eq!(priming_delta.tx_key, sub.registration_tx_key());
+    assert_eq!(sub.tx_key(), Some(priming_delta.tx_key));
     client.execute_tx(add_name("b", "Bob")).await.unwrap();
     let delta = next_delta(&mut sub).await;
     assert_eq!(

--- a/triplox-client/src/subscription.rs
+++ b/triplox-client/src/subscription.rs
@@ -41,7 +41,8 @@ pub struct Delta {
 /// Implements `Stream<Item = Result<Delta>>`; use `StreamExt::next().await` or
 /// stream combinators. Dropping it cancels the HTTP/2 stream and unsubscribes.
 pub struct Subscription {
-    tx_key: TxKey,
+    registration_tx_key: TxKey,
+    tx_key: Option<TxKey>,
     deltas: mpsc::Receiver<Result<Delta>>,
     reader: JoinHandle<()>,
 }
@@ -69,7 +70,12 @@ async fn read_deltas(mut frames: FrameStream, sender: mpsc::Sender<Result<Delta>
 
 impl Subscription {
     /// The registration tx_key. A priming delta can equal it; later deltas are strictly after it.
-    pub fn tx_key(&self) -> TxKey {
+    pub fn registration_tx_key(&self) -> TxKey {
+        self.registration_tx_key
+    }
+
+    /// The latest consumed delta's transaction key, or `None` before any delta is returned.
+    pub fn tx_key(&self) -> Option<TxKey> {
         self.tx_key
     }
 
@@ -98,7 +104,8 @@ impl Subscription {
         let (sender, deltas) = mpsc::channel(SUBSCRIPTION_QUEUE_CAPACITY);
         let reader = tokio::spawn(read_deltas(frames, sender));
         Ok(Subscription {
-            tx_key,
+            registration_tx_key: tx_key,
+            tx_key: None,
             deltas,
             reader,
         })
@@ -110,7 +117,11 @@ impl Stream for Subscription {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        this.deltas.poll_recv(cx)
+        let result = this.deltas.poll_recv(cx);
+        if let Poll::Ready(Some(Ok(delta))) = &result {
+            this.tx_key = Some(delta.tx_key);
+        }
+        result
     }
 }
 
@@ -264,6 +275,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tx_key_tracks_consumption_of_buffered_deltas() {
+        let later_key = TxKey {
+            tx_id: SAMPLE_TX_KEY.tx_id + 1,
+            system_time: SAMPLE_TX_KEY.system_time + chrono::Duration::seconds(1),
+        };
+        let mut payload = open_bytes();
+        payload.extend(delta_bytes("Alice"));
+        payload.extend(
+            encode_subscription_frame(&SubscriptionFrame::Delta {
+                tx_key: later_key,
+                rows: vec![],
+            })
+            .unwrap(),
+        );
+        let stream = futures::stream::once(async move { Ok(Bytes::from(payload)) });
+        let mut sub = Subscription::from_byte_stream(stream).await.unwrap();
+        timeout(Duration::from_secs(1), &mut sub.reader)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(sub.tx_key(), None, "buffering must not advance the key");
+        for expected in [*SAMPLE_TX_KEY, later_key] {
+            let delta = sub.next().await.unwrap().unwrap();
+            assert_eq!(delta.tx_key, expected);
+            assert_eq!(sub.tx_key(), Some(expected));
+            assert_eq!(sub.registration_tx_key(), *SAMPLE_TX_KEY);
+        }
+        assert!(sub.next().await.is_none());
+        assert_eq!(sub.tx_key(), Some(later_key));
+    }
+
+    #[tokio::test]
+    async fn pending_read_leaves_tx_key_absent() {
+        let stream = futures::stream::once(async { Ok(Bytes::from(open_bytes())) })
+            .chain(futures::stream::pending());
+        let mut sub = Subscription::from_byte_stream(stream).await.unwrap();
+        assert!(timeout(Duration::from_millis(10), sub.next())
+            .await
+            .is_err());
+        assert_eq!(sub.tx_key(), None);
+        assert_eq!(sub.registration_tx_key(), *SAMPLE_TX_KEY);
+    }
+
+    #[tokio::test]
     async fn subscription_surfaces_unknown_frame_kind_error() {
         let mut payload = Vec::new();
         payload.extend(open_bytes());
@@ -272,13 +328,15 @@ mod tests {
             futures::stream::once(async move { Ok::<Bytes, io::Error>(Bytes::from(payload)) });
 
         let mut sub = Subscription::from_byte_stream(stream).await.unwrap();
-        assert_eq!(sub.tx_key(), *SAMPLE_TX_KEY);
+        assert_eq!(sub.registration_tx_key(), *SAMPLE_TX_KEY);
+        assert_eq!(sub.tx_key(), None);
 
         let err = sub.next().await.expect("an item").unwrap_err();
         assert!(err
             .to_string()
             .contains("unknown subscription frame kind: heartbeat"));
         assert!(sub.next().await.is_none(), "done after error");
+        assert_eq!(sub.tx_key(), None);
     }
 
     #[tokio::test]
@@ -311,9 +369,11 @@ mod tests {
             vec![(vec![DataType::String("Alice".to_string())], 1)]
         );
 
+        assert_eq!(sub.tx_key(), Some(delta.tx_key));
         let err = sub.next().await.expect("second item").unwrap_err();
         assert!(err.to_string().contains("4000"));
         assert!(sub.next().await.is_none(), "done after error");
+        assert_eq!(sub.tx_key(), Some(delta.tx_key));
     }
 
     struct CountingByteStream {

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -91,14 +91,14 @@
        :else ::timeout))))
 
 (defn registration-tx-key
-  "The immutable registration tx-key of a subscription, as a map."
+  "The immutable registration tx-key of a subscription."
   [^Subscription sub]
   (let [b (.registrationTxKey sub)]
     {:tx-id (.txId b)
      :system-time (.systemTime b)}))
 
 (defn tx-key
-  "The latest consumed delta's tx-key as a map, or nil before any delta is returned."
+  "The latest consumed delta's tx-key, or nil before any delta is consumed."
   [^Subscription sub]
   (when-let [b (.txKey sub)]
     {:tx-id (.txId b)

--- a/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
+++ b/triplox-jvm/src/main/clojure/xyz/triplox/api.clj
@@ -90,10 +90,17 @@
        (.isDone ^Subscription sub) nil
        :else ::timeout))))
 
-(defn tx-key
-  "The registration tx-key of a subscription, as a map."
+(defn registration-tx-key
+  "The immutable registration tx-key of a subscription, as a map."
   [^Subscription sub]
-  (let [b (.txKey ^Subscription sub)]
+  (let [b (.registrationTxKey sub)]
+    {:tx-id (.txId b)
+     :system-time (.systemTime b)}))
+
+(defn tx-key
+  "The latest consumed delta's tx-key as a map, or nil before any delta is returned."
+  [^Subscription sub]
+  (when-let [b (.txKey sub)]
     {:tx-id (.txId b)
      :system-time (.systemTime b)}))
 

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
@@ -26,7 +26,8 @@ public final class Subscription implements AutoCloseable {
     private static final int QUEUE_CAPACITY = 128;
     private static final short INTERNAL_ERROR = 4000;
 
-    private final TxKey txKey;
+    private final TxKey registrationTxKey;
+    private volatile TxKey txKey;
     private final Closeable closeable;
     private final Thread reader;
     private final BlockingQueue<QueueEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
@@ -44,7 +45,7 @@ public final class Subscription implements AutoCloseable {
     }
 
     Subscription(TxKey txKey, Closeable closeable, MessageUnpacker unpacker) {
-        this.txKey = txKey;
+        this.registrationTxKey = txKey;
         this.closeable = closeable;
         this.reader = new Thread(() -> readLoop(unpacker), "triplox-subscription-reader");
         this.reader.setDaemon(true);
@@ -53,7 +54,7 @@ public final class Subscription implements AutoCloseable {
 
     /**
      * Wrap a streaming subscription response: read the leading {@code open} frame
-     * for {@link #txKey()}, then start the reader thread.
+     * for {@link #registrationTxKey()}, then start the reader thread.
      */
     static Subscription open(InputStream stream) throws IOException {
         return open(stream, stream);
@@ -73,6 +74,11 @@ public final class Subscription implements AutoCloseable {
     }
 
     /** The registration tx_key. A priming delta can equal it; later deltas are strictly after it. */
+    public TxKey registrationTxKey() {
+        return registrationTxKey;
+    }
+
+    /** The latest consumed delta's transaction key, or null before any delta is returned. */
     public TxKey txKey() {
         return txKey;
     }
@@ -91,6 +97,7 @@ public final class Subscription implements AutoCloseable {
 
     private Delta unwrap(QueueEvent event) {
         if (event instanceof QueueEvent.DeltaEvent(Delta delta1)) {
+            txKey = delta1.txKey();
             return delta1;
         }
         closed = true;

--- a/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
+++ b/triplox-jvm/src/main/java/xyz/triplox/client/Subscription.java
@@ -27,7 +27,7 @@ public final class Subscription implements AutoCloseable {
     private static final short INTERNAL_ERROR = 4000;
 
     private final TxKey registrationTxKey;
-    private volatile TxKey txKey;
+    private TxKey txKey;
     private final Closeable closeable;
     private final Thread reader;
     private final BlockingQueue<QueueEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -52,16 +52,35 @@
 (def first-user-entity-id 8796093022208)
 (def user-entity-ids (range first-user-entity-id (+ first-user-entity-id 100)))
 
-(deftest subscribe-returns-tx-key-and-times-out
+(deftest subscribe-returns-registration-tx-key-and-times-out
   (with-open [sub (api/subscribe *conn* names-query)]
-    (is (some? (:tx-id (api/tx-key sub))))
+    (is (some? (:tx-id (api/registration-tx-key sub))))
+    (is (nil? (api/tx-key sub)))
     ;; No transaction after the subscription -> bounded take! times out.
-    (is (= ::api/timeout (api/take! sub 200)))))
+    (is (= ::api/timeout (api/take! sub 200)))
+    (is (nil? (api/tx-key sub)))))
 
-(deftest subscribe-receives-delta
+(deftest subscription-tx-key-tracks-consumed-deltas
+  (api/transact *conn* [{:name "Alice"}])
   (with-open [sub (api/subscribe *conn* names-query)]
-    (api/transact *conn* [{:name "Ivan"}])
-    (is (= [[["Ivan"] 1]] (take-delta! sub)))))
+    (let [registration (api/registration-tx-key sub)]
+      (is (nil? (api/tx-key sub)))
+      (is (= [[["Alice"] 1]] (api/take! sub)))
+      (is (= registration (api/tx-key sub)))
+      (doseq [name ["Ivan" "Petr"]]
+        (let [previous (api/tx-key sub)
+              tx (api/transact *conn* [{:name name}])]
+          (is (:committed? tx))
+          (is (= previous (api/tx-key sub)))
+          (is (= [[[name] 1]] (api/take! sub 1000)))
+          (is (= (select-keys tx [:tx-id :system-time]) (api/tx-key sub)))
+          (is (= registration (api/registration-tx-key sub)))))
+      (let [consumed (api/tx-key sub)]
+        (is (= ::api/timeout (api/take! sub 200)))
+        (is (= consumed (api/tx-key sub)))
+        (.close sub)
+        (is (nil? (api/take! sub)))
+        (is (= consumed (api/tx-key sub)))))))
 
 (deftest retract-entity-emits-retraction
   (api/transact *conn* [{:name "Alice" :age 30}])

--- a/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
+++ b/triplox-jvm/src/test/clojure/xyz/triplox/integration/subscription_test.clj
@@ -49,6 +49,7 @@
 
 (def graph-nodes (mapv #(hash-map :db/id % :node/label %) [graph-a graph-b graph-c graph-d graph-e]))
 
+;; TODO remove this when something for #428 lands
 (def first-user-entity-id 8796093022208)
 (def user-entity-ids (range first-user-entity-id (+ first-user-entity-id 100)))
 
@@ -69,12 +70,11 @@
       (is (= registration (api/tx-key sub)))
       (doseq [name ["Ivan" "Petr"]]
         (let [previous (api/tx-key sub)
-              tx (api/transact *conn* [{:name name}])]
-          (is (:committed? tx))
+              tx (-> (api/transact *conn* [{:name name}])
+                     (select-keys [:tx-id :system-time]))]
           (is (= previous (api/tx-key sub)))
           (is (= [[[name] 1]] (api/take! sub 1000)))
-          (is (= (select-keys tx [:tx-id :system-time]) (api/tx-key sub)))
-          (is (= registration (api/registration-tx-key sub)))))
+          (is (= tx (api/tx-key sub)))))
       (let [consumed (api/tx-key sub)]
         (is (= ::api/timeout (api/take! sub 200)))
         (is (= consumed (api/tx-key sub)))

--- a/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
@@ -10,61 +10,10 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class SubscriptionTest {
-
-    @Test
-    void txKeyTracksConsumptionOfBufferedDeltas() throws Exception {
-        var laterKey = new TxKey(8L, sampleBasis().systemTime().plusSeconds(1));
-        byte[] body;
-        try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packOpenFrame(packer);
-            packDeltaFrame(packer, "Alice");
-            packer.packMapHeader(3);
-            packer.packString("kind"); packer.packString("delta");
-            packer.packString("tx_key"); WireCodec.packTxKey(packer, laterKey);
-            packer.packString("rows"); packer.packArrayHeader(0);
-            body = packer.toByteArray();
-        }
-        var readerFinished = new CountDownLatch(1);
-        try (Subscription sub = Subscription.open(new ByteArrayInputStream(body), readerFinished::countDown)) {
-            assertTrue(readerFinished.await(5, TimeUnit.SECONDS), "reader should buffer all deltas and reach EOF");
-            assertEquals(sampleBasis(), sub.registrationTxKey());
-            assertNull(sub.txKey(), "buffering must not advance the key");
-
-            assertEquals(sampleBasis(), sub.take().txKey());
-            assertEquals(sampleBasis(), sub.txKey());
-            var delta = sub.poll(5, TimeUnit.SECONDS);
-            assertNotNull(delta);
-            assertEquals(laterKey, delta.txKey());
-            assertTrue(delta.rows().isEmpty());
-            assertEquals(laterKey, sub.txKey());
-            assertEquals(sampleBasis(), sub.registrationTxKey());
-            assertNull(sub.take());
-            assertEquals(laterKey, sub.txKey());
-        }
-    }
-
-    @Test
-    void closingBeforeConsumptionLeavesTxKeyAbsent() throws Exception {
-        byte[] body;
-        try (var packer = MessagePack.newDefaultBufferPacker()) {
-            packOpenFrame(packer);
-            packDeltaFrame(packer, "Alice");
-            body = packer.toByteArray();
-        }
-        var readerFinished = new CountDownLatch(1);
-        try (Subscription sub = Subscription.open(new ByteArrayInputStream(body), readerFinished::countDown)) {
-            assertTrue(readerFinished.await(5, TimeUnit.SECONDS));
-            sub.close();
-            assertNull(sub.take());
-            assertNull(sub.txKey());
-            assertEquals(sampleBasis(), sub.registrationTxKey());
-        }
-    }
 
     @Test
     void clientDisablesReadTimeoutForLongRunningRequests() {

--- a/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/SubscriptionTest.java
@@ -10,10 +10,61 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class SubscriptionTest {
+
+    @Test
+    void txKeyTracksConsumptionOfBufferedDeltas() throws Exception {
+        var laterKey = new TxKey(8L, sampleBasis().systemTime().plusSeconds(1));
+        byte[] body;
+        try (var packer = MessagePack.newDefaultBufferPacker()) {
+            packOpenFrame(packer);
+            packDeltaFrame(packer, "Alice");
+            packer.packMapHeader(3);
+            packer.packString("kind"); packer.packString("delta");
+            packer.packString("tx_key"); WireCodec.packTxKey(packer, laterKey);
+            packer.packString("rows"); packer.packArrayHeader(0);
+            body = packer.toByteArray();
+        }
+        var readerFinished = new CountDownLatch(1);
+        try (Subscription sub = Subscription.open(new ByteArrayInputStream(body), readerFinished::countDown)) {
+            assertTrue(readerFinished.await(5, TimeUnit.SECONDS), "reader should buffer all deltas and reach EOF");
+            assertEquals(sampleBasis(), sub.registrationTxKey());
+            assertNull(sub.txKey(), "buffering must not advance the key");
+
+            assertEquals(sampleBasis(), sub.take().txKey());
+            assertEquals(sampleBasis(), sub.txKey());
+            var delta = sub.poll(5, TimeUnit.SECONDS);
+            assertNotNull(delta);
+            assertEquals(laterKey, delta.txKey());
+            assertTrue(delta.rows().isEmpty());
+            assertEquals(laterKey, sub.txKey());
+            assertEquals(sampleBasis(), sub.registrationTxKey());
+            assertNull(sub.take());
+            assertEquals(laterKey, sub.txKey());
+        }
+    }
+
+    @Test
+    void closingBeforeConsumptionLeavesTxKeyAbsent() throws Exception {
+        byte[] body;
+        try (var packer = MessagePack.newDefaultBufferPacker()) {
+            packOpenFrame(packer);
+            packDeltaFrame(packer, "Alice");
+            body = packer.toByteArray();
+        }
+        var readerFinished = new CountDownLatch(1);
+        try (Subscription sub = Subscription.open(new ByteArrayInputStream(body), readerFinished::countDown)) {
+            assertTrue(readerFinished.await(5, TimeUnit.SECONDS));
+            sub.close();
+            assertNull(sub.take());
+            assertNull(sub.txKey());
+            assertEquals(sampleBasis(), sub.registrationTxKey());
+        }
+    }
 
     @Test
     void clientDisablesReadTimeoutForLongRunningRequests() {
@@ -30,6 +81,7 @@ class SubscriptionTest {
             assertEquals(4000, Short.toUnsignedInt(ex.code()));
             assertTrue(ex.getMessage().contains("subscription stream failed"));
             assertNotNull(ex.getCause());
+            assertNull(sub.txKey());
         }
     }
 
@@ -66,10 +118,12 @@ class SubscriptionTest {
             var delta = sub.poll(5, TimeUnit.SECONDS);
             assertNotNull(delta, "expected queued delta before terminal error");
             assertEquals("Alice", delta.rows().getFirst().values().getFirst());
+            assertEquals(delta.txKey(), sub.txKey());
 
             var ex = assertThrows(TriploxException.class, () -> sub.poll(5, TimeUnit.SECONDS));
             assertEquals(4000, Short.toUnsignedInt(ex.code()));
             assertTrue(ex.getMessage().contains("boom"));
+            assertEquals(delta.txKey(), sub.txKey());
         }
     }
 
@@ -81,6 +135,7 @@ class SubscriptionTest {
 
             assertNull(delta);
             assertTrue(sub.isDone());
+            assertNull(sub.txKey());
         }
     }
 
@@ -102,6 +157,7 @@ class SubscriptionTest {
 
             assertTrue(sub.isDone());
             assertNull(sub.poll(5, TimeUnit.SECONDS));
+            assertEquals(sampleBasis(), sub.txKey());
         }
     }
 

--- a/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
+++ b/triplox-jvm/src/test/java/xyz/triplox/client/integration/SubscriptionTest.java
@@ -34,15 +34,20 @@ class SubscriptionTest {
         try (var node = TriploxNode.connect(host(), port())) {
             defineNameSchema(node);
             try (Subscription sub = node.subscribe(NAMES_QUERY)) {
-                assertNotNull(sub.txKey());
+                var registration = sub.registrationTxKey();
+                assertNotNull(registration);
+                assertNull(sub.txKey());
 
-                node.executeTx(List.of(new TxOp.Put(map(":name", "Ivan"))));
+                var tx = node.executeTx(List.of(new TxOp.Put(map(":name", "Ivan"))));
 
                 Delta delta = sub.poll(10, TimeUnit.SECONDS);
                 assertNotNull(delta, "expected a delta within 10s");
                 assertEquals(1, delta.rows().size());
                 assertEquals(List.of("Ivan"), delta.rows().get(0).values());
                 assertEquals(1L, delta.rows().get(0).weight());
+                assertEquals(tx.txKey(), sub.txKey());
+                assertEquals(delta.txKey(), sub.txKey());
+                assertEquals(registration, sub.registrationTxKey());
             }
         }
     }
@@ -54,6 +59,7 @@ class SubscriptionTest {
             try (Subscription sub = node.subscribe(NAMES_QUERY)) {
                 // No transaction after the subscription -> poll returns null on timeout.
                 assertNull(sub.poll(300, TimeUnit.MILLISECONDS));
+                assertNull(sub.txKey());
             }
         }
     }

--- a/website/src/content/docs/incremental-queries/overview.md
+++ b/website/src/content/docs/incremental-queries/overview.md
@@ -53,6 +53,14 @@ Every Client API has a concept of a `subscribe` method which registers the incre
 
 When an incremental query gets registered it takes out a DB value at a given `TxKey`. For now, this is the `TxKey` the node has caught up to indexing, meaning you can currently only register incremental queries at roughly where the indexer is at. It builds, what is called in [DBSP](https://docs.rs/dbsp/latest/dbsp/) terminology, a circuit. This circuit gets bootstrapped by the data from the given `TxKey`, meaning the data that is currently present in the indexes. You can think of this bootstrapping as running the standard query through the circuit. This means the circuit initialization might take quite a while depending on how much data is already in the indexes that is relevant for the given incremental query. I want to give some intuition of why the circuit needs to get bootstrapped with the old data when we are only interested in future deltas. Consider a join of two abstract relations $A \bowtie B$. When something in $A$ changes (written as $\Delta A$) we still might need to join it against the old data, i.e. $\Delta A \bowtie B_{old}$, to know if actually to emit a tuple from the query.
 
+Subscriptions expose two transaction keys. The immutable registration key is available immediately through
+`registration_tx_key()` in Rust, `registrationTxKey()` in Java, or `registration-tx-key` in Clojure.
+The consumed key, exposed through `tx_key()`, `txKey()`, or `tx-key`, starts as `None`, `null`, or `nil`.
+It updates when the subscription returns a delta to the caller, including the initial result delta.
+Background buffering does not advance it, and timeouts, errors, and closure leave it unchanged.
+An empty initial result emits no delta, so the consumed key remains absent until a later delta is consumed.
+This key tracks delivery to the caller, not completion of application processing or the latest server transaction.
+
 ### Views
 
 A view in traditional DBMSs acts like a virtual table. The data is often computed when access is requested or updated periodically. Systems like [Materialize](https://github.com/materializeinc/materialize) update the views incrementally. Once you have incremental queries, it is "easy" to implement views on top. I prefer to rather give the more primitive option of an incremental query and let users decide how they want to maintain their views. If there is a high demand for views maintained on the server, we can reconsider.

--- a/website/src/content/docs/incremental-queries/overview.md
+++ b/website/src/content/docs/incremental-queries/overview.md
@@ -53,14 +53,6 @@ Every Client API has a concept of a `subscribe` method which registers the incre
 
 When an incremental query gets registered it takes out a DB value at a given `TxKey`. For now, this is the `TxKey` the node has caught up to indexing, meaning you can currently only register incremental queries at roughly where the indexer is at. It builds, what is called in [DBSP](https://docs.rs/dbsp/latest/dbsp/) terminology, a circuit. This circuit gets bootstrapped by the data from the given `TxKey`, meaning the data that is currently present in the indexes. You can think of this bootstrapping as running the standard query through the circuit. This means the circuit initialization might take quite a while depending on how much data is already in the indexes that is relevant for the given incremental query. I want to give some intuition of why the circuit needs to get bootstrapped with the old data when we are only interested in future deltas. Consider a join of two abstract relations $A \bowtie B$. When something in $A$ changes (written as $\Delta A$) we still might need to join it against the old data, i.e. $\Delta A \bowtie B_{old}$, to know if actually to emit a tuple from the query.
 
-Subscriptions expose two transaction keys. The immutable registration key is available immediately through
-`registration_tx_key()` in Rust, `registrationTxKey()` in Java, or `registration-tx-key` in Clojure.
-The consumed key, exposed through `tx_key()`, `txKey()`, or `tx-key`, starts as `None`, `null`, or `nil`.
-It updates when the subscription returns a delta to the caller, including the initial result delta.
-Background buffering does not advance it, and timeouts, errors, and closure leave it unchanged.
-An empty initial result emits no delta, so the consumed key remains absent until a later delta is consumed.
-This key tracks delivery to the caller, not completion of application processing or the latest server transaction.
-
 ### Views
 
 A view in traditional DBMSs acts like a virtual table. The data is often computed when access is requested or updated periodically. Systems like [Materialize](https://github.com/materializeinc/materialize) update the views incrementally. Once you have incremental queries, it is "easy" to implement views on top. I prefer to rather give the more primitive option of an incremental query and let users decide how they want to maintain their views. If there is a high demand for views maintained on the server, we can reconsider.


### PR DESCRIPTION
Preserve the registration key separately and expose an initially absent consumed `TxKey` in Rust, Java, and Clojure. 
This will be useful when comparing standard query results of other engines to the incremental version.