### PR TITLE
Supporting placeholders in queries

### DIFF
--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -7,6 +7,7 @@ use edn::query::{
 
 use crate::query::{build_var_index, compile_find_plan, FindPlan};
 use crate::query_validation::validate_query;
+use crate::rewrite::rewrite_query;
 use crate::schema::Schema;
 
 mod descriptor;
@@ -30,8 +31,9 @@ impl IncrementalQueryPlan {
 }
 
 pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<IncrementalQueryPlan> {
-    reject_unsupported_query_shape(query)?;
-    validate_query(query, &[])?;
+    let query = rewrite_query(query);
+    reject_unsupported_query_shape(&query)?;
+    validate_query(&query, &[])?;
 
     let descriptors = descriptor::describe_where_clauses(&query.where_clauses, schema)?;
     let where_plan = planner::plan_scope(&descriptors, None)?;
@@ -898,18 +900,27 @@ mod tests {
     }
 
     #[test]
-    fn rejects_entity_placeholder() {
-        assert_plan_err(
-            "[:find ?name :where [_ :name ?name]]",
-            "Placeholders in entity position",
+    fn plans_placeholders_as_independent_variables() {
+        let schema = test_schema();
+        let query = parse_query("[:find ?name :where [_ :name ?name] [_ :age _]]");
+        let explicit = parse_query(
+            "[:find ?name :where [?_internal_0 :name ?name] [?_internal_1 :age ?_internal_2]]",
+        );
+        assert_eq!(
+            plan_query(&query, &schema).unwrap(),
+            plan_query(&explicit, &schema).unwrap()
         );
     }
 
     #[test]
-    fn rejects_value_placeholder() {
+    fn rejects_placeholder_variables_in_or_and_not() {
         assert_plan_err(
-            "[:find ?e :where [?e :name _]]",
-            "Placeholders in value position",
+            "[:find ?e :where (or [?e :name _] [?e :age _])]",
+            "different free variables",
+        );
+        assert_plan_err(
+            "[:find ?e :where [?e :name ?name] (not [?e :age _])]",
+            "in NOT clause is not bound by positive clauses",
         );
     }
 

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -1,5 +1,7 @@
 //! Incremental-query planning helpers.
 
+use std::collections::HashSet;
+
 use anyhow::{bail, Result};
 use edn::query::{
     Limit, OrJoin, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace, Variable, WhereClause,
@@ -31,9 +33,9 @@ impl IncrementalQueryPlan {
 }
 
 pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<IncrementalQueryPlan> {
-    let query = rewrite_query(query);
+    let query = rewrite_query(query).query;
     reject_unsupported_query_shape(&query)?;
-    validate_query(&query, &[])?;
+    validate_query(&query, &[], &HashSet::new())?;
 
     let descriptors = descriptor::describe_where_clauses(&query.where_clauses, schema)?;
     let where_plan = planner::plan_scope(&descriptors, None)?;

--- a/src/inc_query.rs
+++ b/src/inc_query.rs
@@ -1,7 +1,5 @@
 //! Incremental-query planning helpers.
 
-use std::collections::HashSet;
-
 use anyhow::{bail, Result};
 use edn::query::{
     Limit, OrJoin, OrWhereClause, ParsedQuery, Pattern, PatternNonValuePlace, Variable, WhereClause,
@@ -33,11 +31,16 @@ impl IncrementalQueryPlan {
 }
 
 pub(crate) fn plan_query(query: &ParsedQuery, schema: &Schema) -> Result<IncrementalQueryPlan> {
-    let query = rewrite_query(query).query;
-    reject_unsupported_query_shape(&query)?;
-    validate_query(&query, &[], &HashSet::new())?;
+    let rewritten = rewrite_query(query);
+    let query = &rewritten.query;
+    reject_unsupported_query_shape(query)?;
+    validate_query(query, &[], &rewritten.generated_variables)?;
 
-    let descriptors = descriptor::describe_where_clauses(&query.where_clauses, schema)?;
+    let descriptors = descriptor::describe_where_clauses(
+        &query.where_clauses,
+        schema,
+        &rewritten.generated_variables,
+    )?;
     let where_plan = planner::plan_scope(&descriptors, None)?;
     let var_index = build_var_index(&where_plan.output_vars);
     let find_plan = compile_find_plan(&query.find_spec, &var_index)?;
@@ -915,13 +918,13 @@ mod tests {
     }
 
     #[test]
-    fn rejects_placeholder_variables_in_or_and_not() {
+    fn rejects_ordinary_local_variables_in_or_and_not() {
         assert_plan_err(
-            "[:find ?e :where (or [?e :name _] [?e :age _])]",
+            "[:find ?e :where (or [?e :name ?name] [?e :age ?age])]",
             "different free variables",
         );
         assert_plan_err(
-            "[:find ?e :where [?e :name ?name] (not [?e :age _])]",
+            "[:find ?e :where [?e :name ?name] (not [?e :age ?age])]",
             "in NOT clause is not bound by positive clauses",
         );
     }

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -60,7 +60,7 @@ fn non_value_slot(place: &PatternNonValuePlace) -> PatternSlot {
             PatternSlot::Constant(DataType::Keyword(ident.as_ref().clone()).encode())
         }
         PatternNonValuePlace::Placeholder => {
-            unreachable!("entity placeholders are rejected before planning")
+            unreachable!("entity placeholders are rewritten before planning")
         }
     }
 }
@@ -81,7 +81,7 @@ fn value_slot(place: &PatternValuePlace) -> Result<PatternSlot> {
                 .encode(),
         )),
         PatternValuePlace::Placeholder => {
-            unreachable!("value placeholders are rejected before planning")
+            unreachable!("value placeholders are rewritten before planning")
         }
     }
 }

--- a/src/inc_query/descriptor.rs
+++ b/src/inc_query/descriptor.rs
@@ -10,7 +10,9 @@ use crate::codec::Encode;
 use crate::expr::{expr_variables, Expr};
 use crate::incremental::EncodedValue;
 use crate::ops::DataType;
-use crate::query::{convert_predicate, convert_where_fn, non_integer_constant_to_datatype};
+use crate::query::{
+    convert_predicate, convert_where_fn, exposed_variables, non_integer_constant_to_datatype,
+};
 use crate::schema::Schema;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -162,7 +164,11 @@ fn describe_function(function: &WhereFn) -> Result<Descriptor> {
     })
 }
 
-fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descriptor> {
+fn describe_where_clause(
+    clause: &WhereClause,
+    schema: &Schema,
+    generated_variables: &HashSet<Variable>,
+) -> Result<Descriptor> {
     match clause {
         WhereClause::Pattern(pattern) => {
             let pattern = pattern_descriptor(pattern, schema)?;
@@ -175,50 +181,63 @@ fn describe_where_clause(clause: &WhereClause, schema: &Schema) -> Result<Descri
         }
         WhereClause::Pred(predicate) => describe_predicate(predicate),
         WhereClause::WhereFn(function) => describe_function(function),
-        WhereClause::NotJoin(not) => describe_not(not, schema),
-        WhereClause::OrJoin(or) => describe_or(or, schema),
+        WhereClause::NotJoin(not) => describe_not(not, schema, generated_variables),
+        WhereClause::OrJoin(or) => describe_or(or, schema, generated_variables),
         WhereClause::TypeAnnotation(_) | WhereClause::RuleExpr => {
             unreachable!("unsupported clauses are rejected before planning")
         }
     }
 }
 
-fn describe_not(not: &NotJoin, schema: &Schema) -> Result<Descriptor> {
-    let scope = describe_where_clauses(&not.clauses, schema)?;
+fn describe_not(
+    not: &NotJoin,
+    schema: &Schema,
+    generated_variables: &HashSet<Variable>,
+) -> Result<Descriptor> {
+    let scope = describe_where_clauses(&not.clauses, schema, generated_variables)?;
     Ok(Descriptor {
-        variables: scope.variables.clone(),
+        variables: exposed_variables(scope.variables.clone(), generated_variables),
         groundable: Vec::new(),
         kind: DescriptorKind::Not { scope },
     })
 }
 
-fn describe_or_branch(branch: &OrWhereClause, schema: &Schema) -> Result<ScopeDescriptor> {
+fn describe_or_branch(
+    branch: &OrWhereClause,
+    schema: &Schema,
+    generated_variables: &HashSet<Variable>,
+) -> Result<ScopeDescriptor> {
     match branch {
         OrWhereClause::Clause(clause) => {
-            describe_where_clauses(std::slice::from_ref(clause), schema)
+            describe_where_clauses(std::slice::from_ref(clause), schema, generated_variables)
         }
-        OrWhereClause::And(clauses) => describe_where_clauses(clauses, schema),
+        OrWhereClause::And(clauses) => describe_where_clauses(clauses, schema, generated_variables),
     }
 }
 
-fn describe_or(or: &OrJoin, schema: &Schema) -> Result<Descriptor> {
+fn describe_or(
+    or: &OrJoin,
+    schema: &Schema,
+    generated_variables: &HashSet<Variable>,
+) -> Result<Descriptor> {
     let branches = or
         .clauses
         .iter()
-        .map(|branch| describe_or_branch(branch, schema))
+        .map(|branch| describe_or_branch(branch, schema, generated_variables))
         .collect::<Result<Vec<_>>>()?;
     let first = branches
         .first()
         .ok_or_else(|| anyhow!("OR clause must have at least one branch"))?;
-    let variables = first.variables.clone();
+    let variables = exposed_variables(first.variables.clone(), generated_variables);
     let groundable = first
         .groundable
         .iter()
         .filter(|variable| {
-            branches
-                .iter()
-                .skip(1)
-                .all(|branch| branch.groundable.contains(variable))
+            !generated_variables.contains(*variable)
+                && branches
+                    .iter()
+                    .skip(1)
+                    .all(|branch| branch.groundable.contains(variable))
         })
         .cloned()
         .collect();
@@ -233,10 +252,11 @@ fn describe_or(or: &OrJoin, schema: &Schema) -> Result<Descriptor> {
 pub(super) fn describe_where_clauses(
     clauses: &[WhereClause],
     schema: &Schema,
+    generated_variables: &HashSet<Variable>,
 ) -> Result<ScopeDescriptor> {
     let descriptors = clauses
         .iter()
-        .map(|clause| describe_where_clause(clause, schema))
+        .map(|clause| describe_where_clause(clause, schema, generated_variables))
         .collect::<Result<Vec<_>>>()?;
     let variables = ordered_union(
         descriptors
@@ -266,7 +286,8 @@ mod tests {
     #[test]
     fn triple_variables_are_all_groundable_in_encounter_order() {
         let query = parse_query("[:find ?e ?name :where [?e :name ?name]]");
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
 
         assert_eq!(scope.variables, vec!["?e".to_var(), "?name".to_var()]);
         assert_eq!(scope.groundable, scope.variables);
@@ -281,7 +302,8 @@ mod tests {
     #[test]
     fn scope_metadata_is_the_ordered_union_of_its_descriptors() {
         let query = parse_query("[:find ?name ?age :where [?e :name ?name] [?e :age ?age]]");
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
 
         assert_eq!(
             scope.variables,
@@ -293,7 +315,8 @@ mod tests {
     #[test]
     fn or_metadata_uses_first_branch_order_for_groundable_intersection() {
         let query = parse_query("[:find ?e ?v :where (or [?e :name ?v] [?v :follows ?e])]");
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
         let descriptor = &scope.descriptors[0];
 
         assert_eq!(descriptor.variables, vec!["?e".to_var(), "?v".to_var()]);
@@ -308,7 +331,8 @@ mod tests {
     #[test]
     fn not_metadata_mentions_variables_without_grounding_them() {
         let query = parse_query("[:find ?e :where [?e :name ?name] (not [?e :age ?age])]");
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
         let descriptor = &scope.descriptors[1];
 
         assert_eq!(descriptor.variables, vec!["?e".to_var(), "?age".to_var()]);
@@ -323,7 +347,8 @@ mod tests {
     #[test]
     fn predicate_metadata_mentions_variables_without_grounding_them() {
         let query = parse_query("[:find ?age :where [?e :age ?age] [(< ?age 30)]]");
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
         let descriptor = &scope.descriptors[1];
 
         assert_eq!(descriptor.variables, vec!["?age".to_var()]);
@@ -342,7 +367,8 @@ mod tests {
               [(+ ?age 1) ?next]
               [(+ ?next 1) ?next]]",
         );
-        let scope = describe_where_clauses(&query.where_clauses, &test_schema()).unwrap();
+        let scope =
+            describe_where_clauses(&query.where_clauses, &test_schema(), &HashSet::new()).unwrap();
 
         let new_result = &scope.descriptors[0];
         assert_eq!(

--- a/src/inc_query/planner.rs
+++ b/src/inc_query/planner.rs
@@ -73,8 +73,9 @@ struct PendingDescriptor<'a> {
 
 fn order_descriptors<'a>(
     descriptors: &'a [Descriptor],
-    initial_grounded: &[Variable],
+    incoming_vars: Option<&[Variable]>,
 ) -> Result<Vec<&'a Descriptor>> {
+    let initial_grounded = incoming_vars.unwrap_or_default();
     let mut ordered = Vec::with_capacity(descriptors.len());
     let mut grounded = initial_grounded.iter().cloned().collect::<HashSet<_>>();
     let mut remaining = descriptors
@@ -90,10 +91,13 @@ fn order_descriptors<'a>(
             .iter()
             .enumerate()
             .filter(|(_, descriptor)| {
-                descriptor
-                    .required_variables
-                    .iter()
-                    .all(|variable| grounded.contains(variable))
+                (incoming_vars.is_some()
+                    || !ordered.is_empty()
+                    || !matches!(descriptor.descriptor.kind, DescriptorKind::Not { .. }))
+                    && descriptor
+                        .required_variables
+                        .iter()
+                        .all(|variable| grounded.contains(variable))
             })
             .max_by_key(|(index, descriptor)| {
                 let shared = descriptor
@@ -110,6 +114,13 @@ fn order_descriptors<'a>(
             let descriptor = remaining
                 .first()
                 .expect("non-empty remaining descriptors must have a first descriptor");
+            if descriptor
+                .required_variables
+                .iter()
+                .all(|variable| grounded.contains(variable))
+            {
+                bail!("Cannot plan `not` without a positive relation");
+            }
             let missing = descriptor
                 .required_variables
                 .iter()
@@ -215,7 +226,17 @@ fn plan_difference(
         .cloned()
         .collect::<Vec<_>>();
     let negative = plan_scope(scope, Some(key_vars.clone()))?;
-    debug_assert_eq!(negative.output_vars, key_vars);
+    let negative = if negative.output_vars == key_vars {
+        negative
+    } else {
+        RelPlan {
+            incoming_vars: negative.incoming_vars.clone(),
+            output_vars: key_vars.clone(),
+            kind: RelPlanKind::Chain {
+                children: vec![negative],
+            },
+        }
+    };
 
     Ok(RelPlan {
         incoming_vars: Some(incoming_vars.clone()),
@@ -246,8 +267,7 @@ pub(super) fn plan_scope(
     scope: &ScopeDescriptor,
     incoming_vars: Option<Vec<Variable>>,
 ) -> Result<RelPlan> {
-    let initial_grounded = incoming_vars.as_deref().unwrap_or_default();
-    let ordered = order_descriptors(&scope.descriptors, initial_grounded)?;
+    let ordered = order_descriptors(&scope.descriptors, incoming_vars.as_deref())?;
     if ordered.is_empty() {
         bail!("Incremental queries require at least one triple pattern");
     }
@@ -316,7 +336,7 @@ mod tests {
             }),
         };
 
-        let error = order_descriptors(&[descriptor], &[]).unwrap_err();
+        let error = order_descriptors(&[descriptor], None).unwrap_err();
 
         assert!(error.to_string().contains("?missing"));
         assert!(error.to_string().contains("Insufficient bindings"));

--- a/src/incremental/circuit.rs
+++ b/src/incremental/circuit.rs
@@ -600,6 +600,60 @@ mod tests {
     }
 
     #[test]
+    fn local_not_placeholders_preserve_multiple_supports_and_outer_changes() {
+        for query in [
+            "[:find ?e :where [?e :name _] (not [?e :age _])]",
+            "[:find ?e :where (not [_ :age _]) [?e :name _]]",
+            "[:find ?e :where [?e :name _] (not (or [?e :age _] [?e :follows _]))]",
+        ] {
+            let storage = tempfile::tempdir().unwrap();
+            let mut circuit = QueryCircuit::build(query_plan(query), storage.path()).unwrap();
+            let row = vec![DataType::Long(100)];
+            let alice = triple(100, NAME, "Alice".into());
+            let bob = triple(100, NAME, "Bob".into());
+            let age30 = triple(100, AGE, DataType::Long(30));
+            let age40 = triple(100, AGE, DataType::Long(40));
+            for (batch, expected) in [
+                (vec![Tup2(alice.clone(), 1)], vec![(row.clone(), 1)]),
+                (
+                    vec![Tup2(age30.clone(), 1), Tup2(age40.clone(), 1)],
+                    vec![(row.clone(), -1)],
+                ),
+                (vec![Tup2(age30, -1)], vec![]),
+                (vec![Tup2(alice, -1)], vec![]),
+                (vec![Tup2(bob.clone(), 1)], vec![]),
+                (vec![Tup2(age40, -1)], vec![(row.clone(), 1)]),
+                (vec![Tup2(bob, -1)], vec![(row, -1)]),
+            ] {
+                assert_eq!(circuit.apply(batch).unwrap(), expected, "{query}");
+            }
+        }
+    }
+
+    #[test]
+    fn local_or_placeholders_retract_only_after_the_last_match() {
+        let storage = tempfile::tempdir().unwrap();
+        let query = "[:find ?e :where (or [?e :age _] [?e :follows _])]";
+        let mut circuit = QueryCircuit::build(query_plan(query), storage.path()).unwrap();
+        let row = vec![DataType::Long(100)];
+        let age30 = triple(100, AGE, DataType::Long(30));
+        let age40 = triple(100, AGE, DataType::Long(40));
+        let follows = triple(100, FOLLOWS, DataType::Long(200));
+        for (batch, expected) in [
+            (vec![Tup2(age30.clone(), 1)], vec![(row.clone(), 1)]),
+            (
+                vec![Tup2(age40.clone(), 1), Tup2(follows.clone(), 1)],
+                vec![],
+            ),
+            (vec![Tup2(age30, -1)], vec![]),
+            (vec![Tup2(age40, -1)], vec![]),
+            (vec![Tup2(follows, -1)], vec![(row, -1)]),
+        ] {
+            assert_eq!(circuit.apply(batch).unwrap(), expected);
+        }
+    }
+
+    #[test]
     fn query_circuit_uses_file_backed_storage_root() {
         let dir = tempfile::tempdir().unwrap();
         let storage_path = dir.path().join("query-1");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod ops;
 pub mod partition;
 mod query;
 mod query_validation;
+mod rewrite;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod schema;
 #[cfg(not(any(test, feature = "test-helpers")))]

--- a/src/node.rs
+++ b/src/node.rs
@@ -2688,6 +2688,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_incremental_local_placeholder_snapshots() {
+        let node = node_with_local_placeholder_facts().await;
+        let basis = node.db().await.unwrap().tx_key();
+        for (query, mut expected) in local_placeholder_cases() {
+            let mut subscription = node
+                .register_incremental_query(parse_query(query), &[])
+                .await
+                .unwrap_or_else(|error| panic!("{query}: {error:#}"));
+            let mut rows = Vec::new();
+            assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+            sort_query_rows(&mut expected);
+            assert_eq!(rows, expected, "{query}");
+        }
+    }
+
+    fn local_placeholder_updates() -> Vec<Vec<TxOp>> {
+        let retract = |entity, attribute, value| TxOp::Retract {
+            entity: EntityRef::Id(entity),
+            attribute,
+            value,
+        };
+        let add = |entity, attribute, value| TxOp::Add {
+            entity: EntityRef::Id(entity),
+            attribute,
+            value,
+        };
+        vec![
+            vec![retract(100, kw!(:tags), "blue".into())],
+            vec![retract(101, kw!(:name), "Bob".into())],
+            vec![add(101, kw!(:name), "Robert".into())],
+            vec![retract(101, kw!(:tags), "red".into())],
+            vec![retract(100, kw!(:tags), "red".into())],
+            vec![
+                retract(100, kw!(:age), 30_i64.into()),
+                retract(101, kw!(:age), 40_i64.into()),
+            ],
+            vec![
+                retract(100, kw!(:name), "Alice".into()),
+                retract(101, kw!(:name), "Robert".into()),
+                retract(102, kw!(:name), "Carol".into()),
+            ],
+            vec![add(100, kw!(:tags), "green".into())],
+            vec![add(100, kw!(:name), "Alice".into())],
+            vec![retract(100, kw!(:tags), "green".into())],
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_incremental_local_placeholder_updates() {
+        for (query, _) in local_placeholder_cases() {
+            let node = node_with_local_placeholder_facts().await;
+            let basis = node.db().await.unwrap().tx_key();
+            let mut subscription = node
+                .register_incremental_query(parse_query(query), &[])
+                .await
+                .unwrap_or_else(|error| panic!("{query}: {error:#}"));
+            let mut rows = Vec::new();
+            assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query).await;
+            for updates in local_placeholder_updates() {
+                let basis = execute_and_flush(&node, updates).await;
+                assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, query)
+                    .await;
+            }
+            assert!(
+                try_recv_incremental_delta(&mut subscription)
+                    .await
+                    .is_none(),
+                "unexpected remaining delta for {query}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_incremental_placeholders_match_explicit_variables() {
         for (query, explicit) in [
             (

--- a/src/node.rs
+++ b/src/node.rs
@@ -558,39 +558,83 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_query_rejects_entity_placeholder() {
+    async fn test_query_placeholders_match_explicit_variables() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
-
-        let db = node.db().await.unwrap();
-        let err = db
-            .query("[:find ?name :where [_ :name ?name]]")
+        for (entity, name, age) in [(100, "Alice", 30_i64), (101, "Alice", 40), (102, "Bob", 50)] {
+            node.execute_tx(vec![
+                TxOp::Add {
+                    entity: EntityRef::Id(entity),
+                    attribute: kw!(:name),
+                    value: name.into(),
+                },
+                TxOp::Add {
+                    entity: EntityRef::Id(entity),
+                    attribute: kw!(:age),
+                    value: age.into(),
+                },
+            ])
             .await
-            .unwrap_err();
-
-        assert!(
-            err.to_string().contains("entity position"),
-            "unexpected error: {}",
-            err
-        );
+            .unwrap();
+        }
+        let db = node.db().await.unwrap();
+        for (query, explicit) in [
+            (
+                "[:find ?name :where [_ :name ?name]]",
+                "[:find ?name :where [?entity :name ?name]]",
+            ),
+            (
+                "[:find ?e :where [?e :name _]]",
+                "[:find ?e :where [?e :name ?value]]",
+            ),
+            (
+                "[:find ?e :where [?e :name]]",
+                "[:find ?e :where [?e :name ?value]]",
+            ),
+            (
+                "[:find ?name :where [_ :name ?name] [_ :age _]]",
+                "[:find ?name :where [?entity :name ?name] [?other :age ?age]]",
+            ),
+            (
+                "[:find (count ?name) :where [_ :name ?name]]",
+                "[:find (count ?name) :where [?entity :name ?name]]",
+            ),
+        ] {
+            let mut actual = db.query(query).await.unwrap();
+            let mut expected = db.query(explicit).await.unwrap();
+            assert!(!expected.is_empty(), "{explicit}");
+            sort_query_rows(&mut actual);
+            sort_query_rows(&mut expected);
+            assert_eq!(actual, expected, "{query}");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_query_rejects_value_placeholder() {
+    async fn test_query_placeholder_rewrite_preserves_validation() {
         let node = Node::memory_node().await;
         define_test_schema(&node).await;
-
         let db = node.db().await.unwrap();
-        let err = db
-            .query("[:find ?e :where [?e :name _]]")
-            .await
-            .unwrap_err();
-
-        assert!(
-            err.to_string().contains("value position"),
-            "unexpected error: {}",
-            err
-        );
+        for (query, error) in [
+            (
+                "[:find ?e :where (or [?e :name _] [?e :age _])]",
+                "different free variables",
+            ),
+            (
+                "[:find ?e :where [?e :name ?name] (not [?e :age _])]",
+                "in NOT clause is not bound by positive clauses",
+            ),
+            (
+                "[:find ?e :where [?e _ _]]",
+                "Attribute position must be a keyword or entid",
+            ),
+            (
+                "[:find ?e :where [?e :name _ ?tx]]",
+                "Transaction positions are not supported",
+            ),
+        ] {
+            let err = db.query(query).await.unwrap_err();
+            assert!(err.to_string().contains(error), "{query}: {err}");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2522,37 +2566,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_incremental_query_rejects_entity_placeholder() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
+    async fn test_incremental_placeholders_match_explicit_variables() {
+        for (query, explicit) in [
+            (
+                "[:find ?name :where [_ :name ?name]]",
+                "[:find ?name :where [?entity :name ?name]]",
+            ),
+            (
+                "[:find ?e :where [?e :name _]]",
+                "[:find ?e :where [?e :name ?value]]",
+            ),
+            (
+                "[:find ?name :where [_ :name ?name] [_ :age _]]",
+                "[:find ?name :where [?entity :name ?name] [?other :age ?age]]",
+            ),
+            (
+                "[:find (count ?name) :where [_ :name ?name]]",
+                "[:find (count ?name) :where [?entity :name ?name]]",
+            ),
+        ] {
+            let node = Node::memory_node().await;
+            define_test_schema(&node).await;
+            flush_wal(&node).await;
+            let mut subscription = node
+                .register_incremental_query(parse_query(query), &[])
+                .await
+                .unwrap();
+            let mut rows = Vec::new();
+            let mut additions = Vec::new();
+            for (entity, name, age) in
+                [(100, "Alice", 30_i64), (101, "Alice", 40), (102, "Bob", 50)]
+            {
+                additions.extend([
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity),
+                        attribute: kw!(:name),
+                        value: name.into(),
+                    },
+                    TxOp::Add {
+                        entity: EntityRef::Id(entity),
+                        attribute: kw!(:age),
+                        value: age.into(),
+                    },
+                ]);
+            }
+            let basis = execute_and_flush(&node, additions).await;
+            assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, explicit)
+                .await;
 
-        let err = node
-            .register_incremental_query(parse_query("[:find ?name :where [_ :name ?name]]"), &[])
-            .await
-            .unwrap_err();
-
-        assert!(
-            err.to_string().contains("Placeholders in entity position"),
-            "unexpected error: {}",
-            err
-        );
-    }
-
-    #[tokio::test]
-    async fn test_register_incremental_query_rejects_value_placeholder() {
-        let node = Node::memory_node().await;
-        define_test_schema(&node).await;
-
-        let err = node
-            .register_incremental_query(parse_query("[:find ?e :where [?e :name _]]"), &[])
-            .await
-            .unwrap_err();
-
-        assert!(
-            err.to_string().contains("Placeholders in value position"),
-            "unexpected error: {}",
-            err
-        );
+            for entity in [100, 101] {
+                let basis = execute_and_flush(
+                    &node,
+                    vec![TxOp::Retract {
+                        entity: EntityRef::Id(entity),
+                        attribute: kw!(:name),
+                        value: "Alice".into(),
+                    }],
+                )
+                .await;
+                assert_incremental_matches_db(&node, &mut subscription, &mut rows, basis, explicit)
+                    .await;
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -616,11 +616,11 @@ mod tests {
         let db = node.db().await.unwrap();
         for (query, error) in [
             (
-                "[:find ?e :where (or [?e :name _] [?e :age _])]",
+                "[:find ?e :where (or [?e :name ?name] [?e :age ?age])]",
                 "different free variables",
             ),
             (
-                "[:find ?e :where [?e :name ?name] (not [?e :age _])]",
+                "[:find ?e :where [?e :name ?name] (not [?e :age ?age])]",
                 "in NOT clause is not bound by positive clauses",
             ),
             (
@@ -631,9 +631,131 @@ mod tests {
                 "[:find ?e :where [?e :name _ ?tx]]",
                 "Transaction positions are not supported",
             ),
+            (
+                "[:find ?e :where (or [?e :name ?_internal_99] [?e :age ?age])]",
+                "different free variables",
+            ),
+            (
+                "[:find ?e :where [?e :name _] (or-join [?e] [?e :tags _])]",
+                "do not support explicit or-join",
+            ),
+            (
+                "[:find ?e :where [?e :name _] (not-join [?e] [?e :tags _])]",
+                "do not support explicit not-join",
+            ),
         ] {
             let err = db.query(query).await.unwrap_err();
             assert!(err.to_string().contains(error), "{query}: {err}");
+        }
+    }
+
+    async fn node_with_local_placeholder_facts() -> Node<MemoryLog> {
+        let node = Node::memory_node().await;
+        define_test_schema(&node).await;
+        let mut facts = Vec::new();
+        for (entity, name) in [(100, "Alice"), (101, "Bob"), (102, "Carol")] {
+            facts.push(TxOp::Add {
+                entity: EntityRef::Id(entity),
+                attribute: kw!(:name),
+                value: name.into(),
+            });
+        }
+        for (entity, age) in [(100, 30_i64), (101, 40)] {
+            facts.push(TxOp::Add {
+                entity: EntityRef::Id(entity),
+                attribute: kw!(:age),
+                value: age.into(),
+            });
+        }
+        for (entity, tag) in [(100, "red"), (100, "blue"), (101, "red")] {
+            facts.push(TxOp::Add {
+                entity: EntityRef::Id(entity),
+                attribute: kw!(:tags),
+                value: tag.into(),
+            });
+        }
+        execute_and_flush(&node, facts).await;
+        node
+    }
+
+    fn local_placeholder_cases() -> Vec<(&'static str, Vec<Vec<DataType>>)> {
+        let entities = |ids: &[i64]| ids.iter().map(|id| vec![DataType::Long(*id)]).collect();
+        vec![
+            (
+                "[:find ?e :where [?e :name _] (not [?e :tags _])]",
+                entities(&[102]),
+            ),
+            (
+                "[:find ?e :where (or [?e :tags _] [?e :age _])]",
+                entities(&[100, 101]),
+            ),
+            (
+                "[:find ?e :where [?e :name _] (or [?e :tags _] (and [?e :age _] [_ :tags _]))]",
+                entities(&[100, 101]),
+            ),
+            (
+                "[:find ?e :where (not [?e :tags _]) [?e :name _]]",
+                entities(&[102]),
+            ),
+            (
+                "[:find ?e :where [?e :name _] (not (or [?e :tags _] [?e :age _]))]",
+                entities(&[102]),
+            ),
+            (
+                "[:find ?e :where (or (and [?e :name _] (not [?e :tags _])) [?e :age _])]",
+                entities(&[100, 101, 102]),
+            ),
+            (
+                "[:find ?e :where [?e :name _] (not [?e :name _] (not [?e :tags _]))]",
+                entities(&[100, 101]),
+            ),
+            (
+                r#"[:find ?e :where (not [_ :tags "missing"]) [?e :name _]]"#,
+                entities(&[100, 101, 102]),
+            ),
+            (
+                "[:find ?e :where (not [_ :tags _]) [?e :name _]]",
+                entities(&[]),
+            ),
+            (
+                "[:find ?e :where [?e :name _] (or [_ :tags _] [_ :age _])]",
+                entities(&[100, 101, 102]),
+            ),
+            (
+                r#"[:find ?e :where [?e :name "missing"] (or [_ :tags _] [_ :age _])]"#,
+                entities(&[]),
+            ),
+            (
+                r#"[:find ?e :where [?e :name "missing"] (not [_ :tags "missing"])]"#,
+                entities(&[]),
+            ),
+            (
+                "[:find ?tag :where (or [_ :tags ?tag] (and [_ :tags ?tag] [_ :age _]))]",
+                vec![vec!["blue".into()], vec!["red".into()]],
+            ),
+            (
+                "[:find (count ?e) :where (or [?e :tags _] [?e :age _])]",
+                vec![vec![DataType::Long(2)]],
+            ),
+            (
+                "[:find (count ?e) :where [?e :name _] (not [?e :tags _])]",
+                vec![vec![DataType::Long(1)]],
+            ),
+        ]
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_local_placeholders() {
+        let node = node_with_local_placeholder_facts().await;
+        let db = node.db().await.unwrap();
+        for (query, mut expected) in local_placeholder_cases() {
+            let mut actual = db
+                .query(query)
+                .await
+                .unwrap_or_else(|error| panic!("{query}: {error:#}"));
+            sort_query_rows(&mut expected);
+            sort_query_rows(&mut actual);
+            assert_eq!(actual, expected, "{query}");
         }
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -331,11 +331,28 @@ pub(crate) fn convert_where_fn(wf: &WhereFn) -> Result<FnExpr, Error> {
 // Variable collection from clauses
 // ---------------------------------------------------------------------------
 
+/// Remove generated variables when crossing an OR or NOT boundary.
+pub(crate) fn exposed_variables(
+    variables: impl IntoIterator<Item = Variable>,
+    generated_variables: &HashSet<Variable>,
+) -> Vec<Variable> {
+    variables
+        .into_iter()
+        .filter(|variable| !generated_variables.contains(variable))
+        .collect()
+}
+
 /// Extract variables bound by an OrWhereClause.
-pub(crate) fn or_branch_bound_variables(branch: &OrWhereClause) -> Vec<Variable> {
+pub(crate) fn or_branch_bound_variables(
+    branch: &OrWhereClause,
+    generated_variables: &HashSet<Variable>,
+) -> Vec<Variable> {
     match branch {
-        OrWhereClause::Clause(clause) => clause_bound_variables(clause),
-        OrWhereClause::And(children) => children.iter().flat_map(clause_bound_variables).collect(),
+        OrWhereClause::Clause(clause) => clause_bound_variables(clause, generated_variables),
+        OrWhereClause::And(children) => children
+            .iter()
+            .flat_map(|clause| clause_bound_variables(clause, generated_variables))
+            .collect(),
     }
 }
 
@@ -347,7 +364,10 @@ pub(crate) fn or_branch_mentioned_variables(branch: &OrWhereClause) -> Vec<Varia
 /// Recursively extract variables bound by a single WhereClause.
 /// Only positive (Pattern/OrJoin/WhereFn) clauses contribute variables. NotJoin and Pred
 /// clauses do not introduce new variables.
-pub(crate) fn clause_bound_variables(clause: &WhereClause) -> Vec<Variable> {
+pub(crate) fn clause_bound_variables(
+    clause: &WhereClause,
+    generated_variables: &HashSet<Variable>,
+) -> Vec<Variable> {
     match clause {
         WhereClause::Pattern(pattern) => pattern_variables(pattern),
         WhereClause::OrJoin(oj) => {
@@ -355,7 +375,12 @@ pub(crate) fn clause_bound_variables(clause: &WhereClause) -> Vec<Variable> {
             // Extract from the first branch only.
             oj.clauses
                 .first()
-                .map(or_branch_bound_variables)
+                .map(|branch| {
+                    exposed_variables(
+                        or_branch_bound_variables(branch, generated_variables),
+                        generated_variables,
+                    )
+                })
                 .unwrap_or_default()
         }
         WhereClause::WhereFn(wf) => {
@@ -386,6 +411,7 @@ pub(crate) fn clause_mentioned_variables(clause: &WhereClause) -> Vec<Variable> 
 pub fn query_variable_order(
     in_bindings: &[Binding],
     where_clauses: &[WhereClause],
+    generated_variables: &HashSet<Variable>,
 ) -> Vec<Variable> {
     let mut seen = HashSet::new();
     let mut order = Vec::new();
@@ -411,7 +437,7 @@ pub fn query_variable_order(
         .collect();
 
     for clause in reordered {
-        for var in clause_bound_variables(clause) {
+        for var in clause_bound_variables(clause, generated_variables) {
             if seen.insert(var.clone()) {
                 order.push(var);
             }
@@ -661,7 +687,7 @@ fn apply_order_and_limit(
     find_spec: &FindSpec,
 ) -> Result<QueryResult, Error> {
     if let Some(orders) = order {
-        // Also resolved in validate_query(); duplicated here to keep the API simple.
+        // Also resolved in validate_query(&HashSet::new()); duplicated here to keep the API simple.
         let sort_keys = resolve_order_columns(orders, find_spec)?;
         // TODO: replace with Vec::try_sort_by once stabilized (rust-lang/rust#130044)
         // TODO: For large result sets, consider on-disk sorting to avoid OOM.
@@ -740,9 +766,10 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    let query = rewrite_query(query);
-    validate_query(&query, args)?;
-    let logical_plan = build_logical_plan(&query, args)?;
+    let rewritten = rewrite_query(query);
+    let query = &rewritten.query;
+    validate_query(query, args, &rewritten.generated_variables)?;
+    let logical_plan = build_logical_plan(query, args, &rewritten.generated_variables)?;
     let output_variables = logical_plan.output_variables().to_vec();
     let stages = logical_plan.materialize(db, None)?;
     let bindings = GenericJoinEngine::execute(&stages, BindingBag::unit())?;
@@ -782,14 +809,16 @@ mod tests {
     #[test]
     fn test_query_variable_order_single_pattern() {
         let parsed = parse_query("[:find ?e ?name :where [?e :name ?name]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(order, vec!["?e".to_var(), "?name".to_var()]);
     }
 
     #[test]
     fn test_query_variable_order_multiple_patterns() {
         let parsed = parse_query("[:find ?e ?name ?age :where [?e :name ?name] [?e :age ?age]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(
             order,
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
@@ -799,14 +828,16 @@ mod tests {
     #[test]
     fn test_query_variable_order_with_constants() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"]]"#);
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(order, vec!["?e".to_var()]);
     }
 
     #[test]
     fn test_query_variable_order_with_or_clause() {
         let parsed = parse_query("[:find ?e :where (or [?e _ 10] [?e _ 15])]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(order, vec!["?e".to_var()]);
     }
 
@@ -815,14 +846,16 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e ?age :where (or [?e :name "alice"] [?e :name "bob"]) [?e :age ?age]]"#,
         );
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(order, vec!["?e".to_var(), "?age".to_var(),]);
     }
 
     #[test]
     fn test_query_variable_order_ignores_predicates() {
         let parsed = parse_query("[:find ?e ?age :where [?e :age ?age] [(< ?age 30)]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(order, vec!["?e".to_var(), "?age".to_var(),]);
     }
 
@@ -830,7 +863,8 @@ mod tests {
     fn test_query_variable_order_with_fn_expr() {
         let parsed =
             parse_query("[:find ?e ?next_age :where [?e :age ?age] [(+ ?age 1) ?next_age]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(
             order,
             vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
@@ -842,7 +876,8 @@ mod tests {
         // FnExpr appears first, but its output should still come after Triple vars
         let parsed =
             parse_query("[:find ?e ?next_age :where [(+ ?age 1) ?next_age] [?e :age ?age]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(
             order,
             vec!["?e".to_var(), "?age".to_var(), "?next_age".to_var(),]
@@ -853,7 +888,8 @@ mod tests {
     fn test_query_variable_order_with_and_inside_or() {
         let parsed =
             parse_query("[:find ?e ?name ?age :where (or (and [?e :name ?name] [?e :age ?age]))]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(
             order,
             vec!["?e".to_var(), "?name".to_var(), "?age".to_var(),]
@@ -1005,7 +1041,8 @@ mod tests {
     #[test]
     fn test_query_variable_order_with_in_vars() {
         let parsed = parse_query("[:find ?e ?name :in ?name :where [?e :person/name ?name]]");
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         // ?name from :in should come first, then ?e from WHERE
         assert_eq!(order, vec!["?name".to_var(), "?e".to_var(),]);
     }
@@ -1016,7 +1053,7 @@ mod tests {
     fn test_regexp_like_valid_query() {
         let parsed =
             parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "^B")]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_ok(), "expected ok, got {:?}", result);
     }
 
@@ -1024,7 +1061,7 @@ mod tests {
     fn test_regexp_like_invalid_pattern_rejected_at_plan_time() {
         let parsed =
             parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name "[")]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1040,7 +1077,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?name :where [?e :name ?name] [?e :pat ?pat] [(regexp_like ?name ?pat)]]"#,
         );
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("string literal"), "unexpected error: {}", msg);
@@ -1049,7 +1086,7 @@ mod tests {
     #[test]
     fn test_regexp_like_wrong_arity_rejected() {
         let parsed = parse_query(r#"[:find ?name :where [?e :name ?name] [(regexp_like ?name)]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("expects 2 args"));
     }
@@ -1060,7 +1097,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?name ?hit :where [?e :name ?name] [(regexp_like ?name "^B") ?hit]]"#,
         );
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1075,7 +1112,8 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?name ?flag :where [?e :name ?name] [?e :age ?age] [(if (> ?age 30) 1 0) ?flag]]"#,
         );
-        let order = query_variable_order(&parsed.in_bindings, &parsed.where_clauses);
+        let order =
+            query_variable_order(&parsed.in_bindings, &parsed.where_clauses, &HashSet::new());
         assert_eq!(
             order,
             vec![
@@ -1092,7 +1130,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?name ?flag :where [?e :name ?name] [?e :age ?age] [(if (> ?age 30) ?age 0) ?flag]]"#,
         );
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_ok());
     }
 
@@ -1101,7 +1139,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e ?flag :where [?e :name "Alice"] [(if (> ?unbound 30) 1 0) ?flag]]"#,
         );
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("?unbound"));
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -33,6 +33,7 @@ use crate::query::binding_bag::{BindingBag, BindingRow};
 use crate::query::engine::GenericJoinEngine;
 use crate::query::plan::build_logical_plan;
 use crate::query_validation::validate_query;
+use crate::rewrite::rewrite_query;
 use regex::Regex;
 
 /// Each inner Vec is a projected row of decoded DataType values.
@@ -739,8 +740,9 @@ where
     D: DbReadOps + Send + Sync + 'static,
     M: DbMetadataOps + Send + Sync + 'static,
 {
-    validate_query(query, args)?;
-    let logical_plan = build_logical_plan(query, args)?;
+    let query = rewrite_query(query);
+    validate_query(&query, args)?;
+    let logical_plan = build_logical_plan(&query, args)?;
     let output_variables = logical_plan.output_variables().to_vec();
     let stages = logical_plan.materialize(db, None)?;
     let bindings = GenericJoinEngine::execute(&stages, BindingBag::unit())?;

--- a/src/query/patterns/not.rs
+++ b/src/query/patterns/not.rs
@@ -47,11 +47,9 @@ where
             "NOT incoming variables must be the NOT variable set"
         );
         ensure!(
-            logical_plan
-                .output_variables()
+            variables
                 .iter()
-                .collect::<HashSet<_>>()
-                == variables_set,
+                .all(|variable| logical_plan.output_variables().contains(variable)),
             "NOT body does not produce the NOT variable set"
         );
         Ok(Self {
@@ -77,7 +75,7 @@ where
             })?;
         GenericJoinEngine::execute(&stages, BindingBag::unit())
             .with_context(|| format!("NOT pattern {} logical plan failed", self.id))?
-            .reorder(&self.variables)
+            .project(&self.variables)
     }
 }
 

--- a/src/query/patterns/or.rs
+++ b/src/query/patterns/or.rs
@@ -50,14 +50,11 @@ where
             "OR incoming variables must be OR variables"
         );
 
-        let expected: HashSet<&Variable> = variables.iter().collect();
         for (branch_index, branch_plan) in branch_plans.iter().enumerate() {
             ensure!(
-                branch_plan
-                    .output_variables()
+                variables
                     .iter()
-                    .collect::<HashSet<_>>()
-                    == expected,
+                    .all(|variable| branch_plan.output_variables().contains(variable)),
                 "OR branch {branch_index} does not produce the OR variable set"
             );
             ensure!(
@@ -103,7 +100,7 @@ where
                 })?;
             let branch = GenericJoinEngine::execute(&stages, BindingBag::unit())
                 .with_context(|| format!("OR pattern {} failed in branch {branch_index}", self.id))?
-                .reorder(&self.variables)?;
+                .project(&self.variables)?;
             result = result.distinct_union(&branch)?;
         }
         Ok(result)

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -14,8 +14,9 @@ use crate::db_value::DB;
 use crate::expr::{expr_variables, Expr};
 use crate::ops::{DataType, QueryArg};
 use crate::query::{
-    convert_predicate, convert_where_fn, non_value_place_to_datatype, pattern_variables,
-    query_variable_order, resolve_attribute_from_pattern, value_place_to_datatype,
+    convert_predicate, convert_where_fn, exposed_variables, non_value_place_to_datatype,
+    pattern_variables, query_variable_order, resolve_attribute_from_pattern,
+    value_place_to_datatype,
 };
 
 use super::binding_bag::BindingBag;
@@ -154,13 +155,17 @@ enum DescriptorKind {
     },
 }
 
-struct DescriptorBuilder {
+struct DescriptorBuilder<'a> {
     next_id: PatternId,
+    generated_variables: &'a HashSet<Variable>,
 }
 
-impl DescriptorBuilder {
-    fn new() -> Self {
-        Self { next_id: 0 }
+impl<'a> DescriptorBuilder<'a> {
+    fn new(generated_variables: &'a HashSet<Variable>) -> Self {
+        Self {
+            next_id: 0,
+            generated_variables,
+        }
     }
 
     fn allocate_id(&mut self) -> PatternId {
@@ -242,8 +247,8 @@ impl DescriptorBuilder {
                 let variables = branches[0]
                     .iter()
                     .flat_map(|descriptor| descriptor.variables.iter().cloned())
-                    .unique()
-                    .collect();
+                    .unique();
+                let variables = exposed_variables(variables, self.generated_variables);
                 Ok(Descriptor {
                     id,
                     variables,
@@ -256,8 +261,8 @@ impl DescriptorBuilder {
                 let variables = children
                     .iter()
                     .flat_map(|descriptor| descriptor.variables.iter().cloned())
-                    .unique()
-                    .collect();
+                    .unique();
+                let variables = exposed_variables(variables, self.generated_variables);
                 Ok(Descriptor {
                     id,
                     variables,
@@ -812,6 +817,7 @@ fn plan_descriptor(
     descriptor: Descriptor,
     incoming_variables: Option<Vec<Variable>>,
     variable_order: &[Variable],
+    generated_variables: &HashSet<Variable>,
 ) -> Result<LogicalDescriptor> {
     let kind = match descriptor.kind {
         DescriptorKind::Triple(pattern) => LogicalDescriptorKind::Triple(pattern),
@@ -832,13 +838,18 @@ fn plan_descriptor(
                 .into_iter()
                 .enumerate()
                 .map(|(branch_index, branch)| {
-                    plan_scope(branch, variable_order, Some(incoming_variables.clone()))
-                        .with_context(|| {
-                            format!(
-                                "Failed to plan OR descriptor {} branch {branch_index}",
-                                descriptor.id
-                            )
-                        })
+                    plan_scope(
+                        branch,
+                        variable_order,
+                        Some(incoming_variables.clone()),
+                        generated_variables,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "Failed to plan OR descriptor {} branch {branch_index}",
+                            descriptor.id
+                        )
+                    })
                 })
                 .collect::<Result<Vec<_>>>()?;
             LogicalDescriptorKind::Or { branches }
@@ -852,8 +863,13 @@ fn plan_descriptor(
                 descriptor.id
             );
             LogicalDescriptorKind::Not {
-                children: plan_scope(children, variable_order, Some(incoming_variables))
-                    .with_context(|| format!("Failed to plan NOT descriptor {}", descriptor.id))?,
+                children: plan_scope(
+                    children,
+                    variable_order,
+                    Some(incoming_variables),
+                    generated_variables,
+                )
+                .with_context(|| format!("Failed to plan NOT descriptor {}", descriptor.id))?,
             }
         }
     };
@@ -868,6 +884,7 @@ fn plan_scope(
     descriptors: Vec<Descriptor>,
     variable_order: &[Variable],
     incoming_variables: Option<Vec<Variable>>,
+    generated_variables: &HashSet<Variable>,
 ) -> Result<LogicalPlan> {
     let relevant: HashSet<&Variable> = descriptors
         .iter()
@@ -881,6 +898,17 @@ fn plan_scope(
             .filter(|variable| relevant.contains(variable))
             .collect::<Vec<_>>()
     });
+    // Preserve the parent order, then append variables introduced only in this scope.
+    let mut scope_order = variable_order.to_vec();
+    for variable in descriptors
+        .iter()
+        .flat_map(|descriptor| &descriptor.variables)
+    {
+        if generated_variables.contains(variable) && !scope_order.contains(variable) {
+            scope_order.push(variable.clone());
+        }
+    }
+    let variable_order = scope_order.as_slice();
     let stages = plan_stages(&descriptors, variable_order, incoming_variables.as_deref())?;
     let mut descriptor_input_layouts = HashMap::new();
     let mut previous_target: &[Variable] = &[];
@@ -925,7 +953,12 @@ fn plan_scope(
                 }
                 _ => None,
             };
-            plan_descriptor(descriptor, descriptor_input_layout, variable_order)
+            plan_descriptor(
+                descriptor,
+                descriptor_input_layout,
+                variable_order,
+                generated_variables,
+            )
         })
         .collect::<Result<Vec<_>>>()?;
     Ok(LogicalPlan {
@@ -938,9 +971,14 @@ fn plan_scope(
 pub(crate) fn build_logical_plan(
     query: &edn::query::ParsedQuery,
     arguments: &[QueryArg],
+    generated_variables: &HashSet<Variable>,
 ) -> Result<LogicalPlan> {
-    let variable_order = query_variable_order(&query.in_bindings, &query.where_clauses);
-    let mut builder = DescriptorBuilder::new();
+    let variable_order = query_variable_order(
+        &query.in_bindings,
+        &query.where_clauses,
+        generated_variables,
+    );
+    let mut builder = DescriptorBuilder::new(generated_variables);
     let mut descriptors: Vec<Descriptor> = query
         .in_bindings
         .iter()
@@ -949,7 +987,7 @@ pub(crate) fn build_logical_plan(
         .collect();
     descriptors.extend(builder.where_clauses(&query.where_clauses)?);
 
-    plan_scope(descriptors, &variable_order, None)
+    plan_scope(descriptors, &variable_order, None, generated_variables)
 }
 
 #[cfg(test)]
@@ -1034,9 +1072,9 @@ mod tests {
             QueryArg::Scalar(DataType::String("Alice".into())),
             QueryArg::Collection(vec![DataType::Long(20), DataType::Long(40)]),
         ];
-        validate_query(&query, &arguments).unwrap();
+        validate_query(&query, &arguments, &HashSet::new()).unwrap();
 
-        let plan = build_logical_plan(&query, &arguments).unwrap();
+        let plan = build_logical_plan(&query, &arguments, &HashSet::new()).unwrap();
 
         assert_eq!(
             plan.output_variables(),
@@ -1074,9 +1112,9 @@ mod tests {
     fn plans_function_with_already_bound_output() {
         let query =
             edn::parse::parse_query("[:find ?e :where [?e :age ?age] [(+ ?age 1) ?e]]").unwrap();
-        validate_query(&query, &[]).unwrap();
+        validate_query(&query, &[], &HashSet::new()).unwrap();
 
-        build_logical_plan(&query, &[]).unwrap();
+        build_logical_plan(&query, &[], &HashSet::new()).unwrap();
     }
 
     #[test]
@@ -1089,7 +1127,8 @@ mod tests {
             (not [?e :blocked-by ?x] [?x :active ?e])]"#,
         )
         .unwrap();
-        let mut builder = DescriptorBuilder::new();
+        let generated_variables = HashSet::new();
+        let mut builder = DescriptorBuilder::new(&generated_variables);
 
         let descriptors = builder.where_clauses(&query.where_clauses).unwrap();
 
@@ -1351,7 +1390,7 @@ mod tests {
     fn projects_incoming_layout_before_selecting_proposers() {
         let descriptors = vec![relation(0, &["?x"])];
         let incoming = vec![var("?outer"), var("?x")];
-        let plan = plan_scope(descriptors, &[var("?x")], Some(incoming)).unwrap();
+        let plan = plan_scope(descriptors, &[var("?x")], Some(incoming), &HashSet::new()).unwrap();
 
         assert_eq!(plan.incoming_variables(), Some(&[var("?x")][..]));
         assert_eq!(
@@ -1366,8 +1405,13 @@ mod tests {
     #[test]
     fn plans_projected_zero_column_incoming_as_validation_only_participant() {
         let descriptors = vec![relation(0, &["?x"])];
-        let plan =
-            plan_scope(descriptors.clone(), &[var("?x")], Some(vec![var("?outer")])).unwrap();
+        let plan = plan_scope(
+            descriptors.clone(),
+            &[var("?x")],
+            Some(vec![var("?outer")]),
+            &HashSet::new(),
+        )
+        .unwrap();
 
         assert_eq!(plan.incoming_variables(), Some(&[][..]));
         assert_eq!(
@@ -1388,7 +1432,7 @@ mod tests {
             ]
         );
 
-        let root = plan_scope(descriptors, &[var("?x")], None).unwrap();
+        let root = plan_scope(descriptors, &[var("?x")], None, &HashSet::new()).unwrap();
         assert_eq!(root.incoming_variables(), None);
         assert_eq!(root.stages.as_slice(), &plan.stages[1..]);
     }
@@ -1432,7 +1476,7 @@ mod tests {
         .unwrap();
         let arguments = [QueryArg::Collection(vec![DataType::Long(1)])];
 
-        let plan = build_logical_plan(&query, &arguments).unwrap();
+        let plan = build_logical_plan(&query, &arguments, &HashSet::new()).unwrap();
         let LogicalDescriptorKind::Not { children } = &plan.descriptors[1].kind else {
             panic!("expected NOT descriptor");
         };
@@ -1453,7 +1497,7 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         let query = edn::parse::parse_query("[:find ?e ?v :where [?e :name ?v]]").unwrap();
-        let logical = build_logical_plan(&query, &[])?;
+        let logical = build_logical_plan(&query, &[], &HashSet::new())?;
         let db = db_at_tx_id(
             &components,
             runtime.handle(),
@@ -1481,7 +1525,7 @@ mod tests {
         let components = runtime.block_on(in_memory_slate());
         let query = edn::parse::parse_query("[:find ?x :in [?x ...] :where [(>= ?x 0)]]").unwrap();
         let arguments = [QueryArg::Collection(vec![DataType::Long(1)])];
-        let logical = build_logical_plan(&query, &arguments)?;
+        let logical = build_logical_plan(&query, &arguments, &HashSet::new())?;
         let db = db_at_tx_id(&components, runtime.handle(), HashMap::new(), 0);
 
         let stages = logical.materialize(db, None)?;
@@ -1512,7 +1556,7 @@ mod tests {
             DataType::Long(1),
             DataType::Long(2),
         ])];
-        let logical = build_logical_plan(&query, &arguments)?;
+        let logical = build_logical_plan(&query, &arguments, &HashSet::new())?;
         let db = db_at_tx_id(&components, runtime.handle(), HashMap::new(), 0);
 
         let stages = logical.materialize(db, None)?;
@@ -1546,7 +1590,7 @@ mod tests {
             ]),
             QueryArg::Collection(vec![DataType::Long(10)]),
         ];
-        let logical = build_logical_plan(&query, &arguments)?;
+        let logical = build_logical_plan(&query, &arguments, &HashSet::new())?;
         let db = db_at_tx_id(&components, runtime.handle(), HashMap::new(), 0);
 
         let or_pattern = logical.descriptors[2].materialize(db)?;
@@ -1615,7 +1659,7 @@ mod tests {
             DataType::Long(3),
             DataType::Long(4),
         ])];
-        let logical = build_logical_plan(&query, &arguments)?;
+        let logical = build_logical_plan(&query, &arguments, &HashSet::new())?;
         let db = db_at_tx_id(&components, runtime.handle(), HashMap::new(), 0);
 
         let stages = logical.materialize(db, None)?;
@@ -1636,7 +1680,7 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new()?;
         let components = runtime.block_on(in_memory_slate());
         let query = edn::parse::parse_query("[:find ?e :where [?e :missing \"value\"]]").unwrap();
-        let logical = build_logical_plan(&query, &[])?;
+        let logical = build_logical_plan(&query, &[], &HashSet::new())?;
         let db = db_at_tx_id(&components, runtime.handle(), HashMap::new(), 0);
 
         let error = logical
@@ -1656,7 +1700,7 @@ mod tests {
             edn::parse::parse_query("[:find ?x :in [?x ...] :where (or [(= ?x 1)] [(= ?x 2)])]")
                 .unwrap();
         let arguments = [QueryArg::Collection(vec![DataType::Long(1)])];
-        let root = build_logical_plan(&query, &arguments)?;
+        let root = build_logical_plan(&query, &arguments, &HashSet::new())?;
         let LogicalDescriptorKind::Or { branches } = &root.descriptors[1].kind else {
             panic!("expected OR descriptor");
         };

--- a/src/query_validation.rs
+++ b/src/query_validation.rs
@@ -11,7 +11,7 @@ use crate::expr::expr_variables;
 use crate::ops::{DataType, QueryArg};
 use crate::query::{
     build_var_index, clause_mentioned_variables, convert_predicate, convert_where_fn,
-    or_branch_bound_variables, or_branch_mentioned_variables, pattern_variables,
+    exposed_variables, or_branch_bound_variables, or_branch_mentioned_variables, pattern_variables,
     query_variable_order, resolve_order_columns,
 };
 
@@ -87,10 +87,11 @@ fn validate_supported_where_clauses(where_clauses: &[WhereClause]) -> Result<(),
 fn validate_not_clauses(
     where_clauses: &[WhereClause],
     var_index: &HashMap<&Variable, usize>,
+    generated_variables: &HashSet<Variable>,
 ) -> Result<(), Error> {
     validate_where_clauses_recursively(where_clauses, &mut |clause: &WhereClause| {
         if let WhereClause::NotJoin(nj) = clause {
-            for var in not_clause_variables(&nj.clauses) {
+            for var in exposed_variables(not_clause_variables(&nj.clauses), generated_variables) {
                 if !var_index.contains_key(&var) {
                     return Err(anyhow::anyhow!(
                         "Variable {} in NOT clause is not bound by positive clauses",
@@ -249,29 +250,45 @@ fn validate_aggregate_clauses(
     Ok(())
 }
 
-fn validate_or_clauses(clauses: &[WhereClause]) -> Result<(), Error> {
+fn validate_or_clauses(
+    clauses: &[WhereClause],
+    generated_variables: &HashSet<Variable>,
+) -> Result<(), Error> {
     validate_where_clauses_recursively(clauses, &mut |clause: &WhereClause| match clause {
-        WhereClause::OrJoin(oj) => validate_or_branch_variables(&oj.clauses),
+        WhereClause::OrJoin(oj) => validate_or_branch_variables(&oj.clauses, generated_variables),
         _ => Ok(()),
     })
 }
 
 /// Validate that all OR branches have the same free variables.
-fn validate_or_branch_variables(branches: &[OrWhereClause]) -> Result<(), Error> {
+fn validate_or_branch_variables(
+    branches: &[OrWhereClause],
+    generated_variables: &HashSet<Variable>,
+) -> Result<(), Error> {
     if branches.is_empty() {
         return Err(anyhow::anyhow!("OR clause must have at least one branch"));
     }
 
-    let first_bound_vars: HashSet<Variable> = or_branch_bound_variables(&branches[0])
-        .into_iter()
-        .collect();
-    let first_mentioned_vars: HashSet<Variable> = or_branch_mentioned_variables(&branches[0])
-        .into_iter()
-        .collect();
+    let first_bound_vars: HashSet<Variable> = exposed_variables(
+        or_branch_bound_variables(&branches[0], generated_variables),
+        generated_variables,
+    )
+    .into_iter()
+    .collect();
+    let first_mentioned_vars: HashSet<Variable> = exposed_variables(
+        or_branch_mentioned_variables(&branches[0]),
+        generated_variables,
+    )
+    .into_iter()
+    .collect();
 
     for (i, branch) in branches.iter().enumerate().skip(1) {
-        let branch_bound_vars: HashSet<Variable> =
-            or_branch_bound_variables(branch).into_iter().collect();
+        let branch_bound_vars: HashSet<Variable> = exposed_variables(
+            or_branch_bound_variables(branch, generated_variables),
+            generated_variables,
+        )
+        .into_iter()
+        .collect();
         if branch_bound_vars != first_bound_vars {
             return Err(anyhow::anyhow!(
                 "OR branch {} has different free variables {{{}}} than branch 1 {{{}}}",
@@ -282,7 +299,9 @@ fn validate_or_branch_variables(branches: &[OrWhereClause]) -> Result<(), Error>
         }
 
         let branch_mentioned_vars: HashSet<Variable> =
-            or_branch_mentioned_variables(branch).into_iter().collect();
+            exposed_variables(or_branch_mentioned_variables(branch), generated_variables)
+                .into_iter()
+                .collect();
         if branch_mentioned_vars != first_mentioned_vars {
             return Err(anyhow::anyhow!(
                 "OR branch {} mentions different variables {{{}}} than branch 1 {{{}}}",
@@ -340,18 +359,26 @@ fn validate_in_bindings(in_bindings: &[Binding], args: &[QueryArg]) -> Result<()
 /// Validate a query before execution.
 // TODO: Move query validation into the edn parsing crate so that invalid
 // queries are rejected at parse time rather than at execution time.
-pub(crate) fn validate_query(query: &ParsedQuery, args: &[QueryArg]) -> Result<(), Error> {
+pub(crate) fn validate_query(
+    query: &ParsedQuery,
+    args: &[QueryArg],
+    generated_variables: &HashSet<Variable>,
+) -> Result<(), Error> {
     validate_in_bindings(&query.in_bindings, args)?;
     validate_supported_where_clauses(&query.where_clauses)?;
     validate_patterns(&query.where_clauses)?;
 
-    let join_order = query_variable_order(&query.in_bindings, &query.where_clauses);
+    let join_order = query_variable_order(
+        &query.in_bindings,
+        &query.where_clauses,
+        generated_variables,
+    );
     if join_order.is_empty() {
         return Err(anyhow::anyhow!("Query has no groundable variables!"));
     }
     let var_index = build_var_index(&join_order);
-    validate_or_clauses(&query.where_clauses)?;
-    validate_not_clauses(&query.where_clauses, &var_index)?;
+    validate_or_clauses(&query.where_clauses, generated_variables)?;
+    validate_not_clauses(&query.where_clauses, &var_index, generated_variables)?;
     validate_predicate_clauses(&query.where_clauses, &var_index)?;
     validate_fn_clauses(&query.where_clauses, &var_index)?;
     validate_aggregate_clauses(&query.find_spec, &var_index)?;
@@ -404,7 +431,7 @@ mod tests {
     #[test]
     fn test_validate_predicate_unbound_variable() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"] [(< ?unbound 30)]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("?unbound"));
     }
@@ -412,7 +439,7 @@ mod tests {
     #[test]
     fn test_validate_predicate_no_variables() {
         let parsed = parse_query(r#"[:find ?e :where [?e :name "Alice"] [(< 1 2)]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -423,7 +450,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_repeated_variable_in_single_pattern() {
         let parsed = parse_query("{:find [?x] :where [[?x :g/to ?x]]}");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Repeated variable ?x in a single pattern is not supported"),
@@ -435,7 +462,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_source_variables_in_patterns() {
         let parsed = parse_query("[:find ?e :where [$other ?e :name ?name]]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Query source variables are not supported by triple patterns"),
@@ -447,7 +474,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_transaction_positions() {
         let parsed = parse_query("[:find ?tx :where [1 :name \"Alice\" ?tx]]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Transaction positions are not supported by triple patterns"),
@@ -463,7 +490,7 @@ mod tests {
             "[:find ?e :where [?e _ ?name]]",
         ] {
             let parsed = parse_query(query);
-            let err = validate_query(&parsed, &[]).unwrap_err();
+            let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
             assert!(
                 err.to_string()
                     .contains("Attribute position must be a keyword or entid"),
@@ -477,7 +504,7 @@ mod tests {
     fn test_validate_rejects_explicit_or_join() {
         let parsed =
             parse_query(r#"[:find ?e :where (or-join [?e] [?e :name "Alice"] [?e :name "Bob"])]"#);
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string().contains("explicit or-join"),
             "unexpected error: {}",
@@ -489,7 +516,7 @@ mod tests {
     fn test_validate_rejects_explicit_not_join() {
         let parsed =
             parse_query(r#"[:find ?e :where [?e :name "Alice"] (not-join [?e] [?e :age 30])]"#);
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string().contains("explicit not-join"),
             "unexpected error: {}",
@@ -500,7 +527,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_not_without_positive_variables() {
         let parsed = parse_query("[:find ?e :where (not [?e :age 30])]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Query has no groundable variables"),
@@ -513,7 +540,7 @@ mod tests {
     fn test_validate_rejects_unbound_not_variable() {
         let parsed =
             parse_query(r#"[:find ?name :where [?person :name ?name] (not [?e :age 30])]"#);
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Variable ?e in NOT clause is not bound by positive clauses"),
@@ -527,7 +554,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e :where (or [?e :name "A"] (or [?e :name "B"] [?v :name "C"]))]"#,
         );
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert_eq!(
             err.to_string(),
             "OR branch 2 mentions different variables {?e, ?v} than branch 1 {?e}"
@@ -539,7 +566,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e :where [?e :name "A"] (not (or [?e :name "B"] [?v :name "C"]))]"#,
         );
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert_eq!(
             err.to_string(),
             "OR branch 2 has different free variables {?v} than branch 1 {?e}"
@@ -551,7 +578,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e :where (or [?e :name "A"] (and [?e :name "B"] (not [?v :age 30])))]"#,
         );
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("OR branch 2 mentions different variables"),
@@ -565,7 +592,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e :where (or [?e :name "A"] (and [?e :name "B"] [(< ?unbound 30)]))]"#,
         );
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("OR branch 2 mentions different variables"),
@@ -579,7 +606,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e ?age :where [?e :age ?age] (or (and [?e :name "A"] [(< ?age 30)]) (and [?e :name "B"] [(< ?age 40)]))]"#,
         );
-        assert!(validate_query(&parsed, &[]).is_ok());
+        assert!(validate_query(&parsed, &[], &HashSet::new()).is_ok());
     }
 
     #[test]
@@ -587,7 +614,7 @@ mod tests {
         let parsed = parse_query(
             r#"[:find ?e :where [?e :age ?age] (or (and [?e :name "A"] [(+ ?age 1) ?next]) (and [?e :name "B"] [(+ ?unbound 1) ?next]))]"#,
         );
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("OR branch 2 mentions different variables"),
@@ -600,7 +627,7 @@ mod tests {
     fn test_validate_fn_unbound_input() {
         let parsed =
             parse_query(r#"[:find ?e :where [?e :name "Alice"] [(+ ?unbound 1) ?result]]"#);
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("?unbound"));
     }
@@ -608,7 +635,7 @@ mod tests {
     #[test]
     fn test_validate_fn_accepts_already_bound_output() {
         let parsed = parse_query("[:find ?e :where [?e :age ?age] [(+ ?age 1) ?e]]");
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_ok());
     }
 
@@ -618,14 +645,14 @@ mod tests {
         // because query_variable_order reorders FnExpr clauses after Triples
         let parsed =
             parse_query("[:find ?e ?next_age :where [(+ ?age 1) ?next_age] [?e :age ?age]]");
-        let result = validate_query(&parsed, &[]);
+        let result = validate_query(&parsed, &[], &HashSet::new());
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_order_var_not_in_find() {
         let parsed = parse_query("[:find ?e :where [?e :name ?name] :order [?name :asc]]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string().contains("ORDER BY variable"),
             "unexpected error: {}",
@@ -637,7 +664,7 @@ mod tests {
     fn test_validate_limit_variable_requires_in_binding() {
         // Variable limit without :in binding should fail
         let parsed = parse_query("[:find ?e :where [?e :name ?name] :limit ?limit]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("not bound as a scalar in :in clause"),
@@ -650,15 +677,24 @@ mod tests {
     fn test_validate_limit_variable_with_in_binding() {
         let parsed = parse_query("[:find ?e :in ?limit :where [?e :name ?name] :limit ?limit]");
         // Providing a scalar Long arg should pass validation
-        assert!(validate_query(&parsed, &[QueryArg::Scalar(DataType::Long(10))]).is_ok());
+        assert!(validate_query(
+            &parsed,
+            &[QueryArg::Scalar(DataType::Long(10))],
+            &HashSet::new()
+        )
+        .is_ok());
     }
 
     #[test]
     fn test_validate_limit_variable_rejects_collection_binding() {
         let parsed =
             parse_query("[:find ?e :in [?limit ...] :where [?e :name ?name] :limit ?limit]");
-        let err =
-            validate_query(&parsed, &[QueryArg::Collection(vec![DataType::Long(10)])]).unwrap_err();
+        let err = validate_query(
+            &parsed,
+            &[QueryArg::Collection(vec![DataType::Long(10)])],
+            &HashSet::new(),
+        )
+        .unwrap_err();
         assert!(
             err.to_string()
                 .contains("not bound as a scalar in :in clause"),
@@ -670,7 +706,7 @@ mod tests {
     #[test]
     fn test_validate_rejects_sexpr_in_aggregate() {
         let parsed = parse_query("[:find ?e (count (+ ?age 1)) :where [?e :age ?age]]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Nested expressions are not supported"),
@@ -682,7 +718,7 @@ mod tests {
     #[test]
     fn test_validate_in_arg_count_mismatch() {
         let parsed = parse_query("[:find ?e :in ?x :where [?e :name ?x]]");
-        let err = validate_query(&parsed, &[]).unwrap_err();
+        let err = validate_query(&parsed, &[], &HashSet::new()).unwrap_err();
         assert!(
             err.to_string().contains("1 binding(s) but 0 argument(s)"),
             "unexpected error: {}",

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,0 +1,124 @@
+use edn::query::{
+    OrJoin, OrWhereClause, ParsedQuery, PatternNonValuePlace, PatternValuePlace, Variable,
+    WhereClause,
+};
+
+#[derive(Default)]
+struct Rewriter {
+    next_variable: usize,
+}
+
+impl Rewriter {
+    fn fresh_variable(&mut self) -> Variable {
+        let variable = Variable::from_valid_name(&format!("?_internal_{}", self.next_variable));
+        self.next_variable += 1;
+        variable
+    }
+
+    fn rewrite_clause(&mut self, clause: &mut WhereClause) {
+        match clause {
+            WhereClause::Pattern(pattern) => {
+                if matches!(pattern.entity, PatternNonValuePlace::Placeholder) {
+                    pattern.entity = PatternNonValuePlace::Variable(self.fresh_variable());
+                }
+                if matches!(pattern.value, PatternValuePlace::Placeholder) {
+                    pattern.value = PatternValuePlace::Variable(self.fresh_variable());
+                }
+            }
+            WhereClause::OrJoin(or) => {
+                for branch in &mut or.clauses {
+                    match branch {
+                        OrWhereClause::Clause(clause) => self.rewrite_clause(clause),
+                        OrWhereClause::And(clauses) => self.rewrite_clauses(clauses),
+                    }
+                }
+                // Rebuild the OR to discard its cached mentioned variables.
+                *or = OrJoin::new(or.unify_vars.clone(), std::mem::take(&mut or.clauses));
+            }
+            WhereClause::NotJoin(not) => self.rewrite_clauses(&mut not.clauses),
+            WhereClause::Pred(_)
+            | WhereClause::WhereFn(_)
+            | WhereClause::RuleExpr
+            | WhereClause::TypeAnnotation(_) => {}
+        }
+    }
+
+    fn rewrite_clauses(&mut self, clauses: &mut [WhereClause]) {
+        for clause in clauses {
+            self.rewrite_clause(clause);
+        }
+    }
+}
+
+pub(crate) fn rewrite_query(query: &ParsedQuery) -> ParsedQuery {
+    let mut query = query.clone();
+    Rewriter::default().rewrite_clauses(&mut query.where_clauses);
+    query
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(query: &str) -> ParsedQuery {
+        edn::parse::parse_query(query).unwrap()
+    }
+
+    #[test]
+    fn rewrites_each_entity_and_value_placeholder_independently() {
+        let query = parse_query("[:find ?name :where [_ :name ?name] [_ :age _]]");
+        let original = query.clone();
+        let expected = parse_query(
+            "[:find ?name :where [?_internal_0 :name ?name] [?_internal_1 :age ?_internal_2]]",
+        );
+
+        assert_eq!(rewrite_query(&query), expected);
+        assert_eq!(rewrite_query(&query), expected);
+        assert_eq!(rewrite_query(&expected), expected);
+        assert_eq!(query, original);
+    }
+
+    #[test]
+    fn rewrites_nested_clauses_and_clears_or_variable_caches() {
+        let mut query = parse_query(
+            "[:find ?e :where (or [?e :name _]
+                (and [_ :age _] (not [_ :email _]))) [_ :name _]]",
+        );
+        let WhereClause::OrJoin(or) = &mut query.where_clauses[0] else {
+            panic!("expected OR");
+        };
+        assert_eq!(or.mentioned_variables().len(), 1);
+
+        let mut rewritten = rewrite_query(&query);
+        let expected = parse_query(
+            "[:find ?e :where (or [?e :name ?_internal_0]
+                (and [?_internal_1 :age ?_internal_2]
+                     (not [?_internal_3 :email ?_internal_4])))
+                [?_internal_5 :name ?_internal_6]]",
+        );
+        assert_eq!(rewritten, expected);
+        let WhereClause::OrJoin(or) = &mut rewritten.where_clauses[0] else {
+            panic!("expected OR");
+        };
+        assert_eq!(or.mentioned_variables().len(), 6);
+    }
+
+    #[test]
+    fn preserves_other_positions_and_query_fields() {
+        let query = parse_query(
+            "[:find ?e :with ?value :in [?input _] :where
+                [?e _ ?value _] [(+ ?value 1) [?result _]]
+                :order [?e :asc] :limit 10]",
+        );
+        assert_eq!(rewrite_query(&query), query);
+    }
+
+    #[test]
+    fn does_not_avoid_user_variable_names() {
+        let query = parse_query("[:find ?_internal_0 :where [_ :name ?_internal_0]]");
+        assert_eq!(
+            rewrite_query(&query),
+            parse_query("[:find ?_internal_0 :where [?_internal_0 :name ?_internal_0]]")
+        );
+    }
+}

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,17 +1,26 @@
+use std::collections::HashSet;
+
 use edn::query::{
     OrJoin, OrWhereClause, ParsedQuery, PatternNonValuePlace, PatternValuePlace, Variable,
     WhereClause,
 };
 
+#[derive(Debug)]
+pub(crate) struct RewrittenQuery {
+    pub query: ParsedQuery,
+    pub generated_variables: HashSet<Variable>,
+}
+
 #[derive(Default)]
 struct Rewriter {
-    next_variable: usize,
+    generated_variables: HashSet<Variable>,
 }
 
 impl Rewriter {
     fn fresh_variable(&mut self) -> Variable {
-        let variable = Variable::from_valid_name(&format!("?_internal_{}", self.next_variable));
-        self.next_variable += 1;
+        let variable =
+            Variable::from_valid_name(&format!("?_internal_{}", self.generated_variables.len()));
+        self.generated_variables.insert(variable.clone());
         variable
     }
 
@@ -50,10 +59,14 @@ impl Rewriter {
     }
 }
 
-pub(crate) fn rewrite_query(query: &ParsedQuery) -> ParsedQuery {
+pub(crate) fn rewrite_query(query: &ParsedQuery) -> RewrittenQuery {
     let mut query = query.clone();
-    Rewriter::default().rewrite_clauses(&mut query.where_clauses);
-    query
+    let mut rewriter = Rewriter::default();
+    rewriter.rewrite_clauses(&mut query.where_clauses);
+    RewrittenQuery {
+        query,
+        generated_variables: rewriter.generated_variables,
+    }
 }
 
 #[cfg(test)]
@@ -72,10 +85,12 @@ mod tests {
             "[:find ?name :where [?_internal_0 :name ?name] [?_internal_1 :age ?_internal_2]]",
         );
 
-        assert_eq!(rewrite_query(&query), expected);
-        assert_eq!(rewrite_query(&query), expected);
-        assert_eq!(rewrite_query(&expected), expected);
+        assert_eq!(rewrite_query(&query).query, expected);
+        assert_eq!(rewrite_query(&query).query, expected);
+        assert_eq!(rewrite_query(&expected).query, expected);
         assert_eq!(query, original);
+        assert_eq!(rewrite_query(&query).generated_variables.len(), 3);
+        assert!(rewrite_query(&expected).generated_variables.is_empty());
     }
 
     #[test]
@@ -89,7 +104,7 @@ mod tests {
         };
         assert_eq!(or.mentioned_variables().len(), 1);
 
-        let mut rewritten = rewrite_query(&query);
+        let mut rewritten = rewrite_query(&query).query;
         let expected = parse_query(
             "[:find ?e :where (or [?e :name ?_internal_0]
                 (and [?_internal_1 :age ?_internal_2]
@@ -110,14 +125,14 @@ mod tests {
                 [?e _ ?value _] [(+ ?value 1) [?result _]]
                 :order [?e :asc] :limit 10]",
         );
-        assert_eq!(rewrite_query(&query), query);
+        assert_eq!(rewrite_query(&query).query, query);
     }
 
     #[test]
     fn does_not_avoid_user_variable_names() {
         let query = parse_query("[:find ?_internal_0 :where [_ :name ?_internal_0]]");
         assert_eq!(
-            rewrite_query(&query),
+            rewrite_query(&query).query,
             parse_query("[:find ?_internal_0 :where [?_internal_0 :name ?_internal_0]]")
         );
     }


### PR DESCRIPTION
The approach has the following 3 steps.
- Add a rewrite step that transforms placeholders to generated variables.
- Allow for generated variables to differ across `or` branches. They are projected away before getting unioned.
- Allow for generated variables to not appear outside `not`. They are not visible on the outside of the `not` and only appear in the left side of the join of the anti-join.